### PR TITLE
Added ignored test when MongoDB extension is not installed

### DIFF
--- a/tests/Gedmo/References/ReferencesListenerTest.php
+++ b/tests/Gedmo/References/ReferencesListenerTest.php
@@ -19,6 +19,10 @@ class ReferencesListenerTest extends BaseTestCaseOM
     {
         parent::setUp();
 
+        if (!class_exists('Mongo')) {
+            $this->markTestSkipped('Missing Mongo extension.');
+        }
+
         $reader = new AnnotationReader();
 
         $this->dm = $this->getMockDocumentManager('test', new MongoDBAnnotationDriver($reader, __DIR__ . '/Fixture/ODM/MongoDB'));


### PR DESCRIPTION
Added ignored test when MongoDB extension is not installed (else tests fail)

All other MongoDB tests were already ignored
