### PR TITLE
[Sluggable] Small improvement to make exception message more explicit.

### DIFF
--- a/lib/Gedmo/Sluggable/Mapping/Driver/Annotation.php
+++ b/lib/Gedmo/Sluggable/Mapping/Driver/Annotation.php
@@ -102,7 +102,8 @@ class Annotation implements AnnotationDriverInterface
                     throw new InvalidMappingException("Cannot slug field - [{$field}] type is not valid and must be 'string' in class - {$meta->name}");
                 }
                 if (!is_null($sluggable->slugField) and !$meta->hasField($sluggable->slugField)) {
-                    throw new InvalidMappingException("Unable to find slug [{$field}] as mapped property in entity - {$meta->name}");
+
+                    throw new InvalidMappingException(sprintf('The "%s" property - which is defined as the "slugField" for the "%s" property - does not exist or is not mapped to Doctrine in "%s"', $sluggable->slugField, $field, $meta->name));
                 }
                 $config['fields'][$sluggable->slugField][] = array('field' => $field, 'position' => $sluggable->position, 'slugField' => $sluggable->slugField);
             }


### PR DESCRIPTION
Hey guys!

I had a typo in my `slug` field mapping, so I thought I'd improve the exception message that I generated. This (hopefully) tells the user to look at their "slugField" field, which is where the problem is.

Thanks!
