### PR TITLE
Edited doc/tree.md via GitHub

### DIFF
--- a/doc/tree.md
+++ b/doc/tree.md
@@ -186,7 +186,7 @@ cache is activated
             return $this->title;
         }
         
-        public function setParent(Category $parent)
+        public function setParent(Category $parent = null)
         {
             $this->parent = $parent;    
         }


### PR DESCRIPTION
Adding the default param value of null allows you to remove a node from the tree.

One of the tests shows this:

```
// tests/Gedmo/Tree/Fixture/Closure/Category.php
public function setParent(Category $parent = null)
{
    $this->parent = $parent;
}
```

while another doesn't

```
// tests/Gedmo/Tree/Fixture/Category.php
public function setParent(Category $parent)
{
    $this->parentId = $parent;
}
```

I'm a Symfony2 / Doctrine Noob so I'm not sure if null can be defined in the Entity annotations or YAML.

Cheers Leevi
