### PR TITLE
Update doctrine-extensions-mapping-2-1.xsd

### DIFF
--- a/schemas/orm/doctrine-extensions-mapping-2-1.xsd
+++ b/schemas/orm/doctrine-extensions-mapping-2-1.xsd
@@ -144,6 +144,7 @@ people to push their own additional attributes/elements into the same field elem
     <xs:restriction base="xs:token">
       <xs:enumeration value="default"/>
       <xs:enumeration value="camel"/>
+      <xs:enumeration value="upper"/>
     </xs:restriction>
   </xs:simpleType>
 


### PR DESCRIPTION
Fix bad schema for XML using style upper.

Currently the schemas in XML mapping are

default
camel
