### PR TITLE
Fixed case sensitive typo in docs

### DIFF
--- a/doc/translatable.md
+++ b/doc/translatable.md
@@ -632,7 +632,7 @@ use Gedmo\Translatable\Entity\MappedSuperclass\AbstractTranslation;
 
 /**
  * @ORM\Table(name="article_translations", indexes={
- *      @ORM\index(name="article_translation_idx", columns={"locale", "object_class", "field", "foreign_key"})
+ *      @ORM\Index(name="article_translation_idx", columns={"locale", "object_class", "field", "foreign_key"})
  * })
  * @ORM\Entity(repositoryClass="Gedmo\Translatable\Entity\Repository\TranslationRepository")
  */


### PR DESCRIPTION
Changed @ORM\index to @ORM\Index. The first will throw an error on a case sensitive OS.
