### PR TITLE
[Tree][MaterializedPath] Fix getChildrenQueryBuilder method for node defined without end separator

### DIFF
--- a/tests/Gedmo/Tree/Fixture/MPCategoryWithTrimmedSeparator.php
+++ b/tests/Gedmo/Tree/Fixture/MPCategoryWithTrimmedSeparator.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tree\Fixture;
+
+use Gedmo\Tree\Node as NodeInterface;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity(repositoryClass="Gedmo\Tree\Entity\Repository\MaterializedPathRepository")
+ * @Gedmo\Tree(type="materializedPath")
+ */
+class MPCategoryWithTrimmedSeparator
+{
+    /**
+     * @ORM\Column(name="id", type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     */
+    private $id;
+
+    /**
+     * @Gedmo\TreePath(appendId=false, startsWithSeparator=false, endsWithSeparator=false)
+     * @ORM\Column(name="path", type="string", length=3000, nullable=true)
+     */
+    private $path;
+
+    /**
+     * @Gedmo\TreePathSource
+     * @ORM\Column(name="title", type="string", length=64)
+     */
+    private $title;
+
+    /**
+     * @Gedmo\TreeParent
+     * @ORM\ManyToOne(targetEntity="MPCategoryWithTrimmedSeparator", inversedBy="children")
+     * @ORM\JoinColumns({
+     *   @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
+     * })
+     */
+    private $parentId;
+
+    /**
+     * @Gedmo\TreeLevel
+     * @ORM\Column(name="lvl", type="integer", nullable=true)
+     */
+    private $level;
+
+    /**
+     * @ORM\OneToMany(targetEntity="MPCategoryWithTrimmedSeparator", mappedBy="parent")
+     */
+    private $children;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    public function setParent(MPCategoryWithTrimmedSeparator $parent = null)
+    {
+        $this->parentId = $parent;
+    }
+
+    public function getParent()
+    {
+        return $this->parentId;
+    }
+
+    public function setPath($path)
+    {
+        $this->path = $path;
+    }
+
+    public function getPath()
+    {
+        return $this->path;
+    }
+
+    public function getLevel()
+    {
+        return $this->level;
+    }
+}


### PR DESCRIPTION
This PR fixing getChildrenQueyrBuilder method for materialized path node without end separator.
I added getChildrenForEntityWithTrimmedSeparators test which should covers most of issues.
Basically with such options `@Gedmo\TreePath(appendId=false, startsWithSeparator=false, endsWithSeparator=false)` includeNode did not work.
