### PR TITLE
fixing #276

### DIFF
--- a/lib/Gedmo/Tree/TreeListener.php
+++ b/lib/Gedmo/Tree/TreeListener.php
@@ -259,7 +259,11 @@ class TreeListener extends MappedEventSubscriber
         $ea = $this->getEventAdapter($eventArgs);
         $om = $ea->getObjectManager();
         $meta = $eventArgs->getClassMetadata();
-        $this->loadMetadataForObjectClass($om, $meta);
+        try {
+            $this->loadMetadataForObjectClass($om, $meta);
+        } catch (\ReflectionException $e) {
+            return;
+        }
         if (isset(self::$configurations[$this->name][$meta->name]) && self::$configurations[$this->name][$meta->name]) {
             $this->getStrategy($om, $meta->name)->processMetadataLoad($om, $meta);
         }


### PR DESCRIPTION
#276 still exists after previous fix 99c915892812aa35f0ce396d7014b9d104e1ba3c . doctrine:mapping:convert --from-database still throws an exception about a non-existing class. The class metadata is generated by Doctrine\ORM\Mapping\Driver\DatabaseDriver so there might not be an actual entity class file for it. But Gedmo\Tree\TreeListener would try to load the class for its reflection info, which causes the exception. This should not be expected as tree behaviors should only apply to existing entities.

FYI, Here's the call stack generated by xdebug before the exception happens. 

```
sf2-blue/vendor/doctrine/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php.Doctrine\ORM\Mapping\ClassMetadataInfo->getReflectionClass : lineno 516() sf2-blue/vendor/doctrine/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php at line 516   
sf2-blue/vendor/gedmo-doctrine-extensions/lib/Gedmo/Tree/Mapping/Driver/Annotation.php.Gedmo\Tree\Mapping\Driver\Annotation->readExtendedMetadata : lineno 109() sf2-blue/vendor/gedmo-doctrine-extensions/lib/Gedmo/Tree/Mapping/Driver/Annotation.php at line 109 
sf2-blue/vendor/gedmo-doctrine-extensions/lib/Gedmo/Mapping/ExtensionMetadataFactory.php.Gedmo\Mapping\ExtensionMetadataFactory->getExtensionMetadata : lineno 95() sf2-blue/vendor/gedmo-doctrine-extensions/lib/Gedmo/Mapping/ExtensionMetadataFactory.php at line 95 
sf2-blue/vendor/gedmo-doctrine-extensions/lib/Gedmo/Mapping/MappedEventSubscriber.php.Gedmo\Mapping\MappedEventSubscriber->loadMetadataForObjectClass : lineno 191() sf2-blue/vendor/gedmo-doctrine-extensions/lib/Gedmo/Mapping/MappedEventSubscriber.php at line 191  
sf2-blue/vendor/gedmo-doctrine-extensions/lib/Gedmo/Tree/TreeListener.php.Gedmo\Tree\TreeListener->loadClassMetadata : lineno 262() sf2-blue/vendor/gedmo-doctrine-extensions/lib/Gedmo/Tree/TreeListener.php at line 262   
sf2-blue/vendor/doctrine-common/lib/Doctrine/Common/EventManager.php.Doctrine\Common\EventManager->dispatchEvent : lineno 64() sf2-blue/vendor/doctrine-common/lib/Doctrine/Common/EventManager.php at line 64  
sf2-blue/vendor/doctrine/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php.Doctrine\ORM\Mapping\ClassMetadataFactory->loadMetadata : lineno 317() sf2-blue/vendor/doctrine/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php at line 317    
sf2-blue/vendor/doctrine/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php.Doctrine\ORM\Mapping\ClassMetadataFactory->getMetadataFor : lineno 177() sf2-blue/vendor/doctrine/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php at line 177  
sf2-blue/vendor/doctrine/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php.Doctrine\ORM\Mapping\ClassMetadataFactory->getAllMetadata : lineno 124() sf2-blue/vendor/doctrine/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php at line 124  
sf2-blue/vendor/doctrine/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php.Doctrine\ORM\Tools\Console\Command\ConvertMappingCommand->execute : lineno 129() sf2-blue/vendor/doctrine/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php at line 129    
sf2-blue/vendor/symfony/src/Symfony/Bundle/DoctrineBundle/Command/Proxy/ConvertMappingDoctrineCommand.php.Symfony\Bundle\DoctrineBundle\Command\Proxy\ConvertMappingDoctrineCommand->execute : lineno 50() sf2-blue/vendor/symfony/src/Symfony/Bundle/DoctrineBundle/Command/Proxy/ConvertMappingDoctrineCommand.php at line 50 
sf2-blue/vendor/symfony/src/Symfony/Component/Console/Command/Command.php.Symfony\Component\Console\Command\Command->run : lineno 224() sf2-blue/vendor/symfony/src/Symfony/Component/Console/Command/Command.php at line 224   
sf2-blue/vendor/symfony/src/Symfony/Component/Console/Application.php.Symfony\Component\Console\Application->doRun : lineno 194() sf2-blue/vendor/symfony/src/Symfony/Component/Console/Application.php at line 194 
sf2-blue/vendor/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php.Symfony\Bundle\FrameworkBundle\Console\Application->doRun : lineno 75() sf2-blue/vendor/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php at line 75    
sf2-blue/vendor/symfony/src/Symfony/Component/Console/Application.php.Symfony\Component\Console\Application->run : lineno 118() sf2-blue/vendor/symfony/src/Symfony/Component/Console/Application.php at line 118   
sf2-blue/app/console.{main} : lineno 22() sf2-blue/app/console at line 22   

```
