### PR TITLE
Fixes #394 - Error accessing getPaths() and getFileExtension() for YamlDriver and XmlDriver

### DIFF
--- a/lib/Gedmo/Mapping/ExtensionMetadataFactory.php
+++ b/lib/Gedmo/Mapping/ExtensionMetadataFactory.php
@@ -154,8 +154,8 @@ final class ExtensionMetadataFactory
             $driver = new $driverClassName();
             $driver->setOriginalDriver($omDriver);
             if ($driver instanceof FileDriver) {
-                $driver->setPaths($omDriver->getLocator()->getPaths());
-                $driver->setExtension($omDriver->getLocator()->getFileExtension());
+                $driver->setPaths($omDriver->getPaths());
+                $driver->setExtension($omDriver->getFileExtension());
             }
             if ($driver instanceof AnnotationDriverInterface) {
                 $driver->setAnnotationReader($this->annotationReader);


### PR DESCRIPTION
The previously used `->getLocator()->getPaths()` syntax applies to the Doctrine\Common\Persistence\Mapping\Driver\FileDriver type. However, here in ExtensionMetadataFactory.php, 'FileDriver' is used as a namespace alias for Gedmo\Mapping\Driver\File. The original Doctrine drivers on which `->getLocator()->getPaths()` was called (instances of YamlDriver or XmlDriver) do not extend Doctrine's FileDriver, and thus have no `getLocator()` method nor `$locator` field. Fortunately, `YamlDriver` and `XmlDriver` _do_ extend Doctrine's `AbstractFileDriver`, which defines `getPaths()` and `getFileExtension()` methods directly.

Examples of errors thrown prior to this fix:

```
PHP Fatal error:  Call to undefined method Doctrine\ORM\Mapping\Driver\YamlDriver::getLocator()
```

And from Issue #394:

```
Fatal error: Call to undefined method Doctrine\ORM\Mapping\Driver\SimplifiedXmlDriver::getPaths()
```
