### PR TITLE
[Loggable] Allow to specify gedmo:versioned in attribute-override for xml driver

### DIFF
--- a/lib/Gedmo/Loggable/Mapping/Driver/Xml.php
+++ b/lib/Gedmo/Loggable/Mapping/Driver/Xml.php
@@ -51,6 +51,14 @@ class Xml extends BaseXml
         if (isset($xmlDoctrine->field)) {
             $this->inspectElementForVersioned($xmlDoctrine->field, $config, $meta);
         }
+        if (
+            isset($xmlDoctrine->{'attribute-overrides'}) &&
+            isset($xmlDoctrine->{'attribute-overrides'}->{'attribute-override'})
+        ) {
+            foreach ($xmlDoctrine->{'attribute-overrides'}->{'attribute-override'} as $overrideMapping) {
+                $this->inspectElementForVersioned($overrideMapping, $config, $meta);
+            }
+        }
         if (isset($xmlDoctrine->{'many-to-one'})) {
             $this->inspectElementForVersioned($xmlDoctrine->{'many-to-one'}, $config, $meta);
         }


### PR DESCRIPTION
Loggable Xml driver doesn't allow to specify `gedmo:versioned` attribute in attributes-override like [Yaml driver does](https://github.com/Atlantic18/DoctrineExtensions/blob/v2.4.x/lib/Gedmo/Loggable/Mapping/Driver/Yaml.php#L61)

Example usage
```xml
 <?xml version="1.0" encoding="UTF-8"?>
 
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
                   xmlns:gedmo="http://gediminasm.org/schemas/orm/doctrine-extensions-mapping">
     <mapped-superclass name="App/Entity/Acme" table="app_acme">
         <attribute-overrides>
             <attribute-override name="name">
                 <field name="name" column="name" type="string">
                     <gedmo:versioned/>
                 </field>
             </attribute-override>
         </attribute-overrides>

         <gedmo:loggable log-entry-class="App\Entity\AcmeLogEntry"/>
     </mapped-superclass>
 </doctrine-mapping>
```