### PR TITLE
make 'transliterate' do only that rather than transliterate && urlize, m...

### DIFF
--- a/lib/Gedmo/Sluggable/SluggableListener.php
+++ b/lib/Gedmo/Sluggable/SluggableListener.php
@@ -250,6 +250,7 @@ class SluggableListener extends MappedEventSubscriber
                     $this->transliterator,
                     array($slug, $options['separator'], $object)
                 );
+                $slug = Util\Urlizer::urlize($slug, $options['separator']);
                 // stylize the slug
                 switch ($options['style']) {
                     case 'camel':

--- a/lib/Gedmo/Sluggable/Util/Urlizer.php
+++ b/lib/Gedmo/Sluggable/Util/Urlizer.php
@@ -276,7 +276,6 @@ class Urlizer
         if (preg_match('/[\x80-\xff]/', $text) && self::validUtf8($text)) {
             $text = self::utf8ToAscii($text);
         }
-        return self::postProcessText($text, $separator);
     }
 
     /**


### PR DESCRIPTION
Right now the call to transliterate also calls postProcessText at the end. Which means it does not deal "only" with the transliteration but actually creates the slug by adding the separator, removing whitespaces etc ...

Other transliterators deal with only the transliteration so currently they need to be modified to add the urlizing process too.

Suggest to have transliteration do just the transliteration and make the urlization happen once the slug has been transliterated.
