### PR TITLE
Fixed RTEL support

### DIFF
--- a/lib/Gedmo/Tree/Mapping/Driver/Xml.php
+++ b/lib/Gedmo/Tree/Mapping/Driver/Xml.php
@@ -161,9 +161,11 @@ class Xml extends BaseXml
                     $manyToOneMapping = $manyToOneMapping->children(self::GEDMO_NAMESPACE_URI);;
                     if (isset($manyToOneMapping->{'tree-parent'})) {
                         $field = $this->_getAttribute($manyToOneMappingDoctrine, 'field');
-                        if ($meta->associationMappings[$field]['targetEntity'] != $meta->name) {
+                        $targetEntity = $meta->associationMappings[$field]['targetEntity'];
+                        $reflectionClass = new \ReflectionClass($targetEntity);
+                        if ($targetEntity != $meta->name && !$reflectionClass->isSubclassOf($meta->name)) {
                             throw new InvalidMappingException("Unable to find ancestor/parent child relation through ancestor field - [{$field}] in class - {$meta->name}");
-                        }
+                        }			
                         $config['parent'] = $field;
                     }
                 }


### PR DESCRIPTION
When using doctrine RTEL, we  define the target entity with an interface:

``` xml
        <many-to-one field="parent" target-entity="IR\Bundle\CategoryBundle\Model\CategoryInterface" inversed-by="children">
            <join-column name="parent_id" referenced-column-name="id" on-delete="CASCADE" />
            <gedmo:tree-parent />
            <gedmo:sortable-group />
        </many-to-one> 
```

``` yaml
# app/config/config.yml
doctrine:
    # ....
    orm:
        # ....
        resolve_target_entities:
            IR\Bundle\CategoryBundle\Model\CategoryInterface: Acme\CategoryBundle\Entity\Category
```

The condition will always fail since it checks if the following classes are equals:

`Acme\CategoryBundle\Entity\Category` and `IR\Bundle\CategoryBundle\Model\CategoryModel`
