### PR TITLE
Added missing DB index

### DIFF
--- a/lib/Gedmo/Translatable/Entity/Translation.php
+++ b/lib/Gedmo/Translatable/Entity/Translation.php
@@ -12,9 +12,10 @@ use Doctrine\ORM\Mapping\Entity;
  *
  * @Table(
  *         name="ext_translations",
- *         indexes={@index(name="translations_lookup_idx", columns={
- *             "locale", "object_class", "foreign_key"
- *         })},
+ *         indexes={
+ *             @index(name="translations_lookup_idx", columns={"locale", "object_class", "foreign_key"}),
+ *             @index(name="translations_lookup_idx_2", columns={"object_class", "foreign_key"})
+ *         },
  *         uniqueConstraints={@UniqueConstraint(name="lookup_unique_idx", columns={
  *             "locale", "object_class", "field", "foreign_key"
  *         })}


### PR DESCRIPTION
I have enabled the "slow queries" log in MySQL and found these queries:

``` sql
SELECT e0_.content AS content0, e0_.field AS field1, e0_.locale AS locale2
FROM ext_translations e0_
WHERE e0_.foreign_key = 61 AND e0_.object_class = 'MyClass'
ORDER BY e0_.locale ASC;
```

The `EXPLAIN` showed me that no index was used, so I added the missing index in the mapping.
