### PR TITLE
[tree] Updated default sort order to include root order

### DIFF
--- a/lib/Gedmo/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/lib/Gedmo/Tree/Entity/Repository/NestedTreeRepository.php
@@ -326,7 +326,10 @@ class NestedTreeRepository extends AbstractTreeRepository
             }
         }
         if (!$sortByField) {
-            $qb->orderBy('node.' . $config['left'], 'ASC');
+            if (isset($config['root'])) {
+                $qb->addOrderBy('node.' . $config['root'], 'ASC');
+            }
+            $qb->addOrderBy('node.' . $config['left'], 'ASC', true);
         } else {
             if ($meta->hasField($sortByField) && in_array(strtolower($direction), array('asc', 'desc'))) {
                 $qb->orderBy('node.' . $sortByField, $direction);


### PR DESCRIPTION
When using multiple roots and using the repo's `childrenQueryBuilder` method, the nodes are just ordered by `lft` which causes the trees to be merged together. This is not so good when using the tree to build the options in a choice widget.

I dont think this is the best solution, it may be better to add a `root_order` field or similar. But it works well for my purposes and keeps the trees separate.
