### PR TITLE
Adding missing use of InvalidMappingException

### DIFF
--- a/lib/Gedmo/Translatable/TranslatableListener.php
+++ b/lib/Gedmo/Translatable/TranslatableListener.php
@@ -12,6 +12,7 @@ use MongoId;
 use Gedmo\Mapping\MappedEventSubscriber;
 use Gedmo\Mapping\ObjectManagerHelper as OMH;
 use Gedmo\Translatable\TranslationInterface;
+use Gedmo\Exception\InvalidMappingException;
 
 /**
  * Translatable listener handles the generation and


### PR DESCRIPTION
Adding this use permit to correctly trow the error line ~296 in method persistNewTranslation().
