### PR TITLE
Add read-through annotation caching and re-generation

### DIFF
--- a/lib/Gedmo/Mapping/ExtensionMetadataFactory.php
+++ b/lib/Gedmo/Mapping/ExtensionMetadataFactory.php
@@ -99,12 +99,15 @@ final class ExtensionMetadataFactory
         if ($config) {
             $this->driver->validateFullMetadata($meta, $config);
             $config['useObjectClass'] = $useObjectName;
-            // cache the metadata
-            $cacheId = self::getCacheId($meta->name, $this->extensionNamespace);
-            if ($cacheDriver = $this->objectManager->getMetadataFactory()->getCacheDriver()) {
-                $cacheDriver->save($cacheId, $config, null);
-            }
         }
+
+        // cache the metadata (even if it's empty)
+        // caching empty metadata will prevent re-parsing non-existent annotations
+        $cacheId = self::getCacheId($meta->name, $this->extensionNamespace);
+        if ($cacheDriver = $this->objectManager->getMetadataFactory()->getCacheDriver()) {
+            $cacheDriver->save($cacheId, $config, null);
+        }
+
         return $config;
     }
 


### PR DESCRIPTION
This fixes a bug when Gedmo-specific annotation caches are dropped without dropping the related Doctrine annotation. This forces Gedmo metadata re-generation on a cache miss. In order to prevent useless annotation parsing, an empty cache entries are created for Doctrine extensions which are enabled but not present on a given class.

Fixes #89
