### PR TITLE
TimestampableTrait: conflicting visibility

### DIFF
--- a/lib/Gedmo/Timestampable/Traits/TimestampableEntity.php
+++ b/lib/Gedmo/Timestampable/Traits/TimestampableEntity.php
@@ -17,13 +17,13 @@ trait TimestampableEntity
      * @Gedmo\Timestampable(on="create")
      * @ORM\Column(type="datetime")
      */
-    private $createdAt;
+    protected $createdAt;
 
     /**
      * @Gedmo\Timestampable(on="update")
      * @ORM\Column(type="datetime")
      */
-    private $updatedAt;
+    protected $updatedAt;
 
     /**
      * Sets createdAt.


### PR DESCRIPTION
Private visibility of createdAt/ updatedAt properties will hide them from any class that does inherit the trait.

``` php
class Base { use TimestampableTrait; } // is fine
class ComplexEntity extends Base {} // is not timestampable
```

The problem was hard to track for a project that required a magnitude of tables to share a small set of columns from traits and thus using a BaseEntity to set those up.

Might likely effect other traits/ super classes and ODM as well.
