### PR TITLE
Add class to get the root path of gedmo

### DIFF
--- a/src/Gedmo.php
+++ b/src/Gedmo.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Gedmo;
+
+/**
+ * The Gedmo class make it easier to get the root path of gedmo.
+ *
+ * @author Alexander Schranz <alexander@sulu.io>
+ * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+final class Gedmo
+{
+    /**
+     * Return the Gedmo root path.
+     *
+     * @return string
+     */
+    public static function getRootPath()
+    {
+        return __DIR__;
+    }
+}

--- a/tests/Gedmo/GedmoTest.php
+++ b/tests/Gedmo/GedmoTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Gedmo\Tree;
+
+use Gedmo\Gedmo;
+
+/**
+ * These are tests for Gedmo class
+ *
+ * @author Alexander Schranz <alexander.schranz@sulu.io>
+ *
+ * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+class GedmoTest extends \PHPUnit\Framework\TestCase
+{
+    public function testGetRootPath()
+    {
+        $this->assertSame(
+            realpath(dirname(__DIR__, 2) . '/src'),
+            Gedmo::getRootPath()
+        );
+    }
+}


### PR DESCRIPTION
We are currently doing in our bundles the following to get the gedmo root path:

```php
        $gedmoReflection = new \ReflectionClass(\Gedmo\Exception::class);
        $parameters['gedmo_directory'] = \dirname($gedmoReflection->getFileName());
```

[Example](https://github.com/sulu/SuluCommunityBundle/blob/501d109dcc0691f9fcd647069d6111b0f9829dea/Tests/Application/Kernel.php#L50-L51)

And use then this parameter to configure doctrine:

```yaml
doctrine:
    orm:
        mappings:
            gedmo_tree:
                type: xml
                prefix: Gedmo\Tree\Entity
                dir: "%gedmo_directory%/Tree/Entity"
                alias: GedmoTree
                is_bundle: false
```

[Example](https://github.com/sulu/SuluCommunityBundle/blob/501d109dcc0691f9fcd647069d6111b0f9829dea/Tests/Application/config/config.yml#L4-L12)

I think it would be great to avoid this reflection and provide a class which returns the root directory of the gedmo extensions.

This would avoided in future a bc break like from 2.0 to 3.0 where the `lib` was changed to `src` directory, when there is another official way to get the correct gedmo root directory.