### PR TITLE
YAML mapping: Check if field mapped as sluggable is identifier only in entities, not mapped superclasses.

### DIFF
--- a/lib/Gedmo/Sluggable/Mapping/Driver/Yaml.php
+++ b/lib/Gedmo/Sluggable/Mapping/Driver/Yaml.php
@@ -80,7 +80,7 @@ class Yaml extends File implements Driver
                         $config['slugs'][$field]['separator'] = isset($slug['separator']) ?
                             (string)$slug['separator'] : '-';
 
-                        if ($meta->isIdentifier($field) && !$config['slugs'][$field]['unique']) {
+                        if (!$meta->isMappedSuperclass && $meta->isIdentifier($field) && !$config['slugs'][$field]['unique']) {
                             throw new InvalidMappingException("Identifier field - [{$field}] slug must be unique in order to maintain primary key in class - {$meta->name}");
                         }
                     }


### PR DESCRIPTION
Issue was fixed for the XML driver only, see PR 317 https://github.com/l3pp4rd/DoctrineExtensions/pull/317

You might also want to fix it in the Annotations driver, it's just that I stumbled across this when using YAML mapping.

I'm afraid this is a massively blocking issue for two of my vendor bundles. :(
