### PR TITLE
Clear the wrapper cache after the flush event is done

### DIFF
--- a/lib/Gedmo/Sluggable/SluggableListener.php
+++ b/lib/Gedmo/Sluggable/SluggableListener.php
@@ -6,6 +6,7 @@ use Doctrine\Common\EventArgs;
 use Gedmo\Mapping\MappedEventSubscriber;
 use Gedmo\Sluggable\Mapping\Event\SluggableAdapter;
 use Doctrine\Common\Persistence\ObjectManager;
+use Gedmo\Tool\Wrapper\AbstractWrapper;
 
 /**
  * The SluggableListener handles the generation of slugs
@@ -224,6 +225,8 @@ class SluggableListener extends MappedEventSubscriber
         }
 
         $this->manageFiltersAfterGeneration($om);
+
+        AbstractWrapper::clear();
     }
 
     /**


### PR DESCRIPTION
During the onFlush event of the SluggableListener a temperary cache is created in the AbstractWrapper (when checking for similar slugs). This cache doesn't get cleared once the process is completed, resulting in increasing memory consumption.
