### PR TITLE
if PersistDefaultLocaleTranslation is set, force postLoad personal translations

### DIFF
--- a/lib/Gedmo/Translatable/TranslatableListener.php
+++ b/lib/Gedmo/Translatable/TranslatableListener.php
@@ -447,7 +447,7 @@ class TranslatableListener extends MappedEventSubscriber
             return;
         }
 
-        if (isset($config['fields']) && $locale !== $this->defaultLocale) {
+        if (isset($config['fields']) && ($locale !== $this->defaultLocale || $this->persistDefaultLocaleTranslation)) {
             // fetch translations
             $translationClass = $this->getTranslationClass($ea, $config['useObjectClass']);
             $result = $ea->loadTranslations(


### PR DESCRIPTION
If persist_default_translation: true , only on default locale not loaded translations values.
