### PR TITLE
[Mapping] Fix simplexml_load_file() breakage on libxml_disable_entity_loader(true)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,6 @@ a release.
 ---
 
 ## [Unreleased]
+### Mapping
+#### Fixed
+- Fix failing simplexml_load_file()

--- a/lib/Gedmo/Mapping/Driver/Xml.php
+++ b/lib/Gedmo/Mapping/Driver/Xml.php
@@ -86,7 +86,7 @@ abstract class Xml extends File
     protected function _loadMappingFile($file)
     {
         $result = array();
-        $xmlElement = simplexml_load_file($file);
+        $xmlElement = simplexml_load_string(file_get_contents($file));
         $xmlElement = $xmlElement->children(self::DOCTRINE_NAMESPACE_URI);
 
         if (isset($xmlElement->entity)) {


### PR DESCRIPTION
If libxml_disable_entity_loader(true), simplexml_load_file() fails; this avoids the limitation by avoiding file operations in libXML.
( see https://bugs.php.net/bug.php?id=62577 )

The only difference here is that the file operations are done via file_get_contents() and the resulting string is passed to simplexml_load_string() from PHP, instead of simplexml_load_file() doing these two things internally.