### PR TITLE
Remove ext-mongo references

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,11 +41,7 @@
         "doctrine/common": "^2.13 || ^3.0",
         "doctrine/event-manager": "^1.0"
     },
-    "provide": {
-        "ext-mongo": "1.6.12"
-    },
     "require-dev": {
-        "alcaeus/mongo-php-adapter": "^1.1",
         "doctrine/cache": "^1.11 || ^2.0",
         "doctrine/doctrine-bundle": "^2.3",
         "doctrine/mongodb-odm": "^2.0",


### PR DESCRIPTION
Since there is a conflict with `"doctrine/mongodb-odm": "<2.0"`, I think this code should belong to the client. In another PR I'll remove references to non-existing classes of `doctrine/mongodb-odm >= 2`