### PR TITLE
Fix class loading

### DIFF
--- a/lib/Gedmo/Mapping/ExtensionMetadataFactory.php
+++ b/lib/Gedmo/Mapping/ExtensionMetadataFactory.php
@@ -116,10 +116,10 @@ class ExtensionMetadataFactory
             $driverName = substr($driverName, 0, strpos($driverName, 'Driver'));
             // create driver instance
             $driverClassName = $this->extensionNamespace . '\Mapping\Driver\\' . $driverName;
-            if (!ClassLoader::classExists($driverClassName)) {
+            if (!class_exists($driverClassName) && !ClassLoader::classExists($driverClassName)) {
                 // @TODO: implement XML driver also
                 $driverClassName = $this->extensionNamespace . '\Mapping\Driver\Annotation';
-                if (!ClassLoader::classExists($driverClassName)) {
+                if (!class_exists($driverClassName) && !ClassLoader::classExists($driverClassName)) {
                     throw new \Gedmo\Exception\RuntimeException("Failed to fallback to annotation driver: ({$driverClassName}), extension driver was not found.");
                 }
             }


### PR DESCRIPTION
Fix mapping driver class loading. Doctrine ClassLoader does not let symfony autoloader work.
This fix does not look pretty but it solves this exception:

```
Failed to fallback to annotation driver: (Gedmo\Timestampable\Mapping\Driver\Annotation), extension driver was not found.
```

thrown by

```
doctrine-extensions/lib/Gedmo/Mapping/ExtensionMetadataFactory.php at line 123
```

when using the timestampable listener.
