### PR TITLE
Removed outdate „implements Node” in Gedmo\Tree documentation

### DIFF
--- a/doc/tree.md
+++ b/doc/tree.md
@@ -516,7 +516,7 @@ class CategoryRepository extends NestedTreeRepository
  * @Gedmo\Tree(type="nested")
  * @Entity(repositoryClass="Entity\Repository\CategoryRepository")
  */
-class Category implements Node
+class Category
 {
     //...
 }


### PR DESCRIPTION
Removed outdate „implements Node” in Gedmo\Tree documentation
