### PR TITLE
[Tree] makes resolving TreeListener lazy

### DIFF
--- a/src/Tree/Document/MongoDB/Repository/MaterializedPathRepository.php
+++ b/src/Tree/Document/MongoDB/Repository/MaterializedPathRepository.php
@@ -109,7 +109,7 @@ class MaterializedPathRepository extends AbstractTreeRepository
     public function getChildrenQueryBuilder($node = null, $direct = false, $sortByField = null, $direction = 'asc', $includeNode = false)
     {
         $meta = $this->getClassMetadata();
-        $config = $this->listener->getConfiguration($this->dm, $meta->name);
+        $config = $this->getTreeListener()->getConfiguration($this->dm, $meta->name);
         $separator = preg_quote($config['path_separator']);
         $qb = $this->dm->createQueryBuilder()
             ->find($meta->name);
@@ -200,6 +200,6 @@ class MaterializedPathRepository extends AbstractTreeRepository
      */
     protected function validate()
     {
-        return Strategy::MATERIALIZED_PATH === $this->listener->getStrategy($this->dm, $this->getClassMetadata()->name)->getName();
+        return Strategy::MATERIALIZED_PATH === $this->getTreeListener()->getStrategy($this->dm, $this->getClassMetadata()->name)->getName();
     }
 }

--- a/src/Tree/Entity/Repository/ClosureTreeRepository.php
+++ b/src/Tree/Entity/Repository/ClosureTreeRepository.php
@@ -28,7 +28,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
     public function getRootNodesQueryBuilder($sortByField = null, $direction = 'asc')
     {
         $meta = $this->getClassMetadata();
-        $config = $this->listener->getConfiguration($this->_em, $meta->name);
+        $config = $this->getTreeListener()->getConfiguration($this->_em, $meta->name);
         $qb = $this->getQueryBuilder();
         $qb->select('node')
             ->from($config['useObjectClass'], 'node')
@@ -75,7 +75,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
         if (!$this->_em->getUnitOfWork()->isInIdentityMap($node)) {
             throw new InvalidArgumentException('Node is not managed by UnitOfWork');
         }
-        $config = $this->listener->getConfiguration($this->_em, $meta->name);
+        $config = $this->getTreeListener()->getConfiguration($this->_em, $meta->name);
         $closureMeta = $this->_em->getClassMetadata($config['closure']);
 
         $dql = "SELECT c, node FROM {$closureMeta->name} c";
@@ -108,7 +108,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
     public function childrenQueryBuilder($node = null, $direct = false, $sortByField = null, $direction = 'ASC', $includeNode = false)
     {
         $meta = $this->getClassMetadata();
-        $config = $this->listener->getConfiguration($this->_em, $meta->name);
+        $config = $this->getTreeListener()->getConfiguration($this->_em, $meta->name);
 
         $qb = $this->getQueryBuilder();
         if (null !== $node) {
@@ -227,7 +227,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
         if (!$wrapped->hasValidIdentifier()) {
             throw new InvalidArgumentException('Node is not managed by UnitOfWork');
         }
-        $config = $this->listener->getConfiguration($this->_em, $meta->name);
+        $config = $this->getTreeListener()->getConfiguration($this->_em, $meta->name);
         $pk = $meta->getSingleIdentifierFieldName();
         $nodeId = $wrapped->getIdentifier();
         $parent = $wrapped->getPropertyValue($config['parent']);
@@ -252,7 +252,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
                 $q->setParameters(compact('parent', 'id'));
                 $q->getSingleScalarResult();
 
-                $this->listener
+                $this->getTreeListener()
                     ->getStrategy($this->_em, $meta->name)
                     ->updateNode($this->_em, $nodeToReparent, $node);
 
@@ -288,12 +288,12 @@ class ClosureTreeRepository extends AbstractTreeRepository
     public function buildTreeArray(array $nodes)
     {
         $meta = $this->getClassMetadata();
-        $config = $this->listener->getConfiguration($this->_em, $meta->name);
+        $config = $this->getTreeListener()->getConfiguration($this->_em, $meta->name);
         $nestedTree = [];
         $idField = $meta->getSingleIdentifierFieldName();
         $hasLevelProp = !empty($config['level']);
         $levelProp = $hasLevelProp ? $config['level'] : self::SUBQUERY_LEVEL;
-        $childrenIndex = $this->repoUtils->getChildrenIndex();
+        $childrenIndex = $this->getRepoUtils()->getChildrenIndex();
 
         if (count($nodes) > 0) {
             $firstLevel = $hasLevelProp ? $nodes[0][0]['descendant'][$levelProp] : $nodes[0][$levelProp];
@@ -348,7 +348,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
     public function getNodesHierarchyQueryBuilder($node = null, $direct = false, array $options = [], $includeNode = false)
     {
         $meta = $this->getClassMetadata();
-        $config = $this->listener->getConfiguration($this->_em, $meta->name);
+        $config = $this->getTreeListener()->getConfiguration($this->_em, $meta->name);
         $idField = $meta->getSingleIdentifierFieldName();
         $subQuery = '';
         $hasLevelProp = isset($config['level']) && $config['level'];
@@ -395,14 +395,14 @@ class ClosureTreeRepository extends AbstractTreeRepository
      */
     protected function validate()
     {
-        return Strategy::CLOSURE === $this->listener->getStrategy($this->_em, $this->getClassMetadata()->name)->getName();
+        return Strategy::CLOSURE === $this->getTreeListener()->getStrategy($this->_em, $this->getClassMetadata()->name)->getName();
     }
 
     public function verify()
     {
         $nodeMeta = $this->getClassMetadata();
         $nodeIdField = $nodeMeta->getSingleIdentifierFieldName();
-        $config = $this->listener->getConfiguration($this->_em, $nodeMeta->name);
+        $config = $this->getTreeListener()->getConfiguration($this->_em, $nodeMeta->name);
         $closureMeta = $this->_em->getClassMetadata($config['closure']);
         $errors = [];
 
@@ -473,7 +473,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
     public function rebuildClosure()
     {
         $nodeMeta = $this->getClassMetadata();
-        $config = $this->listener->getConfiguration($this->_em, $nodeMeta->name);
+        $config = $this->getTreeListener()->getConfiguration($this->_em, $nodeMeta->name);
         $closureMeta = $this->_em->getClassMetadata($config['closure']);
 
         $insertClosures = function ($entries) use ($closureMeta) {
@@ -529,7 +529,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
         $conn = $this->_em->getConnection();
         $nodeMeta = $this->getClassMetadata();
         $nodeIdField = $nodeMeta->getSingleIdentifierFieldName();
-        $config = $this->listener->getConfiguration($this->_em, $nodeMeta->name);
+        $config = $this->getTreeListener()->getConfiguration($this->_em, $nodeMeta->name);
         $closureMeta = $this->_em->getClassMetadata($config['closure']);
         $closureTableName = $closureMeta->getTableName();
 
@@ -562,7 +562,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
     public function updateLevelValues()
     {
         $nodeMeta = $this->getClassMetadata();
-        $config = $this->listener->getConfiguration($this->_em, $nodeMeta->name);
+        $config = $this->getTreeListener()->getConfiguration($this->_em, $nodeMeta->name);
         $levelUpdatesCount = 0;
 
         if (!empty($config['level'])) {

--- a/src/Tree/Entity/Repository/MaterializedPathRepository.php
+++ b/src/Tree/Entity/Repository/MaterializedPathRepository.php
@@ -86,7 +86,7 @@ class MaterializedPathRepository extends AbstractTreeRepository
     public function getPathQueryBuilder($node)
     {
         $meta = $this->getClassMetadata();
-        $config = $this->listener->getConfiguration($this->_em, $meta->name);
+        $config = $this->getTreeListener()->getConfiguration($this->_em, $meta->name);
         $alias = 'materialized_path_entity';
         $qb = $this->getQueryBuilder()
             ->select($alias)
@@ -152,7 +152,7 @@ class MaterializedPathRepository extends AbstractTreeRepository
     public function getChildrenQueryBuilder($node = null, $direct = false, $sortByField = null, $direction = 'asc', $includeNode = false)
     {
         $meta = $this->getClassMetadata();
-        $config = $this->listener->getConfiguration($this->_em, $meta->name);
+        $config = $this->getTreeListener()->getConfiguration($this->_em, $meta->name);
         $separator = addcslashes($config['path_separator'], '%');
         $alias = 'materialized_path_entity';
         $path = $config['path'];
@@ -263,7 +263,7 @@ class MaterializedPathRepository extends AbstractTreeRepository
     public function getNodesHierarchy($node = null, $direct = false, array $options = [], $includeNode = false)
     {
         $meta = $this->getClassMetadata();
-        $config = $this->listener->getConfiguration($this->_em, $meta->name);
+        $config = $this->getTreeListener()->getConfiguration($this->_em, $meta->name);
         $path = $config['path'];
 
         $nodes = $this->getNodesHierarchyQuery($node, $direct, $options, $includeNode)->getArrayResult();
@@ -282,6 +282,6 @@ class MaterializedPathRepository extends AbstractTreeRepository
      */
     protected function validate()
     {
-        return Strategy::MATERIALIZED_PATH === $this->listener->getStrategy($this->_em, $this->getClassMetadata()->name)->getName();
+        return Strategy::MATERIALIZED_PATH === $this->getTreeListener()->getStrategy($this->_em, $this->getClassMetadata()->name)->getName();
     }
 }

--- a/src/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/src/Tree/Entity/Repository/NestedTreeRepository.php
@@ -35,7 +35,7 @@ class NestedTreeRepository extends AbstractTreeRepository
     public function getRootNodesQueryBuilder($sortByField = null, $direction = 'asc')
     {
         $meta = $this->getClassMetadata();
-        $config = $this->listener->getConfiguration($this->_em, $meta->name);
+        $config = $this->getTreeListener()->getConfiguration($this->_em, $meta->name);
         $qb = $this->getQueryBuilder();
         $qb
             ->select('node')
@@ -98,7 +98,7 @@ class NestedTreeRepository extends AbstractTreeRepository
             $node = $args[0];
             $wrapped = new EntityWrapper($node, $this->_em);
             $meta = $this->getClassMetadata();
-            $config = $this->listener->getConfiguration($this->_em, $meta->name);
+            $config = $this->getTreeListener()->getConfiguration($this->_em, $meta->name);
             $position = substr($method, 9);
             if ('Of' === substr($method, -2)) {
                 if (!isset($args[1])) {
@@ -147,7 +147,7 @@ class NestedTreeRepository extends AbstractTreeRepository
         if (!$node instanceof $meta->name) {
             throw new InvalidArgumentException('Node is not related to this repository');
         }
-        $config = $this->listener->getConfiguration($this->_em, $meta->name);
+        $config = $this->getTreeListener()->getConfiguration($this->_em, $meta->name);
         $wrapped = new EntityWrapper($node, $this->_em);
         if (!$wrapped->hasValidIdentifier()) {
             throw new InvalidArgumentException('Node is not managed by UnitOfWork');
@@ -200,7 +200,7 @@ class NestedTreeRepository extends AbstractTreeRepository
     public function childrenQueryBuilder($node = null, $direct = false, $sortByField = null, $direction = 'ASC', $includeNode = false)
     {
         $meta = $this->getClassMetadata();
-        $config = $this->listener->getConfiguration($this->_em, $meta->name);
+        $config = $this->getTreeListener()->getConfiguration($this->_em, $meta->name);
 
         $qb = $this->getQueryBuilder();
         $qb->select('node')
@@ -316,7 +316,7 @@ class NestedTreeRepository extends AbstractTreeRepository
     public function getLeafsQueryBuilder($root = null, $sortByField = null, $direction = 'ASC')
     {
         $meta = $this->getClassMetadata();
-        $config = $this->listener->getConfiguration($this->_em, $meta->name);
+        $config = $this->getTreeListener()->getConfiguration($this->_em, $meta->name);
 
         if (isset($config['root']) && is_null($root)) {
             if (is_null($root)) {
@@ -407,7 +407,7 @@ class NestedTreeRepository extends AbstractTreeRepository
             throw new InvalidArgumentException('Node is not managed by UnitOfWork');
         }
 
-        $config = $this->listener->getConfiguration($this->_em, $meta->name);
+        $config = $this->getTreeListener()->getConfiguration($this->_em, $meta->name);
         $parent = $wrapped->getPropertyValue($config['parent']);
 
         $left = $wrapped->getPropertyValue($config['left']);
@@ -484,7 +484,7 @@ class NestedTreeRepository extends AbstractTreeRepository
             throw new InvalidArgumentException('Node is not managed by UnitOfWork');
         }
 
-        $config = $this->listener->getConfiguration($this->_em, $meta->name);
+        $config = $this->getTreeListener()->getConfiguration($this->_em, $meta->name);
         $parent = $wrapped->getPropertyValue($config['parent']);
 
         $left = $wrapped->getPropertyValue($config['left']);
@@ -626,7 +626,7 @@ class NestedTreeRepository extends AbstractTreeRepository
         $meta = $this->getClassMetadata();
         if ($node instanceof $meta->name) {
             $wrapped = new EntityWrapper($node, $this->_em);
-            $config = $this->listener->getConfiguration($this->_em, $meta->name);
+            $config = $this->getTreeListener()->getConfiguration($this->_em, $meta->name);
             $right = $wrapped->getPropertyValue($config['right']);
             $left = $wrapped->getPropertyValue($config['left']);
             $rootId = isset($config['root']) ? $wrapped->getPropertyValue($config['root']) : null;
@@ -743,7 +743,7 @@ class NestedTreeRepository extends AbstractTreeRepository
     {
         $meta = $this->getClassMetadata();
         if ($node instanceof $meta->name || null === $node) {
-            $config = $this->listener->getConfiguration($this->_em, $meta->name);
+            $config = $this->getTreeListener()->getConfiguration($this->_em, $meta->name);
             if ($verify && is_array($this->verify())) {
                 return false;
             }
@@ -790,7 +790,7 @@ class NestedTreeRepository extends AbstractTreeRepository
 
         $errors = [];
         $meta = $this->getClassMetadata();
-        $config = $this->listener->getConfiguration($this->_em, $meta->name);
+        $config = $this->getTreeListener()->getConfiguration($this->_em, $meta->name);
         if (isset($config['root'])) {
             $trees = $this->getRootNodes();
             foreach ($trees as $tree) {
@@ -816,7 +816,7 @@ class NestedTreeRepository extends AbstractTreeRepository
             return;
         }
         $meta = $this->getClassMetadata();
-        $config = $this->listener->getConfiguration($this->_em, $meta->name);
+        $config = $this->getTreeListener()->getConfiguration($this->_em, $meta->name);
         $self = $this;
         $em = $this->_em;
 
@@ -856,7 +856,7 @@ class NestedTreeRepository extends AbstractTreeRepository
     public function getNodesHierarchyQueryBuilder($node = null, $direct = false, array $options = [], $includeNode = false)
     {
         $meta = $this->getClassMetadata();
-        $config = $this->listener->getConfiguration($this->_em, $meta->name);
+        $config = $this->getTreeListener()->getConfiguration($this->_em, $meta->name);
 
         return $this->childrenQueryBuilder(
             $node,
@@ -888,7 +888,7 @@ class NestedTreeRepository extends AbstractTreeRepository
      */
     protected function validate()
     {
-        return Strategy::NESTED === $this->listener->getStrategy($this->_em, $this->getClassMetadata()->name)->getName();
+        return Strategy::NESTED === $this->getTreeListener()->getStrategy($this->_em, $this->getClassMetadata()->name)->getName();
     }
 
     /**
@@ -901,7 +901,7 @@ class NestedTreeRepository extends AbstractTreeRepository
     private function verifyTree(&$errors, $root = null)
     {
         $meta = $this->getClassMetadata();
-        $config = $this->listener->getConfiguration($this->_em, $meta->name);
+        $config = $this->getTreeListener()->getConfiguration($this->_em, $meta->name);
 
         $identifier = $meta->getSingleIdentifierFieldName();
         if (isset($config['root'])) {
@@ -926,7 +926,7 @@ class NestedTreeRepository extends AbstractTreeRepository
             $qb->setParameter('rid', $rootId);
         }
         $min = intval($qb->getQuery()->getSingleScalarResult());
-        $edge = $this->listener->getStrategy($this->_em, $meta->name)->max($this->_em, $config['useObjectClass'], $rootId);
+        $edge = $this->getTreeListener()->getStrategy($this->_em, $meta->name)->max($this->_em, $config['useObjectClass'], $rootId);
         // check duplicate right and left values
         for ($i = $min; $i <= $edge; ++$i) {
             $qb = $this->getQueryBuilder();
@@ -1047,7 +1047,7 @@ class NestedTreeRepository extends AbstractTreeRepository
     private function removeSingle(EntityWrapper $wrapped)
     {
         $meta = $this->getClassMetadata();
-        $config = $this->listener->getConfiguration($this->_em, $meta->name);
+        $config = $this->getTreeListener()->getConfiguration($this->_em, $meta->name);
 
         $pk = $meta->getSingleIdentifierFieldName();
         $nodeId = $wrapped->getIdentifier();


### PR DESCRIPTION
When defining a tree repository as a service the TreeListener is not yet registered with the EM when the repository is instantiated as these are being lazy loaded by the doctrine bundle.

This PR makes the resolving of the TreeListener and instantiation of RepositoryUtils lazy, allowing the Respository to function as a service again

This should fix #2077, #1760 