### PR TITLE
fix(sluggable): fix error when flush 2 entities use Gedmo\Slug and inherit from same entity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tests/temp/*.log
 /composer.lock
 /composer.phar
 .idea
+.zcache

--- a/lib/Gedmo/Sluggable/SluggableListener.php
+++ b/lib/Gedmo/Sluggable/SluggableListener.php
@@ -449,6 +449,12 @@ class SluggableListener extends MappedEventSubscriber
                 if ($base !== false && $meta->getReflectionProperty($config['unique_base'])->getValue($obj) !== $base) {
                     continue; // if unique_base field is not the same, do not take slug as similar
                 }
+
+                // Check if similar persisted slugs are from class parents, childs, or brother, if not : continue
+                if (!is_subclass_of($obj, $meta->name) && !is_subclass_of($object, get_class($obj)) && $meta->name !== get_class($obj)) {
+                    continue;
+                }
+
                 $slug = $meta->getReflectionProperty($config['slug'])->getValue($obj);
                 $quotedPreferredSlug = preg_quote($preferredSlug);
                 if (preg_match("@^{$quotedPreferredSlug}.*@smi", $slug)) {

--- a/tests/Gedmo/Sluggable/Fixture/Issue1962/Bus.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue1962/Bus.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Sluggable\Fixture\Issue1962;
+
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * @ORM\Entity
+ */
+class Bus extends Vehicle
+{
+    /**
+     * @ORM\Column(length=128, nullable=true)
+     */
+    private $description;
+
+    /**
+     * @ORM\Column(length=128)
+     */
+    protected $title;
+
+    /**
+     * @Gedmo\Slug(fields={"title"})
+     * @ORM\Column(length=128, unique=true)
+     */
+    private $slug;
+
+    public function setDescription($description)
+    {
+        $this->description = $description;
+    }
+
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    public function getSlug()
+    {
+        return $this->slug;
+    }
+}

--- a/tests/Gedmo/Sluggable/Fixture/Issue1962/Car.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue1962/Car.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Sluggable\Fixture\Issue1962;
+
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * @ORM\Entity
+ */
+class Car extends Vehicle
+{
+    /**
+     * @ORM\Column(length=128, nullable=true)
+     */
+    private $description;
+
+    /**
+     * @ORM\Column(length=128)
+     */
+    protected $title;
+
+    /**
+     * @Gedmo\Slug(fields={"title"})
+     * @ORM\Column(length=128, unique=true)
+     */
+    private $slug;
+
+    public function setDescription($description)
+    {
+        $this->description = $description;
+    }
+
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    public function getSlug()
+    {
+        return $this->slug;
+    }
+}

--- a/tests/Gedmo/Sluggable/Fixture/Issue1962/Vehicle.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue1962/Vehicle.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Sluggable\Fixture\Issue1962;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\InheritanceType("JOINED")
+ * @ORM\DiscriminatorColumn(name="discriment", type="string")
+ * @ORM\DiscriminatorMap({"car" = "Car", "bus" = "Bus"})
+ */
+abstract class Vehicle
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+}

--- a/tests/Gedmo/Sluggable/Issue/Issue1962Test.php
+++ b/tests/Gedmo/Sluggable/Issue/Issue1962Test.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Gedmo\Sluggable;
+
+use Doctrine\Common\EventManager;
+use Sluggable\Fixture\Issue1962\Bus;
+use Tool\BaseTestCaseORM;
+use Sluggable\Fixture\Issue1962\Car;
+
+/**
+ * These are tests for Sluggable behavior
+ *
+ * @author Pierre-Yves CARIOU <cariou.p@gmail.com>
+ * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+class Issue1962Test extends BaseTestCaseORM
+{
+    const VEHICLE = 'Sluggable\\Fixture\\Issue1962\\Vehicle';
+    const CAR = 'Sluggable\\Fixture\\Issue1962\\Car';
+    const BUS = 'Sluggable\\Fixture\\Issue1962\\Bus';
+
+    protected function setUp()
+    {
+        parent::setUp();
+    }
+
+    /**
+     * @test
+     */
+    public function testSlugGeneration()
+    {
+        $evm = new EventManager();
+        $evm->addEventSubscriber(new SluggableListener());
+        $this->getMockSqliteEntityManager($evm);
+
+        $audi = new Car();
+        $audi->setDescription('audi car');
+        $audi->setTitle('Audi');
+
+        $ratp = new Bus();
+        $ratp->setDescription('Bus electrique qui arrive toujours à l\'heure');
+        $ratp->setTitle('ratp');
+
+        $this->em->persist($audi);
+        $this->em->persist($ratp);
+        $this->em->flush();
+
+        $this->assertEquals('audi', $audi->getSlug());
+        $this->assertEquals('ratp', $ratp->getSlug());
+    }
+
+    protected function getUsedEntityFixtures()
+    {
+        return array(
+            self::VEHICLE,
+            self::CAR,
+            self::BUS,
+        );
+    }
+}


### PR DESCRIPTION
See issue https://github.com/Atlantic18/DoctrineExtensions/issues/1962 to know what is the problem

This PR create a test to reproduce the error and fix it :-)