### PR TITLE
id property can be nullable

### DIFF
--- a/src/Translatable/Document/MappedSuperclass/AbstractPersonalTranslation.php
+++ b/src/Translatable/Document/MappedSuperclass/AbstractPersonalTranslation.php
@@ -12,7 +12,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoODM;
 abstract class AbstractPersonalTranslation
 {
     /**
-     * @var int
+     * @var string|null
      *
      * @MongoODM\Id
      */
@@ -50,7 +50,7 @@ abstract class AbstractPersonalTranslation
     /**
      * Get id
      *
-     * @return int $id
+     * @return string|null $id
      */
     public function getId()
     {

--- a/src/Translatable/Entity/MappedSuperclass/AbstractPersonalTranslation.php
+++ b/src/Translatable/Entity/MappedSuperclass/AbstractPersonalTranslation.php
@@ -12,7 +12,7 @@ use Doctrine\ORM\Mapping as ORM;
 abstract class AbstractPersonalTranslation
 {
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(type="integer")
      * @ORM\Id
@@ -52,7 +52,7 @@ abstract class AbstractPersonalTranslation
     /**
      * Get id
      *
-     * @return int $id
+     * @return int|null $id
      */
     public function getId()
     {


### PR DESCRIPTION
In case of MongoDB, the Id by default it's a string: https://www.doctrine-project.org/projects/doctrine-mongodb-odm/en/2.2/reference/basic-mapping.html#doctrine-mapping-types

`id: string to ObjectId by default, but other formats are possible`

I've added `null` to the identifiers since the current configuration is to autogenerate them, so instantiating (an object extending these abstract classes) them and calling `getId` will return `null`.