### PR TITLE
Timestamp type causes incorrect dates to be set

### DIFF
--- a/doc/timestampable.md
+++ b/doc/timestampable.md
@@ -165,9 +165,9 @@ class Article
     private $title;
 
     /**
-     * @var timestamp $created
+     * @var date $created
      *
-     * @ODM\Timestamp
+     * @ODM\Date
      * @Gedmo\Timestampable(on="create")
      */
     private $created;


### PR DESCRIPTION
I noticed that if you use @ODM\Timestamp as the type for Timestampable fields, the dates get stored incorrectly in MongoDB. The dates appear as "44458-08-30 15:33:20 +0000" - my guess would be one assumes seconds and the other microseconds.

Using @ODM\Date type for both created and updated fields fixes the issue.
