### PR TITLE
translatable defaul-locale bug

### DIFF
--- a/lib/Gedmo/Translatable/TranslatableListener.php
+++ b/lib/Gedmo/Translatable/TranslatableListener.php
@@ -562,6 +562,9 @@ class TranslatableListener extends MappedEventSubscriber
                 if (in_array($field, $translatableFields)) {
                     if ($locale !== $this->defaultLocale) {
                         $ea->setOriginalObjectProperty($uow, $oid, $field, $changes[0]);
+                        if($changes[0]!=null && !is_object( $changes[0])){
+                            $ea->setTranslationValue($object, $field, $changes[0]);
+                        }
                         unset($modifiedChangeSet[$field]);
                     }
                 }
@@ -574,6 +577,9 @@ class TranslatableListener extends MappedEventSubscriber
                 if ($modifiedChangeSet) {
                     foreach ($modifiedChangeSet as $field => $changes) {
                         $ea->setOriginalObjectProperty($uow, $oid, $field, $changes[0]);
+                        if($changes[0]!=null && !is_object( $changes[0])){
+                            $ea->setTranslationValue($object, $field, $changes[0]);
+                        }                        
                     }
                     $ea->recomputeSingleObjectChangeset($uow, $meta, $object);
                 }


### PR DESCRIPTION
If I update translation of non-default-locale, it also update's the value on the main table (default-locale-value). This will fix it. 
