### PR TITLE
[Sortable] Fixes issue with off by one error when incrementing sort position field

### DIFF
--- a/lib/Gedmo/Sortable/SortableListener.php
+++ b/lib/Gedmo/Sortable/SortableListener.php
@@ -223,11 +223,14 @@ class SortableListener extends MappedEventSubscriber
         // Compute position if it is negative
         if ($newPosition < 0) {
             $newPosition += $this->maxPositions[$hash] + 2; // position == -1 => append at end of list
-            if ($newPosition < 0) $newPosition = 0;
+
+            if ($newPosition < 0) {
+                $newPosition = 0;
+            }
+        } else {
+            $newPosition = min(array($this->maxPositions[$hash], $newPosition));
         }
 
-        // Set position to max position if it is too big
-        $newPosition = min(array($this->maxPositions[$hash] + 1, $newPosition));
         // Compute relocations
         /*
         CASE 1: shift backwards
@@ -265,8 +268,10 @@ class SortableListener extends MappedEventSubscriber
         }
         $newPosition += $applyDelta;
 
-        // Add relocation
-        call_user_func_array(array($this, 'addRelocation'), $relocation);
+        if ($relocation) {
+            // Add relocation
+            call_user_func_array(array($this, 'addRelocation'), $relocation);
+        }
 
         // Set new position
         $meta->getReflectionProperty($config['position'])->setValue($object, $newPosition);

--- a/tests/Gedmo/Sortable/SortableTest.php
+++ b/tests/Gedmo/Sortable/SortableTest.php
@@ -456,6 +456,65 @@ class SortableTest extends BaseTestCaseORM
         $this->assertEquals(5, $node1->getPosition());
     }
 
+    /**
+     * @test
+     */
+    function testIncrementPositionOfLastObjectByOne()
+    {
+        $node0 = $this->em->find(self::NODE, $this->nodeId);
+
+        $nodes = array($node0);
+
+        for ($i = 2; $i <= 5; $i++) {
+            $node = new Node();
+            $node->setName("Node".$i);
+            $node->setPath("/");
+            $this->em->persist($node);
+            $nodes[] = $node;
+        }
+        $this->em->flush();
+
+        $this->assertEquals(4, $nodes[4]->getPosition());
+        
+        $node4NewPosition = $nodes[4]->getPosition();
+        $node4NewPosition++;
+
+        $nodes[4]->setPosition($node4NewPosition);
+
+        $this->em->persist($nodes[4]);
+        $this->em->flush();
+
+        $this->assertEquals(4, $nodes[4]->getPosition());
+    }
+
+    /**
+     * @test
+     */
+    function testSetOutOfBoundsHighPosition()
+    {
+        $node0 = $this->em->find(self::NODE, $this->nodeId);
+
+        $nodes = array($node0);
+
+        for ($i = 2; $i <= 5; $i++) {
+            $node = new Node();
+            $node->setName("Node".$i);
+            $node->setPath("/");
+            $this->em->persist($node);
+            $nodes[] = $node;
+        }
+        $this->em->flush();
+
+        $this->assertEquals(4, $nodes[4]->getPosition());
+
+        $nodes[4]->setPosition(100);
+
+        $this->em->persist($nodes[4]);
+        $this->em->flush();
+
+        $this->assertEquals(4, $nodes[4]->getPosition());
+    }
+
     protected function getUsedEntityFixtures()
     {
         return array(


### PR DESCRIPTION
BUG: Found issue with incrementing position field with Sortable

The calculation of the max sort position is off by one. This means when incrementing the last object's sort position or setting an out of bounds sort position on any of the other objects it is possible to get a non-sequential sort number.

E.g.

list[0]
list[1]
list[2]
list[3] <- incrementing the sort position of this will result in [0,1,2,4]
