### PR TITLE
Fix updating uploadable entity

### DIFF
--- a/lib/Gedmo/Uploadable/UploadableListener.php
+++ b/lib/Gedmo/Uploadable/UploadableListener.php
@@ -308,7 +308,9 @@ class UploadableListener extends MappedEventSubscriber
             if ($config['filePathField']) {
                 $this->pendingFileRemovals[] = $this->getFilePathFieldValue($meta, $config, $object);
             } else {
-                $this->pendingFileRemovals[] = $this->getFileNameFieldValue($meta, $config, $object);
+                $path     = $this->getPath($meta, $config, $object);
+                $fileName = $this->getFileNameFieldValue($meta, $config, $object);
+                $this->pendingFileRemovals[] = $path . DIRECTORY_SEPARATOR . $fileName;
             }
         }
 


### PR DESCRIPTION
Currently for entities which have UploadableFileName set and do not have UploadableFilePath, uploadable extension fails to unlink previous file as pendingFileRemovals contains file name only and not full path.

This pull request corrects file path in pendingFileRemovals array which leads to proper files unlinking.
