### PR TITLE
Sortable: Grouped items numbering

### DIFF
--- a/lib/Gedmo/Sortable/SortableListener.php
+++ b/lib/Gedmo/Sortable/SortableListener.php
@@ -385,7 +385,7 @@ class SortableListener extends MappedEventSubscriber
         // see issue #226
         foreach ($groups as $group => $val) {
             if (is_object($val) && $uow->isScheduledForInsert($val)) {
-                return 0;
+                return -1;
             }
         }
 


### PR DESCRIPTION
Ungrouped items seem to start at 0 whereas grouped items start at 1. i.e. in this example the top level (species) is an entity which doesn't have a field with a \SortableGroup and the second level (breed) does :
- Dogs (0)
  - Greyhound (1)
  - Bloodhound (2)
- Cats (1)
  - Tabby (1)
  - Siamese (2)

(This is my first ever attempt at a pull request so let me know if I've breached protocol or could have done something better)
