### PR TITLE
Tree\AbstractClosure: enable attribute override

### DIFF
--- a/lib/Gedmo/Tree/Entity/MappedSuperclass/AbstractClosure.php
+++ b/lib/Gedmo/Tree/Entity/MappedSuperclass/AbstractClosure.php
@@ -14,7 +14,7 @@ abstract class AbstractClosure
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
      */
-    private $id;
+    protected $id;
 
     /**
      * Mapped by listener
@@ -31,7 +31,7 @@ abstract class AbstractClosure
     /**
      * @ORM\Column(type="integer")
      */
-    private $depth;
+    protected $depth;
 
     /**
      * Get id


### PR DESCRIPTION
`private` attributes are very restrictive.
Though making them `protected` is not mandatory, it's better to enable users to customize them.

For example, in our business we gain ~5% performance changing `$depth` to a smallint unsigned.
