### PR TITLE
phpdoc Fixes

### DIFF
--- a/lib/Gedmo/Mapping/Driver/AbstractAnnotationDriver.php
+++ b/lib/Gedmo/Mapping/Driver/AbstractAnnotationDriver.php
@@ -54,7 +54,7 @@ abstract class AbstractAnnotationDriver implements AnnotationDriverInterface
     /**
      * @param object $meta
      *
-     * @return array
+     * @return \ReflectionClass
      */
     public function getMetaReflectionClass($meta)
     {
@@ -85,7 +85,7 @@ abstract class AbstractAnnotationDriver implements AnnotationDriverInterface
     }
 
     /**
-     * @param Doctrine\Common\Persistence\Mapping\ClassMetaData $meta
+     * @param \Doctrine\Common\Persistence\Mapping\ClassMetaData $meta
      * @param array         $config
      */
     public function validateFullMetadata(ClassMetadata $meta, array $config)

--- a/lib/Gedmo/Translatable/Document/MappedSuperclass/AbstractPersonalTranslation.php
+++ b/lib/Gedmo/Translatable/Document/MappedSuperclass/AbstractPersonalTranslation.php
@@ -39,7 +39,7 @@ abstract class AbstractPersonalTranslation
     protected $field;
 
     /**
-     * @var text $content
+     * @var string $content
      *
      * @MongoODM\String
      */

--- a/lib/Gedmo/Translatable/Document/MappedSuperclass/AbstractTranslation.php
+++ b/lib/Gedmo/Translatable/Document/MappedSuperclass/AbstractTranslation.php
@@ -47,7 +47,7 @@ abstract class AbstractTranslation
     protected $foreignKey;
 
     /**
-     * @var text $content
+     * @var string $content
      *
      * @MongoODM\String
      */
@@ -154,7 +154,7 @@ abstract class AbstractTranslation
     /**
      * Set content
      *
-     * @param text $content
+     * @param string $content
      * @return AbstractTranslation
      */
     public function setContent($content)
@@ -166,7 +166,7 @@ abstract class AbstractTranslation
     /**
      * Get content
      *
-     * @return text $content
+     * @return string $content
      */
     public function getContent()
     {

--- a/lib/Gedmo/Translatable/Entity/MappedSuperclass/AbstractTranslation.php
+++ b/lib/Gedmo/Translatable/Entity/MappedSuperclass/AbstractTranslation.php
@@ -156,7 +156,7 @@ abstract class AbstractTranslation
     /**
      * Set content
      *
-     * @param text $content
+     * @param string $content
      * @return AbstractTranslation
      */
     public function setContent($content)
@@ -168,7 +168,7 @@ abstract class AbstractTranslation
     /**
      * Get content
      *
-     * @return text $content
+     * @return string $content
      */
     public function getContent()
     {

--- a/lib/Gedmo/Translatable/Mapping/Event/TranslatableAdapter.php
+++ b/lib/Gedmo/Translatable/Mapping/Event/TranslatableAdapter.php
@@ -44,7 +44,7 @@ interface TranslatableAdapter extends AdapterInterface
     /**
      * Search for existing translation record
      *
-     * AbstractWrapper $wrapped
+     * @param AbstractWrapper $wrapped
      * @param string $locale
      * @param string $field
      * @param string $translationClass
@@ -56,7 +56,7 @@ interface TranslatableAdapter extends AdapterInterface
     /**
      * Removes all associated translations for given object
      *
-     * AbstractWrapper $wrapped
+     * @param AbstractWrapper $wrapped
      * @param string $transClass
      * @param string $objectClass
      * @return void

--- a/lib/Gedmo/Translatable/Query/TreeWalker/TranslationWalker.php
+++ b/lib/Gedmo/Translatable/Query/TreeWalker/TranslationWalker.php
@@ -58,14 +58,14 @@ class TranslationWalker extends SqlWalker
     /**
      * DBAL database platform
      *
-     * @var Doctrine\DBAL\Platforms\AbstractPlatform
+     * @var \Doctrine\DBAL\Platforms\AbstractPlatform
      */
     private $platform;
 
     /**
      * DBAL database connection
      *
-     * @var Doctrine\DBAL\Connection
+     * @var \Doctrine\DBAL\Connection
      */
     private $conn;
 
@@ -225,7 +225,7 @@ class TranslationWalker extends SqlWalker
      * Walks from clause, and creates translation joins
      * for the translated components
      *
-     * @param Doctrine\ORM\Query\AST\FromClause $from
+     * @param \Doctrine\ORM\Query\AST\FromClause $from
      * @return string
      */
     private function joinTranslations($from)

--- a/lib/Gedmo/Translatable/TranslatableListener.php
+++ b/lib/Gedmo/Translatable/TranslatableListener.php
@@ -291,6 +291,7 @@ class TranslatableListener extends MappedEventSubscriber
     {
         $locale = $this->locale;
         if (isset(self::$configurations[$this->name][$meta->name]['locale'])) {
+            /** @var \ReflectionClass $class */
             $class = $meta->getReflectionClass();
             $reflectionProperty = $class->getProperty(self::$configurations[$this->name][$meta->name]['locale']);
             if (!$reflectionProperty) {
@@ -507,7 +508,7 @@ class TranslatableListener extends MappedEventSubscriber
      * @param TranslatableAdapter $ea
      * @param object $object
      * @param boolean $isInsert
-     * @throws UnexpectedValueException - if locale is not valid, or
+     * @throws \UnexpectedValueException - if locale is not valid, or
      *      primary key is composite, missing or invalid
      * @return void
      */


### PR DESCRIPTION
A bunch of phpdoc fixes, I needed to do it before plunging more into the code ;)

Some of them may seem useless but all of them actually fixed warnings in PhpStorm (e.g. adding the `\` for absolute namespaces in phpdoc)
