### PR TITLE
Additional Blameable Entity example: association

### DIFF
--- a/doc/blameable.md
+++ b/doc/blameable.md
@@ -163,7 +163,7 @@ class Article
      *
      * @Gedmo\Blameable(on="create")
      * @ORM\ManyToOne(targetEntity="Path\To\Entity\User")
-     * @ORM\JoinColumn(name="created_by", referencedColumnName="id", nullable=true, onDelete="SET NULL")
+     * @ORM\JoinColumn(name="created_by", referencedColumnName="id")
      */
     private $createdBy;
 
@@ -172,7 +172,7 @@ class Article
      *
      * @Gedmo\Blameable(on="update")
      * @ORM\ManyToOne(targetEntity="Path\To\Entity\User")
-     * @ORM\JoinColumn(name="updated_by", referencedColumnName="id", nullable=true, onDelete="SET NULL")
+     * @ORM\JoinColumn(name="updated_by", referencedColumnName="id")
      */
     private $updatedBy;
 


### PR DESCRIPTION
Hi,

there was no information in the documentation on how to set up a blameable column that is not a string field, but an association. I've added a simple example in the blameable entity part of the blameable annotation-section...

Thanks in advance for merging the PR!

Kind regards,
David
