### PR TITLE
[Documentation] Filters are disabled by default in Doctrine ^2.7

### DIFF
--- a/doc/symfony4.md
+++ b/doc/symfony4.md
@@ -141,7 +141,6 @@ doctrine:
                 enabled: true
 ```  
 
-
 <a name="ext-listeners"></a>
 
 ## Doctrine extension listener services

--- a/doc/symfony4.md
+++ b/doc/symfony4.md
@@ -138,13 +138,6 @@ doctrine:
         filters:
             softdeleteable:
                 class: Gedmo\SoftDeleteable\Filter\SoftDeleteableFilter
-```     
-
-With Doctrine ^2.7 - You MUST add `enabled: true` on the filter, as filters are disabled by default.
-```yaml
-        filters:
-            softdeleteable:
-                class: Gedmo\SoftDeleteable\Filter\SoftDeleteableFilter
                 enabled: true
 ```  
 

--- a/doc/symfony4.md
+++ b/doc/symfony4.md
@@ -139,6 +139,16 @@ doctrine:
             softdeleteable:
                 class: Gedmo\SoftDeleteable\Filter\SoftDeleteableFilter
 ```     
+
+With Doctrine ^2.7 - You MUST add `enabled: true` on the filter, as filters are disabled by default.
+```yaml
+        filters:
+            softdeleteable:
+                class: Gedmo\SoftDeleteable\Filter\SoftDeleteableFilter
+                enabled: true
+```  
+
+
 <a name="ext-listeners"></a>
 
 ## Doctrine extension listener services


### PR DESCRIPTION
After about an hour of debugging - I figured out that in Doctrine ^2.7, filters are disabled by default, and `enabled: true` is required.