### PR TITLE
Add Coding standards check for Github Actions

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -1,0 +1,28 @@
+name: "Coding Standards"
+
+on:
+  pull_request: null
+
+jobs:
+  coding-standards:
+    name: "Coding Standards"
+    runs-on: "ubuntu-20.04"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v2"
+
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          coverage: "none"
+          php-version: "7.4"
+
+      - name: "Install dependencies with Composer"
+        uses: "ramsey/composer-install@v1"
+        with:
+          dependency-versions: "highest"
+
+      - name: "Run PHP-CS-Fixer"
+        run: "bin/php-cs-fixer fix --ansi --verbose --diff --dry-run"
+

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 bin
 vendor
 
-.php_cs.cache
+.php-cs-fixer.cache
 composer.lock
 tests/phpunit.xml
 tests/temp/*.php

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -7,12 +7,14 @@ $finder = PhpCsFixer\Finder::create()
         __DIR__ . '/tests',
     ]);
 
-return PhpCsFixer\Config::create()
+$config = new PhpCsFixer\Config();
+return $config
     ->setRules([
         '@PSR2' => true,
         '@Symfony' => true,
         'array_syntax' => ['syntax' => 'short'],
         'ordered_imports' => ['sort_algorithm' => 'alpha'],
         'phpdoc_summary' => false,
+        'phpdoc_to_comment' => false,
     ])
     ->setFinder($finder);

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "doctrine/doctrine-bundle": "^2.3",
         "doctrine/mongodb-odm": "^2.0",
         "doctrine/orm": "^2.6.3",
-        "friendsofphp/php-cs-fixer": "^2.16",
+        "friendsofphp/php-cs-fixer": "^3.0",
         "phpunit/phpunit": "^8.5",
         "symfony/cache": "^4.4 || ^5.0",
         "symfony/yaml": "^4.1"

--- a/example/em.php
+++ b/example/em.php
@@ -14,7 +14,7 @@ $connection = [
     'driver' => 'pdo_mysql',
 ];
 if (!file_exists(__DIR__.'/../vendor/autoload.php')) {
-    die('cannot find vendors, read README.md how to use composer');
+    exit('cannot find vendors, read README.md how to use composer');
 }
 // First of all autoloading of vendors
 $loader = require __DIR__.'/../vendor/autoload.php';

--- a/src/Blameable/Mapping/Driver/Annotation.php
+++ b/src/Blameable/Mapping/Driver/Annotation.php
@@ -19,7 +19,7 @@ class Annotation extends AbstractAnnotationDriver
     /**
      * Annotation field is blameable
      */
-    const BLAMEABLE = 'Gedmo\\Mapping\\Annotation\\Blameable';
+    public const BLAMEABLE = 'Gedmo\\Mapping\\Annotation\\Blameable';
 
     /**
      * List of types which are valid for blame

--- a/src/DoctrineExtensions.php
+++ b/src/DoctrineExtensions.php
@@ -2,6 +2,7 @@
 
 namespace Gedmo;
 
+use function class_exists;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\Common\Annotations\PsrCachedReader;
@@ -12,7 +13,6 @@ use Doctrine\ODM\MongoDB\Mapping\Driver as DriverMongodbODM;
 use Doctrine\ORM\Mapping\Driver as DriverORM;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
-use function class_exists;
 
 /**
  * Version class allows to checking the dependencies required
@@ -26,7 +26,7 @@ final class DoctrineExtensions
     /**
      * Current version of extensions
      */
-    const VERSION = '3.1.0';
+    public const VERSION = '3.1.0';
 
     /**
      * Hooks all extensions metadata mapping drivers

--- a/src/IpTraceable/Mapping/Driver/Annotation.php
+++ b/src/IpTraceable/Mapping/Driver/Annotation.php
@@ -19,7 +19,7 @@ class Annotation extends AbstractAnnotationDriver
     /**
      * Annotation field is ipTraceable
      */
-    const IP_TRACEABLE = 'Gedmo\\Mapping\\Annotation\\IpTraceable';
+    public const IP_TRACEABLE = 'Gedmo\\Mapping\\Annotation\\IpTraceable';
 
     /**
      * List of types which are valid for IP

--- a/src/Loggable/LoggableListener.php
+++ b/src/Loggable/LoggableListener.php
@@ -19,17 +19,17 @@ class LoggableListener extends MappedEventSubscriber
     /**
      * Create action
      */
-    const ACTION_CREATE = 'create';
+    public const ACTION_CREATE = 'create';
 
     /**
      * Update action
      */
-    const ACTION_UPDATE = 'update';
+    public const ACTION_UPDATE = 'update';
 
     /**
      * Remove action
      */
-    const ACTION_REMOVE = 'remove';
+    public const ACTION_REMOVE = 'remove';
 
     /**
      * Username for identification

--- a/src/Loggable/Mapping/Driver/Annotation.php
+++ b/src/Loggable/Mapping/Driver/Annotation.php
@@ -21,12 +21,12 @@ class Annotation extends AbstractAnnotationDriver
     /**
      * Annotation to define that this object is loggable
      */
-    const LOGGABLE = 'Gedmo\\Mapping\\Annotation\\Loggable';
+    public const LOGGABLE = 'Gedmo\\Mapping\\Annotation\\Loggable';
 
     /**
      * Annotation to define that this property is versioned
      */
-    const VERSIONED = 'Gedmo\\Mapping\\Annotation\\Versioned';
+    public const VERSIONED = 'Gedmo\\Mapping\\Annotation\\Versioned';
 
     /**
      * {@inheritdoc}

--- a/src/Mapping/Annotation/Tree.php
+++ b/src/Mapping/Annotation/Tree.php
@@ -24,6 +24,6 @@ final class Tree extends Annotation
     /** @var int */
     public $lockingTimeout = 3;
 
-    /** @var string $identifierMethod */
+    /** @var string */
     public $identifierMethod;
 }

--- a/src/Mapping/Annotation/TreeRoot.php
+++ b/src/Mapping/Annotation/TreeRoot.php
@@ -15,6 +15,6 @@ use Doctrine\Common\Annotations\Annotation;
  */
 final class TreeRoot extends Annotation
 {
-    /** @var string $identifierMethod */
+    /** @var string */
     public $identifierMethod;
 }

--- a/src/Mapping/Driver/Xml.php
+++ b/src/Mapping/Driver/Xml.php
@@ -17,8 +17,8 @@ use SimpleXMLElement;
  */
 abstract class Xml extends File
 {
-    const GEDMO_NAMESPACE_URI = 'http://gediminasm.org/schemas/orm/doctrine-extensions-mapping';
-    const DOCTRINE_NAMESPACE_URI = 'http://doctrine-project.org/schemas/orm/doctrine-mapping';
+    public const GEDMO_NAMESPACE_URI = 'http://gediminasm.org/schemas/orm/doctrine-extensions-mapping';
+    public const DOCTRINE_NAMESPACE_URI = 'http://doctrine-project.org/schemas/orm/doctrine-mapping';
 
     /**
      * File extension

--- a/src/Mapping/Event/AdapterInterface.php
+++ b/src/Mapping/Event/AdapterInterface.php
@@ -93,9 +93,9 @@ interface AdapterInterface
     /**
      * Recompute the single object changeset from a UnitOfWork
      *
-     * @param UnitOfWork                                         $uow
+     * @param UnitOfWork                                  $uow
      * @param \Doctrine\Persistence\Mapping\ClassMetadata $meta
-     * @param object                                             $object
+     * @param object                                      $object
      *
      * @return void
      */

--- a/src/Mapping/MappedEventSubscriber.php
+++ b/src/Mapping/MappedEventSubscriber.php
@@ -2,6 +2,7 @@
 
 namespace Gedmo\Mapping;
 
+use function class_exists;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\Common\Annotations\PsrCachedReader;
@@ -13,7 +14,6 @@ use Doctrine\Common\EventSubscriber;
 use Doctrine\Persistence\ObjectManager;
 use Gedmo\Mapping\Event\AdapterInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
-use function class_exists;
 
 /**
  * This is extension of event subscriber class and is
@@ -231,7 +231,7 @@ abstract class MappedEventSubscriber implements EventSubscriber
 
             if (class_exists(ArrayAdapter::class)) {
                 $reader = new PsrCachedReader($reader, new ArrayAdapter());
-            } else if (class_exists(ArrayCache::class)) {
+            } elseif (class_exists(ArrayCache::class)) {
                 $reader = new PsrCachedReader($reader, CacheAdapter::wrap(new ArrayCache()));
             }
 

--- a/src/ReferenceIntegrity/Mapping/Driver/Annotation.php
+++ b/src/ReferenceIntegrity/Mapping/Driver/Annotation.php
@@ -20,12 +20,12 @@ class Annotation extends AbstractAnnotationDriver
     /**
      * Annotation to identify the fields which manages the reference integrity
      */
-    const REFERENCE_INTEGRITY = 'Gedmo\\Mapping\\Annotation\\ReferenceIntegrity';
+    public const REFERENCE_INTEGRITY = 'Gedmo\\Mapping\\Annotation\\ReferenceIntegrity';
 
     /**
      * ReferenceIntegrityAction extension annotation
      */
-    const ACTION = 'Gedmo\\Mapping\\Annotation\\ReferenceIntegrityAction';
+    public const ACTION = 'Gedmo\\Mapping\\Annotation\\ReferenceIntegrityAction';
 
     /**
      * {@inheritdoc}

--- a/src/ReferenceIntegrity/Mapping/Validator.php
+++ b/src/ReferenceIntegrity/Mapping/Validator.php
@@ -10,9 +10,9 @@ namespace Gedmo\ReferenceIntegrity\Mapping;
  */
 class Validator
 {
-    const NULLIFY = 'nullify';
-    const PULL = 'pull';
-    const RESTRICT = 'restrict';
+    public const NULLIFY = 'nullify';
+    public const PULL = 'pull';
+    public const RESTRICT = 'restrict';
 
     /**
      * List of actions which are valid as integrity check

--- a/src/References/Mapping/Driver/Annotation.php
+++ b/src/References/Mapping/Driver/Annotation.php
@@ -18,17 +18,17 @@ class Annotation implements AnnotationDriverInterface
     /**
      * Annotation to mark field as reference to one
      */
-    const REFERENCE_ONE = 'Gedmo\\Mapping\\Annotation\\ReferenceOne';
+    public const REFERENCE_ONE = 'Gedmo\\Mapping\\Annotation\\ReferenceOne';
 
     /**
      * Annotation to mark field as reference to many
      */
-    const REFERENCE_MANY = 'Gedmo\\Mapping\\Annotation\\ReferenceMany';
+    public const REFERENCE_MANY = 'Gedmo\\Mapping\\Annotation\\ReferenceMany';
 
     /**
      * Annotation to mark field as reference to many
      */
-    const REFERENCE_MANY_EMBED = 'Gedmo\\Mapping\\Annotation\\ReferenceManyEmbed';
+    public const REFERENCE_MANY_EMBED = 'Gedmo\\Mapping\\Annotation\\ReferenceManyEmbed';
 
     private $annotations = [
         'referenceOne' => self::REFERENCE_ONE,

--- a/src/Sluggable/Handler/RelativeSlugHandler.php
+++ b/src/Sluggable/Handler/RelativeSlugHandler.php
@@ -20,7 +20,7 @@ use Gedmo\Tool\Wrapper\AbstractWrapper;
  */
 class RelativeSlugHandler implements SlugHandlerInterface
 {
-    const SEPARATOR = '/';
+    public const SEPARATOR = '/';
 
     /**
      * @var ObjectManager

--- a/src/Sluggable/Handler/TreeSlugHandler.php
+++ b/src/Sluggable/Handler/TreeSlugHandler.php
@@ -19,7 +19,7 @@ use Gedmo\Tool\Wrapper\AbstractWrapper;
  */
 class TreeSlugHandler implements SlugHandlerWithUniqueCallbackInterface
 {
-    const SEPARATOR = '/';
+    public const SEPARATOR = '/';
 
     /**
      * @var ObjectManager

--- a/src/Sluggable/Mapping/Driver/Annotation.php
+++ b/src/Sluggable/Mapping/Driver/Annotation.php
@@ -22,17 +22,17 @@ class Annotation extends AbstractAnnotationDriver
      * Annotation to identify field as one which holds the slug
      * together with slug options
      */
-    const SLUG = 'Gedmo\\Mapping\\Annotation\\Slug';
+    public const SLUG = 'Gedmo\\Mapping\\Annotation\\Slug';
 
     /**
      * SlugHandler extension annotation
      */
-    const HANDLER = 'Gedmo\\Mapping\\Annotation\\SlugHandler';
+    public const HANDLER = 'Gedmo\\Mapping\\Annotation\\SlugHandler';
 
     /**
      * SlugHandler option annotation
      */
-    const HANDLER_OPTION = 'Gedmo\\Mapping\\Annotation\\SlugHandlerOption';
+    public const HANDLER_OPTION = 'Gedmo\\Mapping\\Annotation\\SlugHandlerOption';
 
     /**
      * List of types which are valid for slug and sluggable fields

--- a/src/SoftDeleteable/Mapping/Driver/Annotation.php
+++ b/src/SoftDeleteable/Mapping/Driver/Annotation.php
@@ -21,7 +21,7 @@ class Annotation extends AbstractAnnotationDriver
     /**
      * Annotation to define that this object is loggable
      */
-    const SOFT_DELETEABLE = 'Gedmo\\Mapping\\Annotation\\SoftDeleteable';
+    public const SOFT_DELETEABLE = 'Gedmo\\Mapping\\Annotation\\SoftDeleteable';
 
     /**
      * {@inheritdoc}

--- a/src/SoftDeleteable/Mapping/Event/Adapter/ODM.php
+++ b/src/SoftDeleteable/Mapping/Event/Adapter/ODM.php
@@ -4,7 +4,6 @@ namespace Gedmo\SoftDeleteable\Mapping\Event\Adapter;
 
 use Gedmo\Mapping\Event\Adapter\ODM as BaseAdapterODM;
 use Gedmo\SoftDeleteable\Mapping\Event\SoftDeleteableAdapter;
-use Gedmo\Timestampable\Mapping\Event\TimestampableAdapter;
 
 /**
  * Doctrine event adapter for ORM adapted

--- a/src/SoftDeleteable/SoftDeleteableListener.php
+++ b/src/SoftDeleteable/SoftDeleteableListener.php
@@ -20,14 +20,14 @@ class SoftDeleteableListener extends MappedEventSubscriber
      *
      * @var string
      */
-    const PRE_SOFT_DELETE = 'preSoftDelete';
+    public const PRE_SOFT_DELETE = 'preSoftDelete';
 
     /**
      * Post soft-delete event
      *
      * @var string
      */
-    const POST_SOFT_DELETE = 'postSoftDelete';
+    public const POST_SOFT_DELETE = 'postSoftDelete';
 
     /**
      * {@inheritdoc}

--- a/src/Sortable/Mapping/Driver/Annotation.php
+++ b/src/Sortable/Mapping/Driver/Annotation.php
@@ -19,12 +19,12 @@ class Annotation extends AbstractAnnotationDriver
     /**
      * Annotation to mark field as one which will store node position
      */
-    const POSITION = 'Gedmo\\Mapping\\Annotation\\SortablePosition';
+    public const POSITION = 'Gedmo\\Mapping\\Annotation\\SortablePosition';
 
     /**
      * Annotation to mark field as sorting group
      */
-    const GROUP = 'Gedmo\\Mapping\\Annotation\\SortableGroup';
+    public const GROUP = 'Gedmo\\Mapping\\Annotation\\SortableGroup';
 
     /**
      * List of types which are valid for position fields

--- a/src/Timestampable/Mapping/Driver/Annotation.php
+++ b/src/Timestampable/Mapping/Driver/Annotation.php
@@ -19,7 +19,7 @@ class Annotation extends AbstractAnnotationDriver
     /**
      * Annotation field is timestampable
      */
-    const TIMESTAMPABLE = 'Gedmo\\Mapping\\Annotation\\Timestampable';
+    public const TIMESTAMPABLE = 'Gedmo\\Mapping\\Annotation\\Timestampable';
 
     /**
      * List of types which are valid for timestamp

--- a/src/Translatable/Mapping/Driver/Annotation.php
+++ b/src/Translatable/Mapping/Driver/Annotation.php
@@ -19,24 +19,24 @@ class Annotation extends AbstractAnnotationDriver
     /**
      * Annotation to identity translation entity to be used for translation storage
      */
-    const ENTITY_CLASS = 'Gedmo\\Mapping\\Annotation\\TranslationEntity';
+    public const ENTITY_CLASS = 'Gedmo\\Mapping\\Annotation\\TranslationEntity';
 
     /**
      * Annotation to identify field as translatable
      */
-    const TRANSLATABLE = 'Gedmo\\Mapping\\Annotation\\Translatable';
+    public const TRANSLATABLE = 'Gedmo\\Mapping\\Annotation\\Translatable';
 
     /**
      * Annotation to identify field which can store used locale or language
      * alias is LANGUAGE
      */
-    const LOCALE = 'Gedmo\\Mapping\\Annotation\\Locale';
+    public const LOCALE = 'Gedmo\\Mapping\\Annotation\\Locale';
 
     /**
      * Annotation to identify field which can store used locale or language
      * alias is LOCALE
      */
-    const LANGUAGE = 'Gedmo\\Mapping\\Annotation\\Language';
+    public const LANGUAGE = 'Gedmo\\Mapping\\Annotation\\Language';
 
     /**
      * {@inheritdoc}

--- a/src/Translatable/Query/TreeWalker/TranslationWalker.php
+++ b/src/Translatable/Query/TreeWalker/TranslationWalker.php
@@ -35,21 +35,21 @@ class TranslationWalker extends SqlWalker
      *
      * @internal
      */
-    const HINT_TRANSLATION_FALLBACKS = '__gedmo.translatable.stored.fallbacks';
+    public const HINT_TRANSLATION_FALLBACKS = '__gedmo.translatable.stored.fallbacks';
 
     /**
      * Customized object hydrator name
      *
      * @internal
      */
-    const HYDRATE_OBJECT_TRANSLATION = '__gedmo.translatable.object.hydrator';
+    public const HYDRATE_OBJECT_TRANSLATION = '__gedmo.translatable.object.hydrator';
 
     /**
      * Customized object hydrator name
      *
      * @internal
      */
-    const HYDRATE_SIMPLE_OBJECT_TRANSLATION = '__gedmo.translatable.simple_object.hydrator';
+    public const HYDRATE_SIMPLE_OBJECT_TRANSLATION = '__gedmo.translatable.simple_object.hydrator';
 
     /**
      * Stores all component references from select clause

--- a/src/Translatable/TranslatableListener.php
+++ b/src/Translatable/TranslatableListener.php
@@ -30,17 +30,17 @@ class TranslatableListener extends MappedEventSubscriber
      * Query hint to override the fallback of translations
      * integer 1 for true, 0 false
      */
-    const HINT_FALLBACK = 'gedmo.translatable.fallback';
+    public const HINT_FALLBACK = 'gedmo.translatable.fallback';
 
     /**
      * Query hint to override the fallback locale
      */
-    const HINT_TRANSLATABLE_LOCALE = 'gedmo.translatable.locale';
+    public const HINT_TRANSLATABLE_LOCALE = 'gedmo.translatable.locale';
 
     /**
      * Query hint to use inner join strategy for translations
      */
-    const HINT_INNER_JOIN = 'gedmo.translatable.inner_join.translations';
+    public const HINT_INNER_JOIN = 'gedmo.translatable.inner_join.translations';
 
     /**
      * Locale which is set on this listener.
@@ -468,7 +468,7 @@ class TranslatableListener extends MappedEventSubscriber
                     }
                 }
                 // update translation
-                if ($translated !== null
+                if (null !== $translated
                     || (!$this->translationFallback && (!isset($config['fallback'][$field]) || !$config['fallback'][$field]))
                     || ($this->translationFallback && isset($config['fallback'][$field]) && !$config['fallback'][$field])
                 ) {

--- a/src/Tree/Entity/Repository/ClosureTreeRepository.php
+++ b/src/Tree/Entity/Repository/ClosureTreeRepository.php
@@ -20,7 +20,7 @@ use Gedmo\Tree\Strategy;
 class ClosureTreeRepository extends AbstractTreeRepository
 {
     /** Alias for the level value used in the subquery of the getNodesHierarchy method */
-    const SUBQUERY_LEVEL = 'level';
+    public const SUBQUERY_LEVEL = 'level';
 
     /**
      * {@inheritdoc}

--- a/src/Tree/Mapping/Driver/Annotation.php
+++ b/src/Tree/Mapping/Driver/Annotation.php
@@ -21,57 +21,57 @@ class Annotation extends AbstractAnnotationDriver
     /**
      * Annotation to define the tree type
      */
-    const TREE = 'Gedmo\\Mapping\\Annotation\\Tree';
+    public const TREE = 'Gedmo\\Mapping\\Annotation\\Tree';
 
     /**
      * Annotation to mark field as one which will store left value
      */
-    const LEFT = 'Gedmo\\Mapping\\Annotation\\TreeLeft';
+    public const LEFT = 'Gedmo\\Mapping\\Annotation\\TreeLeft';
 
     /**
      * Annotation to mark field as one which will store right value
      */
-    const RIGHT = 'Gedmo\\Mapping\\Annotation\\TreeRight';
+    public const RIGHT = 'Gedmo\\Mapping\\Annotation\\TreeRight';
 
     /**
      * Annotation to mark relative parent field
      */
-    const PARENT = 'Gedmo\\Mapping\\Annotation\\TreeParent';
+    public const PARENT = 'Gedmo\\Mapping\\Annotation\\TreeParent';
 
     /**
      * Annotation to mark node level
      */
-    const LEVEL = 'Gedmo\\Mapping\\Annotation\\TreeLevel';
+    public const LEVEL = 'Gedmo\\Mapping\\Annotation\\TreeLevel';
 
     /**
      * Annotation to mark field as tree root
      */
-    const ROOT = 'Gedmo\\Mapping\\Annotation\\TreeRoot';
+    public const ROOT = 'Gedmo\\Mapping\\Annotation\\TreeRoot';
 
     /**
      * Annotation to specify closure tree class
      */
-    const CLOSURE = 'Gedmo\\Mapping\\Annotation\\TreeClosure';
+    public const CLOSURE = 'Gedmo\\Mapping\\Annotation\\TreeClosure';
 
     /**
      * Annotation to specify path class
      */
-    const PATH = 'Gedmo\\Mapping\\Annotation\\TreePath';
+    public const PATH = 'Gedmo\\Mapping\\Annotation\\TreePath';
 
     /**
      * Annotation to specify path source class
      */
-    const PATH_SOURCE = 'Gedmo\\Mapping\\Annotation\\TreePathSource';
+    public const PATH_SOURCE = 'Gedmo\\Mapping\\Annotation\\TreePathSource';
 
     /**
      * Annotation to specify path hash class
      */
-    const PATH_HASH = 'Gedmo\\Mapping\\Annotation\\TreePathHash';
+    public const PATH_HASH = 'Gedmo\\Mapping\\Annotation\\TreePathHash';
 
     /**
      * Annotation to mark the field to be used to hold the lock time
      */
-    const LOCK_TIME = 'Gedmo\\Mapping\\Annotation\\TreeLockTime';
+    public const LOCK_TIME = 'Gedmo\\Mapping\\Annotation\\TreeLockTime';
 
     /**
      * List of tree strategies available

--- a/src/Tree/RepositoryInterface.php
+++ b/src/Tree/RepositoryInterface.php
@@ -36,10 +36,10 @@ interface RepositoryInterface extends RepositoryUtilsInterface
     /**
      * Get list of children followed by given $node
      *
-     * @param object               $node - if null, all tree nodes will be taken
-     * @param bool                 $direct - true to take only direct children
-     * @param null|string|string[] $sortByField - field name(s) to sort by
-     * @param string               $direction - sort direction : "ASC" or "DESC"
+     * @param object               $node        - if null, all tree nodes will be taken
+     * @param bool                 $direct      - true to take only direct children
+     * @param string|string[]|null $sortByField - field name(s) to sort by
+     * @param string               $direction   - sort direction : "ASC" or "DESC"
      * @param bool                 $includeNode - Include the root node in results?
      *
      * @return array - list of given $node children, null on failure

--- a/src/Tree/Strategy.php
+++ b/src/Tree/Strategy.php
@@ -10,17 +10,17 @@ interface Strategy
     /**
      * NestedSet strategy
      */
-    const NESTED = 'nested';
+    public const NESTED = 'nested';
 
     /**
      * Closure strategy
      */
-    const CLOSURE = 'closure';
+    public const CLOSURE = 'closure';
 
     /**
      * Materialized Path strategy
      */
-    const MATERIALIZED_PATH = 'materializedPath';
+    public const MATERIALIZED_PATH = 'materializedPath';
 
     /**
      * Get the name of strategy

--- a/src/Tree/Strategy/AbstractMaterializedPath.php
+++ b/src/Tree/Strategy/AbstractMaterializedPath.php
@@ -21,9 +21,9 @@ use MongoDB\BSON\UTCDateTime;
  */
 abstract class AbstractMaterializedPath implements Strategy
 {
-    const ACTION_INSERT = 'insert';
-    const ACTION_UPDATE = 'update';
-    const ACTION_REMOVE = 'remove';
+    public const ACTION_INSERT = 'insert';
+    public const ACTION_UPDATE = 'update';
+    public const ACTION_REMOVE = 'remove';
 
     /**
      * TreeListener

--- a/src/Tree/Strategy/ORM/MaterializedPath.php
+++ b/src/Tree/Strategy/ORM/MaterializedPath.php
@@ -25,7 +25,7 @@ class MaterializedPath extends AbstractMaterializedPath
         $path = addcslashes($wrapped->getPropertyValue($config['path']), '%');
 
         $separator = $config['path_ends_with_separator'] ? null : $config['path_separator'];
-        
+
         // Remove node's children
         $qb = $om->createQueryBuilder();
         $qb->select('e')

--- a/src/Tree/Strategy/ORM/Nested.php
+++ b/src/Tree/Strategy/ORM/Nested.php
@@ -26,22 +26,22 @@ class Nested implements Strategy
     /**
      * Previous sibling position
      */
-    const PREV_SIBLING = 'PrevSibling';
+    public const PREV_SIBLING = 'PrevSibling';
 
     /**
      * Next sibling position
      */
-    const NEXT_SIBLING = 'NextSibling';
+    public const NEXT_SIBLING = 'NextSibling';
 
     /**
      * Last child position
      */
-    const LAST_CHILD = 'LastChild';
+    public const LAST_CHILD = 'LastChild';
 
     /**
      * First child position
      */
-    const FIRST_CHILD = 'FirstChild';
+    public const FIRST_CHILD = 'FirstChild';
 
     /**
      * TreeListener

--- a/src/Uploadable/Events.php
+++ b/src/Uploadable/Events.php
@@ -22,7 +22,7 @@ final class Events
      *
      * @var string
      */
-    const uploadablePreFileProcess = 'uploadablePreFileProcess';
+    public const uploadablePreFileProcess = 'uploadablePreFileProcess';
     /**
      * The uploadablePostFileProcess event occurs after a file is processed inside
      * the Uploadable listener. This means it happens after the file is validated and moved
@@ -30,5 +30,5 @@ final class Events
      *
      * @var string
      */
-    const uploadablePostFileProcess = 'uploadablePostFileProcess';
+    public const uploadablePostFileProcess = 'uploadablePostFileProcess';
 }

--- a/src/Uploadable/Mapping/Driver/Annotation.php
+++ b/src/Uploadable/Mapping/Driver/Annotation.php
@@ -20,11 +20,11 @@ class Annotation extends AbstractAnnotationDriver
     /**
      * Annotation to define that this object is loggable
      */
-    const UPLOADABLE = 'Gedmo\\Mapping\\Annotation\\Uploadable';
-    const UPLOADABLE_FILE_MIME_TYPE = 'Gedmo\\Mapping\\Annotation\\UploadableFileMimeType';
-    const UPLOADABLE_FILE_NAME = 'Gedmo\\Mapping\\Annotation\\UploadableFileName';
-    const UPLOADABLE_FILE_PATH = 'Gedmo\\Mapping\\Annotation\\UploadableFilePath';
-    const UPLOADABLE_FILE_SIZE = 'Gedmo\\Mapping\\Annotation\\UploadableFileSize';
+    public const UPLOADABLE = 'Gedmo\\Mapping\\Annotation\\Uploadable';
+    public const UPLOADABLE_FILE_MIME_TYPE = 'Gedmo\\Mapping\\Annotation\\UploadableFileMimeType';
+    public const UPLOADABLE_FILE_NAME = 'Gedmo\\Mapping\\Annotation\\UploadableFileName';
+    public const UPLOADABLE_FILE_PATH = 'Gedmo\\Mapping\\Annotation\\UploadableFilePath';
+    public const UPLOADABLE_FILE_SIZE = 'Gedmo\\Mapping\\Annotation\\UploadableFileSize';
 
     /**
      * {@inheritdoc}

--- a/src/Uploadable/Mapping/Validator.php
+++ b/src/Uploadable/Mapping/Validator.php
@@ -16,13 +16,13 @@ use Gedmo\Exception\UploadableInvalidPathException;
  */
 class Validator
 {
-    const UPLOADABLE_FILE_MIME_TYPE = 'UploadableFileMimeType';
-    const UPLOADABLE_FILE_NAME = 'UploadableFileName';
-    const UPLOADABLE_FILE_PATH = 'UploadableFilePath';
-    const UPLOADABLE_FILE_SIZE = 'UploadableFileSize';
-    const FILENAME_GENERATOR_SHA1 = 'SHA1';
-    const FILENAME_GENERATOR_ALPHANUMERIC = 'ALPHANUMERIC';
-    const FILENAME_GENERATOR_NONE = 'NONE';
+    public const UPLOADABLE_FILE_MIME_TYPE = 'UploadableFileMimeType';
+    public const UPLOADABLE_FILE_NAME = 'UploadableFileName';
+    public const UPLOADABLE_FILE_PATH = 'UploadableFilePath';
+    public const UPLOADABLE_FILE_SIZE = 'UploadableFileSize';
+    public const FILENAME_GENERATOR_SHA1 = 'SHA1';
+    public const FILENAME_GENERATOR_ALPHANUMERIC = 'ALPHANUMERIC';
+    public const FILENAME_GENERATOR_NONE = 'NONE';
 
     /**
      * Determines if we should throw an exception in the case the "allowedTypes" and

--- a/src/Uploadable/UploadableListener.php
+++ b/src/Uploadable/UploadableListener.php
@@ -36,8 +36,8 @@ use Gedmo\Uploadable\MimeType\MimeTypeGuesserInterface;
  */
 class UploadableListener extends MappedEventSubscriber
 {
-    const ACTION_INSERT = 'INSERT';
-    const ACTION_UPDATE = 'UPDATE';
+    public const ACTION_INSERT = 'INSERT';
+    public const ACTION_UPDATE = 'UPDATE';
 
     /**
      * Default path to move files in

--- a/tests/Gedmo/Blameable/BlameableDocumentTest.php
+++ b/tests/Gedmo/Blameable/BlameableDocumentTest.php
@@ -19,11 +19,11 @@ use Tool\BaseTestCaseMongoODM;
  */
 class BlameableDocumentTest extends BaseTestCaseMongoODM
 {
-    const TEST_USERNAME = 'testuser';
+    public const TEST_USERNAME = 'testuser';
 
-    const TYPE = 'Blameable\Fixture\Document\Type';
-    const USER = 'Blameable\Fixture\Document\User';
-    const ARTICLE = 'Blameable\Fixture\Document\Article';
+    public const TYPE = 'Blameable\Fixture\Document\Type';
+    public const USER = 'Blameable\Fixture\Document\User';
+    public const ARTICLE = 'Blameable\Fixture\Document\Article';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Blameable/BlameableTest.php
+++ b/tests/Gedmo/Blameable/BlameableTest.php
@@ -19,9 +19,9 @@ use Tool\BaseTestCaseORM;
  */
 class BlameableTest extends BaseTestCaseORM
 {
-    const ARTICLE = 'Blameable\\Fixture\\Entity\\Article';
-    const COMMENT = 'Blameable\\Fixture\\Entity\\Comment';
-    const TYPE = 'Blameable\\Fixture\\Entity\\Type';
+    public const ARTICLE = 'Blameable\\Fixture\\Entity\\Article';
+    public const COMMENT = 'Blameable\\Fixture\\Entity\\Comment';
+    public const TYPE = 'Blameable\\Fixture\\Entity\\Type';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Blameable/ChangeTest.php
+++ b/tests/Gedmo/Blameable/ChangeTest.php
@@ -17,7 +17,7 @@ use Tool\BaseTestCaseORM;
  */
 class ChangeTest extends BaseTestCaseORM
 {
-    const FIXTURE = 'Blameable\\Fixture\\Entity\\TitledArticle';
+    public const FIXTURE = 'Blameable\\Fixture\\Entity\\TitledArticle';
 
     private $listener;
 

--- a/tests/Gedmo/Blameable/NoInterfaceTest.php
+++ b/tests/Gedmo/Blameable/NoInterfaceTest.php
@@ -17,7 +17,7 @@ use Tool\BaseTestCaseORM;
  */
 class NoInterfaceTest extends BaseTestCaseORM
 {
-    const FIXTURE = 'Blameable\\Fixture\\Entity\\WithoutInterface';
+    public const FIXTURE = 'Blameable\\Fixture\\Entity\\WithoutInterface';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Blameable/NoUserTest.php
+++ b/tests/Gedmo/Blameable/NoUserTest.php
@@ -14,7 +14,7 @@ use Tool\BaseTestCaseMongoODM;
  */
 class NoUserTest extends BaseTestCaseMongoODM
 {
-    const ARTICLE = 'Blameable\Fixture\Document\Article';
+    public const ARTICLE = 'Blameable\Fixture\Document\Article';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Blameable/ProtectedPropertySupperclassTest.php
+++ b/tests/Gedmo/Blameable/ProtectedPropertySupperclassTest.php
@@ -18,8 +18,8 @@ use Tool\BaseTestCaseORM;
  */
 class ProtectedPropertySupperclassTest extends BaseTestCaseORM
 {
-    const SUPERCLASS = 'Blameable\\Fixture\\Entity\\SupperClassExtension';
-    const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
+    public const SUPERCLASS = 'Blameable\\Fixture\\Entity\\SupperClassExtension';
+    public const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Blameable/TraitUsageTest.php
+++ b/tests/Gedmo/Blameable/TraitUsageTest.php
@@ -17,7 +17,7 @@ use Tool\BaseTestCaseORM;
  */
 class TraitUsageTest extends BaseTestCaseORM
 {
-    const TARGET = 'Blameable\\Fixture\\Entity\\UsingTrait';
+    public const TARGET = 'Blameable\\Fixture\\Entity\\UsingTrait';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/IpTraceable/ChangeTest.php
+++ b/tests/Gedmo/IpTraceable/ChangeTest.php
@@ -17,8 +17,8 @@ use Tool\BaseTestCaseORM;
  */
 class ChangeTest extends BaseTestCaseORM
 {
-    const TEST_IP = '34.234.1.10';
-    const FIXTURE = 'IpTraceable\\Fixture\\TitledArticle';
+    public const TEST_IP = '34.234.1.10';
+    public const FIXTURE = 'IpTraceable\\Fixture\\TitledArticle';
 
     protected $listener;
 

--- a/tests/Gedmo/IpTraceable/IpTraceableDocumentTest.php
+++ b/tests/Gedmo/IpTraceable/IpTraceableDocumentTest.php
@@ -18,10 +18,10 @@ use Tool\BaseTestCaseMongoODM;
  */
 class IpTraceableDocumentTest extends BaseTestCaseMongoODM
 {
-    const TEST_IP = '34.234.1.10';
+    public const TEST_IP = '34.234.1.10';
 
-    const ARTICLE = 'IpTraceable\Fixture\Document\Article';
-    const TYPE = 'IpTraceable\Fixture\Document\Type';
+    public const ARTICLE = 'IpTraceable\Fixture\Document\Article';
+    public const TYPE = 'IpTraceable\Fixture\Document\Type';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/IpTraceable/IpTraceableTest.php
+++ b/tests/Gedmo/IpTraceable/IpTraceableTest.php
@@ -19,11 +19,11 @@ use Tool\BaseTestCaseORM;
  */
 class IpTraceableTest extends BaseTestCaseORM
 {
-    const TEST_IP = '34.234.1.10';
+    public const TEST_IP = '34.234.1.10';
 
-    const ARTICLE = 'IpTraceable\\Fixture\\Article';
-    const COMMENT = 'IpTraceable\\Fixture\\Comment';
-    const TYPE = 'IpTraceable\\Fixture\\Type';
+    public const ARTICLE = 'IpTraceable\\Fixture\\Article';
+    public const COMMENT = 'IpTraceable\\Fixture\\Comment';
+    public const TYPE = 'IpTraceable\\Fixture\\Type';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/IpTraceable/NoInterfaceTest.php
+++ b/tests/Gedmo/IpTraceable/NoInterfaceTest.php
@@ -17,8 +17,8 @@ use Tool\BaseTestCaseORM;
  */
 class NoInterfaceTest extends BaseTestCaseORM
 {
-    const TEST_IP = '34.234.1.10';
-    const FIXTURE = 'IpTraceable\\Fixture\\WithoutInterface';
+    public const TEST_IP = '34.234.1.10';
+    public const FIXTURE = 'IpTraceable\\Fixture\\WithoutInterface';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/IpTraceable/TraitUsageTest.php
+++ b/tests/Gedmo/IpTraceable/TraitUsageTest.php
@@ -17,8 +17,8 @@ use Tool\BaseTestCaseORM;
  */
 class TraitUsageTest extends BaseTestCaseORM
 {
-    const TEST_IP = '34.234.1.10';
-    const TARGET = 'IpTraceable\\Fixture\\UsingTrait';
+    public const TEST_IP = '34.234.1.10';
+    public const TARGET = 'IpTraceable\\Fixture\\UsingTrait';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Loggable/LoggableDocumentTest.php
+++ b/tests/Gedmo/Loggable/LoggableDocumentTest.php
@@ -21,10 +21,10 @@ use Tool\BaseTestCaseMongoODM;
  */
 class LoggableDocumentTest extends BaseTestCaseMongoODM
 {
-    const ARTICLE = 'Loggable\\Fixture\\Document\\Article';
-    const COMMENT = 'Loggable\\Fixture\\Document\\Comment';
-    const RELATED_ARTICLE = 'Loggable\\Fixture\\Document\\RelatedArticle';
-    const COMMENT_LOG = 'Loggable\\Fixture\\Document\\Log\\Comment';
+    public const ARTICLE = 'Loggable\\Fixture\\Document\\Article';
+    public const COMMENT = 'Loggable\\Fixture\\Document\\Comment';
+    public const RELATED_ARTICLE = 'Loggable\\Fixture\\Document\\RelatedArticle';
+    public const COMMENT_LOG = 'Loggable\\Fixture\\Document\\Log\\Comment';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Loggable/LoggableEntityTest.php
+++ b/tests/Gedmo/Loggable/LoggableEntityTest.php
@@ -22,10 +22,10 @@ use Tool\BaseTestCaseORM;
  */
 class LoggableEntityTest extends BaseTestCaseORM
 {
-    const ARTICLE = 'Loggable\Fixture\Entity\Article';
-    const COMMENT = 'Loggable\Fixture\Entity\Comment';
-    const RELATED_ARTICLE = 'Loggable\Fixture\Entity\RelatedArticle';
-    const COMMENT_LOG = 'Loggable\Fixture\Entity\Log\Comment';
+    public const ARTICLE = 'Loggable\Fixture\Entity\Article';
+    public const COMMENT = 'Loggable\Fixture\Entity\Comment';
+    public const RELATED_ARTICLE = 'Loggable\Fixture\Entity\RelatedArticle';
+    public const COMMENT_LOG = 'Loggable\Fixture\Entity\Log\Comment';
 
     private $articleId;
     private $LoggableListener;

--- a/tests/Gedmo/Mapping/ExtensionODMTest.php
+++ b/tests/Gedmo/Mapping/ExtensionODMTest.php
@@ -10,7 +10,7 @@ use Tool\BaseTestCaseMongoODM;
 
 class ExtensionODMTest extends BaseTestCaseMongoODM
 {
-    const USER = 'Mapping\\Fixture\\Document\\User';
+    public const USER = 'Mapping\\Fixture\\Document\\User';
 
     private $encoderListener;
 

--- a/tests/Gedmo/Mapping/ExtensionORMTest.php
+++ b/tests/Gedmo/Mapping/ExtensionORMTest.php
@@ -10,7 +10,7 @@ use Tool\BaseTestCaseORM;
 
 class ExtensionORMTest extends BaseTestCaseORM
 {
-    const USER = 'Mapping\\Fixture\\User';
+    public const USER = 'Mapping\\Fixture\\User';
 
     private $encoderListener;
 

--- a/tests/Gedmo/Mapping/LoggableMappingTest.php
+++ b/tests/Gedmo/Mapping/LoggableMappingTest.php
@@ -17,7 +17,7 @@ use Gedmo\Mapping\ExtensionMetadataFactory;
  */
 class LoggableMappingTest extends \PHPUnit\Framework\TestCase
 {
-    const YAML_CATEGORY = 'Mapping\Fixture\Yaml\Category';
+    public const YAML_CATEGORY = 'Mapping\Fixture\Yaml\Category';
     private $em;
 
     public function setUp(): void

--- a/tests/Gedmo/Mapping/MappingTest.php
+++ b/tests/Gedmo/Mapping/MappingTest.php
@@ -15,8 +15,8 @@ use Tree\Fixture\BehavioralCategory;
  */
 class MappingTest extends \PHPUnit\Framework\TestCase
 {
-    const TEST_ENTITY_CATEGORY = "Tree\Fixture\BehavioralCategory";
-    const TEST_ENTITY_TRANSLATION = "Gedmo\Translatable\Entity\Translation";
+    public const TEST_ENTITY_CATEGORY = "Tree\Fixture\BehavioralCategory";
+    public const TEST_ENTITY_TRANSLATION = "Gedmo\Translatable\Entity\Translation";
 
     private $em;
     private $timestampable;

--- a/tests/Gedmo/Mapping/SluggableMappingTest.php
+++ b/tests/Gedmo/Mapping/SluggableMappingTest.php
@@ -17,8 +17,8 @@ use Gedmo\Mapping\ExtensionMetadataFactory;
  */
 class SluggableMappingTest extends \PHPUnit\Framework\TestCase
 {
-    const TEST_YAML_ENTITY_CLASS = 'Mapping\Fixture\Yaml\Category';
-    const SLUGGABLE = 'Mapping\Fixture\Sluggable';
+    public const TEST_YAML_ENTITY_CLASS = 'Mapping\Fixture\Yaml\Category';
+    public const SLUGGABLE = 'Mapping\Fixture\Sluggable';
     private $em;
 
     public function setUp(): void

--- a/tests/Gedmo/Mapping/TimestampableMappingTest.php
+++ b/tests/Gedmo/Mapping/TimestampableMappingTest.php
@@ -17,7 +17,7 @@ use Gedmo\Mapping\ExtensionMetadataFactory;
  */
 class TimestampableMappingTest extends \PHPUnit\Framework\TestCase
 {
-    const TEST_YAML_ENTITY_CLASS = 'Mapping\Fixture\Yaml\Category';
+    public const TEST_YAML_ENTITY_CLASS = 'Mapping\Fixture\Yaml\Category';
     private $em;
 
     public function setUp(): void

--- a/tests/Gedmo/Mapping/TranslatableMappingTest.php
+++ b/tests/Gedmo/Mapping/TranslatableMappingTest.php
@@ -17,7 +17,7 @@ use Gedmo\Mapping\ExtensionMetadataFactory;
  */
 class TranslatableMappingTest extends \PHPUnit\Framework\TestCase
 {
-    const TEST_YAML_ENTITY_CLASS = 'Mapping\Fixture\Yaml\User';
+    public const TEST_YAML_ENTITY_CLASS = 'Mapping\Fixture\Yaml\User';
     private $em;
 
     public function setUp(): void

--- a/tests/Gedmo/Mapping/TreeMappingTest.php
+++ b/tests/Gedmo/Mapping/TreeMappingTest.php
@@ -17,9 +17,9 @@ use Gedmo\Mapping\ExtensionMetadataFactory;
  */
 class TreeMappingTest extends \PHPUnit\Framework\TestCase
 {
-    const TEST_YAML_ENTITY_CLASS = 'Mapping\Fixture\Yaml\Category';
-    const YAML_CLOSURE_CATEGORY = 'Mapping\Fixture\Yaml\ClosureCategory';
-    const YAML_MATERIALIZED_PATH_CATEGORY = 'Mapping\Fixture\Yaml\MaterializedPathCategory';
+    public const TEST_YAML_ENTITY_CLASS = 'Mapping\Fixture\Yaml\Category';
+    public const YAML_CLOSURE_CATEGORY = 'Mapping\Fixture\Yaml\ClosureCategory';
+    public const YAML_MATERIALIZED_PATH_CATEGORY = 'Mapping\Fixture\Yaml\MaterializedPathCategory';
 
     /**
      * @var \Doctrine\ORM\EntityManager

--- a/tests/Gedmo/ReferenceIntegrity/ReferenceIntegrityDocumentTest.php
+++ b/tests/Gedmo/ReferenceIntegrity/ReferenceIntegrityDocumentTest.php
@@ -13,23 +13,23 @@ use Tool\BaseTestCaseMongoODM;
  */
 class ReferenceIntegrityDocumentTest extends BaseTestCaseMongoODM
 {
-    const TYPE_ONE_NULLIFY_CLASS = 'ReferenceIntegrity\Fixture\Document\OneNullify\Type';
-    const ARTICLE_ONE_NULLIFY_CLASS = 'ReferenceIntegrity\Fixture\Document\OneNullify\Article';
+    public const TYPE_ONE_NULLIFY_CLASS = 'ReferenceIntegrity\Fixture\Document\OneNullify\Type';
+    public const ARTICLE_ONE_NULLIFY_CLASS = 'ReferenceIntegrity\Fixture\Document\OneNullify\Article';
 
-    const TYPE_MANY_NULLIFY_CLASS = 'ReferenceIntegrity\Fixture\Document\ManyNullify\Type';
-    const ARTICLE_MANY_NULLIFY_CLASS = 'ReferenceIntegrity\Fixture\Document\ManyNullify\Article';
+    public const TYPE_MANY_NULLIFY_CLASS = 'ReferenceIntegrity\Fixture\Document\ManyNullify\Type';
+    public const ARTICLE_MANY_NULLIFY_CLASS = 'ReferenceIntegrity\Fixture\Document\ManyNullify\Article';
 
-    const TYPE_ONE_PULL_CLASS = 'ReferenceIntegrity\Fixture\Document\OnePull\Type';
-    const ARTICLE_ONE_PULL_CLASS = 'ReferenceIntegrity\Fixture\Document\OnePull\Article';
+    public const TYPE_ONE_PULL_CLASS = 'ReferenceIntegrity\Fixture\Document\OnePull\Type';
+    public const ARTICLE_ONE_PULL_CLASS = 'ReferenceIntegrity\Fixture\Document\OnePull\Article';
 
-    const TYPE_MANY_PULL_CLASS = 'ReferenceIntegrity\Fixture\Document\ManyPull\Type';
-    const ARTICLE_MANY_PULL_CLASS = 'ReferenceIntegrity\Fixture\Document\ManyPull\Article';
+    public const TYPE_MANY_PULL_CLASS = 'ReferenceIntegrity\Fixture\Document\ManyPull\Type';
+    public const ARTICLE_MANY_PULL_CLASS = 'ReferenceIntegrity\Fixture\Document\ManyPull\Article';
 
-    const TYPE_ONE_RESTRICT_CLASS = 'ReferenceIntegrity\Fixture\Document\OneRestrict\Type';
-    const ARTICLE_ONE_RESTRICT_CLASS = 'ReferenceIntegrity\Fixture\Document\OneRestrict\Article';
+    public const TYPE_ONE_RESTRICT_CLASS = 'ReferenceIntegrity\Fixture\Document\OneRestrict\Type';
+    public const ARTICLE_ONE_RESTRICT_CLASS = 'ReferenceIntegrity\Fixture\Document\OneRestrict\Article';
 
-    const TYPE_MANY_RESTRICT_CLASS = 'ReferenceIntegrity\Fixture\Document\ManyRestrict\Type';
-    const ARTICLE_MANY_RESTRICT_CLASS = 'ReferenceIntegrity\Fixture\Document\ManyRestrict\Article';
+    public const TYPE_MANY_RESTRICT_CLASS = 'ReferenceIntegrity\Fixture\Document\ManyRestrict\Type';
+    public const ARTICLE_MANY_RESTRICT_CLASS = 'ReferenceIntegrity\Fixture\Document\ManyRestrict\Article';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Sluggable/AnnotationValidationTest.php
+++ b/tests/Gedmo/Sluggable/AnnotationValidationTest.php
@@ -17,7 +17,7 @@ use Tool\BaseTestCaseORM;
  */
 class AnnotationValidationTest extends BaseTestCaseORM
 {
-    const TARGET = 'Sluggable\\Fixture\\Validate';
+    public const TARGET = 'Sluggable\\Fixture\\Validate';
 
     /**
      * @test

--- a/tests/Gedmo/Sluggable/CustomTransliteratorTest.php
+++ b/tests/Gedmo/Sluggable/CustomTransliteratorTest.php
@@ -17,7 +17,7 @@ use Tool\BaseTestCaseORM;
  */
 class CustomTransliteratorTest extends BaseTestCaseORM
 {
-    const ARTICLE = 'Sluggable\\Fixture\\Article';
+    public const ARTICLE = 'Sluggable\\Fixture\\Article';
 
     public function testStandardTransliteratorFailsOnChineseCharacters()
     {

--- a/tests/Gedmo/Sluggable/Handlers/BothSlugHandlerTest.php
+++ b/tests/Gedmo/Sluggable/Handlers/BothSlugHandlerTest.php
@@ -19,8 +19,8 @@ use Tool\BaseTestCaseORM;
  */
 class BothSlugHandlerTest extends BaseTestCaseORM
 {
-    const OCCUPATION = 'Sluggable\\Fixture\\Handler\\People\\Occupation';
-    const PERSON = 'Sluggable\\Fixture\\Handler\\People\\Person';
+    public const OCCUPATION = 'Sluggable\\Fixture\\Handler\\People\\Occupation';
+    public const PERSON = 'Sluggable\\Fixture\\Handler\\People\\Person';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Sluggable/Handlers/RelativeSlugHandlerDocumentTest.php
+++ b/tests/Gedmo/Sluggable/Handlers/RelativeSlugHandlerDocumentTest.php
@@ -18,8 +18,8 @@ use Tool\BaseTestCaseMongoODM;
  */
 class RelativeSlugHandlerDocumentTest extends BaseTestCaseMongoODM
 {
-    const ARTICLE = 'Sluggable\\Fixture\\Document\\Handler\\Article';
-    const SLUG = 'Sluggable\\Fixture\\Document\\Handler\\RelativeSlug';
+    public const ARTICLE = 'Sluggable\\Fixture\\Document\\Handler\\Article';
+    public const SLUG = 'Sluggable\\Fixture\\Document\\Handler\\RelativeSlug';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Sluggable/Handlers/RelativeSlugHandlerTest.php
+++ b/tests/Gedmo/Sluggable/Handlers/RelativeSlugHandlerTest.php
@@ -18,8 +18,8 @@ use Tool\BaseTestCaseORM;
  */
 class RelativeSlugHandlerTest extends BaseTestCaseORM
 {
-    const SLUG = 'Sluggable\\Fixture\\Handler\\ArticleRelativeSlug';
-    const ARTICLE = 'Sluggable\\Fixture\\Handler\\Article';
+    public const SLUG = 'Sluggable\\Fixture\\Handler\\ArticleRelativeSlug';
+    public const ARTICLE = 'Sluggable\\Fixture\\Handler\\Article';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Sluggable/Handlers/TreeSlugHandlerDocumentTest.php
+++ b/tests/Gedmo/Sluggable/Handlers/TreeSlugHandlerDocumentTest.php
@@ -17,7 +17,7 @@ use Tool\BaseTestCaseMongoODM;
  */
 class TreeSlugHandlerDocumentTest extends BaseTestCaseMongoODM
 {
-    const SLUG = 'Sluggable\\Fixture\\Document\\Handler\\TreeSlug';
+    public const SLUG = 'Sluggable\\Fixture\\Document\\Handler\\TreeSlug';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Sluggable/Handlers/TreeSlugHandlerPrefixSuffixTest.php
+++ b/tests/Gedmo/Sluggable/Handlers/TreeSlugHandlerPrefixSuffixTest.php
@@ -9,7 +9,7 @@ use Tool\BaseTestCaseORM;
 
 class TreeSlugHandlerPrefixSuffixTest extends BaseTestCaseORM
 {
-    const TARGET = 'Sluggable\\Fixture\\Handler\\TreeSlugPrefixSuffix';
+    public const TARGET = 'Sluggable\\Fixture\\Handler\\TreeSlugPrefixSuffix';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Sluggable/Handlers/TreeSlugHandlerTest.php
+++ b/tests/Gedmo/Sluggable/Handlers/TreeSlugHandlerTest.php
@@ -18,7 +18,7 @@ use Tool\BaseTestCaseORM;
  */
 class TreeSlugHandlerTest extends BaseTestCaseORM
 {
-    const TARGET = 'Sluggable\\Fixture\\Handler\\TreeSlug';
+    public const TARGET = 'Sluggable\\Fixture\\Handler\\TreeSlug';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Sluggable/Handlers/TreeSlugHandlerUniqueTest.php
+++ b/tests/Gedmo/Sluggable/Handlers/TreeSlugHandlerUniqueTest.php
@@ -9,7 +9,7 @@ use Tool\BaseTestCaseORM;
 
 class TreeSlugHandlerUniqueTest extends BaseTestCaseORM
 {
-    const TARGET = 'Sluggable\\Fixture\\Handler\\TreeSlug';
+    public const TARGET = 'Sluggable\\Fixture\\Handler\\TreeSlug';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Sluggable/Handlers/UserRelativeSlugHandlerTest.php
+++ b/tests/Gedmo/Sluggable/Handlers/UserRelativeSlugHandlerTest.php
@@ -18,8 +18,8 @@ use Tool\BaseTestCaseORM;
  */
 class UserRelativeSlugHandlerTest extends BaseTestCaseORM
 {
-    const USER = 'Sluggable\\Fixture\\Handler\\User';
-    const COMPANY = 'Sluggable\\Fixture\\Handler\\Company';
+    public const USER = 'Sluggable\\Fixture\\Handler\\User';
+    public const COMPANY = 'Sluggable\\Fixture\\Handler\\Company';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Sluggable/Issue/Issue104Test.php
+++ b/tests/Gedmo/Sluggable/Issue/Issue104Test.php
@@ -17,7 +17,7 @@ use Tool\BaseTestCaseORM;
  */
 class Issue104Test extends BaseTestCaseORM
 {
-    const CAR = 'Sluggable\\Fixture\\Issue104\\Car';
+    public const CAR = 'Sluggable\\Fixture\\Issue104\\Car';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Sluggable/Issue/Issue1058Test.php
+++ b/tests/Gedmo/Sluggable/Issue/Issue1058Test.php
@@ -18,8 +18,8 @@ use Tool\BaseTestCaseORM;
  */
 class Issue1058Test extends BaseTestCaseORM
 {
-    const ARTICLE = 'Sluggable\\Fixture\\Issue1058\\Page';
-    const USER = 'Sluggable\\Fixture\\Issue1058\\User';
+    public const ARTICLE = 'Sluggable\\Fixture\\Issue1058\\Page';
+    public const USER = 'Sluggable\\Fixture\\Issue1058\\User';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Sluggable/Issue/Issue116Test.php
+++ b/tests/Gedmo/Sluggable/Issue/Issue116Test.php
@@ -19,7 +19,7 @@ use Tool\BaseTestCaseORM;
  */
 class Issue116Test extends BaseTestCaseORM
 {
-    const TARGET = 'Sluggable\\Fixture\\Issue116\\Country';
+    public const TARGET = 'Sluggable\\Fixture\\Issue116\\Country';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Sluggable/Issue/Issue1177Test.php
+++ b/tests/Gedmo/Sluggable/Issue/Issue1177Test.php
@@ -17,7 +17,7 @@ use Tool\BaseTestCaseORM;
  */
 class Issue1177Test extends BaseTestCaseORM
 {
-    const ARTICLE = 'Sluggable\\Fixture\\Issue1177\\Article';
+    public const ARTICLE = 'Sluggable\\Fixture\\Issue1177\\Article';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Sluggable/Issue/Issue1240Test.php
+++ b/tests/Gedmo/Sluggable/Issue/Issue1240Test.php
@@ -17,7 +17,7 @@ use Tool\BaseTestCaseORM;
  */
 class Issue1240Test extends BaseTestCaseORM
 {
-    const ARTICLE = 'Sluggable\\Fixture\\Issue1240\\Article';
+    public const ARTICLE = 'Sluggable\\Fixture\\Issue1240\\Article';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Sluggable/Issue/Issue131Test.php
+++ b/tests/Gedmo/Sluggable/Issue/Issue131Test.php
@@ -17,7 +17,7 @@ use Tool\BaseTestCaseORM;
  */
 class Issue131Test extends BaseTestCaseORM
 {
-    const TARGET = 'Sluggable\\Fixture\\Issue131\\Article';
+    public const TARGET = 'Sluggable\\Fixture\\Issue131\\Article';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Sluggable/Issue/Issue449Test.php
+++ b/tests/Gedmo/Sluggable/Issue/Issue449Test.php
@@ -18,8 +18,8 @@ use Tool\BaseTestCaseORM;
  */
 class Issue449Test extends BaseTestCaseORM
 {
-    const TARGET = 'Sluggable\\Fixture\\Issue449\\Article';
-    const SOFT_DELETEABLE_FILTER_NAME = 'soft-deleteable';
+    public const TARGET = 'Sluggable\\Fixture\\Issue449\\Article';
+    public const SOFT_DELETEABLE_FILTER_NAME = 'soft-deleteable';
 
     private $softDeleteableListener;
 

--- a/tests/Gedmo/Sluggable/Issue/Issue633Test.php
+++ b/tests/Gedmo/Sluggable/Issue/Issue633Test.php
@@ -17,7 +17,7 @@ use Tool\BaseTestCaseORM;
  */
 class Issue633Test extends BaseTestCaseORM
 {
-    const TARGET = 'Sluggable\\Fixture\\Issue633\\Article';
+    public const TARGET = 'Sluggable\\Fixture\\Issue633\\Article';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Sluggable/Issue/Issue827Test.php
+++ b/tests/Gedmo/Sluggable/Issue/Issue827Test.php
@@ -20,10 +20,10 @@ use Tool\BaseTestCaseORM;
  */
 class Issue827Test extends BaseTestCaseORM
 {
-    const ARTICLE = 'Sluggable\\Fixture\\Issue827\\Article';
-    const CATEGORY = 'Sluggable\\Fixture\\Issue827\\Category';
-    const COMMENT = 'Sluggable\\Fixture\\Issue827\\Comment';
-    const POST = 'Sluggable\\Fixture\\Issue827\\Post';
+    public const ARTICLE = 'Sluggable\\Fixture\\Issue827\\Article';
+    public const CATEGORY = 'Sluggable\\Fixture\\Issue827\\Category';
+    public const COMMENT = 'Sluggable\\Fixture\\Issue827\\Comment';
+    public const POST = 'Sluggable\\Fixture\\Issue827\\Post';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Sluggable/Issue/Issue939Test.php
+++ b/tests/Gedmo/Sluggable/Issue/Issue939Test.php
@@ -19,8 +19,8 @@ use Tool\BaseTestCaseORM;
  */
 class Issue939Test extends BaseTestCaseORM
 {
-    const ARTICLE = 'Sluggable\\Fixture\\Issue939\\Article';
-    const CATEGORY = 'Sluggable\\Fixture\\Issue939\\Category';
+    public const ARTICLE = 'Sluggable\\Fixture\\Issue939\\Article';
+    public const CATEGORY = 'Sluggable\\Fixture\\Issue939\\Category';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Sluggable/SluggableConfigurationTest.php
+++ b/tests/Gedmo/Sluggable/SluggableConfigurationTest.php
@@ -17,7 +17,7 @@ use Tool\BaseTestCaseORM;
  */
 class SluggableConfigurationTest extends BaseTestCaseORM
 {
-    const ARTICLE = 'Sluggable\\Fixture\\ConfigurationArticle';
+    public const ARTICLE = 'Sluggable\\Fixture\\ConfigurationArticle';
 
     private $articleId;
 

--- a/tests/Gedmo/Sluggable/SluggableDocumentTest.php
+++ b/tests/Gedmo/Sluggable/SluggableDocumentTest.php
@@ -17,7 +17,7 @@ use Tool\BaseTestCaseMongoODM;
  */
 class SluggableDocumentTest extends BaseTestCaseMongoODM
 {
-    const ARTICLE = 'Sluggable\\Fixture\\Document\\Article';
+    public const ARTICLE = 'Sluggable\\Fixture\\Document\\Article';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Sluggable/SluggableFltersTest.php
+++ b/tests/Gedmo/Sluggable/SluggableFltersTest.php
@@ -17,10 +17,10 @@ use Tool\BaseTestCaseORM;
  */
 class SluggableFltersTest extends BaseTestCaseORM
 {
-    const TARGET = 'Sluggable\\Fixture\\Article';
+    public const TARGET = 'Sluggable\\Fixture\\Article';
 
-    const SOFT_DELETEABLE_FILTER_NAME = 'soft-deleteable';
-    const FAKE_FILTER_NAME = 'fake-filter';
+    public const SOFT_DELETEABLE_FILTER_NAME = 'soft-deleteable';
+    public const FAKE_FILTER_NAME = 'fake-filter';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Sluggable/SluggableIdentifierTest.php
+++ b/tests/Gedmo/Sluggable/SluggableIdentifierTest.php
@@ -17,7 +17,7 @@ use Tool\BaseTestCaseORM;
  */
 class SluggableIdentifierTest extends BaseTestCaseORM
 {
-    const TARGET = 'Sluggable\\Fixture\\Identifier';
+    public const TARGET = 'Sluggable\\Fixture\\Identifier';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Sluggable/SluggablePositionTest.php
+++ b/tests/Gedmo/Sluggable/SluggablePositionTest.php
@@ -17,7 +17,7 @@ use Tool\BaseTestCaseORM;
  */
 class SluggablePositionTest extends BaseTestCaseORM
 {
-    const POSITION = 'Sluggable\\Fixture\\Position';
+    public const POSITION = 'Sluggable\\Fixture\\Position';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Sluggable/SluggablePrefixSuffixTest.php
+++ b/tests/Gedmo/Sluggable/SluggablePrefixSuffixTest.php
@@ -12,10 +12,10 @@ use Tool\BaseTestCaseORM;
 
 class SluggablePrefixSuffixTest extends BaseTestCaseORM
 {
-    const PREFIX = 'Sluggable\\Fixture\\Prefix';
-    const SUFFIX = 'Sluggable\\Fixture\\Suffix';
-    const SUFFIX_TREE = 'Sluggable\\Fixture\\SuffixWithTreeHandler';
-    const PREFIX_TREE = 'Sluggable\\Fixture\\PrefixWithTreeHandler';
+    public const PREFIX = 'Sluggable\\Fixture\\Prefix';
+    public const SUFFIX = 'Sluggable\\Fixture\\Suffix';
+    public const SUFFIX_TREE = 'Sluggable\\Fixture\\SuffixWithTreeHandler';
+    public const PREFIX_TREE = 'Sluggable\\Fixture\\PrefixWithTreeHandler';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Sluggable/SluggableTest.php
+++ b/tests/Gedmo/Sluggable/SluggableTest.php
@@ -17,7 +17,7 @@ use Tool\BaseTestCaseORM;
  */
 class SluggableTest extends BaseTestCaseORM
 {
-    const ARTICLE = 'Sluggable\\Fixture\\Article';
+    public const ARTICLE = 'Sluggable\\Fixture\\Article';
     private $articleId;
 
     protected function setUp(): void

--- a/tests/Gedmo/Sluggable/TranslatableManySlugTest.php
+++ b/tests/Gedmo/Sluggable/TranslatableManySlugTest.php
@@ -22,8 +22,8 @@ class TranslatableManySlugTest extends BaseTestCaseORM
     private $articleId;
     private $translatableListener;
 
-    const ARTICLE = 'Sluggable\\Fixture\\TransArticleManySlug';
-    const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
+    public const ARTICLE = 'Sluggable\\Fixture\\TransArticleManySlug';
+    public const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Sluggable/TranslatableSlugTest.php
+++ b/tests/Gedmo/Sluggable/TranslatableSlugTest.php
@@ -24,10 +24,10 @@ class TranslatableSlugTest extends BaseTestCaseORM
     private $articleId;
     private $translatableListener;
 
-    const ARTICLE = 'Sluggable\\Fixture\\TranslatableArticle';
-    const COMMENT = 'Sluggable\\Fixture\\Comment';
-    const PAGE = 'Sluggable\\Fixture\\Page';
-    const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
+    public const ARTICLE = 'Sluggable\\Fixture\\TranslatableArticle';
+    public const COMMENT = 'Sluggable\\Fixture\\Comment';
+    public const PAGE = 'Sluggable\\Fixture\\Page';
+    public const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Sluggable/TransliterationTest.php
+++ b/tests/Gedmo/Sluggable/TransliterationTest.php
@@ -17,7 +17,7 @@ use Tool\BaseTestCaseORM;
  */
 class TransliterationTest extends BaseTestCaseORM
 {
-    const ARTICLE = 'Sluggable\\Fixture\\Article';
+    public const ARTICLE = 'Sluggable\\Fixture\\Article';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/SoftDeleteable/SoftDeleteableDocumentTest.php
+++ b/tests/Gedmo/SoftDeleteable/SoftDeleteableDocumentTest.php
@@ -19,17 +19,17 @@ use Tool\BaseTestCaseMongoODM;
  */
 class SoftDeleteableDocumentTest extends BaseTestCaseMongoODM
 {
-    const ARTICLE_CLASS = 'SoftDeleteable\Fixture\Document\Article';
-    const COMMENT_CLASS = 'SoftDeleteable\Fixture\Document\Comment';
-    const PAGE_CLASS = 'SoftDeleteable\Fixture\Document\Page';
-    const MEGA_PAGE_CLASS = 'SoftDeleteable\Fixture\Document\MegaPage';
-    const MODULE_CLASS = 'SoftDeleteable\Fixture\Document\Module';
-    const OTHER_ARTICLE_CLASS = 'SoftDeleteable\Fixture\Document\OtherArticle';
-    const OTHER_COMMENT_CLASS = 'SoftDeleteable\Fixture\Document\OtherComment';
-    const USER_CLASS = 'SoftDeleteable\Fixture\Document\User';
-    const USER__TIME_AWARE_CLASS = 'SoftDeleteable\Fixture\Document\UserTimeAware';
-    const MAPPED_SUPERCLASS_CHILD_CLASS = 'SoftDeleteable\Fixture\Document\Child';
-    const SOFT_DELETEABLE_FILTER_NAME = 'soft-deleteable';
+    public const ARTICLE_CLASS = 'SoftDeleteable\Fixture\Document\Article';
+    public const COMMENT_CLASS = 'SoftDeleteable\Fixture\Document\Comment';
+    public const PAGE_CLASS = 'SoftDeleteable\Fixture\Document\Page';
+    public const MEGA_PAGE_CLASS = 'SoftDeleteable\Fixture\Document\MegaPage';
+    public const MODULE_CLASS = 'SoftDeleteable\Fixture\Document\Module';
+    public const OTHER_ARTICLE_CLASS = 'SoftDeleteable\Fixture\Document\OtherArticle';
+    public const OTHER_COMMENT_CLASS = 'SoftDeleteable\Fixture\Document\OtherComment';
+    public const USER_CLASS = 'SoftDeleteable\Fixture\Document\User';
+    public const USER__TIME_AWARE_CLASS = 'SoftDeleteable\Fixture\Document\UserTimeAware';
+    public const MAPPED_SUPERCLASS_CHILD_CLASS = 'SoftDeleteable\Fixture\Document\Child';
+    public const SOFT_DELETEABLE_FILTER_NAME = 'soft-deleteable';
 
     private $softDeleteableListener;
 

--- a/tests/Gedmo/SoftDeleteable/SoftDeleteableEntityTest.php
+++ b/tests/Gedmo/SoftDeleteable/SoftDeleteableEntityTest.php
@@ -2,6 +2,7 @@
 
 namespace Gedmo\SoftDeleteable;
 
+use function class_exists;
 use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Common\EventManager;
 use SoftDeleteable\Fixture\Entity\Article;
@@ -14,7 +15,6 @@ use SoftDeleteable\Fixture\Entity\OtherComment;
 use SoftDeleteable\Fixture\Entity\User;
 use SoftDeleteable\Fixture\Entity\UserNoHardDelete;
 use Tool\BaseTestCaseORM;
-use function class_exists;
 
 /**
  * These are tests for SoftDeleteable behavior
@@ -29,17 +29,17 @@ use function class_exists;
  */
 class SoftDeleteableEntityTest extends BaseTestCaseORM
 {
-    const ARTICLE_CLASS = 'SoftDeleteable\Fixture\Entity\Article';
-    const COMMENT_CLASS = 'SoftDeleteable\Fixture\Entity\Comment';
-    const PAGE_CLASS = 'SoftDeleteable\Fixture\Entity\Page';
-    const MEGA_PAGE_CLASS = 'SoftDeleteable\Fixture\Entity\MegaPage';
-    const MODULE_CLASS = 'SoftDeleteable\Fixture\Entity\Module';
-    const OTHER_ARTICLE_CLASS = 'SoftDeleteable\Fixture\Entity\OtherArticle';
-    const OTHER_COMMENT_CLASS = 'SoftDeleteable\Fixture\Entity\OtherComment';
-    const USER_CLASS = 'SoftDeleteable\Fixture\Entity\User';
-    const MAPPED_SUPERCLASS_CHILD_CLASS = 'SoftDeleteable\Fixture\Entity\Child';
-    const SOFT_DELETEABLE_FILTER_NAME = 'soft-deleteable';
-    const USER_NO_HARD_DELETE_CLASS = 'SoftDeleteable\Fixture\Entity\UserNoHardDelete';
+    public const ARTICLE_CLASS = 'SoftDeleteable\Fixture\Entity\Article';
+    public const COMMENT_CLASS = 'SoftDeleteable\Fixture\Entity\Comment';
+    public const PAGE_CLASS = 'SoftDeleteable\Fixture\Entity\Page';
+    public const MEGA_PAGE_CLASS = 'SoftDeleteable\Fixture\Entity\MegaPage';
+    public const MODULE_CLASS = 'SoftDeleteable\Fixture\Entity\Module';
+    public const OTHER_ARTICLE_CLASS = 'SoftDeleteable\Fixture\Entity\OtherArticle';
+    public const OTHER_COMMENT_CLASS = 'SoftDeleteable\Fixture\Entity\OtherComment';
+    public const USER_CLASS = 'SoftDeleteable\Fixture\Entity\User';
+    public const MAPPED_SUPERCLASS_CHILD_CLASS = 'SoftDeleteable\Fixture\Entity\Child';
+    public const SOFT_DELETEABLE_FILTER_NAME = 'soft-deleteable';
+    public const USER_NO_HARD_DELETE_CLASS = 'SoftDeleteable\Fixture\Entity\UserNoHardDelete';
 
     private $softDeleteableListener;
 
@@ -503,7 +503,7 @@ class SoftDeleteableEntityTest extends BaseTestCaseORM
         $this->em->persist($newUser);
         $this->em->flush();
 
-        $user = $repo->findOneBy(array('username' => $username));
+        $user = $repo->findOneBy(['username' => $username]);
 
         $this->assertNull($user->getDeletedAt());
 

--- a/tests/Gedmo/Sortable/SortableDocumentGroupTest.php
+++ b/tests/Gedmo/Sortable/SortableDocumentGroupTest.php
@@ -16,11 +16,11 @@ use Tool\BaseTestCaseMongoODM;
  */
 class SortableDocumentGroupTest extends BaseTestCaseMongoODM
 {
-    const POST = 'Sortable\\Fixture\\Document\\Post';
-    const CATEGORY = 'Sortable\\Fixture\\Document\\Category';
-    const KID = 'Sortable\\Fixture\\Document\\Kid';
-    const KID_DATE1 = '1999-12-31';
-    const KID_DATE2 = '2000-01-01';
+    public const POST = 'Sortable\\Fixture\\Document\\Post';
+    public const CATEGORY = 'Sortable\\Fixture\\Document\\Category';
+    public const KID = 'Sortable\\Fixture\\Document\\Kid';
+    public const KID_DATE1 = '1999-12-31';
+    public const KID_DATE2 = '2000-01-01';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Sortable/SortableDocumentTest.php
+++ b/tests/Gedmo/Sortable/SortableDocumentTest.php
@@ -14,7 +14,7 @@ use Tool\BaseTestCaseMongoODM;
  */
 class SortableDocumentTest extends BaseTestCaseMongoODM
 {
-    const ARTICLE = 'Sortable\\Fixture\\Document\\Article';
+    public const ARTICLE = 'Sortable\\Fixture\\Document\\Article';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Sortable/SortableGroupTest.php
+++ b/tests/Gedmo/Sortable/SortableGroupTest.php
@@ -22,19 +22,19 @@ use Tool\BaseTestCaseORM;
  */
 class SortableGroupTest extends BaseTestCaseORM
 {
-    const CAR = "Sortable\Fixture\Transport\Car";
-    const BUS = "Sortable\Fixture\Transport\Bus";
-    const VEHICLE = "Sortable\Fixture\Transport\Vehicle";
-    const ENGINE = "Sortable\Fixture\Transport\Engine";
-    const RESERVATION = "Sortable\Fixture\Transport\Reservation";
-    const ITEM = "Sortable\Fixture\Item";
-    const CATEGORY = "Sortable\Fixture\Category";
+    public const CAR = "Sortable\Fixture\Transport\Car";
+    public const BUS = "Sortable\Fixture\Transport\Bus";
+    public const VEHICLE = "Sortable\Fixture\Transport\Vehicle";
+    public const ENGINE = "Sortable\Fixture\Transport\Engine";
+    public const RESERVATION = "Sortable\Fixture\Transport\Reservation";
+    public const ITEM = "Sortable\Fixture\Item";
+    public const CATEGORY = "Sortable\Fixture\Category";
 
-    const SEATS = 3;
+    public const SEATS = 3;
 
-    const TRAVEL_DATE_FORMAT = 'Y-m-d H:i';
-    const TODAY = '2013-10-24 12:50';
-    const TOMORROW = '2013-10-25 12:50';
+    public const TRAVEL_DATE_FORMAT = 'Y-m-d H:i';
+    public const TODAY = '2013-10-24 12:50';
+    public const TOMORROW = '2013-10-25 12:50';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Sortable/SortableTest.php
+++ b/tests/Gedmo/Sortable/SortableTest.php
@@ -26,16 +26,16 @@ use Tool\BaseTestCaseORM;
  */
 class SortableTest extends BaseTestCaseORM
 {
-    const NODE = 'Sortable\\Fixture\\Node';
-    const NOTIFY_NODE = 'Sortable\\Fixture\\NotifyNode';
-    const ITEM = 'Sortable\\Fixture\\Item';
-    const CATEGORY = 'Sortable\\Fixture\\Category';
-    const SIMPLE_LIST_ITEM = 'Sortable\\Fixture\\SimpleListItem';
-    const AUTHOR = 'Sortable\\Fixture\\Author';
-    const PAPER = 'Sortable\\Fixture\\Paper';
-    const EVENT = 'Sortable\\Fixture\\Event';
-    const CUSTOMER = 'Sortable\\Fixture\\Customer';
-    const CUSTOMER_TYPE = 'Sortable\\Fixture\\CustomerType';
+    public const NODE = 'Sortable\\Fixture\\Node';
+    public const NOTIFY_NODE = 'Sortable\\Fixture\\NotifyNode';
+    public const ITEM = 'Sortable\\Fixture\\Item';
+    public const CATEGORY = 'Sortable\\Fixture\\Category';
+    public const SIMPLE_LIST_ITEM = 'Sortable\\Fixture\\SimpleListItem';
+    public const AUTHOR = 'Sortable\\Fixture\\Author';
+    public const PAPER = 'Sortable\\Fixture\\Paper';
+    public const EVENT = 'Sortable\\Fixture\\Event';
+    public const CUSTOMER = 'Sortable\\Fixture\\Customer';
+    public const CUSTOMER_TYPE = 'Sortable\\Fixture\\CustomerType';
 
     private $nodeId;
 

--- a/tests/Gedmo/Timestampable/ChangeTest.php
+++ b/tests/Gedmo/Timestampable/ChangeTest.php
@@ -20,7 +20,7 @@ use Tool\BaseTestCaseORM;
  */
 class ChangeTest extends BaseTestCaseORM
 {
-    const FIXTURE = 'Timestampable\\Fixture\\TitledArticle';
+    public const FIXTURE = 'Timestampable\\Fixture\\TitledArticle';
 
     protected $listener;
 

--- a/tests/Gedmo/Timestampable/NoInterfaceTest.php
+++ b/tests/Gedmo/Timestampable/NoInterfaceTest.php
@@ -17,7 +17,7 @@ use Tool\BaseTestCaseORM;
  */
 class NoInterfaceTest extends BaseTestCaseORM
 {
-    const FIXTURE = 'Timestampable\\Fixture\\WithoutInterface';
+    public const FIXTURE = 'Timestampable\\Fixture\\WithoutInterface';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Timestampable/ProtectedPropertySupperclassTest.php
+++ b/tests/Gedmo/Timestampable/ProtectedPropertySupperclassTest.php
@@ -19,8 +19,8 @@ use Tool\BaseTestCaseORM;
  */
 class ProtectedPropertySupperclassTest extends BaseTestCaseORM
 {
-    const SUPERCLASS = 'Timestampable\\Fixture\\SupperClassExtension';
-    const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
+    public const SUPERCLASS = 'Timestampable\\Fixture\\SupperClassExtension';
+    public const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Timestampable/TimestampableDocumentTest.php
+++ b/tests/Gedmo/Timestampable/TimestampableDocumentTest.php
@@ -18,8 +18,8 @@ use Tool\BaseTestCaseMongoODM;
  */
 class TimestampableDocumentTest extends BaseTestCaseMongoODM
 {
-    const ARTICLE = 'Timestampable\Fixture\Document\Article';
-    const TYPE = 'Timestampable\Fixture\Document\Type';
+    public const ARTICLE = 'Timestampable\Fixture\Document\Article';
+    public const TYPE = 'Timestampable\Fixture\Document\Type';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Timestampable/TimestampableEmbeddedDocumentTest.php
+++ b/tests/Gedmo/Timestampable/TimestampableEmbeddedDocumentTest.php
@@ -18,7 +18,7 @@ use Tool\BaseTestCaseMongoODM;
  */
 class TimestampableEmbeddedDocumentTest extends BaseTestCaseMongoODM
 {
-    const BOOK = 'Timestampable\Fixture\Document\Book';
+    public const BOOK = 'Timestampable\Fixture\Document\Book';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Timestampable/TimestampableTest.php
+++ b/tests/Gedmo/Timestampable/TimestampableTest.php
@@ -20,9 +20,9 @@ use Tool\BaseTestCaseORM;
  */
 class TimestampableTest extends BaseTestCaseORM
 {
-    const ARTICLE = 'Timestampable\\Fixture\\Article';
-    const COMMENT = 'Timestampable\\Fixture\\Comment';
-    const TYPE = 'Timestampable\\Fixture\\Type';
+    public const ARTICLE = 'Timestampable\\Fixture\\Article';
+    public const COMMENT = 'Timestampable\\Fixture\\Comment';
+    public const TYPE = 'Timestampable\\Fixture\\Type';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Timestampable/TraitUsageTest.php
+++ b/tests/Gedmo/Timestampable/TraitUsageTest.php
@@ -17,7 +17,7 @@ use Tool\BaseTestCaseORM;
  */
 class TraitUsageTest extends BaseTestCaseORM
 {
-    const TARGET = 'Timestampable\\Fixture\\UsingTrait';
+    public const TARGET = 'Timestampable\\Fixture\\UsingTrait';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Translatable/EntityTranslationTableTest.php
+++ b/tests/Gedmo/Translatable/EntityTranslationTableTest.php
@@ -17,8 +17,8 @@ use Translatable\Fixture\Person;
  */
 class EntityTranslationTableTest extends BaseTestCaseORM
 {
-    const PERSON = 'Translatable\\Fixture\\Person';
-    const TRANSLATION = 'Translatable\\Fixture\\PersonTranslation';
+    public const PERSON = 'Translatable\\Fixture\\Person';
+    public const TRANSLATION = 'Translatable\\Fixture\\PersonTranslation';
 
     private $translatableListener;
 

--- a/tests/Gedmo/Translatable/Fixture/Type/Custom.php
+++ b/tests/Gedmo/Translatable/Fixture/Type/Custom.php
@@ -7,7 +7,7 @@ use Doctrine\DBAL\Types\Type;
 
 class Custom extends Type
 {
-    const NAME = 'custom';
+    public const NAME = 'custom';
 
     public function getSqlDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
     {

--- a/tests/Gedmo/Translatable/InheritanceTest.php
+++ b/tests/Gedmo/Translatable/InheritanceTest.php
@@ -20,12 +20,12 @@ use Translatable\Fixture\TemplatedArticle;
  */
 class InheritanceTest extends BaseTestCaseORM
 {
-    const ARTICLE = 'Translatable\\Fixture\\TemplatedArticle';
-    const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
-    const FILE = 'Translatable\\Fixture\\File';
-    const IMAGE = 'Translatable\\Fixture\\Image';
+    public const ARTICLE = 'Translatable\\Fixture\\TemplatedArticle';
+    public const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
+    public const FILE = 'Translatable\\Fixture\\File';
+    public const IMAGE = 'Translatable\\Fixture\\Image';
 
-    const TREE_WALKER_TRANSLATION = 'Gedmo\\Translatable\\Query\\TreeWalker\\TranslationWalker';
+    public const TREE_WALKER_TRANSLATION = 'Gedmo\\Translatable\\Query\\TreeWalker\\TranslationWalker';
 
     private $translatableListener;
 

--- a/tests/Gedmo/Translatable/Issue/Issue109Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue109Test.php
@@ -19,11 +19,11 @@ use Translatable\Fixture\Article;
  */
 class Issue109Test extends BaseTestCaseORM
 {
-    const ARTICLE = 'Translatable\\Fixture\\Article';
-    const COMMENT = 'Translatable\\Fixture\\Comment';
-    const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
+    public const ARTICLE = 'Translatable\\Fixture\\Article';
+    public const COMMENT = 'Translatable\\Fixture\\Comment';
+    public const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
 
-    const TREE_WALKER_TRANSLATION = 'Gedmo\\Translatable\\Query\\TreeWalker\\TranslationWalker';
+    public const TREE_WALKER_TRANSLATION = 'Gedmo\\Translatable\\Query\\TreeWalker\\TranslationWalker';
 
     private $translatableListener;
 

--- a/tests/Gedmo/Translatable/Issue/Issue1123Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue1123Test.php
@@ -8,9 +8,9 @@ use Translatable\Fixture\Issue1123\ChildEntity;
 
 class Issue1123Test extends BaseTestCaseORM
 {
-    const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
-    const BASE_ENTITY = 'Translatable\\Fixture\\Issue1123\\BaseEntity';
-    const CHILD_ENTITY = 'Translatable\\Fixture\\Issue1123\\ChildEntity';
+    public const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
+    public const BASE_ENTITY = 'Translatable\\Fixture\\Issue1123\\BaseEntity';
+    public const CHILD_ENTITY = 'Translatable\\Fixture\\Issue1123\\ChildEntity';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Translatable/Issue/Issue114Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue114Test.php
@@ -18,9 +18,9 @@ use Translatable\Fixture\Issue114\Category;
  */
 class Issue114Test extends BaseTestCaseORM
 {
-    const CATEGORY = 'Translatable\\Fixture\\Issue114\\Category';
-    const ARTICLE = 'Translatable\\Fixture\\Issue114\\Article';
-    const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
+    public const CATEGORY = 'Translatable\\Fixture\\Issue114\\Category';
+    public const ARTICLE = 'Translatable\\Fixture\\Issue114\\Article';
+    public const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
 
     private $translatableListener;
 

--- a/tests/Gedmo/Translatable/Issue/Issue135Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue135Test.php
@@ -18,11 +18,11 @@ use Translatable\Fixture\Article;
  */
 class Issue135Test extends BaseTestCaseORM
 {
-    const ARTICLE = 'Translatable\\Fixture\\Article';
-    const COMMENT = 'Translatable\\Fixture\\Comment';
-    const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
+    public const ARTICLE = 'Translatable\\Fixture\\Article';
+    public const COMMENT = 'Translatable\\Fixture\\Comment';
+    public const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
 
-    const TREE_WALKER_TRANSLATION = 'Gedmo\\Translatable\\Query\\TreeWalker\\TranslationWalker';
+    public const TREE_WALKER_TRANSLATION = 'Gedmo\\Translatable\\Query\\TreeWalker\\TranslationWalker';
 
     private $translatableListener;
 

--- a/tests/Gedmo/Translatable/Issue/Issue138Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue138Test.php
@@ -18,9 +18,9 @@ use Translatable\Fixture\Issue138\Article;
  */
 class Issue138Test extends BaseTestCaseORM
 {
-    const ARTICLE = 'Translatable\\Fixture\\Issue138\\Article';
-    const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
-    const TREE_WALKER_TRANSLATION = 'Gedmo\\Translatable\\Query\\TreeWalker\\TranslationWalker';
+    public const ARTICLE = 'Translatable\\Fixture\\Issue138\\Article';
+    public const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
+    public const TREE_WALKER_TRANSLATION = 'Gedmo\\Translatable\\Query\\TreeWalker\\TranslationWalker';
 
     private $translatableListener;
 

--- a/tests/Gedmo/Translatable/Issue/Issue165Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue165Test.php
@@ -17,8 +17,8 @@ use Translatable\Fixture\Issue165\SimpleArticle;
  */
 class Issue165Test extends BaseTestCaseMongoODM
 {
-    const ARTICLE = 'Translatable\Fixture\Issue165\SimpleArticle';
-    const TRANSLATION = 'Gedmo\\Translatable\\Document\\Translation';
+    public const ARTICLE = 'Translatable\Fixture\Issue165\SimpleArticle';
+    public const TRANSLATION = 'Gedmo\\Translatable\\Document\\Translation';
 
     private $translatableListener;
     private $articleId;

--- a/tests/Gedmo/Translatable/Issue/Issue173Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue173Test.php
@@ -21,10 +21,10 @@ use Translatable\Fixture\Issue173\Product;
  */
 class Issue173Test extends BaseTestCaseORM
 {
-    const CATEGORY = 'Translatable\\Fixture\\Issue173\\Category';
-    const ARTICLE = 'Translatable\\Fixture\\Issue173\\Article';
-    const PRODUCT = 'Translatable\\Fixture\\Issue173\\Product';
-    const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
+    public const CATEGORY = 'Translatable\\Fixture\\Issue173\\Category';
+    public const ARTICLE = 'Translatable\\Fixture\\Issue173\\Article';
+    public const PRODUCT = 'Translatable\\Fixture\\Issue173\\Product';
+    public const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
 
     private $translatableListener;
 

--- a/tests/Gedmo/Translatable/Issue/Issue2152Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue2152Test.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Gedmo\Translatable\Issue;
 
 use Doctrine\Common\EventManager;
+use Gedmo\Translatable\Entity\Translation;
 use Gedmo\Translatable\TranslatableListener;
 use Tool\BaseTestCaseORM;
-use Gedmo\Translatable\Entity\Translation;
 use Translatable\Fixture\Issue2152\EntityWithTranslatableBoolean;
 
 class Issue2152Test extends BaseTestCaseORM

--- a/tests/Gedmo/Translatable/Issue/Issue84Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue84Test.php
@@ -17,8 +17,8 @@ use Translatable\Fixture\Article;
  */
 class Issue84Test extends BaseTestCaseORM
 {
-    const ARTICLE = 'Translatable\\Fixture\\Article';
-    const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
+    public const ARTICLE = 'Translatable\\Fixture\\Article';
+    public const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
 
     private $translatableListener;
 

--- a/tests/Gedmo/Translatable/Issue/Issue922Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue922Test.php
@@ -10,10 +10,10 @@ use Translatable\Fixture\Issue922\Post;
 
 class Issue922Test extends BaseTestCaseORM
 {
-    const POST = 'Translatable\Fixture\Issue922\Post';
-    const TRANSLATION = 'Gedmo\Translatable\Entity\Translation';
+    public const POST = 'Translatable\Fixture\Issue922\Post';
+    public const TRANSLATION = 'Gedmo\Translatable\Entity\Translation';
 
-    const TREE_WALKER_TRANSLATION = 'Gedmo\\Translatable\\Query\\TreeWalker\\TranslationWalker';
+    public const TREE_WALKER_TRANSLATION = 'Gedmo\\Translatable\\Query\\TreeWalker\\TranslationWalker';
 
     private $translatableListener;
 

--- a/tests/Gedmo/Translatable/MixedValueTranslationTest.php
+++ b/tests/Gedmo/Translatable/MixedValueTranslationTest.php
@@ -18,8 +18,8 @@ use Translatable\Fixture\MixedValue;
  */
 class MixedValueTranslationTest extends BaseTestCaseORM
 {
-    const MIXED = 'Translatable\\Fixture\\MixedValue';
-    const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
+    public const MIXED = 'Translatable\\Fixture\\MixedValue';
+    public const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
 
     private $translatableListener;
 

--- a/tests/Gedmo/Translatable/PersonalTranslationDocumentTest.php
+++ b/tests/Gedmo/Translatable/PersonalTranslationDocumentTest.php
@@ -18,8 +18,8 @@ use Translatable\Fixture\Document\Personal\ArticleTranslation;
  */
 class PersonalTranslationDocumentTest extends BaseTestCaseMongoODM
 {
-    const ARTICLE = 'Translatable\Fixture\Document\Personal\Article';
-    const TRANSLATION = 'Translatable\Fixture\Document\Personal\ArticleTranslation';
+    public const ARTICLE = 'Translatable\Fixture\Document\Personal\Article';
+    public const TRANSLATION = 'Translatable\Fixture\Document\Personal\ArticleTranslation';
 
     private $translatableListener;
     private $id;

--- a/tests/Gedmo/Translatable/PersonalTranslationTest.php
+++ b/tests/Gedmo/Translatable/PersonalTranslationTest.php
@@ -19,9 +19,9 @@ use Translatable\Fixture\Personal\PersonalArticleTranslation;
  */
 class PersonalTranslationTest extends BaseTestCaseORM
 {
-    const ARTICLE = 'Translatable\Fixture\Personal\Article';
-    const TRANSLATION = 'Translatable\Fixture\Personal\PersonalArticleTranslation';
-    const TREE_WALKER_TRANSLATION = 'Gedmo\\Translatable\\Query\\TreeWalker\\TranslationWalker';
+    public const ARTICLE = 'Translatable\Fixture\Personal\Article';
+    public const TRANSLATION = 'Translatable\Fixture\Personal\PersonalArticleTranslation';
+    public const TREE_WALKER_TRANSLATION = 'Gedmo\\Translatable\\Query\\TreeWalker\\TranslationWalker';
 
     private $translatableListener;
 

--- a/tests/Gedmo/Translatable/TranslatableDocumentCollectionTest.php
+++ b/tests/Gedmo/Translatable/TranslatableDocumentCollectionTest.php
@@ -17,8 +17,8 @@ use Translatable\Fixture\Document\SimpleArticle as Article;
  */
 class TranslatableDocumentCollectionTest extends BaseTestCaseMongoODM
 {
-    const ARTICLE = 'Translatable\\Fixture\\Document\\SimpleArticle';
-    const TRANSLATION = 'Gedmo\\Translatable\\Document\\Translation';
+    public const ARTICLE = 'Translatable\\Fixture\\Document\\SimpleArticle';
+    public const TRANSLATION = 'Gedmo\\Translatable\\Document\\Translation';
 
     private $translatableListener;
     private $id;

--- a/tests/Gedmo/Translatable/TranslatableDocumentTest.php
+++ b/tests/Gedmo/Translatable/TranslatableDocumentTest.php
@@ -18,8 +18,8 @@ use Translatable\Fixture\Document\Article;
  */
 class TranslatableDocumentTest extends BaseTestCaseMongoODM
 {
-    const ARTICLE = 'Translatable\\Fixture\\Document\\Article';
-    const TRANSLATION = 'Gedmo\\Translatable\\Document\\Translation';
+    public const ARTICLE = 'Translatable\\Fixture\\Document\\Article';
+    public const TRANSLATION = 'Gedmo\\Translatable\\Document\\Translation';
 
     private $translatableListener;
     private $articleId;

--- a/tests/Gedmo/Translatable/TranslatableEntityCollectionTest.php
+++ b/tests/Gedmo/Translatable/TranslatableEntityCollectionTest.php
@@ -17,9 +17,9 @@ use Translatable\Fixture\Article;
  */
 class TranslatableEntityCollectionTest extends BaseTestCaseORM
 {
-    const ARTICLE = 'Translatable\\Fixture\\Article';
-    const COMMENT = 'Translatable\\Fixture\\Comment';
-    const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
+    public const ARTICLE = 'Translatable\\Fixture\\Article';
+    public const COMMENT = 'Translatable\\Fixture\\Comment';
+    public const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
 
     private $translatableListener;
 

--- a/tests/Gedmo/Translatable/TranslatableEntityDefaultTranslationTest.php
+++ b/tests/Gedmo/Translatable/TranslatableEntityDefaultTranslationTest.php
@@ -17,9 +17,9 @@ use Translatable\Fixture\Article;
  */
 class TranslatableEntityDefaultTranslationTest extends BaseTestCaseORM
 {
-    const ARTICLE = 'Translatable\\Fixture\\Article';
-    const COMMENT = 'Translatable\\Fixture\\Comment';
-    const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
+    public const ARTICLE = 'Translatable\\Fixture\\Article';
+    public const COMMENT = 'Translatable\\Fixture\\Comment';
+    public const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
 
     private $translatableListener;
 

--- a/tests/Gedmo/Translatable/TranslatableIdentifierTest.php
+++ b/tests/Gedmo/Translatable/TranslatableIdentifierTest.php
@@ -17,8 +17,8 @@ use Translatable\Fixture\StringIdentifier;
  */
 class TranslatableIdentifierTest extends BaseTestCaseORM
 {
-    const FIXTURE = 'Translatable\\Fixture\\StringIdentifier';
-    const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
+    public const FIXTURE = 'Translatable\\Fixture\\StringIdentifier';
+    public const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
 
     private $testObjectId;
     private $translatableListener;

--- a/tests/Gedmo/Translatable/TranslatableTest.php
+++ b/tests/Gedmo/Translatable/TranslatableTest.php
@@ -19,10 +19,10 @@ use Translatable\Fixture\Sport;
  */
 class TranslatableTest extends BaseTestCaseORM
 {
-    const ARTICLE = 'Translatable\\Fixture\\Article';
-    const SPORT = 'Translatable\\Fixture\\Sport';
-    const COMMENT = 'Translatable\\Fixture\\Comment';
-    const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
+    public const ARTICLE = 'Translatable\\Fixture\\Article';
+    public const SPORT = 'Translatable\\Fixture\\Sport';
+    public const COMMENT = 'Translatable\\Fixture\\Comment';
+    public const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
 
     private $articleId;
     private $translatableListener;

--- a/tests/Gedmo/Translatable/TranslatableWithEmbeddedTest.php
+++ b/tests/Gedmo/Translatable/TranslatableWithEmbeddedTest.php
@@ -10,10 +10,10 @@ use Translatable\Fixture\Company;
 
 class TranslatableWithEmbeddedTest extends BaseTestCaseORM
 {
-    const FIXTURE = 'Translatable\\Fixture\\Company';
-    const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
+    public const FIXTURE = 'Translatable\\Fixture\\Company';
+    public const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
 
-    const TREE_WALKER_TRANSLATION = 'Gedmo\\Translatable\\Query\\TreeWalker\\TranslationWalker';
+    public const TREE_WALKER_TRANSLATION = 'Gedmo\\Translatable\\Query\\TreeWalker\\TranslationWalker';
 
     /**
      * @var TranslatableListener

--- a/tests/Gedmo/Translatable/TranslationQueryWalkerTest.php
+++ b/tests/Gedmo/Translatable/TranslationQueryWalkerTest.php
@@ -20,11 +20,11 @@ use Translatable\Fixture\Comment;
  */
 class TranslationQueryWalkerTest extends BaseTestCaseORM
 {
-    const ARTICLE = 'Translatable\\Fixture\\Article';
-    const COMMENT = 'Translatable\\Fixture\\Comment';
-    const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
+    public const ARTICLE = 'Translatable\\Fixture\\Article';
+    public const COMMENT = 'Translatable\\Fixture\\Comment';
+    public const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
 
-    const TREE_WALKER_TRANSLATION = 'Gedmo\\Translatable\\Query\\TreeWalker\\TranslationWalker';
+    public const TREE_WALKER_TRANSLATION = 'Gedmo\\Translatable\\Query\\TreeWalker\\TranslationWalker';
 
     /**
      * @var TranslatableListener

--- a/tests/Gedmo/Translator/TranslatableTest.php
+++ b/tests/Gedmo/Translator/TranslatableTest.php
@@ -19,8 +19,8 @@ use Translator\Fixture\PersonCustom;
  */
 class TranslatableTest extends BaseTestCaseORM
 {
-    const PERSON = 'Translator\\Fixture\\Person';
-    const PERSON_CUSTOM_PROXY = 'Translator\\Fixture\\PersonCustom';
+    public const PERSON = 'Translator\\Fixture\\Person';
+    public const PERSON_CUSTOM_PROXY = 'Translator\\Fixture\\PersonCustom';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Tree/ClosureTreeRepositoryTest.php
+++ b/tests/Gedmo/Tree/ClosureTreeRepositoryTest.php
@@ -17,10 +17,10 @@ use Tool\BaseTestCaseORM;
  */
 class ClosureTreeRepositoryTest extends BaseTestCaseORM
 {
-    const CATEGORY = 'Tree\\Fixture\\Closure\\Category';
-    const CLOSURE = 'Tree\\Fixture\\Closure\\CategoryClosure';
-    const CATEGORY_WITHOUT_LEVEL = 'Tree\\Fixture\\Closure\\CategoryWithoutLevel';
-    const CATEGORY_WITHOUT_LEVEL_CLOSURE = 'Tree\\Fixture\\Closure\\CategoryWithoutLevelClosure';
+    public const CATEGORY = 'Tree\\Fixture\\Closure\\Category';
+    public const CLOSURE = 'Tree\\Fixture\\Closure\\CategoryClosure';
+    public const CATEGORY_WITHOUT_LEVEL = 'Tree\\Fixture\\Closure\\CategoryWithoutLevel';
+    public const CATEGORY_WITHOUT_LEVEL_CLOSURE = 'Tree\\Fixture\\Closure\\CategoryWithoutLevelClosure';
 
     protected $listener;
 
@@ -204,7 +204,7 @@ class ClosureTreeRepositoryTest extends BaseTestCaseORM
         $this->assertTrue(((bool) strpos($qb->getQuery()->getDql(), '(SELECT MAX(')));
     }
 
-    public function test_changeChildrenIndex()
+    public function testChangeChildrenIndex()
     {
         $this->populate(self::CATEGORY);
 

--- a/tests/Gedmo/Tree/ClosureTreeTest.php
+++ b/tests/Gedmo/Tree/ClosureTreeTest.php
@@ -20,14 +20,14 @@ use Tree\Fixture\Closure\News;
  */
 class ClosureTreeTest extends BaseTestCaseORM
 {
-    const CATEGORY = 'Tree\\Fixture\\Closure\\Category';
-    const CLOSURE = 'Tree\\Fixture\\Closure\\CategoryClosure';
-    const PERSON = 'Tree\\Fixture\\Closure\\Person';
-    const USER = 'Tree\\Fixture\\Closure\\User';
-    const PERSON_CLOSURE = 'Tree\\Fixture\\Closure\\PersonClosure';
-    const NEWS = 'Tree\\Fixture\\Closure\\News';
-    const CATEGORY_WITHOUT_LEVEL = 'Tree\\Fixture\\Closure\\CategoryWithoutLevel';
-    const CATEGORY_WITHOUT_LEVEL_CLOSURE = 'Tree\\Fixture\\Closure\\CategoryWithoutLevelClosure';
+    public const CATEGORY = 'Tree\\Fixture\\Closure\\Category';
+    public const CLOSURE = 'Tree\\Fixture\\Closure\\CategoryClosure';
+    public const PERSON = 'Tree\\Fixture\\Closure\\Person';
+    public const USER = 'Tree\\Fixture\\Closure\\User';
+    public const PERSON_CLOSURE = 'Tree\\Fixture\\Closure\\PersonClosure';
+    public const NEWS = 'Tree\\Fixture\\Closure\\News';
+    public const CATEGORY_WITHOUT_LEVEL = 'Tree\\Fixture\\Closure\\CategoryWithoutLevel';
+    public const CATEGORY_WITHOUT_LEVEL_CLOSURE = 'Tree\\Fixture\\Closure\\CategoryWithoutLevelClosure';
 
     protected $listener;
 

--- a/tests/Gedmo/Tree/ConcurrencyTest.php
+++ b/tests/Gedmo/Tree/ConcurrencyTest.php
@@ -19,9 +19,9 @@ use Tree\Fixture\Comment;
  */
 class ConcurrencyTest extends BaseTestCaseORM
 {
-    const CATEGORY = 'Tree\\Fixture\\Category';
-    const ARTICLE = 'Tree\\Fixture\\Article';
-    const COMMENT = 'Tree\\Fixture\\Comment';
+    public const CATEGORY = 'Tree\\Fixture\\Category';
+    public const ARTICLE = 'Tree\\Fixture\\Article';
+    public const COMMENT = 'Tree\\Fixture\\Comment';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Tree/Fixture/User.php
+++ b/tests/Gedmo/Tree/Fixture/User.php
@@ -10,7 +10,7 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class User extends Role
 {
-    const PASSWORD_SALT = 'dfJko$~346958rg!DFT]AEtzserf9giq)3/TAeg;aDFa43';
+    public const PASSWORD_SALT = 'dfJko$~346958rg!DFT]AEtzserf9giq)3/TAeg;aDFa43';
 
     /**
      * @ORM\Column(name="email", type="string", unique=true)

--- a/tests/Gedmo/Tree/InMemoryUpdatesTest.php
+++ b/tests/Gedmo/Tree/InMemoryUpdatesTest.php
@@ -17,7 +17,7 @@ use Tree\Fixture\Category;
  */
 class InMemoryUpdatesTest extends BaseTestCaseORM
 {
-    const CATEGORY = 'Tree\\Fixture\\Category';
+    public const CATEGORY = 'Tree\\Fixture\\Category';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Tree/InMemoryUpdatesWithInheritanceTest.php
+++ b/tests/Gedmo/Tree/InMemoryUpdatesWithInheritanceTest.php
@@ -18,9 +18,9 @@ use Tree\Fixture\Genealogy\Woman;
  */
 class InMemoryUpdatesWithInheritanceTest extends BaseTestCaseORM
 {
-    const PERSON = 'Tree\\Fixture\\Genealogy\\Person';
-    const MAN = 'Tree\\Fixture\\Genealogy\\Man';
-    const WOMAN = 'Tree\\Fixture\\Genealogy\\Woman';
+    public const PERSON = 'Tree\\Fixture\\Genealogy\\Person';
+    public const MAN = 'Tree\\Fixture\\Genealogy\\Man';
+    public const WOMAN = 'Tree\\Fixture\\Genealogy\\Woman';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Tree/MaterializedPathODMMongoDBRepositoryTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathODMMongoDBRepositoryTest.php
@@ -288,19 +288,19 @@ class MaterializedPathODMMongoDBRepositoryTest extends BaseTestCaseMongoODM
         $this->assertEquals(2, $count);
     }
 
-    public function testChildCount_ifAnObjectIsPassedWhichIsNotAnInstanceOfTheEntityClassThrowException()
+    public function testChildCountIfAnObjectIsPassedWhichIsNotAnInstanceOfTheEntityClassThrowException()
     {
         $this->expectException('Gedmo\Exception\InvalidArgumentException');
         $this->repo->childCount(new \DateTime());
     }
 
-    public function testChildCount_ifAnObjectIsPassedIsAnInstanceOfTheEntityClassButIsNotHandledByUnitOfWorkThrowException()
+    public function testChildCountIfAnObjectIsPassedIsAnInstanceOfTheEntityClassButIsNotHandledByUnitOfWorkThrowException()
     {
         $this->expectException('Gedmo\Exception\InvalidArgumentException');
         $this->repo->childCount($this->createCategory());
     }
 
-    public function test_changeChildrenIndex()
+    public function testChangeChildrenIndex()
     {
         $childrenIndex = 'myChildren';
         $this->repo->setChildrenIndex($childrenIndex);

--- a/tests/Gedmo/Tree/MaterializedPathODMMongoDBTreeLockingTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathODMMongoDBTreeLockingTest.php
@@ -18,7 +18,7 @@ use Tree\Fixture\Mock\TreeListenerMock;
  */
 class MaterializedPathODMMongoDBTreeLockingTest extends BaseTestCaseMongoODM
 {
-    const ARTICLE = 'Tree\\Fixture\\Document\\Article';
+    public const ARTICLE = 'Tree\\Fixture\\Document\\Article';
 
     protected $config;
     protected $listener;

--- a/tests/Gedmo/Tree/MaterializedPathORMFeaturesTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathORMFeaturesTest.php
@@ -17,7 +17,7 @@ use Tool\BaseTestCaseORM;
  */
 class MaterializedPathORMFeaturesTest extends BaseTestCaseORM
 {
-    const CATEGORY = 'Tree\\Fixture\\MPFeaturesCategory';
+    public const CATEGORY = 'Tree\\Fixture\\MPFeaturesCategory';
 
     protected $config;
     protected $listener;

--- a/tests/Gedmo/Tree/MaterializedPathORMRepositoryTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathORMRepositoryTest.php
@@ -17,8 +17,8 @@ use Tool\BaseTestCaseORM;
  */
 class MaterializedPathORMRepositoryTest extends BaseTestCaseORM
 {
-    const CATEGORY = 'Tree\\Fixture\\MPCategory';
-    const CATEGORY_WITH_TRIMMED_SEPARATOR = 'Tree\\Fixture\\MPCategoryWithTrimmedSeparator';
+    public const CATEGORY = 'Tree\\Fixture\\MPCategory';
+    public const CATEGORY_WITH_TRIMMED_SEPARATOR = 'Tree\\Fixture\\MPCategoryWithTrimmedSeparator';
 
     /** @var \Gedmo\Tree\Entity\Repository\MaterializedPathRepository */
     protected $repo;
@@ -318,19 +318,19 @@ class MaterializedPathORMRepositoryTest extends BaseTestCaseORM
         $this->assertEquals(2, $count);
     }
 
-    public function testChildCount_ifAnObjectIsPassedWhichIsNotAnInstanceOfTheEntityClassThrowException()
+    public function testChildCountIfAnObjectIsPassedWhichIsNotAnInstanceOfTheEntityClassThrowException()
     {
         $this->expectException('Gedmo\Exception\InvalidArgumentException');
         $this->repo->childCount(new \DateTime());
     }
 
-    public function testChildCount_ifAnObjectIsPassedIsAnInstanceOfTheEntityClassButIsNotHandledByUnitOfWorkThrowException()
+    public function testChildCountIfAnObjectIsPassedIsAnInstanceOfTheEntityClassButIsNotHandledByUnitOfWorkThrowException()
     {
         $this->expectException('Gedmo\Exception\InvalidArgumentException');
         $this->repo->childCount($this->createCategory());
     }
 
-    public function test_issue458()
+    public function testIssue458()
     {
         $this->em->clear();
 
@@ -350,7 +350,7 @@ class MaterializedPathORMRepositoryTest extends BaseTestCaseORM
         $this->assertEquals(2, $newNode->getLevel());
     }
 
-    public function test_changeChildrenIndex()
+    public function testChangeChildrenIndex()
     {
         $childrenIndex = 'myChildren';
         $this->repo->setChildrenIndex($childrenIndex);

--- a/tests/Gedmo/Tree/MaterializedPathORMRepositoryTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathORMRepositoryTest.php
@@ -20,7 +20,7 @@ class MaterializedPathORMRepositoryTest extends BaseTestCaseORM
     const CATEGORY = 'Tree\\Fixture\\MPCategory';
     const CATEGORY_WITH_TRIMMED_SEPARATOR = 'Tree\\Fixture\\MPCategoryWithTrimmedSeparator';
 
-    /** @var $this->repo \Gedmo\Tree\Entity\Repository\MaterializedPathRepository */
+    /** @var \Gedmo\Tree\Entity\Repository\MaterializedPathRepository */
     protected $repo;
 
     protected function setUp(): void

--- a/tests/Gedmo/Tree/MaterializedPathORMRootAssociationTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathORMRootAssociationTest.php
@@ -17,7 +17,7 @@ use Tool\BaseTestCaseORM;
  */
 class MaterializedPathORMRootAssociationTest extends BaseTestCaseORM
 {
-    const CATEGORY = 'Tree\\Fixture\\MPCategoryWithRootAssociation';
+    public const CATEGORY = 'Tree\\Fixture\\MPCategoryWithRootAssociation';
 
     protected $config;
     protected $listener;

--- a/tests/Gedmo/Tree/MaterializedPathORMTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathORMTest.php
@@ -17,7 +17,7 @@ use Tool\BaseTestCaseORM;
  */
 class MaterializedPathORMTest extends BaseTestCaseORM
 {
-    const CATEGORY = 'Tree\\Fixture\\MPCategory';
+    public const CATEGORY = 'Tree\\Fixture\\MPCategory';
 
     protected $config;
     protected $listener;

--- a/tests/Gedmo/Tree/MultInheritanceWithJoinedTableTest.php
+++ b/tests/Gedmo/Tree/MultInheritanceWithJoinedTableTest.php
@@ -18,10 +18,10 @@ use Tool\BaseTestCaseORM;
  */
 class MultInheritanceWithJoinedTableTest extends BaseTestCaseORM
 {
-    const USER = 'Tree\\Fixture\\User';
-    const GROUP = 'Tree\\Fixture\\UserGroup';
-    const ROLE = 'Tree\\Fixture\\Role';
-    const USERLDAP = 'Tree\\Fixture\\UserLDAP';
+    public const USER = 'Tree\\Fixture\\User';
+    public const GROUP = 'Tree\\Fixture\\UserGroup';
+    public const ROLE = 'Tree\\Fixture\\Role';
+    public const USERLDAP = 'Tree\\Fixture\\UserLDAP';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Tree/MultiInheritanceTest.php
+++ b/tests/Gedmo/Tree/MultiInheritanceTest.php
@@ -15,10 +15,10 @@ use Tool\BaseTestCaseORM;
  */
 class MultiInheritanceTest extends BaseTestCaseORM
 {
-    const NODE = 'Tree\\Fixture\\Node';
-    const BASE_NODE = 'Tree\\Fixture\\BaseNode';
-    const ANODE = 'Tree\\Fixture\\ANode';
-    const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
+    public const NODE = 'Tree\\Fixture\\Node';
+    public const BASE_NODE = 'Tree\\Fixture\\BaseNode';
+    public const ANODE = 'Tree\\Fixture\\ANode';
+    public const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Tree/MultiInheritanceWithSingleTableTest.php
+++ b/tests/Gedmo/Tree/MultiInheritanceWithSingleTableTest.php
@@ -19,10 +19,10 @@ use Tree\Fixture\Transport\Engine;
  */
 class MultiInheritanceWithSingleTableTest extends BaseTestCaseORM
 {
-    const CAR = "Tree\Fixture\Transport\Car";
-    const BUS = "Tree\Fixture\Transport\Bus";
-    const VEHICLE = "Tree\Fixture\Transport\Vehicle";
-    const ENGINE = "Tree\Fixture\Transport\Engine";
+    public const CAR = "Tree\Fixture\Transport\Car";
+    public const BUS = "Tree\Fixture\Transport\Bus";
+    public const VEHICLE = "Tree\Fixture\Transport\Vehicle";
+    public const ENGINE = "Tree\Fixture\Transport\Engine";
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Tree/NestedTreePositionTest.php
+++ b/tests/Gedmo/Tree/NestedTreePositionTest.php
@@ -18,8 +18,8 @@ use Tree\Fixture\RootCategory;
  */
 class NestedTreePositionTest extends BaseTestCaseORM
 {
-    const CATEGORY = 'Tree\\Fixture\\Category';
-    const ROOT_CATEGORY = 'Tree\\Fixture\\RootCategory';
+    public const CATEGORY = 'Tree\\Fixture\\Category';
+    public const ROOT_CATEGORY = 'Tree\\Fixture\\RootCategory';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Tree/NestedTreeRootAssociationTest.php
+++ b/tests/Gedmo/Tree/NestedTreeRootAssociationTest.php
@@ -17,7 +17,7 @@ use Tree\Fixture\RootAssociationCategory;
  */
 class NestedTreeRootAssociationTest extends BaseTestCaseORM
 {
-    const CATEGORY = 'Tree\\Fixture\\RootAssociationCategory';
+    public const CATEGORY = 'Tree\\Fixture\\RootAssociationCategory';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Tree/NestedTreeRootRepositoryTest.php
+++ b/tests/Gedmo/Tree/NestedTreeRootRepositoryTest.php
@@ -17,7 +17,7 @@ use Tree\Fixture\RootCategory;
  */
 class NestedTreeRootRepositoryTest extends BaseTestCaseORM
 {
-    const CATEGORY = 'Tree\\Fixture\\RootCategory';
+    public const CATEGORY = 'Tree\\Fixture\\RootCategory';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Tree/NestedTreeRootTest.php
+++ b/tests/Gedmo/Tree/NestedTreeRootTest.php
@@ -19,7 +19,7 @@ use Tree\Fixture\RootCategory;
  */
 class NestedTreeRootTest extends BaseTestCaseORM
 {
-    const CATEGORY = 'Tree\\Fixture\\RootCategory';
+    public const CATEGORY = 'Tree\\Fixture\\RootCategory';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Tree/RepositoryTest.php
+++ b/tests/Gedmo/Tree/RepositoryTest.php
@@ -18,8 +18,8 @@ use Tree\Fixture\CategoryUuid;
  */
 class RepositoryTest extends BaseTestCaseORM
 {
-    const CATEGORY = 'Tree\\Fixture\\Category';
-    const CATEGORY_UUID = 'Tree\\Fixture\\CategoryUuid';
+    public const CATEGORY = 'Tree\\Fixture\\Category';
+    public const CATEGORY_UUID = 'Tree\\Fixture\\CategoryUuid';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Tree/TranslatableSluggableTreeTest.php
+++ b/tests/Gedmo/Tree/TranslatableSluggableTreeTest.php
@@ -21,10 +21,10 @@ use Tree\Fixture\BehavioralCategory;
  */
 class TranslatableSluggableTreeTest extends BaseTestCaseORM
 {
-    const CATEGORY = 'Tree\\Fixture\\BehavioralCategory';
-    const ARTICLE = 'Tree\\Fixture\\Article';
-    const COMMENT = 'Tree\\Fixture\\Comment';
-    const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
+    public const CATEGORY = 'Tree\\Fixture\\BehavioralCategory';
+    public const ARTICLE = 'Tree\\Fixture\\Article';
+    public const COMMENT = 'Tree\\Fixture\\Comment';
+    public const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
 
     private $translatableListener;
 

--- a/tests/Gedmo/Tree/TreeObjectHydratorTest.php
+++ b/tests/Gedmo/Tree/TreeObjectHydratorTest.php
@@ -20,8 +20,8 @@ use Tree\Fixture\RootCategory;
  */
 class TreeObjectHydratorTest extends BaseTestCaseORM
 {
-    const CATEGORY = 'Tree\\Fixture\\Category';
-    const ROOT_CATEGORY = 'Tree\\Fixture\\RootCategory';
+    public const CATEGORY = 'Tree\\Fixture\\Category';
+    public const ROOT_CATEGORY = 'Tree\\Fixture\\RootCategory';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Tree/TreeTest.php
+++ b/tests/Gedmo/Tree/TreeTest.php
@@ -18,8 +18,8 @@ use Tree\Fixture\CategoryUuid;
  */
 class TreeTest extends BaseTestCaseORM
 {
-    const CATEGORY = 'Tree\\Fixture\\Category';
-    const CATEGORY_UUID = 'Tree\\Fixture\\CategoryUuid';
+    public const CATEGORY = 'Tree\\Fixture\\Category';
+    public const CATEGORY_UUID = 'Tree\\Fixture\\CategoryUuid';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Uploadable/FileInfo/FileInfoArrayTest.php
+++ b/tests/Gedmo/Uploadable/FileInfo/FileInfoArrayTest.php
@@ -14,7 +14,7 @@ namespace Gedmo\Uploadable\FileInfo;
  */
 class FileInfoArrayTest extends \PHPUnit\Framework\TestCase
 {
-    public function test_constructor_ifKeysAreNotValidOrSomeAreMissingThrowException()
+    public function testConstructorIfKeysAreNotValidOrSomeAreMissingThrowException()
     {
         $this->expectException('RuntimeException');
         $fileInfo = new FileInfoArray([]);

--- a/tests/Gedmo/Uploadable/Mapping/ValidatorTest.php
+++ b/tests/Gedmo/Uploadable/Mapping/ValidatorTest.php
@@ -30,7 +30,7 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
         Validator::$enableMimeTypesConfigException = true;
     }
 
-    public function test_validateField_ifFieldIsNotOfAValidTypeThrowException()
+    public function testValidateFieldIfFieldIsNotOfAValidTypeThrowException()
     {
         $this->expectException('Gedmo\Exception\InvalidMappingException');
         $this->meta->expects($this->once())
@@ -45,13 +45,13 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function test_validatePath_ifPathIsNotAStringOrIsAnEmptyStringThrowException()
+    public function testValidatePathIfPathIsNotAStringOrIsAnEmptyStringThrowException()
     {
         $this->expectException('Gedmo\Exception\UploadableInvalidPathException');
         Validator::validatePath('');
     }
 
-    public function test_validatePathCreatesNewDirectoryWhenItNotExists()
+    public function testValidatePathCreatesNewDirectoryWhenItNotExists()
     {
         $dir = sys_get_temp_dir().'/new/directory-12312432423';
         Validator::validatePath($dir);
@@ -60,7 +60,7 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
         rmdir(dirname($dir));
     }
 
-    public function test_validateConfiguration_ifNeitherFilePathFieldNorFileNameFieldIsNotDefinedThrowException()
+    public function testValidateConfigurationIfNeitherFilePathFieldNorFileNameFieldIsNotDefinedThrowException()
     {
         $this->expectException('Gedmo\Exception\InvalidMappingException');
         $config = ['filePathField' => false, 'fileNameField' => false];
@@ -68,7 +68,7 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
         Validator::validateConfiguration($this->meta, $config);
     }
 
-    public function test_validateConfiguration_ifPathMethodIsNotAValidMethodThrowException()
+    public function testValidateConfigurationIfPathMethodIsNotAValidMethodThrowException()
     {
         $this->expectException('Gedmo\Exception\InvalidMappingException');
         $this->meta->expects($this->once())
@@ -83,7 +83,7 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function test_validateConfiguration_ifCallbackMethodIsNotAValidMethodThrowException()
+    public function testValidateConfigurationIfCallbackMethodIsNotAValidMethodThrowException()
     {
         $this->expectException('Gedmo\Exception\InvalidMappingException');
         $this->meta->expects($this->once())
@@ -98,7 +98,7 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function test_validateConfiguration_ifFilenameGeneratorValueIsNotValidThrowException()
+    public function testValidateConfigurationIfFilenameGeneratorValueIsNotValidThrowException()
     {
         $this->expectException('Gedmo\Exception\InvalidMappingException');
         $this->meta->expects($this->once())
@@ -127,7 +127,7 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function test_validateConfiguration_ifFilenameGeneratorValueIsValidButDoesntImplementNeededInterfaceThrowException()
+    public function testValidateConfigurationIfFilenameGeneratorValueIsValidButDoesntImplementNeededInterfaceThrowException()
     {
         $this->expectException('Gedmo\Exception\InvalidMappingException');
         $this->meta->expects($this->once())
@@ -156,7 +156,7 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function test_validateConfiguration_ifFilenameGeneratorValueIsValidThenDontThrowException()
+    public function testValidateConfigurationIfFilenameGeneratorValueIsValidThenDontThrowException()
     {
         $this->meta->expects($this->once())
             ->method('getReflectionClass')
@@ -184,7 +184,7 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function test_validateConfiguration_ifFilenameGeneratorValueIsAValidClassThenDontThrowException()
+    public function testValidateConfigurationIfFilenameGeneratorValueIsAValidClassThenDontThrowException()
     {
         $this->meta->expects($this->once())
             ->method('getReflectionClass')
@@ -212,7 +212,7 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function test_validateConfiguration_ifMaxSizeIsLessThanZeroThenThrowException()
+    public function testValidateConfigurationIfMaxSizeIsLessThanZeroThenThrowException()
     {
         $this->expectException('Gedmo\Exception\InvalidMappingException');
         $this->meta->expects($this->once())
@@ -236,7 +236,7 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function test_validateConfiguration_ifAllowedTypesAndDisallowedTypesAreSetThenThrowException()
+    public function testValidateConfigurationIfAllowedTypesAndDisallowedTypesAreSetThenThrowException()
     {
         $this->expectException('Gedmo\Exception\InvalidMappingException');
         $this->meta->expects($this->once())

--- a/tests/Gedmo/Uploadable/UploadableEntityTest.php
+++ b/tests/Gedmo/Uploadable/UploadableEntityTest.php
@@ -32,18 +32,18 @@ use Uploadable\Fixture\Entity\Image;
  */
 class UploadableEntityTest extends BaseTestCaseORM
 {
-    const IMAGE_CLASS = 'Uploadable\Fixture\Entity\Image';
-    const ARTICLE_CLASS = 'Uploadable\Fixture\Entity\Article';
-    const FILE_CLASS = 'Uploadable\Fixture\Entity\File';
-    const FILE_APPEND_NUMBER_CLASS = 'Uploadable\Fixture\Entity\FileAppendNumber';
-    const FILE_APPEND_NUMBER__RELATIVE_PATH_CLASS = 'Uploadable\Fixture\Entity\FileAppendNumberRelative';
-    const FILE_WITHOUT_PATH_CLASS = 'Uploadable\Fixture\Entity\FileWithoutPath';
-    const FILE_WITH_SHA1_NAME_CLASS = 'Uploadable\Fixture\Entity\FileWithSha1Name';
-    const FILE_WITH_ALPHANUMERIC_NAME_CLASS = 'Uploadable\Fixture\Entity\FileWithAlphanumericName';
-    const FILE_WITH_CUSTOM_FILENAME_GENERATOR_CLASS = 'Uploadable\Fixture\Entity\FileWithCustomFilenameGenerator';
-    const FILE_WITH_MAX_SIZE_CLASS = 'Uploadable\Fixture\Entity\FileWithMaxSize';
-    const FILE_WITH_ALLOWED_TYPES_CLASS = 'Uploadable\Fixture\Entity\FileWithAllowedTypes';
-    const FILE_WITH_DISALLOWED_TYPES_CLASS = 'Uploadable\Fixture\Entity\FileWithDisallowedTypes';
+    public const IMAGE_CLASS = 'Uploadable\Fixture\Entity\Image';
+    public const ARTICLE_CLASS = 'Uploadable\Fixture\Entity\Article';
+    public const FILE_CLASS = 'Uploadable\Fixture\Entity\File';
+    public const FILE_APPEND_NUMBER_CLASS = 'Uploadable\Fixture\Entity\FileAppendNumber';
+    public const FILE_APPEND_NUMBER__RELATIVE_PATH_CLASS = 'Uploadable\Fixture\Entity\FileAppendNumberRelative';
+    public const FILE_WITHOUT_PATH_CLASS = 'Uploadable\Fixture\Entity\FileWithoutPath';
+    public const FILE_WITH_SHA1_NAME_CLASS = 'Uploadable\Fixture\Entity\FileWithSha1Name';
+    public const FILE_WITH_ALPHANUMERIC_NAME_CLASS = 'Uploadable\Fixture\Entity\FileWithAlphanumericName';
+    public const FILE_WITH_CUSTOM_FILENAME_GENERATOR_CLASS = 'Uploadable\Fixture\Entity\FileWithCustomFilenameGenerator';
+    public const FILE_WITH_MAX_SIZE_CLASS = 'Uploadable\Fixture\Entity\FileWithMaxSize';
+    public const FILE_WITH_ALLOWED_TYPES_CLASS = 'Uploadable\Fixture\Entity\FileWithAllowedTypes';
+    public const FILE_WITH_DISALLOWED_TYPES_CLASS = 'Uploadable\Fixture\Entity\FileWithDisallowedTypes';
 
     /**
      * @var UploadableListener
@@ -426,12 +426,12 @@ class UploadableEntityTest extends BaseTestCaseORM
         $this->em->flush();
     }
 
-    public function test_removeFile_ifItsNotAFileThenReturnFalse()
+    public function testRemoveFileIfItsNotAFileThenReturnFalse()
     {
         $this->assertFalse($this->listener->removeFile('non_existent_file'));
     }
 
-    public function test_moveFile_usingAppendNumberOptionAppendsNumberToFilenameIfItAlreadyExists()
+    public function testMoveFileUsingAppendNumberOptionAppendsNumberToFilenameIfItAlreadyExists()
     {
         $file = new FileAppendNumber();
         $file2 = new FileAppendNumber();
@@ -458,7 +458,7 @@ class UploadableEntityTest extends BaseTestCaseORM
         $this->assertEquals('test-2.txt', $filename);
     }
 
-    public function test_moveFile_usingAppendNumberOptionAppendsNumberToFilenameIfItAlreadyExistsRelativePath()
+    public function testMoveFileUsingAppendNumberOptionAppendsNumberToFilenameIfItAlreadyExistsRelativePath()
     {
         $currDir = __DIR__;
         chdir(realpath(__DIR__.'/../../temp/uploadable'));
@@ -486,7 +486,7 @@ class UploadableEntityTest extends BaseTestCaseORM
         chdir($currDir);
     }
 
-    public function test_moveFile_ifUploadedFileCantBeMovedThrowException()
+    public function testMoveFileIfUploadedFileCantBeMovedThrowException()
     {
         $this->expectException('Gedmo\Exception\UploadableUploadException');
         $this->listener->returnFalseOnMoveUploadedFile = true;
@@ -501,19 +501,19 @@ class UploadableEntityTest extends BaseTestCaseORM
         $this->em->flush();
     }
 
-    public function test_addEntityFileInfo_ifFileInfoIsNotValidThrowException()
+    public function testAddEntityFileInfoIfFileInfoIsNotValidThrowException()
     {
         $this->expectException('RuntimeException');
         $this->listener->addEntityFileInfo(new Image(), 'invalidFileInfo');
     }
 
-    public function test_getEntityFileInfo_ifTheresNoFileInfoForEntityThrowException()
+    public function testGetEntityFileInfoIfTheresNoFileInfoForEntityThrowException()
     {
         $this->expectException('RuntimeException');
         $this->listener->getEntityFileInfo(new Image());
     }
 
-    public function test_fileExceedingMaximumAllowedSizeThrowsException()
+    public function testFileExceedingMaximumAllowedSizeThrowsException()
     {
         $this->expectException('Gedmo\Exception\UploadableMaxSizeException');
         // We set the default path on the listener
@@ -528,7 +528,7 @@ class UploadableEntityTest extends BaseTestCaseORM
         $this->em->flush();
     }
 
-    public function test_fileNotExceedingMaximumAllowedSizeDoesntThrowException()
+    public function testFileNotExceedingMaximumAllowedSizeDoesntThrowException()
     {
         // We set the default path on the listener
         $this->listener->setDefaultPath($this->destinationTestDir);
@@ -547,7 +547,7 @@ class UploadableEntityTest extends BaseTestCaseORM
         $this->assertEquals($size, $file->getFileSize());
     }
 
-    public function test_ifMimeTypeGuesserCantResolveTypeThrowException()
+    public function testIfMimeTypeGuesserCantResolveTypeThrowException()
     {
         $this->expectException('Gedmo\Exception\UploadableCouldntGuessMimeTypeException');
         // We set the default path on the listener
@@ -563,7 +563,7 @@ class UploadableEntityTest extends BaseTestCaseORM
         $this->em->flush();
     }
 
-    public function test_allowedTypesOption_ifMimeTypeIsInvalidThrowException()
+    public function testAllowedTypesOptionIfMimeTypeIsInvalidThrowException()
     {
         $this->expectException('Gedmo\Exception\UploadableInvalidMimeTypeException');
         // We set the default path on the listener
@@ -579,7 +579,7 @@ class UploadableEntityTest extends BaseTestCaseORM
         $this->em->flush();
     }
 
-    public function test_disallowedTypesOption_ifMimeTypeIsInvalidThrowException()
+    public function testDisallowedTypesOptionIfMimeTypeIsInvalidThrowException()
     {
         $this->expectException('Gedmo\Exception\UploadableInvalidMimeTypeException');
         // We set the default path on the listener
@@ -598,13 +598,13 @@ class UploadableEntityTest extends BaseTestCaseORM
     /**
      * @dataProvider invalidFileInfoClassesProvider
      */
-    public function test_setDefaultFileInfoClass_throwExceptionIfInvalidClassArePassed($class)
+    public function testSetDefaultFileInfoClassThrowExceptionIfInvalidClassArePassed($class)
     {
         $this->expectException('Gedmo\Exception\InvalidArgumentException');
         $this->listener->setDefaultFileInfoClass($class);
     }
 
-    public function test_setDefaultFileInfoClass_setClassIfClassIsValid()
+    public function testSetDefaultFileInfoClassSetClassIfClassIsValid()
     {
         $validClass = 'Gedmo\\Uploadable\\FileInfo\\FileInfoArray';
 
@@ -613,7 +613,7 @@ class UploadableEntityTest extends BaseTestCaseORM
         $this->assertEquals($validClass, $this->listener->getDefaultFileInfoClass());
     }
 
-    public function test_useGeneratedFilenameWhenAppendingNumbers()
+    public function testUseGeneratedFilenameWhenAppendingNumbers()
     {
         // We set the default path on the listener
         $this->listener->setDefaultPath($this->destinationTestDir);

--- a/tests/Gedmo/Wrapper/EntityWrapperTest.php
+++ b/tests/Gedmo/Wrapper/EntityWrapperTest.php
@@ -18,7 +18,7 @@ use Wrapper\Fixture\Entity\Article;
  */
 class EntityWrapperTest extends BaseTestCaseORM
 {
-    const ARTICLE = 'Wrapper\\Fixture\\Entity\\Article';
+    public const ARTICLE = 'Wrapper\\Fixture\\Entity\\Article';
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Wrapper/MongoDocumentWrapperTest.php
+++ b/tests/Gedmo/Wrapper/MongoDocumentWrapperTest.php
@@ -18,7 +18,7 @@ use Wrapper\Fixture\Document\Article;
  */
 class MongoDocumentWrapperTest extends BaseTestCaseMongoODM
 {
-    const ARTICLE = 'Wrapper\\Fixture\\Document\\Article';
+    public const ARTICLE = 'Wrapper\\Fixture\\Document\\Article';
     private $articleId;
 
     protected function setUp(): void


### PR DESCRIPTION
Triggered by https://github.com/doctrine-extensions/DoctrineExtensions/pull/2214#pullrequestreview-649006936, this adds a coding standards check job for Github Actions.

~It is draft because~ there are a couple of things to discuss, the job can be seen in https://github.com/franmomu/DoctrineExtensions/pull/4

Seeing the changes proposed by `php-cs-fixer`, just a couple of questions:

```diff
--- Original
+++ New
@@ @@
         if (isset($mapping->field)) {
-            /**
+            /*
              * @var \SimpleXmlElement
              */
```
Is this change ok? or should we change [`phpdoc_to_comment`](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/2.18/doc/rules/phpdoc/phpdoc_to_comment.rst)? to not remove this.

And the other one:

```diff
--- Original
+++ New
@@ @@
                 // update translation
-                if ($translated !== null
+                if (null !== $translated
```

I personally [don't like yoda conditions](https://dev.to/greg0ire/why-using-yoda-conditions-you-should-probably-not), I would disable them, but it's not my call.
