### PR TITLE
Tree closure and master-slave connection

### DIFF
--- a/lib/Gedmo/Tree/Strategy/ORM/Closure.php
+++ b/lib/Gedmo/Tree/Strategy/ORM/Closure.php
@@ -439,7 +439,7 @@ class Closure implements Strategy
             if ($ids) {            
                 // using subquery directly, sqlite acts unfriendly
                 $query = "DELETE FROM {$table} WHERE id IN (".implode(', ', $ids).")";
-                if (!empty($ids) && !$conn->executeQuery($query)) {
+                if (!empty($ids) && !$conn->executeUpdate($query)) {
                     throw new RuntimeException('Failed to remove old closures');
                 }
             }


### PR DESCRIPTION
Found a bug in Tree Closure when deleting old closure entries.
The old code uses `execQuery` that causes erroneus slave delete query as stated here:
https://www.doctrine-project.org/api/dbal/2.7/Doctrine/DBAL/Connections/MasterSlaveConnection.html

(The error only occurs when using doctrine MasterSlaveConnection class and **master** wasn't selected with previous queries)