### PR TITLE
Add a secondary order statement

### DIFF
--- a/lib/Gedmo/Loggable/Entity/Repository/LogEntryRepository.php
+++ b/lib/Gedmo/Loggable/Entity/Repository/LogEntryRepository.php
@@ -52,7 +52,7 @@ class LogEntryRepository extends EntityRepository
         $dql = "SELECT log FROM {$meta->name} log";
         $dql .= " WHERE log.objectId = :objectId";
         $dql .= " AND log.objectClass = :objectClass";
-        $dql .= " ORDER BY log.version DESC";
+        $dql .= " ORDER BY log.version DESC, log.loggedAt DESC";
 
         $objectId = $wrapped->getIdentifier();
         $q = $this->_em->createQuery($dql);


### PR DESCRIPTION
We are using the loggable extension with custom actions. Because some of these actions don't introduce changes to an entity, we don't increment its version. This results in multiple log entries with the same version.
Currently, when fetching the history of an entity via the LogEntryRepository, the entries are only ordered by their version.
This pull request adds a secondary order statement which also orders by the time the log entries were created.
