### PR TITLE
[WIP] [Uploadable] Allow build path relative to default using "pathMethod" property

### DIFF
--- a/doc/uploadable.md
+++ b/doc/uploadable.md
@@ -50,7 +50,8 @@ on how to setup and use the extensions in most optimized way.
     * **pathMethod** - Similar to option "path", but this time it represents the name of a method on the entity that
     will return the path to which the files represented by this entity will be moved. This is useful in several cases.
     For example, you can set specific paths for specific entities, or you can get the path from other sources (like a
-    framework configuration) instead of hardcoding it in the entity. Default: ""
+    framework configuration) instead of hardcoding it in the entity. Default: "". As first argument this method takes
+    default path, so you can return path relative to default.
     * **callback** - This option allows you to set a method name. If this option is set, the method will be called after
     the file is moved. Default value: "". As first argument, this method can receive an array with information about the uploaded file, which
     includes the following keys:

--- a/lib/Gedmo/Uploadable/Mapping/Validator.php
+++ b/lib/Gedmo/Uploadable/Mapping/Validator.php
@@ -16,7 +16,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 
-class Validator 
+class Validator
 {
     const UPLOADABLE_FILE_MIME_TYPE = 'UploadableFileMimeType';
     const UPLOADABLE_FILE_PATH = 'UploadableFilePath';
@@ -86,11 +86,10 @@ class Validator
 
     public static function validateField($meta, $field, $uploadableField, $validFieldTypes)
     {
-        
         if ($meta->isMappedSuperclass) {
             return;
         }
-        
+
         $fieldMapping = $meta->getFieldMapping($field);
 
         if (!in_array($fieldMapping['type'], $validFieldTypes)) {
@@ -110,8 +109,18 @@ class Validator
             throw new UploadableInvalidPathException('Path must be a string containing the path to a valid directory.');
         }
 
-        if (self::$validateWritableDirectory && (!is_dir($path) || !is_writable($path))) {
-            throw new UploadableCantWriteException(sprintf('Directory "%s" does not exist or is not writable',
+        if (!self::$validateWritableDirectory) {
+            return;
+        }
+
+        if (!is_dir($path) && !@mkdir($path, 0777, true)) {
+            throw new UploadableInvalidPathException(sprintf('Unable to create "%s" directory.',
+                $path
+            ));
+        }
+
+        if (!is_writable($path)) {
+            throw new UploadableCantWriteException(sprintf('Directory "%s" does is not writable.',
                 $path
             ));
         }

--- a/lib/Gedmo/Uploadable/UploadableListener.php
+++ b/lib/Gedmo/Uploadable/UploadableListener.php
@@ -169,7 +169,7 @@ class UploadableListener extends MappedEventSubscriber
         // Do we need to remove any files?
         foreach ($ea->getScheduledObjectDeletions($uow) as $object) {
             $meta = $om->getClassMetadata(get_class($object));
-            
+
             if ($config = $this->getConfiguration($om, $meta->name)) {
                 if (isset($config['uploadable']) && $config['uploadable']) {
                     $this->pendingFileRemovals[] = $this->getFilePath($meta, $config, $object);
@@ -281,12 +281,13 @@ class UploadableListener extends MappedEventSubscriber
         $path = $config['path'];
 
         if ($path === '') {
+            $defaultPath = $this->getDefaultPath();
             if ($config['pathMethod'] !== '') {
                 $pathMethod = $refl->getMethod($config['pathMethod']);
                 $pathMethod->setAccessible(true);
-                $path = $pathMethod->invoke($object);
-            } else if ($this->getDefaultPath() !== null) {
-                $path = $this->getDefaultPath();
+                $path = $pathMethod->invokeArgs($object, array($defaultPath));
+            } else if ($defaultPath !== null) {
+                $path = $defaultPath;
             } else {
                 $msg = 'You have to define the path to save files either in the listener, or in the class "%s"';
 
@@ -297,7 +298,6 @@ class UploadableListener extends MappedEventSubscriber
         }
 
         Validator::validatePath($path);
-
         $path = rtrim($path, '\/');
 
         if ($config['fileMimeTypeField']) {

--- a/tests/Gedmo/Uploadable/Fixture/Entity/Image.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/Image.php
@@ -4,7 +4,6 @@ namespace Uploadable\Fixture\Entity;
 
 use Gedmo\Mapping\Annotation as Gedmo;
 use Doctrine\ORM\Mapping as ORM;
-use Doctrine\Common\Collections\ArrayCollection;
 
 /**
  * @ORM\Entity
@@ -42,6 +41,8 @@ class Image
      */
     private $mime;
 
+    private $useBasePath = false;
+
     public function getId()
     {
         return $this->id;
@@ -67,8 +68,12 @@ class Image
         return $this->filePath;
     }
 
-    public function getPath()
+    public function getPath($basePath = null)
     {
+        if ($this->useBasePath) {
+            return $basePath.'/abc/def';
+        }
+
         return __DIR__.'/../../../../temp/uploadable';
     }
 
@@ -90,5 +95,10 @@ class Image
     public function getSize()
     {
         return $this->size;
+    }
+
+    public function setUseBasePath($useBasePath)
+    {
+        $this->useBasePath = $useBasePath;
     }
 }

--- a/tests/Gedmo/Uploadable/Mapping/ValidatorTest.php
+++ b/tests/Gedmo/Uploadable/Mapping/ValidatorTest.php
@@ -24,6 +24,11 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         Validator::$enableMimeTypesConfigException = false;
     }
 
+    public function tearDown()
+    {
+        Validator::$enableMimeTypesConfigException = true;
+    }
+
     /**
      * @expectedException Gedmo\Exception\InvalidMappingException
      */
@@ -49,18 +54,41 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         Validator::validatePath('');
     }
 
-    /**
-     * @expectedException Gedmo\Exception\UploadableCantWriteException
-     */
     public function test_validatePath_ifPassedDirIsNotAValidDirectoryOrIsNotWriteableThrowException()
     {
-        Validator::validatePath('/invalid/directory/12312432423');
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            $this->markTestSkipped('Not possible to test on Windows');
+        }
+
+        $dir = sys_get_temp_dir().'/readonly-directory-12312432423';
+        mkdir($dir, 0000, true);
+        try {
+            Validator::validatePath('/');
+        } catch (\Gedmo\Exception\UploadableCantWriteException $e) {
+            rmdir($dir);
+            return;
+        }
+
+        rmdir($dir);
+        $this->fail(
+            sprintf('An expected exception "%s" has not been raised.', 'Gedmo\Exception\UploadableCantWriteException')
+        );
+    }
+
+    public function test_validatePathCreatesNewDirectoryWhenItNotExists()
+    {
+        $dir = sys_get_temp_dir().'/new/directory-12312432423';
+        Validator::validatePath($dir);
+        $this->assertTrue(is_dir($dir));
+        rmdir($dir);
+        rmdir(dirname($dir));
     }
 
     public function test_validatePath_ifPassedDirIsNotAValidDirectoryOrIsNotWriteableDoesNotThrowExceptionIfDisabled()
     {
         Validator::$validateWritableDirectory = false;
         Validator::validatePath('/invalid/directory/12312432423');
+        Validator::$validateWritableDirectory = true;
     }
 
     /**


### PR DESCRIPTION
Quote from the documentation:

> For example, you can set specific paths for specific entities, or you can get the path from other sources (like a framework configuration) instead of hardcoding it in the entity.

But this is not possible get path from fw config yet. I've added basic support of this:

``` php

$listener->setDefaultPath('/my/path');

/**
 * @ORM\Entity
 * @Gedmo\Uploadable(pathMethod="getPath")
 */
class Photo
{
    public function getPath($defaultPath)
    {
        return $defaultPath.'/photos/'.mt_rand(10, 99).'/'.mt_rand(10, 99);
    }
}
```

**Let's discuss this before merging. How it could be better (put array with file information for adding possibility generate path depends on generated filename)?**
