### PR TITLE
Fix bug preventing dateFormat Yaml option from setting

### DIFF
--- a/lib/Gedmo/Sluggable/Mapping/Driver/Yaml.php
+++ b/lib/Gedmo/Sluggable/Mapping/Driver/Yaml.php
@@ -82,7 +82,7 @@ class Yaml extends File implements Driver
                             (string)$slug['style'] : 'default';
 
                         $config['slugs'][$field]['dateFormat'] = isset($slug['dateFormat']) ?
-                            (bool)$slug['dateFormat'] : 'Y-m-d-H:i';
+                            (string)$slug['dateFormat'] : 'Y-m-d-H:i';
 
                         $config['slugs'][$field]['updatable'] = isset($slug['updatable']) ?
                             (bool)$slug['updatable'] : true;


### PR DESCRIPTION
The dateFormat option is currently unusable if set in a yml file because the value is cast to a boolean in the Yaml driver.
