### PR TITLE
[Translatable] cast the id column to character varying in WHERE clause

### DIFF
--- a/lib/Gedmo/Translatable/Query/TreeWalker/TranslationWalker.php
+++ b/lib/Gedmo/Translatable/Query/TreeWalker/TranslationWalker.php
@@ -307,7 +307,7 @@ class TranslationWalker extends SqlWalker
                     $sql .= ' AND '.$tblAlias.'.'.$transMeta->getQuotedColumnName('objectClass', $this->platform)
                         .' = '.$this->conn->quote($meta->name);
                     $sql .= ' AND '.$tblAlias.'.'.$transMeta->getQuotedColumnName('foreignKey', $this->platform)
-                        .' = '.$compTblAlias.'.'.$idColName;
+                        .' = CAST ('.$compTblAlias.'.'.$idColName.' as character varying)';
                 }
                 isset($this->components[$dqlAlias]) ? $this->components[$dqlAlias] .= $sql : $this->components[$dqlAlias] = $sql;
 


### PR DESCRIPTION
The foreign key column appears to use the character varying type.
Comparing these types does not work with postgres. When using the translation walker, it results in an error message saying this :

> SQLSTATE[42883]: Undefined function: 7 ERROR: operator does not exist: character varying = integer
> LINE 1: ...aBundle\Entity\FilmEditorial' AND t1_.foreign_key = c0_.id L...
> ^
> HINT: No operator matches the given name and argument type(s). You might need to add explicit type casts. 

I solved this problem by casting the id column to character varying
