### PR TITLE
if PersistDefaultLocaleTranslation is set, always join translation table

### DIFF
--- a/lib/Gedmo/Translatable/Query/TreeWalker/TranslationWalker.php
+++ b/lib/Gedmo/Translatable/Query/TreeWalker/TranslationWalker.php
@@ -269,7 +269,7 @@ class TranslationWalker extends SqlWalker
             $locale = $this->listener->getListenerLocale();
         }
         $defaultLocale = $this->listener->getDefaultLocale();
-        if ($locale === $defaultLocale) {
+        if ($locale === $defaultLocale  && !$this->listener->getPersistDefaultLocaleTranslation()) {
             // Skip preparation as there's no need to translate anything
             return;
         }


### PR DESCRIPTION
if PersistDefaultLocaleTranslation is set to true, translations in the default locale should also be fetched from the translation table, aka the translation table should always be joined in the query, instead of skipping that step when we are in the default locale
