### PR TITLE
Allowing NULL values for Personal Translation, PR for #645

### DIFF
--- a/lib/Gedmo/Translatable/TranslatableListener.php
+++ b/lib/Gedmo/Translatable/TranslatableListener.php
@@ -593,7 +593,7 @@ class TranslatableListener extends MappedEventSubscriber
                 $translation->setContent($content);
                 // check if need to update in database
                 $transWrapper = AbstractWrapper::wrap($translation, $om);
-                if ((is_null($content) || is_bool($content) || is_int($content) || (is_string($content) && strlen($content) > 0) || !empty($content)) && ($isInsert || !$transWrapper->getIdentifier() || isset($changeSet[$field]))) {
+                if (((is_null($content) && !$isInsert) || is_bool($content) || is_int($content) || (is_string($content) && strlen($content) > 0) || !empty($content)) && ($isInsert || !$transWrapper->getIdentifier() || isset($changeSet[$field]))) {
                     if ($isInsert && !$objectId && !$ea->usesPersonalTranslation($translationClass)) {
                         // if we do not have the primary key yet available
                         // keep this translation in memory to insert it later with foreign key

--- a/tests/Gedmo/Translatable/TranslatableEntityDefaultTranslationTest.php
+++ b/tests/Gedmo/Translatable/TranslatableEntityDefaultTranslationTest.php
@@ -118,7 +118,7 @@ class TranslatableEntityDefaultTranslationTest extends BaseTestCaseORM
         $this->em->clear();
 
         $trans = $this->repo->findTranslations($this->em->find(self::ARTICLE, $entity->getId()));
-        $this->assertCount(1, $trans);
+        $this->assertCount(0, $trans);
 
         $articles = $this->em->createQuery('SELECT a FROM ' . self::ARTICLE . ' a')->getArrayResult();
         $this->assertCount(1, $articles);
@@ -138,7 +138,7 @@ class TranslatableEntityDefaultTranslationTest extends BaseTestCaseORM
         $this->em->clear();
 
         $trans = $this->repo->findTranslations($this->em->find(self::ARTICLE, $entity->getId()));
-        $this->assertCount(2, $trans);
+        $this->assertCount(1, $trans);
         $this->assertSame('title defaultLocale', $trans['defaultLocale']['title']);
 
         $articles = $this->em->createQuery('SELECT a FROM ' . self::ARTICLE . ' a')->getArrayResult();


### PR DESCRIPTION
This PR allows null values to be saved into personal translation when null value is set for main entity.
It is useful for setPersistDefaultLocaleTranslation set to true when default locale is also stored in translation table.
