### PR TITLE
[slugable] users can set updatable to false and get "editable" slugs with auto generation on empty slugs

### DIFF
--- a/lib/Gedmo/Sluggable/SluggableListener.php
+++ b/lib/Gedmo/Sluggable/SluggableListener.php
@@ -146,10 +146,12 @@ class SluggableListener extends MappedEventSubscriber
             $meta = $om->getClassMetadata(get_class($object));
             if ($config = $this->getConfiguration($om, $meta->name)) {
                 // generate first to exclude this object from similar persisted slugs result
-                $this->generateSlug($ea, $object);
                 foreach ($config['slugs'] as $slugField => $options) {
-                    $slug = $meta->getReflectionProperty($slugField)->getValue($object);
-                    $this->persistedSlugs[$config['useObjectClass']][$slugField][] = $slug;
+                    if (($options['updatable']) || (call_user_func(array($object,"get".ucfirst($slugField))) == "")) {
+                        $this->generateSlug($ea, $object);
+                        $slug = $meta->getReflectionProperty($slugField)->getValue($object);
+                        $this->persistedSlugs[$config['useObjectClass']][$slugField][] = $slug;
+                    }
                 }
             }
         }
@@ -159,9 +161,7 @@ class SluggableListener extends MappedEventSubscriber
             $meta = $om->getClassMetadata(get_class($object));
             if ($config = $this->getConfiguration($om, $meta->name)) {
                 foreach ($config['slugs'] as $slugField => $options) {
-                    if ($options['updatable']) {
-                        $this->generateSlug($ea, $object);
-                    } elseif(call_user_func(array($object,"get".ucfirst($slugField))) == "") {
+                    if (($options['updatable']) || (call_user_func(array($object,"get".ucfirst($slugField))) == "")) {
                         $this->generateSlug($ea, $object);
                     }
                 }

--- a/tests/Gedmo/Sluggable/SluggableConfigurationTest.php
+++ b/tests/Gedmo/Sluggable/SluggableConfigurationTest.php
@@ -98,5 +98,74 @@ class SluggableConfigurationTest extends BaseTestCaseORM
         $this->em->clear();
         $this->articleId = $article->getId();
     }
+
+    public function testUpdatableFalse()
+    {
+        $article = new ConfigurationArticle();
+        $article->setTitle('my title');
+        $article->setCode('my code');
+
+        $this->em->persist($article);
+        $this->em->flush();
+        $this->em->clear();
+
+        $this->assertEquals($article->getSlug(), 'my-title-my-code');
+    }
+
+    public function testUpdatableFalseSetSlug()
+    {
+        $article = new ConfigurationArticle();
+        $article->setTitle('my title');
+        $article->setCode('my code');
+
+        $article->setSlug('my-slug');
+
+        $this->em->persist($article);
+        $this->em->flush();
+        $this->em->clear();
+
+        $this->assertEquals($article->getSlug(), 'my-slug');
+    }
+
+    public function testUpdatableFalseChangeSlug()
+    {
+        $article = $this->em->find(self::ARTICLE, $this->articleId);
+        $article->setSlug('my-new-slug');
+
+        $this->em->persist($article);
+        $this->em->flush();
+        $this->em->clear();
+
+        $this->assertEquals($article->getTitle(), 'my title');
+        $this->assertEquals($article->getCode(), 'my code');
+        $this->assertEquals($article->getSlug(), 'my-new-slug');
+    }
+
+    public function testUpdatableFalseChangeTitle()
+    {
+        $article = $this->em->find(self::ARTICLE, $this->articleId);
+        $article->setTitle('my new title');
+
+        $this->em->persist($article);
+        $this->em->flush();
+        $this->em->clear();
+
+        $this->assertEquals($article->getTitle(), 'my new title');
+        $this->assertEquals($article->getCode(), 'my code');
+        $this->assertEquals($article->getSlug(), 'my-slug');
+    }
+    public function testUpdatableFalseSetSlugNull()
+    {
+        $article = $this->em->find(self::ARTICLE, $this->articleId);
+        $article->setSlug('');
+
+        $this->em->persist($article);
+        $this->em->flush();
+        $this->em->clear();
+
+        $this->assertEquals($article->getTitle(), 'my title');
+        $this->assertEquals($article->getCode(), 'my code');
+        $this->assertEquals($article->getSlug(), 'my-title-my-code');
+    }
 }
 

--- a/tests/Gedmo/Sluggable/SluggableTest.php
+++ b/tests/Gedmo/Sluggable/SluggableTest.php
@@ -163,4 +163,17 @@ class SluggableTest extends BaseTestCaseORM
         $this->em->clear();
         $this->articleId = $article->getId();
     }
+    public function testUpdatableTrueChangeSlug()
+    {
+        $article = $this->em->find(self::ARTICLE, $this->articleId);
+        $article->setSlug('my-title');
+
+        $this->em->persist($article);
+        $this->em->flush();
+        $this->em->clear();
+
+        $this->assertEquals($article->getTitle(), 'my title');
+        $this->assertEquals($article->getCode(), 'my code');
+        $this->assertEquals($article->getSlug(), 'my-title-my-code');
+    }
 }


### PR DESCRIPTION
I have improved a bit behavior of the Slugable fields.

Our clients want to have ability to edit manually slugs and generate them automatically, when slug is empty.

Right now when I set updatable=false , slug is not generated even when its empty, which is not good.
Also, when I set updatable=true it doesnt guarantee, that slug always build based on needed fields - some user
can change slug directly in entity.

So, I have improved a bit behavior of the slugable - users can set updatable to false and
get "editable" slugs with auto generation on empty slugs.
