### PR TITLE
Issue with personal translations and inherited entities

### DIFF
--- a/lib/Gedmo/Mapping/MappedEventSubscriber.php
+++ b/lib/Gedmo/Mapping/MappedEventSubscriber.php
@@ -133,6 +133,12 @@ abstract class MappedEventSubscriber implements EventSubscriber
                         $config = self::$configurations[$this->name][$class];
                     }
                 }
+
+                $objectClass = isset($config['useObjectClass']) ? $config['useObjectClass'] : $class;
+                if ($objectClass !== $class) {
+                    $this->getConfiguration($objectManager, $objectClass);
+                }
+
             }
         }
         return $config;


### PR DESCRIPTION
Issue with translations and inherited entities

In one application I'm working on (http://tusjuegos.com) we are migrating our mythical ORM to Doctrine and Gedmo for translations and slugs (for now).

We found a little issue with 3 of our entities: categories, tags and terms (categories and tags are inherit entities of terms, single table inheritance mode).

**The issue only occurs with a "real" cache system** like APC or Memcached (with ArrayCache not happens).

In the first request all the translations are loaded correctly, with any issue, but in the second one, **Gedmo goes to the table ext_translations to find the translations of Category or Tag instead of terms_translations because in the configurations of _MappedEventSubscriber_ still not exists the configuration of the entity Term, the _useObjectClass_ of entity Category or Tag**.

In the first request, the configuration of Term already exists and all works smoothly.
I do not know very well how Doctrine works and much less how Gedmo is integrated with it, and exactly why this happens. I only know what, when and way to fix it, but I'm not sure if is a decent way.

``` php
/**
 * Entity for a category
 *
 * @ORM\Entity
 **/
class Category extends Term
{}

/**
 * Entity for a tag
 *
 * @ORM\Entity
 **/
class Tag extends Term
{}

/**
 * Entity for a term
 *
 * @ORM\Table
 * @ORM\Entity
 * @ORM\InheritanceType("SINGLE_TABLE")
 * @ORM\DiscriminatorColumn(name="type", type="termtype")
 * @ORM\DiscriminatorMap({"category"="Category", "tag"="Tag"})
 * @Gedmo\TranslationEntity(class="TusJuegos\Entity\TermTranslation")
 **/
abstract class Term extends EntityAbstract implements Translatable, Sluggable
{
    /**
     * @ORM\Column(type="integer")
     * @ORM\Id
     * @ORM\GeneratedValue
     */
    protected $id;

    /**
     * @Gedmo\Translatable
     * @ORM\Column(type="string", length=100)
     */
    protected $name;

    /**
     * @Gedmo\Locale
     */
    protected $locale;

    /**
     * @Gedmo\Translatable
     * @Gedmo\Slug(fields={"name"})
     * @ORM\Column(type="string", length=100)
     */
    protected $url;

    /**
     * @ORM\OneToMany(targetEntity="TermTranslation", mappedBy="object", cascade={"persist", "remove"})
     */
    protected $translations;
}

/**
 * Entity for a translation of a term
 *
 * @ORM\Table(
 *  name="terms_translations",
 *  uniqueConstraints={@ORM\UniqueConstraint(name="uk_lookup_unique_idx", columns{"locale", "object_id", "field"})}
 * )
 * @ORM\Entity
 **/
class TermTranslation extends Gedmo\Translatable\Entity\MappedSuperclass\AbstractPersonalTranslation
{
    /**
     * @ORM\ManyToOne(targetEntity="Term", inversedBy="translations")
     * @ORM\JoinColumn(name="object_id", referencedColumnName="id", onDelete="CASCADE")
     */
    protected $object;

    /**
     * @ORM\Column(type="string", length=100, nullable=true)
     */
    protected $content;
}
```

If I can provide any other info or I can help in anything it will be amazing.
Doctrine & Gedmo combo already helped us so much :)
