### PR TITLE
sortableListener update position

### DIFF
--- a/tests/Gedmo/Sortable/SortableTest.php
+++ b/tests/Gedmo/Sortable/SortableTest.php
@@ -369,6 +369,15 @@ class SortableTest extends BaseTestCaseORM
         $this->assertEquals(0, $author1->getPosition());
         $this->assertEquals(1, $author2->getPosition());
         $this->assertEquals(0, $author3->getPosition());
+        
+        //update position
+        $author3->setPaper($paper1);
+        $author3->setPosition(0);
+        $this->em->persist($author3);
+        $this->em->flush();
+        $this->assertEquals(0, $author3->getPosition());
+        $this->assertEquals(1, $author1->getPosition());
+        $this->assertEquals(2, $author2->getPosition());
     }
 
     /**


### PR DESCRIPTION
When I try to update entity which have Gedmo\SortableGroup on ManyToOne field -  I got error 

<pre>
Warning: array_key_exists(): The first argument should be either a string or an integer in ....\vendor\gedmo\doctrine-extensions\lib\Gedmo\Sortable\SortableListener.php line 197
</pre>


I updated test SortableTest.php::shouldFixIssue226, now it reproduce this bug.
