### PR TITLE
 Sortable position field - [sort] type is not valid and must be 'integer...

### DIFF
--- a/lib/Gedmo/Sortable/Mapping/Driver/Annotation.php
+++ b/lib/Gedmo/Sortable/Mapping/Driver/Annotation.php
@@ -34,7 +34,8 @@ class Annotation extends AbstractAnnotationDriver
     protected $validTypes = array(
         'integer',
         'smallint',
-        'bigint'
+        'bigint',
+        'int'
     );
 
     /**


### PR DESCRIPTION
...' #1067
