### PR TITLE
[Sluggable] abstract slugs

### DIFF
--- a/lib/Gedmo/Mapping/Annotation/Slug.php
+++ b/lib/Gedmo/Mapping/Annotation/Slug.php
@@ -8,7 +8,7 @@ use Doctrine\Common\Annotations\Annotation;
  * Slug annotation for Sluggable behavioral extension
  *
  * @Annotation
- * @Target("PROPERTY")
+ * @Target({"PROPERTY","CLASS"})
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  * @package Gedmo.Mapping.Annotation

--- a/lib/Gedmo/Sluggable/SluggableListener.php
+++ b/lib/Gedmo/Sluggable/SluggableListener.php
@@ -92,7 +92,7 @@ class SluggableListener extends MappedEventSubscriber
     }
 
     /**
-     * Mapps additional metadata
+     * Maps additional metadata
      *
      * @param EventArgs $eventArgs
      * @return void


### PR DESCRIPTION
Allows "abstract" slugs in abstract classes, which are later "finished" in concrete classes. This is useful when I want a class hierarchy with common slug, but each class can have different fields for slug generation.

This patch allows Slug annotation without defining fields when in abstract class, and then setting a Slug annotation in class annotation in concrete class (it's should be sufficient as people won't usually have more than one slug per entity).
