### PR TITLE
[SoftDelete] Deleted Association proxy bug

### DIFF
--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/One.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/One.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace SoftDeleteable\Fixture\Entity;
+
+use Gedmo\Mapping\Annotation as Gedmo;
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * @ORM\Entity
+ * @Gedmo\SoftDeleteable(fieldName="deletedAt")
+ */
+class One
+{
+    /**
+     * @ORM\Column(name="id", type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="IDENTITY")
+     */
+    private $id;
+
+
+    /**
+     * @ORM\Column(name="deletedAt", type="datetime", nullable=true)
+     */
+    private $deletedAt;
+
+    /**
+     * @ORM\OneToOne(targetEntity="Two", cascade={"persist"})
+     */
+    private $two;
+
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+
+    public function setDeletedAt($deletedAt)
+    {
+        $this->deletedAt = $deletedAt;
+    }
+
+    public function getDeletedAt()
+    {
+        return $this->deletedAt;
+    }
+
+    public function setTwo(Two $two)
+    {
+        $this->two = $two;
+    }
+
+    public function getTwo()
+    {
+        return $this->two;
+    }
+}

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/Two.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/Two.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace SoftDeleteable\Fixture\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * @ORM\Entity
+ * @Gedmo\SoftDeleteable(fieldName="deletedAt")
+ */
+class Two
+{
+    /**
+     * @ORM\Column(name="id", type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="IDENTITY")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(name="deletedAt", type="datetime", nullable=true)
+     */
+    private $deletedAt;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setDeletedAt($deletedAt)
+    {
+        $this->deletedAt = $deletedAt;
+    }
+
+    public function getDeletedAt()
+    {
+        return $this->deletedAt;
+    }
+
+}

--- a/tests/Gedmo/SoftDeleteable/SoftDeleteableEntityTest.php
+++ b/tests/Gedmo/SoftDeleteable/SoftDeleteableEntityTest.php
@@ -2,6 +2,8 @@
 
 namespace Gedmo\SoftDeleteable;
 
+use SoftDeleteable\Fixture\Entity\One;
+use SoftDeleteable\Fixture\Entity\Two;
 use Tool\BaseTestCaseORM;
 use Doctrine\Common\EventManager;
 use Doctrine\Common\Util\Debug,
@@ -36,6 +38,8 @@ class SoftDeleteableEntityTest extends BaseTestCaseORM
     const OTHER_COMMENT_CLASS = 'SoftDeleteable\Fixture\Entity\OtherComment';
     const USER_CLASS = 'SoftDeleteable\Fixture\Entity\User';
     const MAPPED_SUPERCLASS_CHILD_CLASS = 'SoftDeleteable\Fixture\Entity\Child';
+    const ONE_CLASS = 'SoftDeleteable\Fixture\Entity\One';
+    const TWO_CLASS = 'SoftDeleteable\Fixture\Entity\Two';
     const SOFT_DELETEABLE_FILTER_NAME = 'soft-deleteable';
 
     private $softDeleteableListener;
@@ -51,6 +55,36 @@ class SoftDeleteableEntityTest extends BaseTestCaseORM
         $config->addFilter(self::SOFT_DELETEABLE_FILTER_NAME, 'Gedmo\SoftDeleteable\Filter\SoftDeleteableFilter');
         $this->em = $this->getMockSqliteEntityManager($evm, $config);
         $this->em->getFilters()->enable(self::SOFT_DELETEABLE_FILTER_NAME);
+    }
+
+    public function testDeleteAssociation()
+    {
+        $oneRepo = $this->em->getRepository(self::ONE_CLASS);
+
+        $one = new One();
+        $one->setTwo($two = new Two());
+
+        $this->em->persist($one);
+        $this->em->persist($two);
+        $this->em->flush();
+        $this->em->clear();
+
+        /** @var One $one */
+        $one = $oneRepo->find(1);
+        $this->assertNotNull($one);
+        $this->assertNotNull($one->getTwo()->getId());
+        $this->assertNull($one->getTwo()->getDeletedAt());
+
+        $this->em->remove($one->getTwo());
+        $this->em->flush();
+        $this->em->clear();
+
+        /** @var One $one */
+        $one = $oneRepo->find(1);
+        $this->assertNotNull($one);
+
+        $one->getTwo()->getDeletedAt(); //will throw exception
+        $this->assertNull($one->getTwo()); //should fail too
     }
 
     /**
@@ -384,6 +418,8 @@ class SoftDeleteableEntityTest extends BaseTestCaseORM
             self::OTHER_ARTICLE_CLASS,
             self::OTHER_COMMENT_CLASS,
             self::MAPPED_SUPERCLASS_CHILD_CLASS,
+            self::ONE_CLASS,
+            self::TWO_CLASS
         );
     }
 }


### PR DESCRIPTION
There is a problem where a softdeleted entity will throw a EntityNotFoundException when loaded via a proxy (by foreign key)

This of course would be a valid error if not using softdelete as the foreign key would be invalid. we would normally deal with this with an `onDelete="SET NULL"`, but that is obviously not an option with softdelete.

I've added a test to demonstrate the error, but i'm not sure how to fix it.
