### PR TITLE
Made Uploadable to work with stream wrappers

### DIFF
--- a/lib/Gedmo/Uploadable/Mapping/Validator.php
+++ b/lib/Gedmo/Uploadable/Mapping/Validator.php
@@ -63,6 +63,14 @@ class Validator
         'decimal'
     );
 
+    /**
+     * Whether to validate if the directory of the file exists and is writable, useful to disable it when using
+     * stream wrappers which don't support is_dir (like Gaufrette)
+     *
+     * @var bool
+     */
+    public static $validateWritableDirectory = true;
+
 
     public static function validateFileMimeTypeField(ClassMetadataInfo $meta, $field)
     {
@@ -105,7 +113,7 @@ class Validator
             throw new UploadableInvalidPathException('Path must be a string containing the path to a valid directory.');
         }
 
-        if (!is_dir($path) || !is_writable($path)) {
+        if (self::$validateWritableDirectory && (!is_dir($path) || !is_writable($path))) {
             throw new UploadableCantWriteException(sprintf('Directory "%s" does not exist or is not writable',
                 $path
             ));

--- a/lib/Gedmo/Uploadable/UploadableListener.php
+++ b/lib/Gedmo/Uploadable/UploadableListener.php
@@ -301,7 +301,7 @@ class UploadableListener extends MappedEventSubscriber
 
         Validator::validatePath($path);
 
-        $path = substr($path, strlen($path) - 1) === DIRECTORY_SEPARATOR ? rtrim($path, DIRECTORY_SEPARATOR) : $path;
+        $path = rtrim($path, '\/');
 
         if ($config['fileMimeTypeField']) {
             $fileMimeTypeField = $refl->getProperty($config['fileMimeTypeField']);
@@ -488,7 +488,7 @@ class UploadableListener extends MappedEventSubscriber
         );
 
         $info['fileName'] = basename($fileInfo->getName());
-        $info['filePath'] = $path.DIRECTORY_SEPARATOR.$info['fileName'];
+        $info['filePath'] = $path.'/'.$info['fileName'];
 
         $hasExtension = strrpos($info['fileName'], '.');
 
@@ -502,12 +502,12 @@ class UploadableListener extends MappedEventSubscriber
         // Now we generate the filename using the configured class
         if ($filenameGeneratorClass) {
             $filename = $filenameGeneratorClass::generate(
-                str_replace($path.DIRECTORY_SEPARATOR, '', $info['fileWithoutExt']),
+                str_replace($path.'/', '', $info['fileWithoutExt']),
                 $info['fileExtension']
             );
             $info['filePath'] = str_replace(
-                DIRECTORY_SEPARATOR.$info['fileName'],
-                DIRECTORY_SEPARATOR.$filename,
+                '/'.$info['fileName'],
+                '/'.$filename,
                 $info['filePath']
             );
             $info['fileName'] = $filename;
@@ -559,7 +559,7 @@ class UploadableListener extends MappedEventSubscriber
      */
     public function doMoveFile($source, $dest, $isUploadedFile = true)
     {
-        return $isUploadedFile ? move_uploaded_file($source, $dest) : copy($source, $dest);
+        return $isUploadedFile ? @move_uploaded_file($source, $dest) : @copy($source, $dest);
     }
 
     /**

--- a/tests/Gedmo/Uploadable/Mapping/ValidatorTest.php
+++ b/tests/Gedmo/Uploadable/Mapping/ValidatorTest.php
@@ -58,6 +58,12 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         Validator::validatePath('/invalid/directory/12312432423');
     }
 
+    public function test_validatePath_ifPassedDirIsNotAValidDirectoryOrIsNotWriteableDoesNotThrowExceptionIfDisabled()
+    {
+        Validator::$validateWritableDirectory = false;
+        Validator::validatePath('/invalid/directory/12312432423');
+    }
+
     /**
      * @expectedException Gedmo\Exception\InvalidMappingException
      */

--- a/tests/Gedmo/Uploadable/UploadableEntityTest.php
+++ b/tests/Gedmo/Uploadable/UploadableEntityTest.php
@@ -133,7 +133,7 @@ class UploadableEntityTest extends BaseTestCaseORM
         // We need to set this again because of the recent refresh
         $firstFile = $image2->getFilePath();
 
-        $this->assertPathEquals($image2->getPath().DIRECTORY_SEPARATOR.$fileInfo['name'], $image2->getFilePath());
+        $this->assertPathEquals($image2->getPath().'/'.$fileInfo['name'], $image2->getFilePath());
         $this->assertTrue(is_file($firstFile));
         $this->assertEquals($fileInfo['size'], $image2->getSize());
         $this->assertEquals($fileInfo['type'], $image2->getMime());
@@ -153,7 +153,7 @@ class UploadableEntityTest extends BaseTestCaseORM
 
         $lastFile = $image2->getFilePath();
 
-        $this->assertPathEquals($image2->getPath().DIRECTORY_SEPARATOR.$fileInfo['name'], $image2->getFilePath());
+        $this->assertPathEquals($image2->getPath().'/'.$fileInfo['name'], $image2->getFilePath());
         $this->assertTrue(is_file($lastFile));
 
         // First file should be removed on update
@@ -196,9 +196,9 @@ class UploadableEntityTest extends BaseTestCaseORM
 
         $art = $artRepo->findOneByTitle('Test');
         $files = $art->getFiles();
-        $file1Path = $file1->getPath().DIRECTORY_SEPARATOR.$fileInfo['name'];
-        $file2Path = $file2->getPath().DIRECTORY_SEPARATOR.$fileInfo['name'];
-        $file3Path = $file3->getPath().DIRECTORY_SEPARATOR.$fileInfo['name'];
+        $file1Path = $file1->getPath().'/'.$fileInfo['name'];
+        $file2Path = $file2->getPath().'/'.$fileInfo['name'];
+        $file3Path = $file3->getPath().'/'.$fileInfo['name'];
 
         $this->assertPathEquals($file1Path, $files[0]->getFilePath());
         $this->assertPathEquals($file2Path, $files[1]->getFilePath());
@@ -313,7 +313,7 @@ class UploadableEntityTest extends BaseTestCaseORM
 
         $this->em->refresh($file);
 
-        $filename = substr($file->getFilePath(), strrpos($this->fixWindowsPath($file->getFilePath()), '/') + 1);
+        $filename = substr($file->getFilePath(), strrpos($file->getFilePath(), '/') + 1);
 
         $this->assertEquals('test-3.txt', $filename);
     }
@@ -330,7 +330,7 @@ class UploadableEntityTest extends BaseTestCaseORM
 
         $this->em->refresh($file);
 
-        $filename = substr($file->getFilePath(), strrpos($this->fixWindowsPath($file->getFilePath()), '/') + 1);
+        $filename = substr($file->getFilePath(), strrpos($file->getFilePath(), '/') + 1);
 
         $this->assertEquals('123.txt', $filename);
     }
@@ -347,7 +347,7 @@ class UploadableEntityTest extends BaseTestCaseORM
 
         $this->em->refresh($file);
 
-        $filePath = $file->getPath().DIRECTORY_SEPARATOR.$fileInfo['name'];
+        $filePath = $file->getPath().'/'.$fileInfo['name'];
 
         $this->assertPathEquals($filePath, $file->getFilePath());
     }
@@ -398,7 +398,7 @@ class UploadableEntityTest extends BaseTestCaseORM
 
         $this->em->refresh($file2);
 
-        $filename = substr($file2->getFilePath(), strrpos($this->fixWindowsPath($file2->getFilePath()), '/') + 1);
+        $filename = substr($file2->getFilePath(), strrpos($file2->getFilePath(), '/') + 1);
 
         $this->assertEquals('test-2.txt', $filename);
     }
@@ -586,7 +586,7 @@ class UploadableEntityTest extends BaseTestCaseORM
         $this->em->persist($file);
         $this->em->flush();
 
-        $filePath = $file->getPath().DIRECTORY_SEPARATOR.str_replace(' ', '-', $fileInfo['name']);
+        $filePath = $file->getPath().'/'.str_replace(' ', '-', $fileInfo['name']);
 
         $this->assertPathEquals($filePath, $file->getFilePath());
 
@@ -597,7 +597,7 @@ class UploadableEntityTest extends BaseTestCaseORM
         $this->em->persist($file);
         $this->em->flush();
 
-        $filePath = $file->getPath().DIRECTORY_SEPARATOR.str_replace(' ', '-', str_replace('.txt', '-2.txt', $fileInfo['name']));
+        $filePath = $file->getPath().'/'.str_replace(' ', '-', str_replace('.txt', '-2.txt', $fileInfo['name']));
 
         $this->assertPathEquals($filePath, $file->getFilePath());
     }
@@ -681,16 +681,7 @@ class UploadableEntityTest extends BaseTestCaseORM
 
     protected function assertPathEquals($expected, $path, $message = '')
     {
-        $this->assertEquals($this->fixWindowsPath($expected), $this->fixWindowsPath($path), $message);
-    }
-
-    protected function fixWindowsPath($path)
-    {
-        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
-            $path = str_replace('\\', '/', $path);
-        }
-
-        return $path;
+        $this->assertEquals($expected, $path, $message);
     }
 }
 


### PR DESCRIPTION
- changed DIRECTORY_SEPARATOR to '/' - Windows does not have any problem with standard slashes - most wrappers use parse_url and it expects the separator to be a slash
  - changed Validator::validatePath that it's able to skip (optionaly, it checks by default) the check of is_dir (some wrappers like Gaufrette don't support is_dir, some of them event don't support directories at all)
