### PR TITLE
Added exception if an attempt is made to set left or right to a value le...

### DIFF
--- a/lib/Gedmo/Tree/Strategy/ORM/Nested.php
+++ b/lib/Gedmo/Tree/Strategy/ORM/Nested.php
@@ -456,7 +456,7 @@ class Nested implements Strategy
                 $root = isset($config['root']) ? $meta->getReflectionProperty($config['root'])->getValue($node) : null;
                 if ($root === $rootId && $left >= $first) {
                     if ($left + $delta < 0) {
-                        throw new UnexpectedValueException(sprintf('Attempting to set left equal to %s for node %s', $left + $delta, $node));
+                        throw new UnexpectedValueException(sprintf('Attempting to set left equal to %s for node %s', $left + $delta, self::objToStr($node)));
                     }
 
                     $meta->getReflectionProperty($config['left'])->setValue($node, $left + $delta);
@@ -465,7 +465,7 @@ class Nested implements Strategy
                 $right = $meta->getReflectionProperty($config['right'])->getValue($node);
                 if ($root === $rootId && $right >= $first) {
                     if ($right + $delta < 0) {
-                        throw new UnexpectedValueException(sprintf('Attempting to set right equal to %s for node %s', $right + $delta, $node));
+                        throw new UnexpectedValueException(sprintf('Attempting to set right equal to %s for node %s', $right + $delta, self::objToStr($node)));
                     }
 
                     $meta->getReflectionProperty($config['right'])->setValue($node, $right + $delta);
@@ -533,14 +533,14 @@ class Nested implements Strategy
                     $uow = $em->getUnitOfWork();
 
                     if ($left + $delta < 0) {
-                        throw new UnexpectedValueException(sprintf('Attempting to set left equal to %s for node %s', $left + $delta, $node));
+                        throw new UnexpectedValueException(sprintf('Attempting to set left equal to %s for node %s', $left + $delta, self::objToStr($node)));
                     }
 
                     $meta->getReflectionProperty($config['left'])->setValue($node, $left + $delta);
                     $uow->setOriginalEntityProperty($oid, $config['left'], $left + $delta);
 
                     if ($right + $delta < 0) {
-                        throw new UnexpectedValueException(sprintf('Attempting to set right equal to %s for node %s', $right + $delta, $node));
+                        throw new UnexpectedValueException(sprintf('Attempting to set right equal to %s for node %s', $right + $delta, self::objToStr($node)));
                     }
 
                     $meta->getReflectionProperty($config['right'])->setValue($node, $right + $delta);
@@ -557,5 +557,16 @@ class Nested implements Strategy
                 }
             }
         }
+    }
+
+    /**
+     * Helper method to show an object as string.
+     *
+     * @param  object $obj
+     * @return string
+     */
+    private static function objToStr($obj)
+    {
+        return method_exists($obj, '__toString') ? (string)$obj : get_class($obj).'@'.spl_object_hash($obj);
     }
 }


### PR DESCRIPTION
...ss than 0.

During my development, I've ended up with a corrupt tree where the left and/or right values were negative (e.g. -8!).

I believe these 4 are the only places in the codebase that set the left or right values.

This simply throws an exception if the left/right + delta is less than 0.

I believe the tree should never get in such a state in the first place, but it did somehow, so this should help in the future if an error occurs again.
