### PR TITLE
[SoftDeletable] fix bug when parsing xml config for boolean values in SoftDeletable

### DIFF
--- a/lib/Gedmo/SoftDeleteable/Mapping/Driver/Xml.php
+++ b/lib/Gedmo/SoftDeleteable/Mapping/Driver/Xml.php
@@ -46,7 +46,15 @@ class Xml extends BaseXml
 
                 $config['timeAware'] = false;
                 if($this->_isAttributeSet($xml->{'soft-deleteable'}, 'time-aware')) {
-                    if (!is_bool($this->_getAttribute($xml->{'soft-deleteable'}, 'time-aware'))) {
+                    $timeAware = $this->_getAttribute($xml->{'soft-deleteable'}, 'time-aware');
+                    if (is_string($timeAware)) {
+                        if ($timeAware === 'true') {
+                            $timeAware = true;
+                        } elseif ($timeAware === 'false') {
+                            $timeAware = false;
+                        }
+                    }
+                    if (!is_bool($timeAware)) {
                         throw new InvalidMappingException("timeAware must be boolean. ".gettype($this->_getAttribute($xml->{'soft-deleteable'}, 'time-aware'))." provided.");
                     }
                     $config['timeAware'] = $this->_getAttribute($xml->{'soft-deleteable'}, 'time-aware');


### PR DESCRIPTION
When using xml config files, the following example would fail:

```
<gedmo:soft-deleteable field-name="deletedAt" time-aware="false" />
```

This would happen because the "false" would not be converted from string to boolean, failing on the validation.
