### PR TITLE
Support Reordering the Whole Tree

### DIFF
--- a/lib/Gedmo/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/lib/Gedmo/Tree/Entity/Repository/NestedTreeRepository.php
@@ -707,10 +707,10 @@ class NestedTreeRepository extends AbstractTreeRepository
     }
 
     /**
-     * Reorders the sibling nodes and child nodes by given $node,
+     * Reorders $node's sibling nodes and child nodes,
      * according to the $sortByField and $direction specified
      *
-     * @param object $node - from which node to start reordering the tree
+     * @param object|null $node - node from which to start reordering the tree; null will reorder everything
      * @param string $sortByField - field name to sort by
      * @param string $direction - sort direction : "ASC" or "DESC"
      * @param boolean $verify - true to verify tree first
@@ -719,7 +719,7 @@ class NestedTreeRepository extends AbstractTreeRepository
     public function reorder($node, $sortByField = null, $direction = 'ASC', $verify = true)
     {
         $meta = $this->getClassMetadata();
-        if ($node instanceof $meta->name) {
+        if ($node instanceof $meta->name || $node==null) {
             $config = $this->listener->getConfiguration($this->_em, $meta->name);
             if ($verify && is_array($this->verify())) {
                 return false;
@@ -738,6 +738,19 @@ class NestedTreeRepository extends AbstractTreeRepository
         } else {
             throw new InvalidArgumentException("Node is not related to this repository");
         }
+    }
+
+    /**
+     * Reorders all nodes in the tree according to the $sortByField and $direction specified.
+     *
+     * @param string $sortByField - field name to sort by
+     * @param string $direction - sort direction : "ASC" or "DESC"
+     * @param boolean $verify - true to verify tree first
+     * @return void
+     */
+    public function reorderAll($sortByField = null, $direction = 'ASC', $verify = true)
+    {
+        $this->reorder(null, $sortByField, $direction, $verify);
     }
 
     /**


### PR DESCRIPTION
-Allow reorder() to take a null $node, such that root nodes can be reordered too. Before, if a root node was provided, it's children and their siblings would be reordered, but the root node and its sibling's wouldn't be rearranged.
-Add a reorderAll() convenience method.
