### PR TITLE
[Tree] Closure mapping fix

### DIFF
--- a/lib/Gedmo/Tree/Strategy/ORM/Closure.php
+++ b/lib/Gedmo/Tree/Strategy/ORM/Closure.php
@@ -61,48 +61,53 @@ class Closure implements Strategy
     {
         $config = $this->listener->getConfiguration($em, $meta->name);
         $closureMetadata = $em->getClassMetadata($config['closure']);
-        // create ancestor mapping
-        $ancestorMapping = array(
-            'fieldName' => 'ancestor',
-            'id' => false,
-            'joinColumns' => array(
-                array(
-                    'name' => 'ancestor',
-                    'referencedColumnName' => 'id',
-                    'unique' => false,
-                    'nullable' => false,
-                    'onDelete' => 'CASCADE',
-                    'onUpdate' => null,
-                    'columnDefinition' => null,
-                )
-            ),
-            'inversedBy' => null,
-            'targetEntity' => $meta->name,
-            'cascade' => null,
-            'fetch' => ClassMetadataInfo::FETCH_LAZY
-        );
-        $closureMetadata->mapManyToOne($ancestorMapping);
-        // create descendant mapping
-        $descendantMapping = array(
-            'fieldName' => 'descendant',
-            'id' => false,
-            'joinColumns' => array(
-                array(
-                    'name' => 'descendant',
-                    'referencedColumnName' => 'id',
-                    'unique' => false,
-                    'nullable' => false,
-                    'onDelete' => 'CASCADE',
-                    'onUpdate' => null,
-                    'columnDefinition' => null,
-                )
-            ),
-            'inversedBy' => null,
-            'targetEntity' => $meta->name,
-            'cascade' => null,
-            'fetch' => ClassMetadataInfo::FETCH_LAZY
-        );
-        $closureMetadata->mapManyToOne($descendantMapping);
+        if (!$closureMetadata->hasAssociation('ancestor')) {
+            // create ancestor mapping
+            $ancestorMapping = array(
+                'fieldName' => 'ancestor',
+                'id' => false,
+                'joinColumns' => array(
+                    array(
+                        'name' => 'ancestor',
+                        'referencedColumnName' => 'id',
+                        'unique' => false,
+                        'nullable' => false,
+                        'onDelete' => 'CASCADE',
+                        'onUpdate' => null,
+                        'columnDefinition' => null,
+                    )
+                ),
+                'inversedBy' => null,
+                'targetEntity' => $meta->name,
+                'cascade' => null,
+                'fetch' => ClassMetadataInfo::FETCH_LAZY
+            );
+            $closureMetadata->mapManyToOne($ancestorMapping);
+        }
+
+        if (!$closureMetadata->hasAssociation('descendant')) {
+            // create descendant mapping
+            $descendantMapping = array(
+                'fieldName' => 'descendant',
+                'id' => false,
+                'joinColumns' => array(
+                    array(
+                        'name' => 'descendant',
+                        'referencedColumnName' => 'id',
+                        'unique' => false,
+                        'nullable' => false,
+                        'onDelete' => 'CASCADE',
+                        'onUpdate' => null,
+                        'columnDefinition' => null,
+                    )
+                ),
+                'inversedBy' => null,
+                'targetEntity' => $meta->name,
+                'cascade' => null,
+                'fetch' => ClassMetadataInfo::FETCH_LAZY
+            );
+            $closureMetadata->mapManyToOne($descendantMapping);
+        }
         // create unique index on ancestor and descendant
         $indexName = substr(strtoupper("IDX_" . md5($closureMetadata->name)), 0, 20);
         $closureMetadata->table['uniqueConstraints'][$indexName] = array(
@@ -110,7 +115,7 @@ class Closure implements Strategy
         );
         // this one may not be very usefull
         $indexName = substr(strtoupper("IDX_" . md5($meta->name . 'depth')), 0, 20);
-        $closureMetadata->table['indexes']['depth_index'] = array(
+        $closureMetadata->table['indexes'][$indexName] = array(
             'columns' => array('depth')
         );
     }

--- a/tests/Gedmo/Tree/ClosureTreeTest.php
+++ b/tests/Gedmo/Tree/ClosureTreeTest.php
@@ -21,6 +21,9 @@ class ClosureTreeTest extends BaseTestCaseORM
 {
     const CATEGORY = "Tree\\Fixture\\Closure\\Category";
     const CLOSURE = "Tree\\Fixture\\Closure\\CategoryClosure";
+    const PERSON = "Tree\\Fixture\\Closure\\Person";
+    const USER = "Tree\\Fixture\\Closure\\User";
+    const PERSON_CLOSURE = "Tree\\Fixture\\Closure\\PersonClosure";
 
     protected function setUp()
     {
@@ -205,7 +208,10 @@ class ClosureTreeTest extends BaseTestCaseORM
     {
         return array(
             self::CATEGORY,
-            self::CLOSURE
+            self::CLOSURE,
+            self::PERSON,
+            self::PERSON_CLOSURE,
+            self::USER
         );
     }
 

--- a/tests/Gedmo/Tree/Fixture/Closure/Person.php
+++ b/tests/Gedmo/Tree/Fixture/Closure/Person.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tree\Fixture\Closure;
+
+/**
+ * @gedmo:Tree(type="closure")
+ * @gedmo:TreeClosure(class="Tree\Fixture\Closure\PersonClosure")
+ * @Entity(repositoryClass="Gedmo\Tree\Entity\Repository\ClosureTreeRepository")
+ * @InheritanceType("JOINED")
+ * @DiscriminatorColumn(name="discriminator", type="string")
+ * @DiscriminatorMap({
+    "user" = "User"
+    })
+ */
+class Person
+{
+    /**
+     * @Column(name="id", type="integer")
+     * @Id
+     * @GeneratedValue
+     */
+    private $id;
+
+    /**
+     * @Column(name="full_name", type="string", length=64)
+     */
+    private $fullName;
+
+    /**
+     * @gedmo:TreeParent
+     * @JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
+     * @ManyToOne(targetEntity="Person", inversedBy="children", cascade={"persist"})
+     */
+    private $parent;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setParent(Category $parent = null)
+    {
+        $this->parent = $parent;
+    }
+
+    public function getParent()
+    {
+        return $this->parent;
+    }
+
+    public function addClosure(CategoryClosure $closure)
+    {
+        $this->closures[] = $closure;
+    }
+}

--- a/tests/Gedmo/Tree/Fixture/Closure/PersonClosure.php
+++ b/tests/Gedmo/Tree/Fixture/Closure/PersonClosure.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tree\Fixture\Closure;
+
+use Gedmo\Tree\Entity\AbstractClosure;
+
+/**
+ * @Entity
+ */
+class PersonClosure extends AbstractClosure
+{
+
+}

--- a/tests/Gedmo/Tree/Fixture/Closure/User.php
+++ b/tests/Gedmo/Tree/Fixture/Closure/User.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tree\Fixture\Closure;
+
+/**
+ * @Entity
+ */
+class User extends Person
+{
+    /**
+     * @Column(name="username", type="string", length=64)
+     */
+    private $username;
+
+
+    public function setUsername($username)
+    {
+        $this->username = $username;
+    }
+
+    public function getUsername()
+    {
+        return $this->username;
+    }
+}


### PR DESCRIPTION
After updating the doctrine extensions I've got the following exception:

Doctrine\ORM\Mapping\MappingException: Property "ancestor" in "MyClassImplementingClosureTable" was already declared, but it must be declared only once

The issue seems to appear when I try to implement the closure table in a base class from a class tree using inheritance. I've included some classes on the Fixtures directory to illustrate the problem. If you remove my changes on the Closure class, it throws the exception described before for the "ancestor", "descendant" and for the depth_index too (which wasn't using the $indexName you generated, so it was throwing an exception too, because it was trying to create two indexes with the same name).

I really don't know if this is the right way to solve this but the unit tests passed and my app is running well for now. But I'd like to know your opinion on this one, and if there's a better way to fix this.

Thanks!
