### PR TITLE
[Tree] Fix node primary key in ClosureTreeRepository

### DIFF
--- a/src/Tree/Entity/Repository/ClosureTreeRepository.php
+++ b/src/Tree/Entity/Repository/ClosureTreeRepository.php
@@ -508,7 +508,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
 
         $nodeIdField = $nodeMeta->getSingleIdentifierFieldName();
         $newClosuresCount = $buildClosures("
-          SELECT node.id AS ancestor, node.$nodeIdField AS descendant, 0 AS depth
+          SELECT node.$nodeIdField AS ancestor, node.$nodeIdField AS descendant, 0 AS depth
           FROM {$nodeMeta->name} AS node
           LEFT JOIN {$closureMeta->name} AS c WITH c.ancestor = node AND c.depth = 0
           WHERE c.id IS NULL


### PR DESCRIPTION
The `rebuildClosure` method generates a SQL error when the node primary key ≠ `id`.

Same as #2191 but in "main" branch.

Sorry I didn't read the sentence :

> All pull requests (new features and bug fixes) should target the main branch. Anything that can be back-ported to v2.4.x will be done by maintainers.