### PR TITLE
Timestampable: added vardatetime to the annotation driver

### DIFF
--- a/lib/Gedmo/Timestampable/Mapping/Driver/Annotation.php
+++ b/lib/Gedmo/Timestampable/Mapping/Driver/Annotation.php
@@ -35,7 +35,8 @@ class Annotation implements AnnotationDriverInterface
         'time',
         'datetime',
         'timestamp',
-        'zenddate'
+        'zenddate',
+        'vardatetime'
     );
 
     /**


### PR DESCRIPTION
Postgresql timestamp has millisecond and to save compatability doctrine has a more liberal DateTime parser is vardatetime.
To avoid InvalidMappingException, I propose to add Timestampable annotation driver vardatetime type.

Many thanks
