### PR TITLE
[Tree] Fix getting root nodes for materialized path

### DIFF
--- a/lib/Gedmo/Tree/Entity/Repository/MaterializedPathRepository.php
+++ b/lib/Gedmo/Tree/Entity/Repository/MaterializedPathRepository.php
@@ -110,7 +110,13 @@ class MaterializedPathRepository extends AbstractTreeRepository
             }
         } else if ($direct) {
             $expr = $qb->expr()->not(
-                $qb->expr()->like($alias.'.'.$path, $qb->expr()->literal('%'.$separator.'%'.$separator.'%'))
+                $qb->expr()->like($alias.'.'.$path,
+                    $qb->expr()->literal(
+                        ($config['path_starts_with_separator'] ? $separator : '')
+                        . '%' . $separator . '%'
+                        . ($config['path_ends_with_separator'] ? $separator : '')
+                    )
+                )
             );
         }
 


### PR DESCRIPTION
If you change TreePath: path_stats_with_separator or path_ends_with_separator, getRootNodes() stop working.

This patch will fix this problem.
