### PR TITLE
Load metadata from parent driver

### DIFF
--- a/lib/Gedmo/Loggable/Mapping/Driver/Annotation.php
+++ b/lib/Gedmo/Loggable/Mapping/Driver/Annotation.php
@@ -39,6 +39,10 @@ class Annotation implements AnnotationDriverInterface
     private $reader;
 
     /**
+     * original driver if it is available
+     */
+    protected $_originalDriver = null;
+    /**
      * {@inheritDoc}
      */
     public function setAnnotationReader($reader)
@@ -93,5 +97,16 @@ class Annotation implements AnnotationDriverInterface
                 $config['versioned'][] = $field;
             }
         }
+    }
+
+    /**
+     * Passes in the mapping read by original driver
+     *
+     * @param $driver
+     * @return void
+     */
+    public function setOriginalDriver($driver)
+    {
+        $this->_originalDriver = $driver;
     }
 }

--- a/lib/Gedmo/Loggable/Mapping/Driver/Yaml.php
+++ b/lib/Gedmo/Loggable/Mapping/Driver/Yaml.php
@@ -46,8 +46,7 @@ class Yaml extends File implements Driver
      */
     public function readExtendedMetadata(ClassMetadata $meta, array &$config)
     {
-        $yaml = $this->_loadMappingFile($this->_findMappingFile($meta->name));
-        $mapping = $yaml[$meta->name];
+        $mapping = $this->_getMapping($meta->name);
 
         if (isset($mapping['gedmo'])) {
             $classMapping = $mapping['gedmo'];

--- a/lib/Gedmo/Mapping/Driver.php
+++ b/lib/Gedmo/Mapping/Driver.php
@@ -38,4 +38,12 @@ interface Driver
      * @return void
      */
     public function validateFullMetadata(ClassMetadata $meta, array $config);
+
+    /**
+     * Passes in the original driver
+     *
+     * @param $driver
+     * @return void
+     */
+    public function setOriginalDriver($driver);
 }

--- a/lib/Gedmo/Mapping/Driver/Chain.php
+++ b/lib/Gedmo/Mapping/Driver/Chain.php
@@ -62,4 +62,15 @@ class Chain implements Driver
         }
         throw new \Gedmo\Exception\UnexpectedValueException('Class ' . $meta->name . ' is not a valid entity or mapped super class.');
     }
+
+    /**
+     * Passes in the mapping read by original driver
+     *
+     * @param $driver
+     * @return void
+     */
+    public function setOriginalDriver($driver)
+    {
+        //not needed here
+    }
 }

--- a/lib/Gedmo/Mapping/ExtensionMetadataFactory.php
+++ b/lib/Gedmo/Mapping/ExtensionMetadataFactory.php
@@ -150,6 +150,7 @@ final class ExtensionMetadataFactory
                 }
             }
             $driver = new $driverClassName();
+            $driver->setOriginalDriver($omDriver);
             if ($driver instanceof FileDriver) {
                 $driver->setPaths($omDriver->getPaths());
             }

--- a/lib/Gedmo/Sluggable/Mapping/Driver/Annotation.php
+++ b/lib/Gedmo/Sluggable/Mapping/Driver/Annotation.php
@@ -49,6 +49,11 @@ class Annotation implements AnnotationDriverInterface
     private $reader;
 
     /**
+     * original driver if it is available
+     */
+    protected $_originalDriver = null;
+
+    /**
      * {@inheritDoc}
      */
     public function setAnnotationReader($reader)
@@ -123,5 +128,16 @@ class Annotation implements AnnotationDriverInterface
     {
         $mapping = $meta->getFieldMapping($field);
         return $mapping && in_array($mapping['type'], $this->validTypes);
+    }
+
+    /**
+     * Passes in the mapping read by original driver
+     *
+     * @param $driver
+     * @return void
+     */
+    public function setOriginalDriver($driver)
+    {
+        $this->_originalDriver = $driver;
     }
 }

--- a/lib/Gedmo/Sluggable/Mapping/Driver/Yaml.php
+++ b/lib/Gedmo/Sluggable/Mapping/Driver/Yaml.php
@@ -49,9 +49,9 @@ class Yaml extends File implements Driver
     /**
      * {@inheritDoc}
      */
-    public function readExtendedMetadata(ClassMetadata $meta, array &$config) {
-        $yaml = $this->_loadMappingFile($this->_findMappingFile($meta->name));
-        $mapping = $yaml[$meta->name];
+    public function readExtendedMetadata(ClassMetadata $meta, array &$config)
+    {
+        $mapping = $this->_getMapping($meta->name);
 
         if (isset($mapping['fields'])) {
             foreach ($mapping['fields'] as $field => $fieldMapping) {

--- a/lib/Gedmo/Timestampable/Mapping/Driver/Annotation.php
+++ b/lib/Gedmo/Timestampable/Mapping/Driver/Annotation.php
@@ -46,6 +46,11 @@ class Annotation implements AnnotationDriverInterface
     private $reader;
 
     /**
+     * original driver if it is available
+     */
+    protected $_originalDriver = null;
+
+    /**
      * {@inheritDoc}
      */
     public function setAnnotationReader($reader)
@@ -109,5 +114,16 @@ class Annotation implements AnnotationDriverInterface
     {
         $mapping = $meta->getFieldMapping($field);
         return $mapping && in_array($mapping['type'], $this->validTypes);
+    }
+
+    /**
+     * Passes in the mapping read by original driver
+     *
+     * @param $driver
+     * @return void
+     */
+    public function setOriginalDriver($driver)
+    {
+        $this->_originalDriver = $driver;
     }
 }

--- a/lib/Gedmo/Timestampable/Mapping/Driver/Yaml.php
+++ b/lib/Gedmo/Timestampable/Mapping/Driver/Yaml.php
@@ -47,10 +47,10 @@ class Yaml extends File implements Driver
     /**
      * {@inheritDoc}
      */
-    public function readExtendedMetadata(ClassMetadata $meta, array &$config) {
-        $yaml = $this->_loadMappingFile($this->_findMappingFile($meta->name));
-        $mapping = $yaml[$meta->name];
-        
+    public function readExtendedMetadata(ClassMetadata $meta, array &$config)
+    {
+        $mapping = $this->_getMapping($meta->name);
+
         if (isset($mapping['fields'])) {
             foreach ($mapping['fields'] as $field => $fieldMapping) {
                 if (isset($fieldMapping['gedmo']['timestampable'])) {

--- a/lib/Gedmo/Translatable/Mapping/Driver/Annotation.php
+++ b/lib/Gedmo/Translatable/Mapping/Driver/Annotation.php
@@ -50,6 +50,11 @@ class Annotation implements AnnotationDriverInterface
     private $reader;
 
     /**
+     * original driver if it is available
+     */
+    protected $_originalDriver = null;
+
+    /**
      * {@inheritDoc}
      */
     public function setAnnotationReader($reader)
@@ -112,5 +117,16 @@ class Annotation implements AnnotationDriverInterface
                 $config['locale'] = $field;
             }
         }
+    }
+
+    /**
+     * Passes in the mapping read by original driver
+     *
+     * @param $driver
+     * @return void
+     */
+    public function setOriginalDriver($driver)
+    {
+        $this->_originalDriver = $driver;
     }
 }

--- a/lib/Gedmo/Translatable/Mapping/Driver/Yaml.php
+++ b/lib/Gedmo/Translatable/Mapping/Driver/Yaml.php
@@ -40,9 +40,9 @@ class Yaml extends File implements Driver
     /**
      * {@inheritDoc}
      */
-    public function readExtendedMetadata(ClassMetadata $meta, array &$config) {
-        $yaml = $this->_loadMappingFile($this->_findMappingFile($meta->name));
-        $mapping = $yaml[$meta->name];
+    public function readExtendedMetadata(ClassMetadata $meta, array &$config)
+    {
+        $mapping = $this->_getMapping($meta->name);
 
         if (isset($mapping['gedmo'])) {
             $classMapping = $mapping['gedmo'];

--- a/lib/Gedmo/Tree/Mapping/Driver/Annotation.php
+++ b/lib/Gedmo/Tree/Mapping/Driver/Annotation.php
@@ -84,6 +84,11 @@ class Annotation implements AnnotationDriverInterface
     private $reader;
 
     /**
+     * original driver if it is available
+     */
+    protected $_originalDriver = null;
+
+    /**
      * {@inheritDoc}
      */
     public function setAnnotationReader($reader)
@@ -247,5 +252,16 @@ class Annotation implements AnnotationDriverInterface
         if ($missingFields) {
             throw new InvalidMappingException("Missing properties: " . implode(', ', $missingFields) . " in class - {$meta->name}");
         }
+    }
+
+    /**
+     * Passes in the mapping read by original driver
+     *
+     * @param $driver
+     * @return void
+     */
+    public function setOriginalDriver($driver)
+    {
+        $this->_originalDriver = $driver;
     }
 }

--- a/lib/Gedmo/Tree/Mapping/Driver/Yaml.php
+++ b/lib/Gedmo/Tree/Mapping/Driver/Yaml.php
@@ -67,9 +67,9 @@ class Yaml extends File implements Driver
     /**
      * {@inheritDoc}
      */
-    public function readExtendedMetadata(ClassMetadata $meta, array &$config) {
-        $yaml = $this->_loadMappingFile($this->_findMappingFile($meta->name));
-        $mapping = $yaml[$meta->name];
+    public function readExtendedMetadata(ClassMetadata $meta, array &$config)
+    {
+        $mapping = $this->_getMapping($meta->name);
 
         if (isset($mapping['gedmo'])) {
             $classMapping = $mapping['gedmo'];

--- a/tests/Gedmo/Mapping/Mock/Extension/Encoder/Mapping/Driver/Annotation.php
+++ b/tests/Gedmo/Mapping/Mock/Extension/Encoder/Mapping/Driver/Annotation.php
@@ -10,6 +10,11 @@ use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 
 class Annotation implements Driver
 {
+    /**
+     * original driver if it is available
+     */
+    protected $_originalDriver = null;
+    
     public function validateFullMetadata(ClassMetadata $meta, array $config)
     {
         // in our case values are independant from each other
@@ -55,5 +60,16 @@ class Annotation implements Driver
                 );
             }
         }
+    }
+    
+    /**
+     * Passes in the mapping read by original driver
+     *
+     * @param $driver
+     * @return void
+     */
+    public function setOriginalDriver($driver)
+    {
+        $this->_originalDriver = $driver;
     }
 }


### PR DESCRIPTION
Added support for loading additional data from original driver.
If original driver doesn't have metadata, then it automatically falls back to trying to load a file.

This is to work around the newly introduced loaders in doctrine which enable you to have multiple mappings in a single file and or one mapping per file, but named only with the class name of FQCN.
