### PR TITLE
Fixed error in example code setDeletedAt() method

### DIFF
--- a/doc/softdeleteable.md
+++ b/doc/softdeleteable.md
@@ -118,7 +118,7 @@ class Article
 
     public function setDeletedAt($deletedAt)
     {
-        return $this->deletedAt;
+        $this->deletedAt = $deletedAt;
     }
 }
 ```


### PR DESCRIPTION
The setter method for $deletedAt was identical to the getter.
