### PR TITLE
Closures on close option

### DIFF
--- a/lib/Gedmo/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/lib/Gedmo/Tree/Entity/Repository/NestedTreeRepository.php
@@ -1161,9 +1161,9 @@ class NestedTreeRepository extends AbstractTreeRepository
                 if (count($node['__children']) > 0) {
                     $output .= $build($node['__children']);
                 }
-                $output .= $options['childClose'];
+                $output .= is_string($options['childClose']) ? $options['childClose'] : $options['childClose']($node);
             }
-            return $output . $options['rootClose'];
+            return $output . (is_string($options['rootClose']) ? $options['rootClose'] : $options['rootClose']($tree));
         };
 
         return $build($nestedTree);


### PR DESCRIPTION
I need to show unlimited level tree as 2 levels "preview" three and I need closures in close options. I use decorator options like

<PRE>
array('decorate' => true,
            'rootOpen' => function($tree) {
                if(count($tree) && ($tree[0]['lvl'] == 0)){
                        return '&lt;div class="catalog-list">';
                }
            },
            'rootClose' => function($child) {
                if(count($child) && ($child[0]['lvl'] == 0)){
                                return '&lt;/div>';
                }
             },
            'childOpen' => '',
            'childClose' => '',
            'nodeDecorator' => function($node) {
                if($node['lvl'] == 1) {
                    return '&lt;h1>'.$node['title'].'&lt;/h1>';
                }elseif($node["isVisibleOnHome"]) {
                    return '&lt;a href="/ware/'.$node['id'].'">'.$node['title'].'&lt;/a>&nbsp;';
                }
            }
</PRE>
