### PR TITLE
Fix sortable behaviour not saving a given rank on an object

### DIFF
--- a/lib/Gedmo/Sortable/SortableListener.php
+++ b/lib/Gedmo/Sortable/SortableListener.php
@@ -123,8 +123,10 @@ class SortableListener extends MappedEventSubscriber
     private function processInsert($em, $config, $meta, $object)
     {
         $uow = $em->getUnitOfWork();
-
+        
+        $old = $meta->getReflectionProperty($config['position'])->getValue($object);
         $newPosition = $meta->getReflectionProperty($config['position'])->getValue($object);
+        
         if (is_null($newPosition)) {
             $newPosition = -1;
         }
@@ -168,8 +170,10 @@ class SortableListener extends MappedEventSubscriber
         call_user_func_array(array($this, 'addRelocation'), $relocation);
 
         // Set new position
-        $meta->getReflectionProperty($config['position'])->setValue($object, $newPosition);
-        $uow->recomputeSingleEntityChangeSet($meta, $object);
+        if ($old < 0 || is_null($old)) {
+            $meta->getReflectionProperty($config['position'])->setValue($object, $newPosition);
+            $uow->recomputeSingleEntityChangeSet($meta, $object);
+        }
     }
 
     /**


### PR DESCRIPTION
Might be related to #443
Personally this is happening to me on a sortable N-N table with extra attributes.

Each time the main object is update, the ArrayCollection is cleared, 
and all N-N rows are inserted by hand with saved values (before clearing the collection)

It ends up having the behaviour ignoring the rank I give to the object.
