### PR TITLE
fixes issue when using default doctrine configuration

### DIFF
--- a/lib/Gedmo/Mapping/MappedEventSubscriber.php
+++ b/lib/Gedmo/Mapping/MappedEventSubscriber.php
@@ -194,7 +194,14 @@ abstract class MappedEventSubscriber implements EventSubscriber
     private function getDefaultAnnotationReader()
     {
         if (null === $this->defaultAnnotationReader) {
-            if (version_compare(\Doctrine\Common\Version::VERSION, '2.1.0RC4-DEV', '>=')) {
+            if (version_compare(\Doctrine\Common\Version::VERSION, '3.0.0-DEV', '>=')) {
+                $reader = new \Doctrine\Common\Annotations\AnnotationReader();
+                \Doctrine\Common\Annotations\AnnotationRegistry::registerAutoloadNamespace(
+                    'Gedmo\\Mapping\\Annotation',
+                    __DIR__ . '/../../'
+                );
+                $reader = new \Doctrine\Common\Annotations\CachedReader($reader, new ArrayCache());
+            } else if (version_compare(\Doctrine\Common\Version::VERSION, '2.1.0RC4-DEV', '>=')) {
                 $reader = new \Doctrine\Common\Annotations\AnnotationReader();
                 \Doctrine\Common\Annotations\AnnotationRegistry::registerAutoloadNamespace(
                     'Gedmo\\Mapping\\Annotation',


### PR DESCRIPTION
Doctrine\Common\Annotations\AnnotationException: [Semantical Error] The annotation "@Entity" in class (...) was never imported.

This happened when moving a doctrine 2.0 project that uses Translatable to Doctrine 2.1. The patch appears to solve it for us.
