### PR TITLE
Allow installing doctrine/cache 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,8 +36,8 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "behat/transliterator": "~1.2",
-        "doctrine/annotations": "^1.2",
-        "doctrine/cache": "^1.0",
+        "doctrine/annotations": "^1.13",
+        "doctrine/cache": "^1.11 || ^2.0",
         "doctrine/collections": "^1.0",
         "doctrine/common": "^2.13 || ^3.0",
         "doctrine/event-manager": "^1.0"
@@ -52,6 +52,7 @@
         "doctrine/orm": "^2.6.3",
         "friendsofphp/php-cs-fixer": "^2.16",
         "phpunit/phpunit": "^8.5",
+        "symfony/cache": "^4.4 || ^5.0",
         "symfony/yaml": "^4.1"
     },
     "conflict": {
@@ -61,7 +62,8 @@
     },
     "suggest": {
         "doctrine/mongodb-odm": "to use the extensions with the MongoDB ODM",
-        "doctrine/orm": "to use the extensions with the ORM"
+        "doctrine/orm": "to use the extensions with the ORM",
+        "symfony/cache": "to cache parsed annotations"
     },
     "config": {
         "bin-dir": "bin",

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,6 @@
         "php": "^7.2 || ^8.0",
         "behat/transliterator": "~1.2",
         "doctrine/annotations": "^1.13",
-        "doctrine/cache": "^1.11 || ^2.0",
         "doctrine/collections": "^1.0",
         "doctrine/common": "^2.13 || ^3.0",
         "doctrine/event-manager": "^1.0"
@@ -47,6 +46,7 @@
     },
     "require-dev": {
         "alcaeus/mongo-php-adapter": "^1.1",
+        "doctrine/cache": "^1.11 || ^2.0",
         "doctrine/doctrine-bundle": "^2.3",
         "doctrine/mongodb-odm": "^2.0",
         "doctrine/orm": "^2.6.3",

--- a/src/DoctrineExtensions.php
+++ b/src/DoctrineExtensions.php
@@ -4,12 +4,15 @@ namespace Gedmo;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\AnnotationRegistry;
-use Doctrine\Common\Annotations\CachedReader;
+use Doctrine\Common\Annotations\PsrCachedReader;
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\Common\Cache\Psr6\CacheAdapter;
 use Doctrine\ODM\MongoDB\Mapping\Driver as DriverMongodbODM;
 use Doctrine\ORM\Mapping\Driver as DriverORM;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use function class_exists;
 
 /**
  * Version class allows to checking the dependencies required
@@ -33,7 +36,7 @@ final class DoctrineExtensions
     {
         self::registerAnnotations();
         if (!$reader) {
-            $reader = new CachedReader(new AnnotationReader(), new ArrayCache());
+            $reader = self::createAnnotationReader();
         }
         $annotationDriver = new DriverORM\AnnotationDriver($reader, [
             __DIR__.'/Translatable/Entity',
@@ -51,7 +54,7 @@ final class DoctrineExtensions
     {
         self::registerAnnotations();
         if (!$reader) {
-            $reader = new CachedReader(new AnnotationReader(), new ArrayCache());
+            $reader = self::createAnnotationReader();
         }
         $annotationDriver = new DriverORM\AnnotationDriver($reader, [
             __DIR__.'/Translatable/Entity/MappedSuperclass',
@@ -69,7 +72,7 @@ final class DoctrineExtensions
     {
         self::registerAnnotations();
         if (!$reader) {
-            $reader = new CachedReader(new AnnotationReader(), new ArrayCache());
+            $reader = self::createAnnotationReader();
         }
         $annotationDriver = new DriverMongodbODM\AnnotationDriver($reader, [
             __DIR__.'/Translatable/Document',
@@ -86,7 +89,7 @@ final class DoctrineExtensions
     {
         self::registerAnnotations();
         if (!$reader) {
-            $reader = new CachedReader(new AnnotationReader(), new ArrayCache());
+            $reader = self::createAnnotationReader();
         }
         $annotationDriver = new DriverMongodbODM\AnnotationDriver($reader, [
             __DIR__.'/Translatable/Document/MappedSuperclass',
@@ -101,5 +104,18 @@ final class DoctrineExtensions
     public static function registerAnnotations()
     {
         AnnotationRegistry::registerFile(__DIR__.'/Mapping/Annotation/All.php');
+    }
+
+    private static function createAnnotationReader()
+    {
+        $reader = new AnnotationReader();
+
+        if (class_exists(ArrayAdapter::class)) {
+            $reader = new PsrCachedReader($reader, new ArrayAdapter());
+        } elseif (class_exists(ArrayCache::class)) {
+            $reader = new PsrCachedReader($reader, CacheAdapter::wrap(new ArrayCache()));
+        }
+
+        return $reader;
     }
 }

--- a/tests/Gedmo/SoftDeleteable/SoftDeleteableEntityTest.php
+++ b/tests/Gedmo/SoftDeleteable/SoftDeleteableEntityTest.php
@@ -14,6 +14,7 @@ use SoftDeleteable\Fixture\Entity\OtherComment;
 use SoftDeleteable\Fixture\Entity\User;
 use SoftDeleteable\Fixture\Entity\UserNoHardDelete;
 use Tool\BaseTestCaseORM;
+use function class_exists;
 
 /**
  * These are tests for SoftDeleteable behavior
@@ -483,6 +484,10 @@ class SoftDeleteableEntityTest extends BaseTestCaseORM
      */
     public function shouldFilterBeQueryCachedCorrectlyWhenToggledForEntity()
     {
+        if (!class_exists(ArrayCache::class)) {
+            $this->markTestSkipped('Test only applies when doctrine/cache 1.x is installed');
+        }
+
         $cache = new ArrayCache();
         $this->em->getConfiguration()->setQueryCacheImpl($cache);
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,8 +3,8 @@
 use Composer\Autoload\ClassLoader;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\AnnotationRegistry;
-use Doctrine\Common\Annotations\CachedReader;
-use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\Common\Annotations\PsrCachedReader;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 /*
  * This is bootstrap for phpUnit unit tests,
@@ -48,5 +48,5 @@ AnnotationRegistry::registerLoader([$loader, 'loadClass']);
 Gedmo\DoctrineExtensions::registerAnnotations();
 
 $reader = new AnnotationReader();
-$reader = new CachedReader($reader, new ArrayCache());
+$reader = new PsrCachedReader($reader, new ArrayAdapter());
 $_ENV['annotation_reader'] = $reader;


### PR DESCRIPTION
This PR uses doctrine/cache to create a cached annotations reader. With doctrine/cache being sunset and the 2.0 release no longer containing implementations, we need a different alternative.

This PR updates the annotations library and will attempt to create a cached reader using either symfony/cache (if it is installed), or doctrine/cache (if the implementations are present, i.e. 1.x is installed). If neither is found, the reader will not cache its parsing result. This logic can be expanded to cover additional cache libraries if desired. Note that this is not performance critical, as annotation parsing is only done when building metadata, which should be cached anyways.