### PR TITLE
remove typehinting for ClassMetadata - refs Issue #220

### DIFF
--- a/doc/mapping.md
+++ b/doc/mapping.md
@@ -123,11 +123,10 @@ Edit **Annotation.php** driver file:
     
     use Gedmo\Mapping\Driver;
     use Doctrine\Common\Annotations\AnnotationReader;
-    use Doctrine\Common\Persistence\Mapping\ClassMetadata;
     
     class Annotation implements Driver
     {
-        public function readExtendedMetadata(ClassMetadata $meta, array &$config) {
+        public function readExtendedMetadata($meta, array &$config) {
             // load our available annotations
             require_once __DIR__ . '/../Annotations.php';
             $reader = new AnnotationReader();

--- a/lib/Gedmo/Loggable/LoggableListener.php
+++ b/lib/Gedmo/Loggable/LoggableListener.php
@@ -3,7 +3,6 @@
 namespace Gedmo\Loggable;
 
 use Doctrine\Common\Persistence\ObjectManager,
-    Doctrine\Common\Persistence\Mapping\ClassMetadata,
     Gedmo\Mapping\MappedEventSubscriber,
     Gedmo\Loggable\Mapping\Event\LoggableAdapter,
     Doctrine\Common\EventArgs;

--- a/lib/Gedmo/Loggable/Mapping/Driver/Annotation.php
+++ b/lib/Gedmo/Loggable/Mapping/Driver/Annotation.php
@@ -3,7 +3,6 @@
 namespace Gedmo\Loggable\Mapping\Driver;
 
 use Gedmo\Mapping\Driver\AnnotationDriverInterface,
-    Doctrine\Common\Persistence\Mapping\ClassMetadata,
     Gedmo\Exception\InvalidMappingException;
 
 /**
@@ -53,7 +52,7 @@ class Annotation implements AnnotationDriverInterface
     /**
      * {@inheritDoc}
      */
-    public function validateFullMetadata(ClassMetadata $meta, array $config)
+    public function validateFullMetadata($meta, array $config)
     {
         if ($config && is_array($meta->identifier) && count($meta->identifier) > 1) {
             throw new InvalidMappingException("Loggable does not support composite identifiers in class - {$meta->name}");
@@ -66,7 +65,7 @@ class Annotation implements AnnotationDriverInterface
     /**
      * {@inheritDoc}
      */
-    public function readExtendedMetadata(ClassMetadata $meta, array &$config)
+    public function readExtendedMetadata($meta, array &$config)
     {
         $class = $meta->getReflectionClass();
         // class annotations

--- a/lib/Gedmo/Loggable/Mapping/Driver/Xml.php
+++ b/lib/Gedmo/Loggable/Mapping/Driver/Xml.php
@@ -3,7 +3,6 @@
 namespace Gedmo\Loggable\Mapping\Driver;
 
 use Gedmo\Mapping\Driver\Xml as BaseXml,
-    Doctrine\Common\Persistence\Mapping\ClassMetadata,
     Gedmo\Exception\InvalidMappingException;
 
 /**
@@ -25,7 +24,7 @@ class Xml extends BaseXml
     /**
      * {@inheritDoc}
      */
-    public function readExtendedMetadata(ClassMetadata $meta, array &$config)
+    public function readExtendedMetadata($meta, array &$config)
     {
         /**
          * @var \SimpleXmlElement $xml
@@ -77,9 +76,9 @@ class Xml extends BaseXml
      *
      * @param SimpleXMLElement $element
      * @param array $config
-     * @param ClassMetadata $meta
+     * @param object $meta
      */
-    private function inspectElementForVersioned(\SimpleXMLElement $element, array &$config, ClassMetadata $meta)
+    private function inspectElementForVersioned(\SimpleXMLElement $element, array &$config, $meta)
     {
         foreach ($element as $mapping) {
             $mappingDoctrine = $mapping;

--- a/lib/Gedmo/Loggable/Mapping/Driver/Yaml.php
+++ b/lib/Gedmo/Loggable/Mapping/Driver/Yaml.php
@@ -4,7 +4,6 @@ namespace Gedmo\Loggable\Mapping\Driver;
 
 use Gedmo\Mapping\Driver\File,
     Gedmo\Mapping\Driver,
-    Doctrine\Common\Persistence\Mapping\ClassMetadata,
     Gedmo\Exception\InvalidMappingException;
 
 /**
@@ -31,7 +30,7 @@ class Yaml extends File implements Driver
     /**
      * {@inheritDoc}
      */
-    public function readExtendedMetadata(ClassMetadata $meta, array &$config)
+    public function readExtendedMetadata($meta, array &$config)
     {
         $mapping = $this->_getMapping($meta->name);
 

--- a/lib/Gedmo/Loggable/Mapping/Event/Adapter/ODM.php
+++ b/lib/Gedmo/Loggable/Mapping/Event/Adapter/ODM.php
@@ -3,7 +3,6 @@
 namespace Gedmo\Loggable\Mapping\Event\Adapter;
 
 use Gedmo\Mapping\Event\Adapter\ODM as BaseAdapterODM;
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Gedmo\Loggable\Mapping\Event\LoggableAdapter;
 
 /**
@@ -29,7 +28,7 @@ final class ODM extends BaseAdapterODM implements LoggableAdapter
     /**
      * {@inheritDoc}
      */
-    public function getNewVersion(ClassMetadata $meta, $object)
+    public function getNewVersion($meta, $object)
     {
         $dm = $this->getObjectManager();
         $objectMeta = $dm->getClassMetadata(get_class($object));

--- a/lib/Gedmo/Loggable/Mapping/Event/Adapter/ORM.php
+++ b/lib/Gedmo/Loggable/Mapping/Event/Adapter/ORM.php
@@ -3,7 +3,6 @@
 namespace Gedmo\Loggable\Mapping\Event\Adapter;
 
 use Gedmo\Mapping\Event\Adapter\ORM as BaseAdapterORM;
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Gedmo\Loggable\Mapping\Event\LoggableAdapter;
 
 /**
@@ -29,7 +28,7 @@ final class ORM extends BaseAdapterORM implements LoggableAdapter
     /**
      * {@inheritDoc}
      */
-    public function getNewVersion(ClassMetadata $meta, $object)
+    public function getNewVersion($meta, $object)
     {
         $em = $this->getObjectManager();
         $objectMeta = $em->getClassMetadata(get_class($object));

--- a/lib/Gedmo/Loggable/Mapping/Event/LoggableAdapter.php
+++ b/lib/Gedmo/Loggable/Mapping/Event/LoggableAdapter.php
@@ -2,7 +2,6 @@
 
 namespace Gedmo\Loggable\Mapping\Event;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Gedmo\Mapping\Event\AdapterInterface;
 
 /**
@@ -27,9 +26,9 @@ interface LoggableAdapter extends AdapterInterface
     /**
      * Get new version number
      *
-     * @param ClassMetadata $meta
+     * @param object $meta
      * @param object $object
      * @return integer
      */
-    function getNewVersion(ClassMetadata $meta, $object);
+    function getNewVersion($meta, $object);
 }

--- a/lib/Gedmo/Mapping/Driver.php
+++ b/lib/Gedmo/Mapping/Driver.php
@@ -2,9 +2,6 @@
 
 namespace Gedmo\Mapping;
 
-
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
-
 /**
  * The mapping driver abstract class, defines the
  * metadata extraction function common among
@@ -22,11 +19,11 @@ interface Driver
      * Read extended metadata configuration for
      * a single mapped class
      *
-     * @param ClassMetadata $meta
+     * @param object $meta
      * @param array $config
      * @return void
      */
-    public function readExtendedMetadata(ClassMetadata $meta, array &$config);
+    public function readExtendedMetadata($meta, array &$config);
 
     /**
      * Passes in the original driver

--- a/lib/Gedmo/Mapping/Driver/Chain.php
+++ b/lib/Gedmo/Mapping/Driver/Chain.php
@@ -2,8 +2,7 @@
 
 namespace Gedmo\Mapping\Driver;
 
-use Gedmo\Mapping\Driver,
-    Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Gedmo\Mapping\Driver;
 
 /**
  * The chain mapping driver enables chained
@@ -47,7 +46,7 @@ class Chain implements Driver
     /**
      * {@inheritDoc}
      */
-    public function readExtendedMetadata(ClassMetadata $meta, array &$config)
+    public function readExtendedMetadata($meta, array &$config)
     {
         foreach ($this->_drivers as $namespace => $driver) {
             if (strpos($meta->name, $namespace) === 0) {

--- a/lib/Gedmo/Mapping/ExtensionMetadataFactory.php
+++ b/lib/Gedmo/Mapping/ExtensionMetadataFactory.php
@@ -64,7 +64,7 @@ final class ExtensionMetadataFactory
     /**
      * Reads extension metadata
      *
-     * @param ClassMetadata $meta
+     * @param object $meta
      * @return array - the metatada configuration
      */
     public function getExtensionMetadata($meta)

--- a/lib/Gedmo/Mapping/MappedEventSubscriber.php
+++ b/lib/Gedmo/Mapping/MappedEventSubscriber.php
@@ -164,7 +164,7 @@ abstract class MappedEventSubscriber implements EventSubscriber
      * event subscribers must subscribe to loadClassMetadata event
      *
      * @param ObjectManager $objectManager
-     * @param ClassMetadata $metadata
+     * @param object $metadata
      * @return void
      */
     public function loadMetadataForObjectClass(ObjectManager $objectManager, $metadata)

--- a/lib/Gedmo/Sluggable/Handler/InversedRelativeSlugHandler.php
+++ b/lib/Gedmo/Sluggable/Handler/InversedRelativeSlugHandler.php
@@ -3,7 +3,6 @@
 namespace Gedmo\Sluggable\Handler;
 
 use Doctrine\Common\Persistence\ObjectManager;
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Gedmo\Sluggable\SluggableListener;
 use Gedmo\Sluggable\Mapping\Event\SluggableAdapter;
 use Gedmo\Tool\Wrapper\AbstractWrapper;
@@ -60,7 +59,7 @@ class InversedRelativeSlugHandler implements SlugHandlerInterface
     /**
      * {@inheritDoc}
      */
-    public static function validate(array $options, ClassMetadata $meta)
+    public static function validate(array $options, $meta)
     {
         if (!isset($options['relationClass']) || !strlen($options['relationClass'])) {
             throw new InvalidMappingException("'relationClass' option must be specified for object slug mapping - {$meta->name}");

--- a/lib/Gedmo/Sluggable/Handler/RelativeSlugHandler.php
+++ b/lib/Gedmo/Sluggable/Handler/RelativeSlugHandler.php
@@ -3,7 +3,6 @@
 namespace Gedmo\Sluggable\Handler;
 
 use Doctrine\Common\Persistence\ObjectManager;
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Gedmo\Sluggable\SluggableListener;
 use Gedmo\Sluggable\Mapping\Event\SluggableAdapter;
 use Gedmo\Tool\Wrapper\AbstractWrapper;
@@ -111,7 +110,7 @@ class RelativeSlugHandler implements SlugHandlerInterface
     /**
      * {@inheritDoc}
      */
-    public static function validate(array $options, ClassMetadata $meta)
+    public static function validate(array $options, $meta)
     {
         if (!$meta->isSingleValuedAssociation($options['relationField'])) {
             throw new InvalidMappingException("Unable to find slug relation through field - [{$options['relationField']}] in class - {$meta->name}");

--- a/lib/Gedmo/Sluggable/Handler/SlugHandlerInterface.php
+++ b/lib/Gedmo/Sluggable/Handler/SlugHandlerInterface.php
@@ -3,7 +3,6 @@
 namespace Gedmo\Sluggable\Handler;
 
 use Doctrine\Common\Persistence\ObjectManager;
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Gedmo\Sluggable\SluggableListener;
 use Gedmo\Sluggable\Mapping\Event\SluggableAdapter;
 
@@ -69,5 +68,5 @@ interface SlugHandlerInterface
      *
      * @param array $options
      */
-    static function validate(array $options, ClassMetadata $meta);
+    static function validate(array $options, $meta);
 }

--- a/lib/Gedmo/Sluggable/Handler/TreeSlugHandler.php
+++ b/lib/Gedmo/Sluggable/Handler/TreeSlugHandler.php
@@ -3,7 +3,6 @@
 namespace Gedmo\Sluggable\Handler;
 
 use Doctrine\Common\Persistence\ObjectManager;
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Gedmo\Sluggable\SluggableListener;
 use Gedmo\Sluggable\Mapping\Event\SluggableAdapter;
 use Gedmo\Tool\Wrapper\AbstractWrapper;
@@ -108,7 +107,7 @@ class TreeSlugHandler implements SlugHandlerInterface
     /**
      * {@inheritDoc}
      */
-    public static function validate(array $options, ClassMetadata $meta)
+    public static function validate(array $options, $meta)
     {
         if (!$meta->isSingleValuedAssociation($options['parentRelationField'])) {
             throw new InvalidMappingException("Unable to find tree parent slug relation through field - [{$options['parentRelationField']}] in class - {$meta->name}");

--- a/lib/Gedmo/Sluggable/Mapping/Driver/Annotation.php
+++ b/lib/Gedmo/Sluggable/Mapping/Driver/Annotation.php
@@ -6,7 +6,6 @@ use Gedmo\Mapping\Annotation\SlugHandler;
 use Gedmo\Mapping\Annotation\SlugHandlerOption;
 use Gedmo\Mapping\Driver\AnnotationDriverInterface,
     Doctrine\Common\Annotations\AnnotationReader,
-    Doctrine\Common\Persistence\Mapping\ClassMetadata,
     Gedmo\Exception\InvalidMappingException;
 
 /**
@@ -73,7 +72,7 @@ class Annotation implements AnnotationDriverInterface
     /**
      * {@inheritDoc}
      */
-    public function readExtendedMetadata(ClassMetadata $meta, array &$config) {
+    public function readExtendedMetadata($meta, array &$config) {
         $class = $meta->getReflectionClass();
         // property annotations
         foreach ($class->getProperties() as $property) {
@@ -151,11 +150,11 @@ class Annotation implements AnnotationDriverInterface
     /**
      * Checks if $field type is valid as Sluggable field
      *
-     * @param ClassMetadata $meta
+     * @param object $meta
      * @param string $field
      * @return boolean
      */
-    protected function isValidField(ClassMetadata $meta, $field)
+    protected function isValidField($meta, $field)
     {
         $mapping = $meta->getFieldMapping($field);
         return $mapping && in_array($mapping['type'], $this->validTypes);

--- a/lib/Gedmo/Sluggable/Mapping/Driver/Xml.php
+++ b/lib/Gedmo/Sluggable/Mapping/Driver/Xml.php
@@ -3,7 +3,6 @@
 namespace Gedmo\Sluggable\Mapping\Driver;
 
 use Gedmo\Mapping\Driver\Xml as BaseXml,
-    Doctrine\Common\Persistence\Mapping\ClassMetadata,
     Gedmo\Exception\InvalidMappingException;
 
 /**
@@ -36,7 +35,7 @@ class Xml extends BaseXml
     /**
      * {@inheritDoc}
      */
-    public function readExtendedMetadata(ClassMetadata $meta, array &$config)
+    public function readExtendedMetadata($meta, array &$config)
     {
         /**
          * @var \SimpleXmlElement $xml
@@ -105,11 +104,11 @@ class Xml extends BaseXml
     /**
      * Checks if $field type is valid as Sluggable field
      *
-     * @param ClassMetadata $meta
+     * @param object $meta
      * @param string $field
      * @return boolean
      */
-    protected function isValidField(ClassMetadata $meta, $field)
+    protected function isValidField($meta, $field)
     {
         $mapping = $meta->getFieldMapping($field);
         return $mapping && in_array($mapping['type'], $this->validTypes);

--- a/lib/Gedmo/Sluggable/Mapping/Driver/Yaml.php
+++ b/lib/Gedmo/Sluggable/Mapping/Driver/Yaml.php
@@ -4,7 +4,6 @@ namespace Gedmo\Sluggable\Mapping\Driver;
 
 use Gedmo\Mapping\Driver\File,
     Gedmo\Mapping\Driver,
-    Doctrine\Common\Persistence\Mapping\ClassMetadata,
     Gedmo\Exception\InvalidMappingException;
 
 /**
@@ -41,7 +40,7 @@ class Yaml extends File implements Driver
     /**
      * {@inheritDoc}
      */
-    public function readExtendedMetadata(ClassMetadata $meta, array &$config)
+    public function readExtendedMetadata($meta, array &$config)
     {
         $mapping = $this->_getMapping($meta->name);
 
@@ -107,11 +106,11 @@ class Yaml extends File implements Driver
     /**
      * Checks if $field type is valid as Sluggable field
      *
-     * @param ClassMetadata $meta
+     * @param object $meta
      * @param string $field
      * @return boolean
      */
-    protected function isValidField(ClassMetadata $meta, $field)
+    protected function isValidField($meta, $field)
     {
         $mapping = $meta->getFieldMapping($field);
         return $mapping && in_array($mapping['type'], $this->validTypes);

--- a/lib/Gedmo/Sluggable/Mapping/Event/Adapter/ODM.php
+++ b/lib/Gedmo/Sluggable/Mapping/Event/Adapter/ODM.php
@@ -3,7 +3,6 @@
 namespace Gedmo\Sluggable\Mapping\Event\Adapter;
 
 use Gedmo\Mapping\Event\Adapter\ODM as BaseAdapterODM;
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Cursor;
 use Gedmo\Sluggable\Mapping\Event\SluggableAdapter;
 use Gedmo\Tool\Wrapper\AbstractWrapper;
@@ -23,7 +22,7 @@ final class ODM extends BaseAdapterODM implements SluggableAdapter
     /**
      * {@inheritDoc}
      */
-    public function getSimilarSlugs($object, ClassMetadata $meta, array $config, $slug)
+    public function getSimilarSlugs($object, $meta, array $config, $slug)
     {
         $dm = $this->getObjectManager();
         $qb = $dm->createQueryBuilder($config['useObjectClass']);

--- a/lib/Gedmo/Sluggable/Mapping/Event/Adapter/ORM.php
+++ b/lib/Gedmo/Sluggable/Mapping/Event/Adapter/ORM.php
@@ -3,7 +3,6 @@
 namespace Gedmo\Sluggable\Mapping\Event\Adapter;
 
 use Gedmo\Mapping\Event\Adapter\ORM as BaseAdapterORM;
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\ORM\Query;
 use Gedmo\Sluggable\Mapping\Event\SluggableAdapter;
 
@@ -22,7 +21,7 @@ final class ORM extends BaseAdapterORM implements SluggableAdapter
     /**
      * {@inheritDoc}
      */
-    public function getSimilarSlugs($object, ClassMetadata $meta, array $config, $slug)
+    public function getSimilarSlugs($object, $meta, array $config, $slug)
     {
         $em = $this->getObjectManager();
         $qb = $em->createQueryBuilder();

--- a/lib/Gedmo/Sluggable/Mapping/Event/SluggableAdapter.php
+++ b/lib/Gedmo/Sluggable/Mapping/Event/SluggableAdapter.php
@@ -2,7 +2,6 @@
 
 namespace Gedmo\Sluggable\Mapping\Event;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Gedmo\Mapping\Event\AdapterInterface;
 
 /**
@@ -21,12 +20,12 @@ interface SluggableAdapter extends AdapterInterface
      * Loads the similar slugs
      *
      * @param object $object
-     * @param ClassMetadata $meta
+     * @param object $meta
      * @param array $config
      * @param string $slug
      * @return array
      */
-    function getSimilarSlugs($object, ClassMetadata $meta, array $config, $slug);
+    function getSimilarSlugs($object, $meta, array $config, $slug);
 
     /**
      * Replace part of slug to all objects

--- a/lib/Gedmo/Sortable/Entity/Repository/SortableRepository.php
+++ b/lib/Gedmo/Sortable/Entity/Repository/SortableRepository.php
@@ -18,7 +18,7 @@ class SortableRepository extends EntityRepository
     protected $config = null;
     protected $meta = null;
     
-    public function __construct(EntityManager $em, ClassMetadata $class)
+    public function __construct(EntityManager $em, $class)
     {
         parent::__construct($em, $class);
         $sortableListener = null;

--- a/lib/Gedmo/Sortable/Mapping/Driver/Annotation.php
+++ b/lib/Gedmo/Sortable/Mapping/Driver/Annotation.php
@@ -5,8 +5,6 @@ namespace Gedmo\Sortable\Mapping\Driver;
 use Gedmo\Mapping\Driver\AnnotationDriverInterface,
     Gedmo\Exception\InvalidMappingException;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
-
 /**
  * This is an annotation mapping driver for Sortable
  * behavioral extension. Used for extraction of extended
@@ -65,7 +63,7 @@ class Annotation implements AnnotationDriverInterface
     /**
      * {@inheritDoc}
      */
-    public function readExtendedMetadata(ClassMetadata $meta, array &$config) {
+    public function readExtendedMetadata($meta, array &$config) {
         $class = $meta->getReflectionClass();
 
         // property annotations
@@ -110,7 +108,7 @@ class Annotation implements AnnotationDriverInterface
     /**
      * Checks if $field type is valid
      *
-     * @param ClassMetadata $meta
+     * @param object $meta
      * @param string $field
      * @return boolean
      */

--- a/lib/Gedmo/Sortable/Mapping/Driver/Xml.php
+++ b/lib/Gedmo/Sortable/Mapping/Driver/Xml.php
@@ -5,8 +5,6 @@ namespace Gedmo\Sortable\Mapping\Driver;
 use Gedmo\Mapping\Driver\Xml as BaseXml,
     Gedmo\Exception\InvalidMappingException;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
-
 /**
  * This is a xml mapping driver for Sortable
  * behavioral extension. Used for extraction of extended
@@ -36,7 +34,7 @@ class Xml extends BaseXml
     /**
      * {@inheritDoc}
      */
-    public function readExtendedMetadata(ClassMetadata $meta, array &$config)
+    public function readExtendedMetadata($meta, array &$config)
     {
         /**
          * @var \SimpleXmlElement $xml
@@ -102,7 +100,7 @@ class Xml extends BaseXml
     /**
      * Checks if $field type is valid as Sortable Position field
      *
-     * @param ClassMetadata $meta
+     * @param object $meta
      * @param string $field
      * @return boolean
      */

--- a/lib/Gedmo/Sortable/Mapping/Driver/Yaml.php
+++ b/lib/Gedmo/Sortable/Mapping/Driver/Yaml.php
@@ -6,8 +6,6 @@ use Gedmo\Mapping\Driver\File,
     Gedmo\Mapping\Driver,
     Gedmo\Exception\InvalidMappingException;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
-
 /**
  * This is a yaml mapping driver for Sortable
  * behavioral extension. Used for extraction of extended
@@ -42,7 +40,7 @@ class Yaml extends File implements Driver
     /**
      * {@inheritDoc}
      */
-    public function readExtendedMetadata(ClassMetadata $meta, array &$config)
+    public function readExtendedMetadata($meta, array &$config)
     {
         $mapping = $this->_getMapping($meta->name);
 
@@ -99,7 +97,7 @@ class Yaml extends File implements Driver
     /**
      * Checks if $field type is valid as SortablePosition field
      *
-     * @param ClassMetadata $meta
+     * @param object $meta
      * @param string $field
      * @return boolean
      */

--- a/lib/Gedmo/Timestampable/Mapping/Driver/Annotation.php
+++ b/lib/Gedmo/Timestampable/Mapping/Driver/Annotation.php
@@ -3,7 +3,6 @@
 namespace Gedmo\Timestampable\Mapping\Driver;
 
 use Gedmo\Mapping\Driver\AnnotationDriverInterface,
-    Doctrine\Common\Persistence\Mapping\ClassMetadata,
     Doctrine\Common\Annotations\AnnotationReader,
     Gedmo\Exception\InvalidMappingException;
 
@@ -62,7 +61,7 @@ class Annotation implements AnnotationDriverInterface
     /**
      * {@inheritDoc}
      */
-    public function readExtendedMetadata(ClassMetadata $meta, array &$config) {
+    public function readExtendedMetadata($meta, array &$config) {
         $class = $meta->getReflectionClass();
         // property annotations
         foreach ($class->getProperties() as $property) {
@@ -102,11 +101,11 @@ class Annotation implements AnnotationDriverInterface
     /**
      * Checks if $field type is valid
      *
-     * @param ClassMetadata $meta
+     * @param object $meta
      * @param string $field
      * @return boolean
      */
-    protected function isValidField(ClassMetadata $meta, $field)
+    protected function isValidField($meta, $field)
     {
         $mapping = $meta->getFieldMapping($field);
         return $mapping && in_array($mapping['type'], $this->validTypes);

--- a/lib/Gedmo/Timestampable/Mapping/Driver/Xml.php
+++ b/lib/Gedmo/Timestampable/Mapping/Driver/Xml.php
@@ -3,7 +3,6 @@
 namespace Gedmo\Timestampable\Mapping\Driver;
 
 use Gedmo\Mapping\Driver\Xml as BaseXml,
-    Doctrine\Common\Persistence\Mapping\ClassMetadata,
     Gedmo\Exception\InvalidMappingException;
 
 /**
@@ -38,7 +37,7 @@ class Xml extends BaseXml
     /**
      * {@inheritDoc}
      */
-    public function readExtendedMetadata(ClassMetadata $meta, array &$config)
+    public function readExtendedMetadata($meta, array &$config)
     {
         /**
          * @var \SimpleXmlElement $mapping
@@ -85,11 +84,11 @@ class Xml extends BaseXml
     /**
      * Checks if $field type is valid
      *
-     * @param ClassMetadata $meta
+     * @param object $meta
      * @param string $field
      * @return boolean
      */
-    protected function isValidField(ClassMetadata $meta, $field)
+    protected function isValidField($meta, $field)
     {
         $mapping = $meta->getFieldMapping($field);
         return $mapping && in_array($mapping['type'], $this->validTypes);

--- a/lib/Gedmo/Timestampable/Mapping/Driver/Yaml.php
+++ b/lib/Gedmo/Timestampable/Mapping/Driver/Yaml.php
@@ -4,7 +4,6 @@ namespace Gedmo\Timestampable\Mapping\Driver;
 
 use Gedmo\Mapping\Driver\File,
     Gedmo\Mapping\Driver,
-    Doctrine\Common\Persistence\Mapping\ClassMetadata,
     Gedmo\Exception\InvalidMappingException;
 
 /**
@@ -43,7 +42,7 @@ class Yaml extends File implements Driver
     /**
      * {@inheritDoc}
      */
-    public function readExtendedMetadata(ClassMetadata $meta, array &$config)
+    public function readExtendedMetadata($meta, array &$config)
     {
         $mapping = $this->_getMapping($meta->name);
 
@@ -85,11 +84,11 @@ class Yaml extends File implements Driver
     /**
      * Checks if $field type is valid
      *
-     * @param ClassMetadata $meta
+     * @param object $meta
      * @param string $field
      * @return boolean
      */
-    protected function isValidField(ClassMetadata $meta, $field)
+    protected function isValidField($meta, $field)
     {
         $mapping = $meta->getFieldMapping($field);
         return $mapping && in_array($mapping['type'], $this->validTypes);

--- a/lib/Gedmo/Timestampable/Mapping/Event/Adapter/ODM.php
+++ b/lib/Gedmo/Timestampable/Mapping/Event/Adapter/ODM.php
@@ -3,7 +3,6 @@
 namespace Gedmo\Timestampable\Mapping\Event\Adapter;
 
 use Gedmo\Mapping\Event\Adapter\ODM as BaseAdapterODM;
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Gedmo\Timestampable\Mapping\Event\TimestampableAdapter;
 
 /**
@@ -21,7 +20,7 @@ final class ODM extends BaseAdapterODM implements TimestampableAdapter
     /**
      * {@inheritDoc}
      */
-    public function getDateValue(ClassMetadata $meta, $field)
+    public function getDateValue($meta, $field)
     {
         $mapping = $meta->getFieldMapping($field);
         if (isset($mapping['type']) && $mapping['type'] === 'timestamp') {

--- a/lib/Gedmo/Timestampable/Mapping/Event/Adapter/ORM.php
+++ b/lib/Gedmo/Timestampable/Mapping/Event/Adapter/ORM.php
@@ -3,7 +3,6 @@
 namespace Gedmo\Timestampable\Mapping\Event\Adapter;
 
 use Gedmo\Mapping\Event\Adapter\ORM as BaseAdapterORM;
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Gedmo\Timestampable\Mapping\Event\TimestampableAdapter;
 
 /**
@@ -21,7 +20,7 @@ final class ORM extends BaseAdapterORM implements TimestampableAdapter
     /**
      * {@inheritDoc}
      */
-    public function getDateValue(ClassMetadata $meta, $field)
+    public function getDateValue($meta, $field)
     {
         if (isset($mapping['type']) && $mapping['type'] == 'zenddate') {
             return new \Zend_Date();

--- a/lib/Gedmo/Timestampable/Mapping/Event/TimestampableAdapter.php
+++ b/lib/Gedmo/Timestampable/Mapping/Event/TimestampableAdapter.php
@@ -2,7 +2,6 @@
 
 namespace Gedmo\Timestampable\Mapping\Event;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Gedmo\Mapping\Event\AdapterInterface;
 
 /**
@@ -20,9 +19,9 @@ interface TimestampableAdapter extends AdapterInterface
     /**
      * Get the date value
      *
-     * @param ClassMetadata $meta
+     * @param object $meta
      * @param string $field
      * @return mixed
      */
-    function getDateValue(ClassMetadata $meta, $field);
+    function getDateValue($meta, $field);
 }

--- a/lib/Gedmo/Timestampable/TimestampableListener.php
+++ b/lib/Gedmo/Timestampable/TimestampableListener.php
@@ -2,8 +2,7 @@
 
 namespace Gedmo\Timestampable;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata,
-    Doctrine\Common\EventArgs,
+use Doctrine\Common\EventArgs,
     Gedmo\Mapping\MappedEventSubscriber;
 
 /**

--- a/lib/Gedmo/Tool/Wrapper/AbstractWrapper.php
+++ b/lib/Gedmo/Tool/Wrapper/AbstractWrapper.php
@@ -23,7 +23,7 @@ abstract class AbstractWrapper implements WrapperInterface
     /**
      * Object metadata
      *
-     * @var \Doctrine\Common\Persistence\Mapping\ClassMetadata
+     * @var object
      */
     protected $meta;
 

--- a/lib/Gedmo/Tool/WrapperInterface.php
+++ b/lib/Gedmo/Tool/WrapperInterface.php
@@ -56,7 +56,7 @@ interface WrapperInterface
     /**
      * Get metadata
      *
-     * @return \Doctrine\Common\Persistence\Mapping\ClassMetadata
+     * @return object
      */
     function getMetadata();
 

--- a/lib/Gedmo/Translatable/Mapping/Driver/Annotation.php
+++ b/lib/Gedmo/Translatable/Mapping/Driver/Annotation.php
@@ -3,7 +3,6 @@
 namespace Gedmo\Translatable\Mapping\Driver;
 
 use Gedmo\Mapping\Driver\AnnotationDriverInterface,
-    Doctrine\Common\Persistence\Mapping\ClassMetadata,
     Gedmo\Exception\InvalidMappingException;
 
 /**
@@ -65,7 +64,7 @@ class Annotation implements AnnotationDriverInterface
     /**
      * {@inheritDoc}
      */
-    public function readExtendedMetadata(ClassMetadata $meta, array &$config) {
+    public function readExtendedMetadata($meta, array &$config) {
         $class = $meta->getReflectionClass();
         // class annotations
         if ($annot = $this->reader->getClassAnnotation($class, self::ENTITY_CLASS)) {

--- a/lib/Gedmo/Translatable/Mapping/Driver/Xml.php
+++ b/lib/Gedmo/Translatable/Mapping/Driver/Xml.php
@@ -3,7 +3,6 @@
 namespace Gedmo\Translatable\Mapping\Driver;
 
 use Gedmo\Mapping\Driver\Xml as BaseXml,
-    Doctrine\Common\Persistence\Mapping\ClassMetadata,
     Gedmo\Exception\InvalidMappingException;
 
 /**
@@ -24,7 +23,7 @@ class Xml extends BaseXml
     /**
      * {@inheritDoc}
      */
-    public function readExtendedMetadata(ClassMetadata $meta, array &$config) {
+    public function readExtendedMetadata($meta, array &$config) {
         /**
          * @var \SimpleXmlElement $xml
          */

--- a/lib/Gedmo/Translatable/Mapping/Driver/Yaml.php
+++ b/lib/Gedmo/Translatable/Mapping/Driver/Yaml.php
@@ -4,7 +4,6 @@ namespace Gedmo\Translatable\Mapping\Driver;
 
 use Gedmo\Mapping\Driver\File,
     Gedmo\Mapping\Driver,
-    Doctrine\Common\Persistence\Mapping\ClassMetadata,
     Gedmo\Exception\InvalidMappingException;
 
 /**
@@ -30,7 +29,7 @@ class Yaml extends File implements Driver
     /**
      * {@inheritDoc}
      */
-    public function readExtendedMetadata(ClassMetadata $meta, array &$config)
+    public function readExtendedMetadata($meta, array &$config)
     {
         $mapping = $this->_getMapping($meta->name);
 

--- a/lib/Gedmo/Translatable/TranslationListener.php
+++ b/lib/Gedmo/Translatable/TranslationListener.php
@@ -4,7 +4,6 @@ namespace Gedmo\Translatable;
 
 use Gedmo\Tool\Wrapper\AbstractWrapper;
 use Doctrine\Common\EventArgs,
-    Doctrine\Common\Persistence\Mapping\ClassMetadata,
     Gedmo\Mapping\MappedEventSubscriber,
     Gedmo\Translatable\Mapping\Event\TranslatableAdapter;
 
@@ -253,12 +252,12 @@ class TranslationListener extends MappedEventSubscriber
      * defined locale first..
      *
      * @param object $object
-     * @param ClassMetadata $meta
+     * @param object $meta
      * @throws RuntimeException - if language or locale property is not
      *         found in entity
      * @return string
      */
-    public function getTranslatableLocale($object, ClassMetadata $meta)
+    public function getTranslatableLocale($object, $meta)
     {
         $locale = $this->locale;
         if (isset($this->configurations[$meta->name]['locale'])) {

--- a/lib/Gedmo/Tree/Entity/Repository/AbstractTreeRepository.php
+++ b/lib/Gedmo/Tree/Entity/Repository/AbstractTreeRepository.php
@@ -18,7 +18,7 @@ abstract class AbstractTreeRepository extends EntityRepository
     /**
      * {@inheritdoc}
      */
-    public function __construct(EntityManager $em, ClassMetadata $class)
+    public function __construct(EntityManager $em, $class)
     {
         parent::__construct($em, $class);
         $treeListener = null;

--- a/lib/Gedmo/Tree/Mapping/Driver/Annotation.php
+++ b/lib/Gedmo/Tree/Mapping/Driver/Annotation.php
@@ -3,7 +3,6 @@
 namespace Gedmo\Tree\Mapping\Driver;
 
 use Gedmo\Mapping\Driver\AnnotationDriverInterface,
-    Doctrine\Common\Persistence\Mapping\ClassMetadata,
     Gedmo\Exception\InvalidMappingException;
 
 /**
@@ -99,7 +98,7 @@ class Annotation implements AnnotationDriverInterface
     /**
      * {@inheritDoc}
      */
-    public function readExtendedMetadata(ClassMetadata $meta, array &$config) {
+    public function readExtendedMetadata($meta, array &$config) {
         $class = $meta->getReflectionClass();
         // class annotations
         if ($annot = $this->reader->getClassAnnotation($class, self::TREE)) {
@@ -193,11 +192,11 @@ class Annotation implements AnnotationDriverInterface
     /**
      * Checks if $field type is valid
      *
-     * @param ClassMetadata $meta
+     * @param object $meta
      * @param string $field
      * @return boolean
      */
-    protected function isValidField(ClassMetadata $meta, $field)
+    protected function isValidField($meta, $field)
     {
         $mapping = $meta->getFieldMapping($field);
         return $mapping && in_array($mapping['type'], $this->validTypes);
@@ -206,12 +205,12 @@ class Annotation implements AnnotationDriverInterface
     /**
      * Validates metadata for nested type tree
      *
-     * @param ClassMetadata $meta
+     * @param object $meta
      * @param array $config
      * @throws InvalidMappingException
      * @return void
      */
-    private function validateNestedTreeMetadata(ClassMetadata $meta, array $config)
+    private function validateNestedTreeMetadata($meta, array $config)
     {
         $missingFields = array();
         if (!isset($config['parent'])) {
@@ -231,12 +230,12 @@ class Annotation implements AnnotationDriverInterface
     /**
      * Validates metadata for closure type tree
      *
-     * @param ClassMetadata $meta
+     * @param object $meta
      * @param array $config
      * @throws InvalidMappingException
      * @return void
      */
-    private function validateClosureTreeMetadata(ClassMetadata $meta, array $config)
+    private function validateClosureTreeMetadata($meta, array $config)
     {
         $missingFields = array();
         if (!isset($config['parent'])) {

--- a/lib/Gedmo/Tree/Mapping/Driver/Xml.php
+++ b/lib/Gedmo/Tree/Mapping/Driver/Xml.php
@@ -3,7 +3,6 @@
 namespace Gedmo\Tree\Mapping\Driver;
 
 use Gedmo\Mapping\Driver\Xml as BaseXml,
-    Doctrine\Common\Persistence\Mapping\ClassMetadata,
     Gedmo\Exception\InvalidMappingException;
 
 /**
@@ -46,7 +45,7 @@ class Xml extends BaseXml
     /**
      * {@inheritDoc}
      */
-    public function readExtendedMetadata(ClassMetadata $meta, array &$config) {
+    public function readExtendedMetadata($meta, array &$config) {
         /**
          * @var \SimpleXmlElement $xml
          */
@@ -133,11 +132,11 @@ class Xml extends BaseXml
     /**
      * Checks if $field type is valid
      *
-     * @param ClassMetadata $meta
+     * @param object $meta
      * @param string $field
      * @return boolean
      */
-    protected function isValidField(ClassMetadata $meta, $field)
+    protected function isValidField($meta, $field)
     {
         $mapping = $meta->getFieldMapping($field);
         return $mapping && in_array($mapping['type'], $this->validTypes);
@@ -146,12 +145,12 @@ class Xml extends BaseXml
     /**
      * Validates metadata for nested type tree
      *
-     * @param ClassMetadata $meta
+     * @param object $meta
      * @param array $config
      * @throws InvalidMappingException
      * @return void
      */
-    private function validateNestedTreeMetadata(ClassMetadata $meta, array $config)
+    private function validateNestedTreeMetadata($meta, array $config)
     {
         $missingFields = array();
         if (!isset($config['parent'])) {
@@ -171,12 +170,12 @@ class Xml extends BaseXml
     /**
      * Validates metadata for closure type tree
      *
-     * @param ClassMetadata $meta
+     * @param object $meta
      * @param array $config
      * @throws InvalidMappingException
      * @return void
      */
-    private function validateClosureTreeMetadata(ClassMetadata $meta, array $config)
+    private function validateClosureTreeMetadata($meta, array $config)
     {
         $missingFields = array();
         if (!isset($config['parent'])) {

--- a/lib/Gedmo/Tree/Mapping/Driver/Yaml.php
+++ b/lib/Gedmo/Tree/Mapping/Driver/Yaml.php
@@ -4,7 +4,6 @@ namespace Gedmo\Tree\Mapping\Driver;
 
 use Gedmo\Mapping\Driver\File,
     Gedmo\Mapping\Driver,
-    Doctrine\Common\Persistence\Mapping\ClassMetadata,
     Gedmo\Exception\InvalidMappingException;
 
 /**
@@ -51,7 +50,7 @@ class Yaml extends File implements Driver
     /**
      * {@inheritDoc}
      */
-    public function readExtendedMetadata(ClassMetadata $meta, array &$config)
+    public function readExtendedMetadata($meta, array &$config)
     {
         $mapping = $this->_getMapping($meta->name);
 
@@ -136,11 +135,11 @@ class Yaml extends File implements Driver
     /**
      * Checks if $field type is valid
      *
-     * @param ClassMetadata $meta
+     * @param object $meta
      * @param string $field
      * @return boolean
      */
-    protected function isValidField(ClassMetadata $meta, $field)
+    protected function isValidField($meta, $field)
     {
         $mapping = $meta->getFieldMapping($field);
         return $mapping && in_array($mapping['type'], $this->validTypes);
@@ -149,12 +148,12 @@ class Yaml extends File implements Driver
     /**
      * Validates metadata for nested type tree
      *
-     * @param ClassMetadata $meta
+     * @param object $meta
      * @param array $config
      * @throws InvalidMappingException
      * @return void
      */
-    private function validateNestedTreeMetadata(ClassMetadata $meta, array $config)
+    private function validateNestedTreeMetadata($meta, array $config)
     {
         $missingFields = array();
         if (!isset($config['parent'])) {
@@ -174,12 +173,12 @@ class Yaml extends File implements Driver
     /**
      * Validates metadata for closure type tree
      *
-     * @param ClassMetadata $meta
+     * @param object $meta
      * @param array $config
      * @throws InvalidMappingException
      * @return void
      */
-    private function validateClosureTreeMetadata(ClassMetadata $meta, array $config)
+    private function validateClosureTreeMetadata($meta, array $config)
     {
         $missingFields = array();
         if (!isset($config['parent'])) {

--- a/lib/Gedmo/Tree/Strategy.php
+++ b/lib/Gedmo/Tree/Strategy.php
@@ -33,7 +33,7 @@ interface Strategy
      * Operations after metadata is loaded
      *
      * @param object $om
-     * @param ClassMetadata $meta
+     * @param object $meta
      */
     function processMetadataLoad($om, $meta);
 

--- a/tests/Gedmo/Mapping/Mock/Extension/Encoder/Mapping/Driver/Annotation.php
+++ b/tests/Gedmo/Mapping/Mock/Extension/Encoder/Mapping/Driver/Annotation.php
@@ -6,7 +6,6 @@ namespace Gedmo\Mapping\Mock\Extension\Encoder\Mapping\Driver;
 
 use Gedmo\Mapping\Driver;
 use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 
 class Annotation implements Driver
 {
@@ -15,7 +14,7 @@ class Annotation implements Driver
      */
     protected $_originalDriver = null;
 
-    public function readExtendedMetadata(ClassMetadata $meta, array &$config) {
+    public function readExtendedMetadata($meta, array &$config) {
         // load our available annotations
         require_once __DIR__ . '/../Annotations.php';
         $reader = new AnnotationReader();


### PR DESCRIPTION
refs Issue #220

I removed all "ClassMetadata" typehints and "use Doctrine\Common\Persistence\Mapping\ClassMetadata" statements.
