### PR TITLE
Add hacky fix for Doctrine Bundle 2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ a release.
 ---
 
 ## [Unreleased]
+### Fixed
+- Add hacky measure to resolve incompatibility with DoctrineBundle 2.3 [#2211](https://github.com/doctrine-extensions/DoctrineExtensions/pull/2211)
 
 ## [3.0.3] - 2021-01-23
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
     },
     "require-dev": {
         "alcaeus/mongo-php-adapter": "^1.1",
+        "doctrine/doctrine-bundle": "^2.3",
         "doctrine/mongodb-odm": "^2.0",
         "doctrine/orm": "^2.6.3",
         "friendsofphp/php-cs-fixer": "^2.16",

--- a/src/Mapping/ExtensionMetadataFactory.php
+++ b/src/Mapping/ExtensionMetadataFactory.php
@@ -139,9 +139,10 @@ class ExtensionMetadataFactory
     protected function getDriver($omDriver)
     {
         if ($omDriver instanceof DoctrineBundleMappingDriver) {
-            $omDriver = (new \ReflectionClass($omDriver))
-                ->getProperty('driver')
-                ->getValue($omDriver);
+            $propertyReflection = (new \ReflectionClass($omDriver))
+                ->getProperty('driver');
+            $propertyReflection->setAccessible(true);
+            $omDriver = $propertyReflection->getValue($omDriver);
         }
 
         $driver = null;

--- a/src/Mapping/ExtensionMetadataFactory.php
+++ b/src/Mapping/ExtensionMetadataFactory.php
@@ -2,6 +2,7 @@
 
 namespace Gedmo\Mapping;
 
+use Doctrine\Bundle\DoctrineBundle\Mapping\MappingDriver as DoctrineBundleMappingDriver;
 use Doctrine\Common\Cache\Cache;
 use Doctrine\Persistence\Mapping\Driver\DefaultFileLocator;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
@@ -137,6 +138,12 @@ class ExtensionMetadataFactory
      */
     protected function getDriver($omDriver)
     {
+        if ($omDriver instanceof DoctrineBundleMappingDriver) {
+            $omDriver = (new \ReflectionClass($omDriver))
+                ->getProperty('driver')
+                ->getValue($omDriver);
+        }
+
         $driver = null;
         $className = get_class($omDriver);
         $driverName = substr($className, strrpos($className, '\\') + 1);


### PR DESCRIPTION
Attempting to resolve #2210 with a quick fix.

The larger problem involves how Doctrine Extensions manages class metadata, and it piggybacking on top of the ORM metadata classes and drivers. Ideally, this would be separated into Extensions' own metadata logic and storage system.

Unfortunately, that large fundamental infrastructure change is unlikely in the near future. So, just trying to do what we can to keep things running until that time may come.