### PR TITLE
Gedmo annotation alias.

### DIFF
--- a/lib/Gedmo/Mapping/MappedEventSubscriber.php
+++ b/lib/Gedmo/Mapping/MappedEventSubscriber.php
@@ -208,6 +208,7 @@ abstract class MappedEventSubscriber implements EventSubscriber
                     __DIR__ . '/../../'
                 );
                 $reader->setDefaultAnnotationNamespace('Doctrine\ORM\Mapping\\');
+                $reader->setAnnotationNamespaceAlias('Gedmo\\Mapping\\Annotation\\', 'gedmo');
                 $reader = new \Doctrine\Common\Annotations\CachedReader($reader, new ArrayCache());
             } else if (version_compare(\Doctrine\Common\Version::VERSION, '2.1.0-BETA3-DEV', '>=')) {
                 $reader = new \Doctrine\Common\Annotations\AnnotationReader();


### PR DESCRIPTION
Someway somehow EventSubscriber doesn't register "gedmo" annotation alias Doctrine 2.1. I'm not sure if there will be a difference with Doctrine common 3.0 so I added alias only for 2.1 version. Without this alias all gedmo annotations simply ignored by reader. 
