### PR TITLE
Fix xml documentation on sluggable extension

### DIFF
--- a/doc/sluggable.md
+++ b/doc/sluggable.md
@@ -274,7 +274,7 @@ Entity\Article:
 <?xml version="1.0" encoding="UTF-8"?>
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
                   xmlns:gedmo="http://gediminasm.org/schemas/orm/doctrine-extensions-mapping">
-    <entity name="Mapping\Fixture\Xml\Sluggable" table="sluggables">
+    <entity name="Entity\Article" table="sluggables">
         <id name="id" type="integer" column="id">
             <generator strategy="AUTO"/>
         </id>
@@ -283,7 +283,7 @@ Entity\Article:
         <field name="code" type="string" length="16"/>
         <field name="ean" type="string" length="13"/>
         <field name="slug" type="string" length="156" unique="true">
-            <gedmo:slug unique="true" style="camel" updatable="false" separator="_", fields="title,code,ean" />
+            <gedmo:slug unique="true" style="camel" updatable="false" separator="_" fields="title,code,ean" />
         </field>
     </entity>
 </doctrine-mapping>


### PR DESCRIPTION
Remove a typo (the comma line 286) and change the name of the xml entity
(No relations between fixture/xml/slug with a doctrine entity...)
