### PR TITLE
Bugfix for when changeset doesnt have the usual pair of old-new values

### DIFF
--- a/lib/Gedmo/Tree/Strategy/ORM/Nested.php
+++ b/lib/Gedmo/Tree/Strategy/ORM/Nested.php
@@ -154,8 +154,16 @@ class Nested implements Strategy
             // set back all other changes
             foreach ($changeSet as $field => $set) {
                 if ($field !== $config['left']) {
-                    $uow->setOriginalEntityProperty($oid, $field, $set[0]);
-                    $wrapped->setPropertyValue($field, $set[1]);
+                    if (is_array($set) && array_key_exists(0, $set) && array_key_exists(1, $set))
+                    {
+                        $uow->setOriginalEntityProperty($oid, $field, $set[0]);
+                        $wrapped->setPropertyValue($field, $set[1]);
+                    }
+                    else
+                    {
+                        $uow->setOriginalEntityProperty($oid, $field, $set);
+                        $wrapped->setPropertyValue($field, $set);
+                    }
                 }
             }
             $uow->recomputeSingleEntityChangeSet($meta, $node);


### PR DESCRIPTION
In some cases (I honestly don't know why, I just know that it happens like this) the changeset values don't have the usual "array(0 => oldvalue, 1 => newvalue)" structure, and instead just has the "newvalue". This addresses such situations. It doesn't break BC, and tests are passing.

A more detailed explanation: I'm using this with Symfony2, SonataAdminBundle and a private bundle of my own that pretty much mimics SonataMediaBundle. For this example, lets assume I'm actually using SonataMediaBundle, and that my Gallery entity is in a Tree hierarchy. If I change the position of my Gallery instance inside the hierarchy, the above situation is triggered.

I looked around and I found out that this https://github.com/sonata-project/SonataMediaBundle/blob/master/Admin/GalleryAdmin.php#L123 causes the changeset to have the above behavior. As the contained value is an ArrayCollection instance, nothing really happens unless you flush twice. The first flush calls this code snippet, which corrupts the entity loaded in memory, and the second flush tries to persist it, trowing an Exception.

As you can see, it's kind of hard to reproduce, and I don't know enough about doctrine to provide more detail on how this happens, but if you need any more info let me know.
