### PR TITLE
Missing type hint

### DIFF
--- a/lib/Gedmo/SoftDeleteable/Traits/SoftDeleteableEntity.php
+++ b/lib/Gedmo/SoftDeleteable/Traits/SoftDeleteableEntity.php
@@ -11,6 +11,7 @@ namespace Gedmo\SoftDeleteable\Traits;
 trait SoftDeleteableEntity
 {
     /**
+     * @var \DateTime
      * @ORM\Column(type="datetime", nullable=true)
      */
     protected $deletedAt;


### PR DESCRIPTION
TYPO3 Flow use type annotations for building and validating database schema.
Without this annotation, doctrine failed to validate the schema with "No mapping found for field 'deletedAt'"
