### PR TITLE
adding typehints for Doctrine\ORM\Mapping\ClassMetadata

### DIFF
--- a/lib/Gedmo/Sortable/Entity/Repository/SortableRepository.php
+++ b/lib/Gedmo/Sortable/Entity/Repository/SortableRepository.php
@@ -18,7 +18,7 @@ class SortableRepository extends EntityRepository
     protected $config = null;
     protected $meta = null;
     
-    public function __construct(EntityManager $em, $class)
+    public function __construct(EntityManager $em, ClassMetadata $class)
     {
         parent::__construct($em, $class);
         $sortableListener = null;

--- a/lib/Gedmo/Tree/Entity/Repository/AbstractTreeRepository.php
+++ b/lib/Gedmo/Tree/Entity/Repository/AbstractTreeRepository.php
@@ -18,7 +18,7 @@ abstract class AbstractTreeRepository extends EntityRepository
     /**
      * {@inheritdoc}
      */
-    public function __construct(EntityManager $em, $class)
+    public function __construct(EntityManager $em, ClassMetadata $class)
     {
         parent::__construct($em, $class);
         $treeListener = null;


### PR DESCRIPTION
in #221 I deleted all typehints for ClassMetadata interfaces... but only those related to Doctrine\Common\Persistence\Mapping\ClassMetadata should be removed, typehints for Doctrine\ORM\Mapping\ClassMetadata can stay
