### PR TITLE
I was missing the postPersistLogEntry()  hook

### DIFF
--- a/lib/Gedmo/Loggable/LoggableListener.php
+++ b/lib/Gedmo/Loggable/LoggableListener.php
@@ -216,7 +216,7 @@ class LoggableListener extends MappedEventSubscriber
      * @param LoggableAdapter $ea
      * @return void
      */
-    private function createLogEntry($action, $object, LoggableAdapter $ea)
+    protected function createLogEntry($action, $object, LoggableAdapter $ea)
     {
         $om = $ea->getObjectManager();
         $wrapped = AbstractWrapper::wrap($object, $om);


### PR DESCRIPTION
since createLogEntry() method is private, it was not possible to extend it and the only way I found was to create a postpersistLogEntry hook.

I tried using the doctrine.postPersist event, but it was too generic and I was finding myself in a PostPersist loop, so the best way was to create a postPersistLogEntry method.
