### PR TITLE
object_id length (varchar 32 chars) is sometimes not big enough

### DIFF
--- a/lib/Gedmo/Loggable/Entity/MappedSuperclass/AbstractLogEntry.php
+++ b/lib/Gedmo/Loggable/Entity/MappedSuperclass/AbstractLogEntry.php
@@ -37,7 +37,7 @@ abstract class AbstractLogEntry
     /**
      * @var string $objectId
      *
-     * @ORM\Column(name="object_id", length=32, nullable=true)
+     * @ORM\Column(name="object_id", length=64, nullable=true)
      */
     protected $objectId;
 


### PR DESCRIPTION
The 32 characters define a very hard limit that can easily be reached if someone uses name tables in his projects (tables with varchars as primary keys). An extension to 64 chars or so would be better.
