### PR TITLE
fix annotation in Gedmo\Loggable\Entity\LogEntry

### DIFF
--- a/lib/Gedmo/Loggable/Entity/LogEntry.php
+++ b/lib/Gedmo/Loggable/Entity/LogEntry.php
@@ -2,23 +2,21 @@
 
 namespace Gedmo\Loggable\Entity;
 
-use Doctrine\ORM\Mapping\Table;
-use Doctrine\ORM\Mapping\Index;
-use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping as ORM;
 
 /**
  * Gedmo\Loggable\Entity\LogEntry
  *
- * @Table(
+ * @ORM\Table(
  *     name="ext_log_entries",
  *  indexes={
- *      @index(name="log_class_lookup_idx", columns={"object_class"}),
- *      @index(name="log_date_lookup_idx", columns={"logged_at"}),
- *      @index(name="log_user_lookup_idx", columns={"username"}),
- *      @index(name="log_version_lookup_idx", columns={"object_id", "object_class", "version"})
+ *      @ORM\Index(name="log_class_lookup_idx", columns={"object_class"}),
+ *      @ORM\Index(name="log_date_lookup_idx", columns={"logged_at"}),
+ *      @ORM\Index(name="log_user_lookup_idx", columns={"username"}),
+ *      @ORM\Index(name="log_version_lookup_idx", columns={"object_id", "object_class", "version"})
  *  }
  * )
- * @Entity(repositoryClass="Gedmo\Loggable\Entity\Repository\LogEntryRepository")
+ * @ORM\Entity(repositoryClass="Gedmo\Loggable\Entity\Repository\LogEntryRepository")
  */
 class LogEntry extends MappedSuperclass\AbstractLogEntry
 {


### PR DESCRIPTION
This PR fixes the error below when doing "cache:clear --env=prod":

[Doctrine\Common\Annotations\AnnotationException]  
[Semantical Error] The class "Table" is not annotated with @Annotation. Are you sure this class can be used as annotation? If so, then you need to add @Annotation to the _class_ doc comment of "Table". If it is indeed no annotation, then you need to add @IgnoreAnnotation("Table") to the _class_ doc comment of class Gedmo\Loggable\Entity\LogEntry.
