### PR TITLE
Added orderBy to child mapping in .yml entity mapping example. 

### DIFF
--- a/doc/tree.md
+++ b/doc/tree.md
@@ -263,6 +263,8 @@ Entity\Category:
     children:
       targetEntity: Entity\Category
       mappedBy: parent
+      orderBy:
+        lft: ASC
 ```
 
 <a name="xml-mapping"></a>


### PR DESCRIPTION
Omitting this causes children to be pulled in the wrong order which can be confusing.
