### PR TITLE
Added missing index 'general_translations_lookup_idx'

### DIFF
--- a/lib/Gedmo/Translatable/Entity/Translation.php
+++ b/lib/Gedmo/Translatable/Entity/Translation.php
@@ -13,8 +13,11 @@ use Doctrine\ORM\Mapping\Entity;
  * @Table(
  *         name="ext_translations",
  *         options={"row_format":"DYNAMIC"},
- *         indexes={@Index(name="translations_lookup_idx", columns={
+ *         indexes={@Index(name="locale_translations_lookup_idx", columns={
  *             "locale", "object_class", "foreign_key"
+ *         }),
+ *         @Index(name="general_translations_lookup_idx", columns={
+ *             "object_class", "foreign_key"
  *         })},
  *         uniqueConstraints={@UniqueConstraint(name="lookup_unique_idx", columns={
  *             "locale", "object_class", "field", "foreign_key"


### PR DESCRIPTION
Created a new index 'general_translations_lookup_idx' and renamed the previous index 'translations_lookup_idx' to 'locale_translations_lookup_idx' so that the query perfomance for translations is significantly improved. No index was used in this select query before.

Reason:
The select query in method \Gedmo\Translatable\Entity\Repository\TranslationRepository::findTranslations() only uses the two columns 'foreignKey' and 'objectClass' but not 'locale' column in the WHERE condition. 
This leads to the fact that the queries all happen without indexes, because the index 'translations_lookup_idx' does not work. Especially in MySQL 8.0 this leads to a significant slowdown and overuse of the system.