### PR TITLE
Make Yaml driver for Tree mapping compliant with resolve target entities

### DIFF
--- a/lib/Gedmo/Tree/Mapping/Driver/Yaml.php
+++ b/lib/Gedmo/Tree/Mapping/Driver/Yaml.php
@@ -162,7 +162,9 @@ class Yaml extends File implements Driver
             foreach ($mapping['manyToOne'] as $field => $relationMapping) {
                 if (isset($relationMapping['gedmo'])) {
                     if (in_array('treeParent', $relationMapping['gedmo'])) {
-                        if ($relationMapping['targetEntity'] != $meta->name) {
+                        $reflectionClass = new \ReflectionClass($meta->name);
+                        if ($relationMapping['targetEntity'] != $meta->name &&
+                            !$reflectionClass->implementsInterface($relationMapping['targetEntity'])) {
                             throw new InvalidMappingException("Unable to find ancestor/parent child relation through ancestor field - [{$field}] in class - {$meta->name}");
                         }
                         $config['parent'] = $field;


### PR DESCRIPTION
This PR fixes an error when using doctrine resolve target entities and trees with Yaml driver (seems working with annotations and not tested with XML driver).

  [Gedmo\Exception\InvalidMappingException]  
  Unable to find ancestor/parent child relation through ancestor field - [parent] in class - MyClass
