### PR TITLE
[Translatable] Set getTranslatableListener method to protected

### DIFF
--- a/lib/Gedmo/Translatable/Entity/Repository/TranslationRepository.php
+++ b/lib/Gedmo/Translatable/Entity/Repository/TranslationRepository.php
@@ -26,7 +26,7 @@ class TranslationRepository extends EntityRepository
      *
      * @var TranslatableListener
      */
-    private $listener;
+    protected $listener;
 
     /**
      * {@inheritdoc}
@@ -230,7 +230,7 @@ class TranslationRepository extends EntityRepository
      *
      * @return TranslatableListener
      */
-    private function getTranslatableListener()
+    protected function getTranslatableListener()
     {
         if (!$this->listener) {
             foreach ($this->_em->getEventManager()->getListeners() as $event => $listeners) {


### PR DESCRIPTION
I was in the need to extends the behaviour of the `findTranslations` method.
But private visibilities prevent me from using this class.
So, i changed `getTranslatableListener` from private to protected. I really don't think that private is the way to go. It seams unnecessary and definitely prevents the class from being extended.
If only protected was the de-facto default keyword people were using... private is almost always a bad choice imho, sorry.