### PR TITLE
Exit early only if there're nodes in insertion list

### DIFF
--- a/lib/Gedmo/Tree/Strategy/ORM/Closure.php
+++ b/lib/Gedmo/Tree/Strategy/ORM/Closure.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Proxy\Proxy;
 use Gedmo\Tree\TreeListener;
 use Doctrine\ORM\Version;
 use Gedmo\Tool\Wrapper\AbstractWrapper;
+use Gedmo\Tree\Node;
 
 /**
  * This strategy makes tree act like
@@ -190,7 +191,11 @@ class Closure implements Strategy
     {
         $uow = $em->getUnitOfWork();
         if ($uow->hasPendingInsertions()) {
-            return;
+            $insertions = $uow->getScheduledEntityInsertions();
+            foreach ($insertions as $insertion) {
+                if ($insertion instanceof Node)
+                    return;
+            }
         }
 
         while ($node = array_shift($this->pendingChildNodeInserts)) {

--- a/tests/Gedmo/Tree/ClosureTreeTest.php
+++ b/tests/Gedmo/Tree/ClosureTreeTest.php
@@ -6,6 +6,7 @@ use Doctrine\Common\EventManager;
 use Tool\BaseTestCaseORM;
 use Doctrine\Common\Util\Debug;
 use Tree\Fixture\Closure\Category;
+use Tree\Fixture\Closure\News;
 use Tree\Fixture\Closure\CategoryClosure;
 
 /**
@@ -24,6 +25,7 @@ class ClosureTreeTest extends BaseTestCaseORM
     const PERSON = "Tree\\Fixture\\Closure\\Person";
     const USER = "Tree\\Fixture\\Closure\\User";
     const PERSON_CLOSURE = "Tree\\Fixture\\Closure\\PersonClosure";
+    const NEWS = "Tree\\Fixture\\Closure\\News";
 
     protected function setUp()
     {
@@ -229,7 +231,8 @@ class ClosureTreeTest extends BaseTestCaseORM
             self::CLOSURE,
             self::PERSON,
             self::PERSON_CLOSURE,
-            self::USER
+            self::USER,
+            self::NEWS
         );
     }
 
@@ -295,5 +298,25 @@ class ClosureTreeTest extends BaseTestCaseORM
         $this->em->persist($mouldCheese);
 
         $this->em->flush();
+    }
+
+    public function testCascadePersistTree()
+    {
+        $politics = new Category();
+        $politics->setTitle('Politics');
+
+        $news = new News('Lorem ipsum', $politics);
+        $this->em->persist($news);
+        $this->em->flush();
+
+        $closure = $this->em->createQueryBuilder()
+                    ->select('c')
+                    ->from(self::CLOSURE, 'c')
+                    ->where('c.ancestor = :ancestor')
+                    ->setParameter('ancestor', $politics->getId())
+                    ->getQuery()
+                    ->getResult();
+
+        $this->assertEquals(1, count($closure));
     }
 }

--- a/tests/Gedmo/Tree/Fixture/Closure/News.php
+++ b/tests/Gedmo/Tree/Fixture/Closure/News.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * File description
+ *
+ * @author Anatoly Marinescu <tolean@zingan.com>
+ */
+
+namespace Tree\Fixture\Closure;
+
+use Gedmo\Mapping\Annotation as Gedmo;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class News
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(name="id", type="integer")
+     * @ORM\GeneratedValue(strategy="IDENTITY")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(name="title", type="string", length=64)
+     */
+    private $title;
+
+    /**
+     * @ORM\OneToOne(targetEntity="Tree\Fixture\Closure\Category", cascade={"persist"})
+     * @ORM\JoinColumn(name="category_id", referencedColumnName="id")
+     */
+    private $category;
+
+    public function __construct($title, Category $category)
+    {
+        $this->title = $title;
+        $this->category = $category;
+    }
+}


### PR DESCRIPTION
It may happen that in the insertion queue there are not only nodes. In that case <code>processPostPersist</code> will not save Closure records correct.
