### PR TITLE
Fix DriverChain with DefaultDriver

### DIFF
--- a/lib/Gedmo/Mapping/Driver/Chain.php
+++ b/lib/Gedmo/Mapping/Driver/Chain.php
@@ -15,6 +15,13 @@ use Gedmo\Mapping\Driver;
 class Chain implements Driver
 {
     /**
+     * The default driver
+     *
+     * @var Driver|null
+     */
+    private $defaultDriver;
+
+    /**
      * List of drivers nested
      * @var array
      */
@@ -42,6 +49,26 @@ class Chain implements Driver
     }
 
     /**
+     * Get the default driver.
+     *
+     * @return Driver|null
+     */
+    public function getDefaultDriver()
+    {
+        return $this->defaultDriver;
+    }
+
+    /**
+     * Set the default driver.
+     *
+     * @param Driver $driver
+     */
+    public function setDefaultDriver(Driver $driver)
+    {
+        $this->defaultDriver = $driver;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function readExtendedMetadata($meta, array &$config)
@@ -52,6 +79,12 @@ class Chain implements Driver
                 return;
             }
         }
+
+        if (null !== $this->defaultDriver) {
+            $this->defaultDriver->readExtendedMetadata($meta, $config);
+            return;
+        }
+
         // commenting it for customized mapping support, debugging of such cases might get harder
         //throw new \Gedmo\Exception\UnexpectedValueException('Class ' . $meta->name . ' is not a valid entity or mapped super class.');
     }

--- a/lib/Gedmo/Mapping/ExtensionMetadataFactory.php
+++ b/lib/Gedmo/Mapping/ExtensionMetadataFactory.php
@@ -139,6 +139,9 @@ final class ExtensionMetadataFactory
             foreach ($omDriver->getDrivers() as $namespace => $nestedOmDriver) {
                 $driver->addDriver($this->getDriver($nestedOmDriver), $namespace);
             }
+            if ($omDriver->getDefaultDriver() !== null) {
+                $driver->setDefaultDriver($this->getDriver($omDriver->getDefaultDriver()));
+            }
         } else {
             $driverName = substr($driverName, 0, strpos($driverName, 'Driver'));
             $isSimplified = false;


### PR DESCRIPTION
The Doctrine DriverChain has the concept of a "default" fallback driver (not tied to a namespace).

This default driver was ignored by Doctrine Extensions, see #671
