### PR TITLE
Add support for locale object implementing __toString method

### DIFF
--- a/lib/Gedmo/Translatable/TranslatableListener.php
+++ b/lib/Gedmo/Translatable/TranslatableListener.php
@@ -300,6 +300,9 @@ class TranslatableListener extends MappedEventSubscriber
             }
             $reflectionProperty->setAccessible(true);
             $value = $reflectionProperty->getValue($object);
+            if (is_object($value) && method_exists($value, '__toString')) {
+                $value = (string)$value;
+            }
             try {
                 $this->validateLocale($value);
                 $locale = $value;


### PR DESCRIPTION
If the translatable object have an object as locale property, the listener don't use it. This patch add the support for this feature.
