### PR TITLE
Better calculation of groups hash to support value objects

### DIFF
--- a/lib/Gedmo/Sortable/Mapping/Event/Adapter/ODM.php
+++ b/lib/Gedmo/Sortable/Mapping/Event/Adapter/ODM.php
@@ -2,6 +2,7 @@
 
 namespace Gedmo\Sortable\Mapping\Event\Adapter;
 
+use Doctrine\ODM\MongoDB\Types\Type;
 use Gedmo\Mapping\Event\Adapter\ODM as BaseAdapterODM;
 use Gedmo\Sortable\Mapping\Event\SortableAdapter;
 use Doctrine\Common\Util\ClassUtils;
@@ -15,6 +16,26 @@ use Doctrine\Common\Util\ClassUtils;
  */
 final class ODM extends BaseAdapterODM implements SortableAdapter
 {
+    public function getGroupsHash(array $groups, array $config)
+    {
+        $data = $config['useObjectClass'];
+        $metadata = $this->getObjectManager()->getClassMetadata($data);
+
+        foreach ($groups as $group => $value) {
+            $type = $metadata->getTypeOfField($group);
+
+            if ($type !== null && Type::hasType($type)) {
+                $value = Type::getType($type)->convertToDatabaseValue($value);
+            } elseif (is_object($value)) {
+                $value = spl_object_hash($value);
+            }
+
+            $data .= "[{$group}][{$value}]";
+        }
+
+        return md5($data);
+    }
+
     public function getMaxPosition(array $config, $meta, $groups)
     {
         $dm = $this->getObjectManager();

--- a/lib/Gedmo/Sortable/SortableListener.php
+++ b/lib/Gedmo/Sortable/SortableListener.php
@@ -117,7 +117,7 @@ class SortableListener extends MappedEventSubscriber
             $groups = $this->getGroups($meta, $config, $object);
 
             // Get hash
-            $hash = $this->getHash($groups, $config);
+            $hash = $ea->getGroupsHash($groups, $config);
 
             // Get max position
             if (!isset($this->maxPositions[$hash])) {
@@ -171,7 +171,7 @@ class SortableListener extends MappedEventSubscriber
         $groups = $this->getGroups($meta, $config, $object);
 
         // Get hash
-        $hash = $this->getHash($groups, $config);
+        $hash = $ea->getGroupsHash($groups, $config);
 
         // Get max position
         if (!isset($this->maxPositions[$hash])) {
@@ -245,7 +245,7 @@ class SortableListener extends MappedEventSubscriber
         }
 
         if ($changed) {
-            $oldHash = $this->getHash($oldGroups, $config);
+            $oldHash = $ea->getGroupsHash($oldGroups, $config);
             $this->maxPositions[$oldHash] = $this->getMaxPosition($ea, $meta, $config, $object, $oldGroups);
             if (array_key_exists($config['position'], $changeSet)) {
                 $oldPosition = $changeSet[$config['position']][0];
@@ -257,7 +257,7 @@ class SortableListener extends MappedEventSubscriber
         }
 
         // Get hash
-        $hash = $this->getHash($groups, $config);
+        $hash = $ea->getGroupsHash($groups, $config);
 
         // Get max position
         if (!isset($this->maxPositions[$hash])) {
@@ -371,7 +371,7 @@ class SortableListener extends MappedEventSubscriber
         $groups = $this->getGroups($meta, $config, $object);
 
         // Get hash
-        $hash = $this->getHash($groups, $config);
+        $hash = $ea->getGroupsHash($groups, $config);
 
         // Get max position
         if (!isset($this->maxPositions[$hash])) {
@@ -531,7 +531,7 @@ class SortableListener extends MappedEventSubscriber
         }
 
         // Get hash
-        $hash = $this->getHash($groups, $config);
+        $hash = $ea->getGroupsHash($groups, $config);
 
         // Check for cached max position
         if (isset($this->maxPositions[$hash])) {


### PR DESCRIPTION
Better calculation of groups hash to support value objects

I use https://github.com/ramsey/uuid-doctrine so groups are often instances of `Ramsey\Uuid`. Before this change the group hash calculation used `spl_object_hash` but UUIDs are value objects which should not be compared by identity.
