### PR TITLE
Correction to $oldSlug for preUpdate event arguments.

### DIFF
--- a/lib/Gedmo/Sluggable/SluggableListener.php
+++ b/lib/Gedmo/Sluggable/SluggableListener.php
@@ -279,7 +279,8 @@ class SluggableListener extends MappedEventSubscriber
             if (!$options['updatable'] && !$isInsert && (!isset($changeSet[$slugField]) || $slug === '__id__')) {
                 continue;
             }
-            $oldSlug = $slug;
+            // must fetch the old slug from changeset, since $object holds the new version
+            $oldSlug = $changeSet[$slugField][0];
             $needToChangeSlug = false;
             // if slug is null or set to empty, regenerate it, or needs an update
             if (empty($slug) || $slug === '__id__' || !isset($changeSet[$slugField])) {


### PR DESCRIPTION
Populating $oldSlug from $changeSet original value rather than from
$object. $object holds the new value at this stage. This meant that
other preUpdate event handlers could not see the original value.
