### PR TITLE
Add phpdoc to object property

### DIFF
--- a/src/Translatable/Document/MappedSuperclass/AbstractPersonalTranslation.php
+++ b/src/Translatable/Document/MappedSuperclass/AbstractPersonalTranslation.php
@@ -26,8 +26,10 @@ abstract class AbstractPersonalTranslation
     protected $locale;
 
     /**
-     * Related entity with ManyToOne relation
+     * Related document with ManyToOne relation
      * must be mapped by user
+     *
+     * @var object
      */
     protected $object;
 

--- a/src/Translatable/Entity/MappedSuperclass/AbstractPersonalTranslation.php
+++ b/src/Translatable/Entity/MappedSuperclass/AbstractPersonalTranslation.php
@@ -37,6 +37,8 @@ abstract class AbstractPersonalTranslation
     /**
      * Related entity with ManyToOne relation
      * must be mapped by user
+     *
+     * @var object
      */
     protected $object;
 


### PR DESCRIPTION
If not specified, when using static analysis, it infers `$object` as `mixed`. 

Another improvement could be to use generics defining this class as generics like:

```php
/**
 * @template T of object
 */
abstract class AbstractPersonalTranslation
{
    /**
     * @psalm-var T
     * 
     * Related entity with ManyToOne relation
     * must be mapped by user
     */
    protected $object;
// ...
```

So users can specify their type with something like:
```php
/**
 * @psalm-extends AbstractPersonalTranslation<PersonalTranslatable>
 */
class PersonalTranslation extends AbstractPersonalTranslation
{
    
}
```
If that's ok, I'll make the PR.