### PR TITLE
[Sluggable] Fix german Umlauts

### DIFF
--- a/lib/Gedmo/Sluggable/Util/Urlizer.php
+++ b/lib/Gedmo/Sluggable/Util/Urlizer.php
@@ -79,7 +79,7 @@ class Urlizer
             chr(195).chr(150) => 'Oe',chr(195).chr(153) => 'U',
             chr(195).chr(154) => 'U', chr(195).chr(155) => 'U',
             chr(195).chr(156) => 'Ue',chr(195).chr(157) => 'Y',
-            chr(195).chr(159) => 's', chr(195).chr(160) => 'a',
+            chr(195).chr(159) => 'ss',chr(195).chr(160) => 'a',
             chr(195).chr(161) => 'a', chr(195).chr(162) => 'a',
             chr(195).chr(163) => 'a', chr(195).chr(164) => 'ae',
             chr(195).chr(165) => 'a', chr(195).chr(167) => 'c',


### PR DESCRIPTION
I've created a version that transforms german umlauts (vocals with diaeresis, like _Ü, Ä, Ö, ü, ä_ and _ö_) correctly: Don't just transform to the base vocal, but instead append an _e_ to the vocal.

Since transforming the old way looks very exceptional for german people (are those diaeresis used somewhere else in the world?), this should be a useful fix.
