### PR TITLE
Fix notice on missing metadata for unmapped fields

### DIFF
--- a/lib/Gedmo/Translatable/Query/TreeWalker/TranslationWalker.php
+++ b/lib/Gedmo/Translatable/Query/TreeWalker/TranslationWalker.php
@@ -340,6 +340,9 @@ class TranslationWalker extends SqlWalker
     {
         $em = $this->getEntityManager();
         foreach ($queryComponents as $alias => $comp) {
+            if (!isset($comp['metadata'])) {
+                continue;
+            }
             $meta = $comp['metadata'];
             $config = $this->listener->getConfiguration($em, $meta->name);
             if ($config && isset($config['fields'])) {

--- a/tests/Gedmo/Translatable/TranslationQueryWalkerTest.php
+++ b/tests/Gedmo/Translatable/TranslationQueryWalkerTest.php
@@ -410,6 +410,24 @@ public function testSubselectByTranslatedField()
         $this->assertEquals('apie maista', $food->getContent());
     }
 
+    /**
+     * @group testSelectWithUnmappedField
+     */
+    public function testSelectWithUnmappedField()
+    {
+        $dql = 'SELECT a.title, count(a.id) AS num FROM ' . self::ARTICLE . ' a';
+        $dql .= ' ORDER BY a.title';
+        $q = $this->em->createQuery($dql);
+        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, self::TREE_WALKER_TRANSLATION);
+
+        // array hydration
+        $this->translationListener->setTranslatableLocale('en_us');
+        $result = $q->getArrayResult();
+        $this->assertEquals(1, count($result));
+        $this->assertEquals('Food', $result[0]['title']);
+        $this->assertEquals(1, $result[0]['num']);
+    }
+
     protected function getUsedEntityFixtures()
     {
         return array(


### PR DESCRIPTION
If you have a query like

```
SELECT a.title, count(a.id) AS num FROM Article
```

`Gedmo\Translatable\Query\TreeWalker\TranslationWalker::extractTranslatedComponents` throws a notice

```
Notice: Undefined index: metadata in lib/Gedmo/Translatable/Query/TreeWalker/TranslationWalker.php on line 343

Notice: Trying to get property of non-object in lib/Gedmo/Translatable/Query/TreeWalker/TranslationWalker.php on line 344
```

since `$comp['metadata']` isn't availabe for `num`.
