### PR TITLE
remove final from ORM Adapter class declaration

### DIFF
--- a/lib/Gedmo/Sluggable/Mapping/Event/Adapter/ORM.php
+++ b/lib/Gedmo/Sluggable/Mapping/Event/Adapter/ORM.php
@@ -14,7 +14,7 @@ use Gedmo\Tool\Wrapper\AbstractWrapper;
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
-final class ORM extends BaseAdapterORM implements SluggableAdapter
+class ORM extends BaseAdapterORM implements SluggableAdapter
 {
     /**
      * {@inheritDoc}


### PR DESCRIPTION
Hi,
in my case, I need to extend the class "Gedmo \ Sluggable \ Mapping \ Event \ Adapter \ ORM" to override the getSimilarSlugs method 

with the "final" type, I must extend the class "Gedmo \ Mapping \ Event \ Adapter \ ORM" suddenly I must redeclare all methods with kind of copy paste
