### PR TITLE
Ensure parent is initialized before node update

### DIFF
--- a/lib/Gedmo/Tree/Strategy/AbstractMaterializedPath.php
+++ b/lib/Gedmo/Tree/Strategy/AbstractMaterializedPath.php
@@ -273,6 +273,9 @@ abstract class AbstractMaterializedPath implements Strategy
         $path .= $config['path_separator'];
 
         if ($parent) {
+            // Ensure parent has been initialized in the case where it's a proxy
+            $om->initializeObject($parent);
+            
             $changeSet = $uow->isScheduledForUpdate($parent) ? $ea->getObjectChangeSet($uow, $parent) : false;
             $pathOrPathSourceHasChanged = $changeSet && (isset($changeSet[$config['path_source']]) || isset($changeSet[$config['path']]));
 


### PR DESCRIPTION
Hi,

This is a fix for issue #458, which ensures that when using the Materialized Path strategy, the parent of the node is initialized before it is updated so that path, level etc. can be calculated.

I looked into adding a test case for this but the current tests use a custom repository which mean that the issue doesn't occur with the test strategy. Are there any examples of tests which use Doctrine proxy classes? I'll be able to add a test case if you can point me in the right direction.

Cheers,
Craig
