### PR TITLE
Update doc/tree.md

### DIFF
--- a/doc/tree.md
+++ b/doc/tree.md
@@ -557,7 +557,6 @@ $htmlTree = $repo->childrenHierarchy(
 $repo = $em->getRepository('Entity\Category');
 $options = array(
     'decorate' => true,
-    'representationField' => 'slug',
     'rootOpen' => '<ul>',
     'rootClose' => '</ul>',
     'childOpen' => '<li>',
@@ -569,9 +568,9 @@ $options = array(
 $htmlTree = $repo->childrenHierarchy(
     null, /* starting from root nodes */
     false, /* load all children, not only direct */
-    true, /* render html */
     $options
 );
+
 ```
 
 ### Generate own node list


### PR DESCRIPTION
An exception has been thrown during the rendering of a template ("Catchable Fatal Error: Argument 3 passed to Gedmo\Tree\Entity\Repository\AbstractTreeRepository::childrenHierarchy() must be an array, boolean given, called in..
