### PR TITLE
Uploadable YAML Driver problem when using both Uploadable and Timestampable behaviors on an Entity

### DIFF
--- a/lib/Gedmo/Uploadable/Mapping/Driver/Yaml.php
+++ b/lib/Gedmo/Uploadable/Mapping/Driver/Yaml.php
@@ -64,7 +64,7 @@ class Yaml extends File implements Driver
 
                 if (isset($mapping['fields'])) {
                     foreach ($mapping['fields'] as $field => $info) {
-                        if (isset($info['gedmo'])) {
+                        if (isset($info['gedmo']) && array_key_exists(0, $info['gedmo'])) {
                             if ($info['gedmo'][0] === 'uploadableFileMimeType') {
                                 $config['fileMimeTypeField'] = $field;
                             } else if ($info['gedmo'][0] === 'uploadableFileSize') {


### PR DESCRIPTION
When using both Uploadable and Timestampable behaviors on an Entity, the Yaml Driver throws an error when trying to access :

```
  [ErrorException]                                                                                                                             
  Notice: Undefined offset: 0 in /path-to-project/vendor/gedmo/doctrine-extensions/lib/Gedmo/Uploadable/Mapping/Driver/Yaml.php line 68
```

The "0" index of this array exists in Uploadable config but not in Timestampable config. That's where it breaks.

My YAML config :

``` yml
Acme\FileBundle\Entity\File:
  type: entity
  table: null
  repositoryClass: Acme\FileBundle\Entity\FileRepository
  id:
    id:
      type: integer
      id: true
      generator:
        strategy: AUTO
  gedmo:
    uploadable:
      allowOverwrite: false
      appendNumber: true
      filenameGenerator: ALPHANUMERIC
  fields:
    name:
      type: string
      length: 255
      nullable: true
    path:
      type: string
      gedmo:
        - uploadableFilePath
    mimeType:
      type: string
      gedmo:
        - uploadableFileMimeType
      nullable: true
    size:
      type: decimal
      gedmo:
        - uploadableFileSize
      nullable: true
    clientFirstName:
      type: string
      length: 100
      nullable: true
    clientLastName:
      type: string
      length: 100
      nullable: true
    clientEmail:
      type: string
      length: 100
      nullable: true
    clientCompany:
      type: string
      length: 255
      nullable: true
    username:
      type: string
      length: 100
    userFirstName:
      type: string
      length: 100
      nullable: true
    userLastName:
      type: string
      length: 100
      nullable: true
    userEmail:
      type: string
      length: 255
      nullable: true
    code:
      type: string
      length: 20
    lifetime:
      type: integer
      length: 4
    lifetimeType:
      type: integer
      length: 4
    ipAddress:
      type: string
      length: 15
      nullable: true
    nbDownloads:
      type: integer
      length: 4
      default: 0
    active:
      type: boolean
      default: true
    createdAt:
      type: date
      gedmo:
        timestampable:
          on: create
    updatedAt:
      type: datetime
      gedmo:
        timestampable:
          on: update
```
