### PR TITLE
Remove some obsolete checks

### DIFF
--- a/src/Sluggable/SluggableListener.php
+++ b/src/Sluggable/SluggableListener.php
@@ -291,8 +291,7 @@ class SluggableListener extends MappedEventSubscriber
                         $needToChangeSlug = true;
                     }
                     $value = $meta->getReflectionProperty($sluggableField)->getValue($object);
-                    // Remove `$value instanceof \DateTime` check when PHP version is bumped to >=5.5
-                    $slug .= ($value instanceof \DateTime || $value instanceof \DateTimeInterface) ? $value->format($options['dateFormat']) : $value;
+                    $slug .= $value instanceof \DateTimeInterface ? $value->format($options['dateFormat']) : $value;
                     $slug .= ' ';
                 }
                 // trim generated slug as it will have unnecessary trailing space

--- a/src/SoftDeleteable/SoftDeleteableListener.php
+++ b/src/SoftDeleteable/SoftDeleteableListener.php
@@ -63,8 +63,7 @@ class SoftDeleteableListener extends MappedEventSubscriber
                 $oldValue = $reflProp->getValue($object);
                 $date = $ea->getDateValue($meta, $config['fieldName']);
 
-                // Remove `$oldValue instanceof \DateTime` check when PHP version is bumped to >=5.5
-                if (isset($config['hardDelete']) && $config['hardDelete'] && ($oldValue instanceof \DateTime || $oldValue instanceof \DateTimeInterface) && $oldValue <= $date) {
+                if (isset($config['hardDelete']) && $config['hardDelete'] && $oldValue instanceof \DateTimeInterface && $oldValue <= $date) {
                     continue; // want to hard delete
                 }
 

--- a/src/Tool/Logging/DBAL/QueryAnalyzer.php
+++ b/src/Tool/Logging/DBAL/QueryAnalyzer.php
@@ -225,8 +225,7 @@ class QueryAnalyzer implements SQLLogger
                     $value = $type->convertToDatabaseValue($value, $this->platform);
                 }
             } else {
-                // Remove `$value instanceof \DateTime` check when PHP version is bumped to >=5.5
-                if (is_object($value) && ($value instanceof \DateTime || $value instanceof \DateTimeInterface)) {
+                if ($value instanceof \DateTimeInterface) {
                     $value = $value->format($this->platform->getDateTimeFormatString());
                 } elseif (!is_null($value)) {
                     $type = Type::getType(gettype($value));

--- a/tests/Gedmo/Blameable/TraitUsageTest.php
+++ b/tests/Gedmo/Blameable/TraitUsageTest.php
@@ -23,10 +23,6 @@ class TraitUsageTest extends BaseTestCaseORM
     {
         parent::setUp();
 
-        if (version_compare(PHP_VERSION, '5.4.0') < 0) {
-            $this->markTestSkipped('PHP >= 5.4 version required for this test.');
-        }
-
         $listener = new BlameableListener();
         $listener->setUserValue('testuser');
         $evm = new EventManager();

--- a/tests/Gedmo/IpTraceable/TraitUsageTest.php
+++ b/tests/Gedmo/IpTraceable/TraitUsageTest.php
@@ -24,10 +24,6 @@ class TraitUsageTest extends BaseTestCaseORM
     {
         parent::setUp();
 
-        if (version_compare(PHP_VERSION, '5.4.0') < 0) {
-            $this->markTestSkipped('PHP >= 5.4 version required for this test.');
-        }
-
         $evm = new EventManager();
         $ipTraceableListener = new IpTraceableListener();
         $ipTraceableListener->setIpValue(self::TEST_IP);

--- a/tests/Gedmo/SoftDeleteable/SoftDeletableDocumentTraitTest.php
+++ b/tests/Gedmo/SoftDeleteable/SoftDeletableDocumentTraitTest.php
@@ -20,13 +20,6 @@ class SoftDeletableDocumentTraitTest extends \PHPUnit\Framework\TestCase
      */
     protected $entity;
 
-    public function setUp(): void
-    {
-        if (version_compare(PHP_VERSION, '5.4.0') < 0) {
-            $this->markTestSkipped('PHP >= 5.4 version required for this test.');
-        }
-    }
-
     public function testGetSetDeletedAt()
     {
         $time = new \DateTime();

--- a/tests/Gedmo/SoftDeleteable/SoftDeletableEntityTraitTest.php
+++ b/tests/Gedmo/SoftDeleteable/SoftDeletableEntityTraitTest.php
@@ -20,13 +20,6 @@ class SoftDeletableEntityTraitTest extends \PHPUnit\Framework\TestCase
      */
     protected $entity;
 
-    public function setUp(): void
-    {
-        if (version_compare(PHP_VERSION, '5.4.0') < 0) {
-            $this->markTestSkipped('PHP >= 5.4 version required for this test.');
-        }
-    }
-
     public function testGetSetDeletedAt()
     {
         $time = new \DateTime();

--- a/tests/Gedmo/Timestampable/TraitUsageTest.php
+++ b/tests/Gedmo/Timestampable/TraitUsageTest.php
@@ -23,10 +23,6 @@ class TraitUsageTest extends BaseTestCaseORM
     {
         parent::setUp();
 
-        if (version_compare(PHP_VERSION, '5.4.0') < 0) {
-            $this->markTestSkipped('PHP >= 5.4 version required for this test.');
-        }
-
         $evm = new EventManager();
         $evm->addEventSubscriber(new TimestampableListener());
 


### PR DESCRIPTION
Remove some obsolete checks related to old PHP versions which are not supported anymore from this package.

I guess these changes are pedantic and don't require a changelog.
Please, let me know if should I create one.