### PR TITLE
Tree minor fixes

### DIFF
--- a/lib/Gedmo/Tree/Document/MongoDB/Repository/AbstractTreeRepository.php
+++ b/lib/Gedmo/Tree/Document/MongoDB/Repository/AbstractTreeRepository.php
@@ -142,7 +142,7 @@ abstract class AbstractTreeRepository extends DocumentRepository implements Repo
      *
      * @return \Doctrine\MongoDB\Query\Builder - QueryBuilder object
      */
-    abstract public function getNodesHierarchyQueryBuilder($node = null, $direct, array $config, array $options = array(), $includeNode = false);
+    abstract public function getNodesHierarchyQueryBuilder($node = null, $direct = false, array $config = array(), array $options = array(), $includeNode = false);
 
     /**
      * Returns a Query configured to return an array of nodes suitable for buildTree method
@@ -155,7 +155,7 @@ abstract class AbstractTreeRepository extends DocumentRepository implements Repo
      *
      * @return \Doctrine\MongoDB\Query\Query - Query object
      */
-    abstract public function getNodesHierarchyQuery($node = null, $direct, array $config, array $options = array(), $includeNode = false);
+    abstract public function getNodesHierarchyQuery($node = null, $direct = false, array $config = array(), array $options = array(), $includeNode = false);
 
     /**
      * Get list of children followed by given $node. This returns a QueryBuilder object

--- a/lib/Gedmo/Tree/Document/MongoDB/Repository/MaterializedPathRepository.php
+++ b/lib/Gedmo/Tree/Document/MongoDB/Repository/MaterializedPathRepository.php
@@ -167,7 +167,7 @@ class MaterializedPathRepository extends AbstractTreeRepository
     /**
      * {@inheritDoc}
      */
-    public function getNodesHierarchyQueryBuilder($node = null, $direct, array $config, array $options = array(), $includeNode = false)
+    public function getNodesHierarchyQueryBuilder($node = null, $direct = false, array $config = array(), array $options = array(), $includeNode = false)
     {
         $sortBy = array(
             'field'     => null,
@@ -184,7 +184,7 @@ class MaterializedPathRepository extends AbstractTreeRepository
     /**
      * {@inheritDoc}
      */
-    public function getNodesHierarchyQuery($node = null, $direct, array $config, array $options = array(), $includeNode = false)
+    public function getNodesHierarchyQuery($node = null, $direct = false, array $config = array(), array $options = array(), $includeNode = false)
     {
         return $this->getNodesHierarchyQueryBuilder($node, $direct, $config, $options, $includeNode)->getQuery();
     }
@@ -192,7 +192,7 @@ class MaterializedPathRepository extends AbstractTreeRepository
     /**
      * {@inheritDoc}
      */
-    public function getNodesHierarchy($node = null, $direct, array $config, array $options = array(), $includeNode = false)
+    public function getNodesHierarchy($node = null, $direct = false, array $config = array(), array $options = array(), $includeNode = false)
     {
         $query = $this->getNodesHierarchyQuery($node, $direct, $config, $options, $includeNode);
         $query->setHydrate(false);

--- a/lib/Gedmo/Tree/Entity/Repository/AbstractTreeRepository.php
+++ b/lib/Gedmo/Tree/Entity/Repository/AbstractTreeRepository.php
@@ -182,7 +182,7 @@ abstract class AbstractTreeRepository extends EntityRepository implements Reposi
      *
      * @return \Doctrine\ORM\QueryBuilder - QueryBuilder object
      */
-    abstract public function getNodesHierarchyQueryBuilder($node = null, $direct, array $config, array $options = array(), $includeNode = false);
+    abstract public function getNodesHierarchyQueryBuilder($node = null, $direct = false, array $config = array(), array $options = array(), $includeNode = false);
 
     /**
      * Returns a Query configured to return an array of nodes suitable for buildTree method
@@ -195,7 +195,7 @@ abstract class AbstractTreeRepository extends EntityRepository implements Reposi
      *
      * @return \Doctrine\ORM\Query - Query object
      */
-    abstract public function getNodesHierarchyQuery($node = null, $direct, array $config, array $options = array(), $includeNode = false);
+    abstract public function getNodesHierarchyQuery($node = null, $direct = false, array $config = array(), array $options = array(), $includeNode = false);
 
     /**
      * Get list of children followed by given $node. This returns a QueryBuilder object

--- a/lib/Gedmo/Tree/Entity/Repository/ClosureTreeRepository.php
+++ b/lib/Gedmo/Tree/Entity/Repository/ClosureTreeRepository.php
@@ -325,7 +325,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
     /**
      * {@inheritdoc}
      */
-    public function getNodesHierarchy($node = null, $direct, array $config, array $options = array(), $includeNode = false)
+    public function getNodesHierarchy($node = null, $direct = false, array $config = array(), array $options = array(), $includeNode = false)
     {
         return $this->getNodesHierarchyQuery($node, $direct, $config, $options, $includeNode)->getArrayResult();
     }
@@ -333,7 +333,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
     /**
      * {@inheritdoc}
      */
-    public function getNodesHierarchyQuery($node = null, $direct, array $config, array $options = array(), $includeNode = false)
+    public function getNodesHierarchyQuery($node = null, $direct = false, array $config = array(), array $options = array(), $includeNode = false)
     {
         return $this->getNodesHierarchyQueryBuilder($node, $direct, $config, $options, $includeNode)->getQuery();
     }
@@ -341,7 +341,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
     /**
      * {@inheritdoc}
      */
-    public function getNodesHierarchyQueryBuilder($node = null, $direct, array $config, array $options = array(), $includeNode = false)
+    public function getNodesHierarchyQueryBuilder($node = null, $direct = false, array $config = array(), array $options = array(), $includeNode = false)
     {
         $meta = $this->getClassMetadata();
         $idField = $meta->getSingleIdentifierFieldName();

--- a/lib/Gedmo/Tree/Entity/Repository/MaterializedPathRepository.php
+++ b/lib/Gedmo/Tree/Entity/Repository/MaterializedPathRepository.php
@@ -149,7 +149,7 @@ class MaterializedPathRepository extends AbstractTreeRepository
     /**
      * {@inheritdoc}
      */
-    public function getNodesHierarchyQueryBuilder($node = null, $direct, array $config, array $options = array(), $includeNode = false)
+    public function getNodesHierarchyQueryBuilder($node = null, $direct = false, array $config = array(), array $options = array(), $includeNode = false)
     {
         $sortBy = array(
             'field'     => null,
@@ -166,7 +166,7 @@ class MaterializedPathRepository extends AbstractTreeRepository
     /**
      * {@inheritdoc}
      */
-    public function getNodesHierarchyQuery($node = null, $direct, array $config, array $options = array(), $includeNode = false)
+    public function getNodesHierarchyQuery($node = null, $direct = false, array $config = array(), array $options = array(), $includeNode = false)
     {
         return $this->getNodesHierarchyQueryBuilder($node, $direct, $config, $options, $includeNode)->getQuery();
     }
@@ -174,7 +174,7 @@ class MaterializedPathRepository extends AbstractTreeRepository
     /**
      * {@inheritdoc}
      */
-    public function getNodesHierarchy($node = null, $direct, array $config, array $options = array(), $includeNode = false)
+    public function getNodesHierarchy($node = null, $direct = false, array $config = array(), array $options = array(), $includeNode = false)
     {
         return $this->getNodesHierarchyQuery($node, $direct, $config, $options, $includeNode)->getArrayResult();
     }

--- a/lib/Gedmo/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/lib/Gedmo/Tree/Entity/Repository/NestedTreeRepository.php
@@ -789,7 +789,7 @@ class NestedTreeRepository extends AbstractTreeRepository
     /**
      * {@inheritDoc}
      */
-    public function getNodesHierarchyQueryBuilder($node = null, $direct, array $config, array $options = array(), $includeNode = false)
+    public function getNodesHierarchyQueryBuilder($node = null, $direct = false, array $config = array(), array $options = array(), $includeNode = false)
     {
         return $this->childrenQueryBuilder(
             $node,
@@ -803,7 +803,7 @@ class NestedTreeRepository extends AbstractTreeRepository
     /**
      * {@inheritDoc}
      */
-    public function getNodesHierarchyQuery($node = null, $direct, array $config, array $options = array(), $includeNode = false)
+    public function getNodesHierarchyQuery($node = null, $direct = false, array $config = array(), array $options = array(), $includeNode = false)
     {
         return $this->getNodesHierarchyQueryBuilder($node, $direct, $config, $options)->getQuery();
     }
@@ -811,7 +811,7 @@ class NestedTreeRepository extends AbstractTreeRepository
     /**
      * {@inheritdoc}
      */
-    public function getNodesHierarchy($node = null, $direct, array $config, array $options = array(), $includeNode = false)
+    public function getNodesHierarchy($node = null, $direct = false, array $config = array(), array $options = array(), $includeNode = false)
     {
         return $this->getNodesHierarchyQuery($node, $direct, $config, $options)->getArrayResult();
     }

--- a/lib/Gedmo/Tree/RepositoryInterface.php
+++ b/lib/Gedmo/Tree/RepositoryInterface.php
@@ -32,7 +32,7 @@ interface RepositoryInterface extends RepositoryUtilsInterface
      *
      * @return array - Array of nodes
      */
-    public function getNodesHierarchy($node = null, $direct, array $config, array $options = array(), $includeNode = false);
+    public function getNodesHierarchy($node = null, $direct = false, array $config = array(), array $options = array(), $includeNode = false);
 
     /**
      * Get list of children followed by given $node


### PR DESCRIPTION
Some minor fixes to the Tree Extension, including:
- Fix a problem with childCount method, which shouldn't include an order by clause in the query (which could bring problems with some vendors). Reported by @ocanipse
- Fix the repository api (added default values to the parameters of "getNodesHierarchyQueryBuilder" method).
