### PR TITLE
[Tree][MaterializedPath] Use path_separator when removing children

### DIFF
--- a/src/Tree/Strategy/ORM/MaterializedPath.php
+++ b/src/Tree/Strategy/ORM/MaterializedPath.php
@@ -24,11 +24,13 @@ class MaterializedPath extends AbstractMaterializedPath
 
         $path = addcslashes($wrapped->getPropertyValue($config['path']), '%');
 
+        $separator = $config['path_ends_with_separator'] ? null : $config['path_separator'];
+        
         // Remove node's children
         $qb = $om->createQueryBuilder();
         $qb->select('e')
             ->from($config['useObjectClass'], 'e')
-            ->where($qb->expr()->like('e.'.$config['path'], $qb->expr()->literal($path.$config['path_separator'].'%')));
+            ->where($qb->expr()->like('e.'.$config['path'], $qb->expr()->literal($path.$separator.'%')));
 
         if (isset($config['level'])) {
             $lvlField = $config['level'];

--- a/src/Tree/Strategy/ORM/MaterializedPath.php
+++ b/src/Tree/Strategy/ORM/MaterializedPath.php
@@ -28,7 +28,7 @@ class MaterializedPath extends AbstractMaterializedPath
         $qb = $om->createQueryBuilder();
         $qb->select('e')
             ->from($config['useObjectClass'], 'e')
-            ->where($qb->expr()->like('e.'.$config['path'], $qb->expr()->literal($path.'%')));
+            ->where($qb->expr()->like('e.'.$config['path'], $qb->expr()->literal($path.$config['path_separator'].'%')));
 
         if (isset($config['level'])) {
             $lvlField = $config['level'];


### PR DESCRIPTION
Consider this tree (without `path_ends_with_separator: false`):
* A
* A-B
* A-B-A
* A-B-B
* A-BA
* A-BB

When removing A-B, not only A-B-A and A-B-B are removed, but A-BA and A-BB are being removed too, while they're not children. This PR uses the `path_separator` configuration option to prevent this.