### PR TITLE
[Sluggable] Use anchored regex query in ODM adapter

### DIFF
--- a/lib/Gedmo/Sluggable/Mapping/Event/Adapter/ODM.php
+++ b/lib/Gedmo/Sluggable/Mapping/Event/Adapter/ODM.php
@@ -30,7 +30,7 @@ final class ODM extends BaseAdapterODM implements SluggableAdapter
         if ($identifier && !$meta->isIdentifier($config['slug'])) {
             $qb->field($meta->identifier)->notEqual($identifier);
         }
-        $qb->field($config['slug'])->Equals(new \MongoRegex('/^' . str_replace('/', '\/', $slug) . '/'));
+        $qb->field($config['slug'])->equals(new \MongoRegex('/^' . preg_quote($slug, '/') . '/'));
         $q = $qb->getQuery();
         $q->setHydrate(false);
 
@@ -54,9 +54,7 @@ final class ODM extends BaseAdapterODM implements SluggableAdapter
 
         $q = $dm
             ->createQueryBuilder($config['useObjectClass'])
-            ->where("function() {
-                return this.{$config['slug']}.indexOf('{$target}') === 0;
-            }")
+            ->field($config['slug'])->equals(new \MongoRegex('/^' . preg_quote($target, '/') . '/'))
             ->getQuery()
         ;
         $q->setHydrate(false);


### PR DESCRIPTION
Using an anchored regex query will take advantage of MongoDB indexes. See: http://www.mongodb.org/display/DOCS/Advanced+Queries#AdvancedQueries-RegularExpressions

After implementing this fix on an older branch, I realized it builds upon: 96550fd512af1decc7042cfa8d77fd0f41f2111b. This commits adds the fix to replaceRelative() and also uses preg_quote() for escaping the slug in the MongoRegex pattern.

---

Note: after running bin/vendors, I noticed a ton of test failures attempting to run this test suite. I believe bin/vendors needs to be updated to account for recent changes in the doctrine/mongodb and mongodb-odm repositories.

Additionally, when I did have the test suite running with older vendor libs, I don't believe the code changed in this commit was even covered by the Sluggable test cases. That's certainly something to look into in the future.
