### PR TITLE
Add @var annotations to the Traits for TYPO3.Flow support

### DIFF
--- a/lib/Gedmo/Blameable/Traits/BlameableDocument.php
+++ b/lib/Gedmo/Blameable/Traits/BlameableDocument.php
@@ -11,12 +11,14 @@ namespace Gedmo\Blameable\Traits;
 trait BlameableDocument
 {
     /**
+     * @var string
      * @Gedmo\Blameable(on="create")
      * @ODM\String
      */
     private $createdBy;
 
     /**
+     * @var string
      * @Gedmo\Blameable(on="update")
      * @ODM\String
      */

--- a/lib/Gedmo/Blameable/Traits/BlameableEntity.php
+++ b/lib/Gedmo/Blameable/Traits/BlameableEntity.php
@@ -11,12 +11,14 @@ namespace Gedmo\Blameable\Traits;
 trait BlameableEntity
 {
     /**
+     * @var string
      * @Gedmo\Blameable(on="create")
      * @ORM\Column(type="string", nullable=true)
      */
     private $createdBy;
 
     /**
+     * @var string
      * @Gedmo\Blameable(on="update")
      * @ORM\Column(type="string", nullable=true)
      */

--- a/lib/Gedmo/IpTraceable/Traits/IpTraceableDocument.php
+++ b/lib/Gedmo/IpTraceable/Traits/IpTraceableDocument.php
@@ -11,12 +11,14 @@ namespace Gedmo\IpTraceable\Traits;
 trait IpTraceableDocument
 {
     /**
+     * @var string
      * @Gedmo\IpTraceable(on="create")
      * @ODM\String
      */
     private $createdFromIp;
 
     /**
+     * @var string
      * @Gedmo\IpTraceable(on="update")
      * @ODM\String
      */

--- a/lib/Gedmo/IpTraceable/Traits/IpTraceableEntity.php
+++ b/lib/Gedmo/IpTraceable/Traits/IpTraceableEntity.php
@@ -11,12 +11,14 @@ namespace Gedmo\IpTraceable\Traits;
 trait IpTraceableEntity
 {
     /**
+     * @var string
      * @Gedmo\IpTraceable(on="create")
      * @ORM\Column(type="string", length=45, nullable=true)
      */
     protected $createdFromIp;
 
     /**
+     * @var string
      * @Gedmo\IpTraceable(on="update")
      * @ORM\Column(type="string", length=45, nullable=true)
      */

--- a/lib/Gedmo/SoftDeleteable/Traits/SoftDeleteableDocument.php
+++ b/lib/Gedmo/SoftDeleteable/Traits/SoftDeleteableDocument.php
@@ -11,6 +11,7 @@ namespace Gedmo\SoftDeleteable\Traits;
 trait SoftDeleteableDocument
 {
     /**
+     * @var \DateTime
      * @ODM\Date
      */
     protected $deletedAt;

--- a/lib/Gedmo/SoftDeleteable/Traits/SoftDeleteableEntity.php
+++ b/lib/Gedmo/SoftDeleteable/Traits/SoftDeleteableEntity.php
@@ -11,6 +11,7 @@ namespace Gedmo\SoftDeleteable\Traits;
 trait SoftDeleteableEntity
 {
     /**
+     * @var \DateTime
      * @ORM\Column(type="datetime", nullable=true)
      */
     protected $deletedAt;

--- a/lib/Gedmo/Timestampable/Traits/TimestampableDocument.php
+++ b/lib/Gedmo/Timestampable/Traits/TimestampableDocument.php
@@ -11,12 +11,14 @@ namespace Gedmo\Timestampable\Traits;
 trait TimestampableDocument
 {
     /**
+     * @var \DateTime
      * @Gedmo\Timestampable(on="create")
      * @ODM\Date
      */
     private $createdAt;
 
     /**
+     * @var \DateTime
      * @Gedmo\Timestampable(on="update")
      * @ODM\Date
      */

--- a/lib/Gedmo/Timestampable/Traits/TimestampableEntity.php
+++ b/lib/Gedmo/Timestampable/Traits/TimestampableEntity.php
@@ -11,12 +11,14 @@ namespace Gedmo\Timestampable\Traits;
 trait TimestampableEntity
 {
     /**
+     * @var \DateTime
      * @Gedmo\Timestampable(on="create")
      * @ORM\Column(type="datetime")
      */
     protected $createdAt;
 
     /**
+     * @var \DateTime
      * @Gedmo\Timestampable(on="update")
      * @ORM\Column(type="datetime")
      */

--- a/lib/Gedmo/Tree/Traits/NestedSetEntity.php
+++ b/lib/Gedmo/Tree/Traits/NestedSetEntity.php
@@ -12,24 +12,28 @@ trait NestedSetEntity
 {
 
     /**
+     * @var integer
      * @Gedmo\TreeRoot
      * @ORM\Column(name="root", type="integer", nullable=true)
      */
     private $root;
 
     /**
+     * @var integer
      * @Gedmo\TreeLevel
      * @ORM\Column(name="lvl", type="integer")
      */
     private $level;
 
     /**
+     * @var integer
      * @Gedmo\TreeLeft
      * @ORM\Column(name="lft", type="integer")
      */
     private $left;
 
     /**
+     * @var integer
      * @Gedmo\TreeRight
      * @ORM\Column(name="rgt", type="integer")
      */


### PR DESCRIPTION
The TYPO3.Flow Frameworks relies heavily on @var annotation in Entities
to properly handle them. This commit adds those @var annotations to
the DoctrineExtension Traits to be compatible with TYPO3.Flow
