### PR TITLE
Makes index usable for non-varchar foreigh keys

### DIFF
--- a/lib/Gedmo/Translatable/Query/TreeWalker/TranslationWalker.php
+++ b/lib/Gedmo/Translatable/Query/TreeWalker/TranslationWalker.php
@@ -307,7 +307,7 @@ class TranslationWalker extends SqlWalker
                     $sql .= ' AND '.$tblAlias.'.'.$transMeta->getQuotedColumnName('objectClass', $this->platform)
                         .' = '.$this->conn->quote($meta->name);
                     $sql .= ' AND '.$tblAlias.'.'.$transMeta->getQuotedColumnName('foreignKey', $this->platform)
-                        .' = '.$compTblAlias.'.'.$idColName;
+                        .' = CONCAT('.$compTblAlias.'.'.$idColName','\'\')';
                 }
                 isset($this->components[$dqlAlias]) ? $this->components[$dqlAlias] .= $sql : $this->components[$dqlAlias] = $sql;
 


### PR DESCRIPTION
If field foreign_key varchar(64) references integer PK none of the indexes can be used (at least in MySQL though). Converting any foreign PK to varchar-compatible type solves the problem
