### PR TITLE
fixed AnnotationException with Doctrine 2.2.0-DEV

### DIFF
--- a/lib/Gedmo/Mapping/MappedEventSubscriber.php
+++ b/lib/Gedmo/Mapping/MappedEventSubscriber.php
@@ -195,7 +195,8 @@ abstract class MappedEventSubscriber implements EventSubscriber
     {
         if (null === $this->defaultAnnotationReader) {
             if (version_compare(\Doctrine\Common\Version::VERSION, '2.2.0-DEV', '>=')) {
-                $reader = new \Doctrine\Common\Annotations\AnnotationReader();
+                $reader = new \Doctrine\Common\Annotations\SimpleAnnotationReader();
+                $reader->addNamespace('Doctrine\ORM\Mapping');
                 \Doctrine\Common\Annotations\AnnotationRegistry::registerAutoloadNamespace(
                     'Gedmo\\Mapping\\Annotation',
                     __DIR__ . '/../../'


### PR DESCRIPTION
When using master branch of doctrine2, I've got the following exception similar to #126.
[Semantical Error] The annotation "@Entity" in class ***\* was never imported.
