### PR TITLE
Fatal error, call to undefined function getObject() in TranslatableListener

### DIFF
--- a/lib/Gedmo/Translatable/TranslatableListener.php
+++ b/lib/Gedmo/Translatable/TranslatableListener.php
@@ -541,7 +541,7 @@ class TranslatableListener extends MappedEventSubscriber
                     && get_class($trans) === $translationClass
                     && $trans->getLocale() === $this->defaultLocale
                     && $trans->getField() === $field
-                    && $this->belongsToObject($trans, $object)) {
+                    && $this->belongsToObject($ea, $trans, $object)) {
                     $this->setTranslationInDefaultLocale($oid, $field, $trans);
                     break;
                 }
@@ -728,23 +728,19 @@ class TranslatableListener extends MappedEventSubscriber
     /**
      * Checks if the translation entity belongs to the object in question
      *
-     * @param   mixed   $trans
-     * @param   mixed   $object
+     * @param   TranslatableAdapter $ea
+     * @param   mixed               $trans
+     * @param   mixed               $object
      * @return  boolean
-     * @throws  \Gedmo\Exception\InvalidArgumentException
      */
-    private function belongsToObject($trans, $object)
+    private function belongsToObject(TranslatableAdapter $ea, $trans, $object)
     {
-        if ($trans instanceof AbstractPersonalTranslation) {
+        if ($ea->usesPersonalTranslation(get_class($trans))) {
             return $trans->getObject() === $object;
-        } elseif ($trans instanceof AbstractTranslation) {
-            return ($trans->getForeignKey() === $object->getId()
-                && ($trans->getObjectClass() === get_class($object)));
-        } else {
-            throw new \Gedmo\Exception\InvalidArgumentException(
-                'Translation class must be instance of AbstractPersonalTranslation or AbstractTranslation'
-            );
         }
+
+        return ($trans->getForeignKey() === $object->getId()
+            && ($trans->getObjectClass() === get_class($object)));
     }
 }
 


### PR DESCRIPTION
The situation is a follows:
- I use the translatableListener, with setPersistDefaultLocaleTranslation=true
- I have an entity which uses a non-personalised translation entity
- I have existing data in this entity, and the translation table is filled
- | add a new translated property to the existing entity
- I try to add translations for this new property to existing row, by using the standard translate() function

I now get a fatal error when trying to add the translation for the new property in the default language: 

This is caused by the following if statement in the translation listener (around line 503)

``` php
if ($locale !== $this->defaultLocale
    && get_class($trans) === $translationClass
    && $trans->getLocale() === $this->defaultLocale
    && $trans->getField() === $field
    && $trans->getObject() === $object) {
```

The thing is that the $trans object does not necessarily has a getObject function, since it does not have to be a personalized translation. It does not crash for the other translations, because they never arrive that deep in the if statement to make the call to getObject.

I fixed it by replacing the final clause of the AND statement by a call to a new function objectBelongsTo(), that does the same check, but keeps in mind that we are dealing with either an instance of AbstractTranslation, or an instance of AbstractPersonalTranslation. Otherwise, it throws an exception.
