### PR TITLE
Fix for wrong UploadFileName on Append Number (#1229)

### DIFF
--- a/lib/Gedmo/Uploadable/UploadableListener.php
+++ b/lib/Gedmo/Uploadable/UploadableListener.php
@@ -594,6 +594,8 @@ class UploadableListener extends MappedEventSubscriber
                 ));
             }
         }
+        
+        $info['fileName'] = basename($info['filePath']);        
 
         if (!$this->doMoveFile($fileInfo->getTmpName(), $info['filePath'], $fileInfo->isUploadedFile())) {
             throw new UploadableUploadException(sprintf('File "%s" was not uploaded, or there was a problem moving it to the location "%s".',


### PR DESCRIPTION
Fixes #1229
UploadableFileName matches the name with the appended number with this update.