### PR TITLE
Check if field mapped as sluggable is identifier only in entities, not mapped superclasses.

### DIFF
--- a/lib/Gedmo/Sluggable/Mapping/Driver/Xml.php
+++ b/lib/Gedmo/Sluggable/Mapping/Driver/Xml.php
@@ -82,7 +82,7 @@ class Xml extends BaseXml
                         'separator' => $this->_isAttributeSet($slug, 'separator') ?
                             $this->_getAttribute($slug, 'separator') : '-',
                     );
-                    if ($meta->isIdentifier($field) && !$config['slugs'][$field]['unique']) {
+                    if (!$meta->isMappedSuperclass && $meta->isIdentifier($field) && !$config['slugs'][$field]['unique']) {
                         throw new InvalidMappingException("Identifier field - [{$field}] slug must be unique in order to maintain primary key in class - {$meta->name}");
                     }
                 }


### PR DESCRIPTION
I'm not sure if this affects also older versions, but in master of doctrine extensions and latest doctrine orm, there is issue caused by [this method](https://github.com/doctrine/doctrine2/blob/master/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php#L981), as the mapped super class doesn't have identifier at all, and we are doing check in the changed line.

This affects only scenario when we define the sluggable in mapped superclass.
