### PR TITLE
Fixed unnecessary type hint

### DIFF
--- a/lib/Gedmo/Tree/Repository/TreeNodeRepository.php
+++ b/lib/Gedmo/Tree/Repository/TreeNodeRepository.php
@@ -353,11 +353,11 @@ class TreeNodeRepository extends EntityRepository
     /**
      * Removes given $node from the tree and reparents its descendants
      * 
-     * @param Node $node
+     * @param object $node
      * @throws RuntimeException - if something fails in transaction
      * @return void
      */
-    public function removeFromTree(Node $node)
+    public function removeFromTree($node)
     {
         $meta = $this->getClassMetadata();
         $config = $this->getConfiguration();


### PR DESCRIPTION
Hi,

I was working with your DoctrineExtension for Tree manipulation, and I noticed there was a type hint for a class called "Node" in the method "removeFromTree" in the TreeNodeRepository class. I have updated the code and removed the typehint. I deducted from other places in that class that the type hint was unnecessary.
