### PR TITLE
remove deprecation alert related to AbstractToken::getUsername()

### DIFF
--- a/src/Loggable/LoggableListener.php
+++ b/src/Loggable/LoggableListener.php
@@ -68,6 +68,8 @@ class LoggableListener extends MappedEventSubscriber
     {
         if (is_string($username)) {
             $this->username = $username;
+        } elseif (is_object($username) && method_exists($username, 'getUserIdentifier')) {
+            $this->username = (string) $username->getUserIdentifier();
         } elseif (is_object($username) && method_exists($username, 'getUsername')) {
             $this->username = (string) $username->getUsername();
         } else {


### PR DESCRIPTION
fix deprecation log on LoggableListener related to AbstractToken::getUsername() now call getUserIdentifier
keep BC to older versions of symfony wich use getUsername still