### PR TITLE
Removed unused order binding

### DIFF
--- a/lib/Gedmo/Loggable/Entity/Repository/LogEntryRepository.php
+++ b/lib/Gedmo/Loggable/Entity/Repository/LogEntryRepository.php
@@ -53,7 +53,7 @@ class LogEntryRepository extends EntityRepository
 
         $objectId = $wrapped->getIdentifier();
         $q = $this->_em->createQuery($dql);
-        $q->setParameters(compact('objectId', 'objectClass', 'order'));
+        $q->setParameters(compact('objectId', 'objectClass'));
         return $q;
     }
 


### PR DESCRIPTION
`order` is hardcoded into query so this is not used as I understand.
