### PR TITLE
TreeListener getStrategy did overwrite the local $class variable.

### DIFF
--- a/lib/Gedmo/Tree/TreeListener.php
+++ b/lib/Gedmo/Tree/TreeListener.php
@@ -70,11 +70,11 @@ class TreeListener extends MappedEventSubscriber
                 $managerName = 'ODM';
             }
             if (!isset($this->strategyInstances[$config['strategy']])) {
-                $class = $this->getNamespace().'\\Strategy\\'.$managerName.'\\'.ucfirst($config['strategy']);
-                if (!class_exists($class)) {
+                $strategyClass = $this->getNamespace().'\\Strategy\\'.$managerName.'\\'.ucfirst($config['strategy']);
+                if (!class_exists($strategyClass)) {
                     throw new \Gedmo\Exception\InvalidArgumentException($managerName." TreeListener does not support tree type: {$config['strategy']}");
                 }
-                $this->strategyInstances[$config['strategy']] = new $class($this);
+                $this->strategyInstances[$config['strategy']] = new $strategyClass($this);
             }
             $this->strategies[$class] = $config['strategy'];
         }


### PR DESCRIPTION
Due to re-use of $class variable name, the correct strategy was actually not correctly cached in the first getStrategy run.
