### PR TITLE
[softdeleteable] avoid validation error on mapped superclass. fix #490

### DIFF
--- a/lib/Gedmo/SoftDeleteable/Mapping/Validator.php
+++ b/lib/Gedmo/SoftDeleteable/Mapping/Validator.php
@@ -34,6 +34,10 @@ class Validator
 
     public static function validateField(ClassMetadataInfo $meta, $field)
     {
+        if ($meta->isMappedSuperclass) {
+            return;
+        }
+
         $fieldMapping = $meta->getFieldMapping($field);
 
         if (!in_array($fieldMapping['type'], self::$validTypes)) {


### PR DESCRIPTION
there we go.

sadly it seems there is no way we can validate the existence of the field at parse time. same as in c1b45fbce24fed38059814b0f7aeee8017cb48db and 81a5a65ac940333068daafe6b809f639825adb27
