### PR TITLE
fix non-empty field regeneration

### DIFF
--- a/lib/Gedmo/Sluggable/SluggableListener.php
+++ b/lib/Gedmo/Sluggable/SluggableListener.php
@@ -278,7 +278,7 @@ class SluggableListener extends MappedEventSubscriber
             $oldSlug = isset($changeSet[$slugField]) ? $changeSet[$slugField][0] : $slug;
             $needToChangeSlug = false;
             // if slug is null, regenerate it, or needs an update
-            if (null === $slug || $slug === '__id__' || !isset($changeSet[$slugField])) {
+            if (null === $slug || $slug === '__id__') {
                 $slug = '';
                 foreach ($options['fields'] as $sluggableField) {
                     if (isset($changeSet[$sluggableField]) || isset($changeSet[$slugField])) {


### PR DESCRIPTION
Case: 
I update title field and want url to stay the same if it wasn't null.
But cos <code> || !isset($changeSet[$slugField])</code> it would be regenerated.
