### PR TITLE
Update to PHP 7.2 and Code Quality by Rector  

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
         "doctrine/orm": "^2.6.3",
         "friendsofphp/php-cs-fixer": "^2.16",
         "phpunit/phpunit": "^8.5",
+        "rector/rector": "^0.11.16",
         "symfony/yaml": "^4.1"
     },
     "conflict": {

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Rector\Core\ValueObject\PhpVersion;
+use Rector\Set\ValueObject\SetList;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $parameters = $containerConfigurator->parameters();
+
+    $parameters->set(Option::ENABLE_CACHE, true);
+    $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_72);
+    $parameters->set(Option::PATHS, [__DIR__ . '/src', __DIR__ . '/tests']);
+
+    $parameters->set(Option::SKIP, [
+        'tests/temp/*',
+        \Rector\Php70\Rector\Ternary\TernaryToNullCoalescingRector::class,
+        \Rector\Php71\Rector\FuncCall\RemoveExtraParametersRector::class,
+        \Rector\CodeQuality\Rector\FuncCall\CompactToVariablesRector::class,
+        \Rector\CodeQuality\Rector\If_\ExplicitBoolCompareRector::class,
+        \Rector\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector::class,
+        \Rector\CodeQuality\Rector\Isset_\IssetOnPropertyObjectToPropertyExistsRector::class,
+    ]);
+
+    $containerConfigurator->import(SetList::PHP_70);
+    $containerConfigurator->import(SetList::PHP_71);
+    $containerConfigurator->import(SetList::PHP_72);
+    $containerConfigurator->import(SetList::CODE_QUALITY);
+};

--- a/src/Blameable/Mapping/Driver/Annotation.php
+++ b/src/Blameable/Mapping/Driver/Annotation.php
@@ -56,11 +56,8 @@ class Annotation extends AbstractAnnotationDriver
                     if (!$this->isValidField($meta, $field)) {
                         throw new InvalidMappingException("Field - [{$field}] type is not valid and must be 'string' or a one-to-many relation in class - {$meta->name}");
                     }
-                } else {
-                    // association
-                    if (!$meta->isSingleValuedAssociation($field)) {
-                        throw new InvalidMappingException("Association - [{$field}] is not valid, it must be a one-to-many relation or a string field - {$meta->name}");
-                    }
+                } elseif (!$meta->isSingleValuedAssociation($field)) {
+                    throw new InvalidMappingException("Association - [{$field}] is not valid, it must be a one-to-many relation or a string field - {$meta->name}");
                 }
                 if (!in_array($blameable->on, ['update', 'create', 'change'])) {
                     throw new InvalidMappingException("Field - [{$field}] trigger 'on' is not one of [update, create, change] in class - {$meta->name}");

--- a/src/Blameable/Mapping/Driver/Yaml.php
+++ b/src/Blameable/Mapping/Driver/Yaml.php
@@ -58,7 +58,7 @@ class Yaml extends File implements Driver
                             throw new InvalidMappingException("Missing parameters on property - {$field}, field must be set on [change] trigger in class - {$meta->name}");
                         }
                         $trackedFieldAttribute = $mappingProperty['field'];
-                        $valueAttribute = isset($mappingProperty['value']) ? $mappingProperty['value'] : null;
+                        $valueAttribute = $mappingProperty['value'] ?? null;
                         if (is_array($trackedFieldAttribute) && null !== $valueAttribute) {
                             throw new InvalidMappingException('Blameable extension does not support multiple value changeset detection yet.');
                         }
@@ -89,7 +89,7 @@ class Yaml extends File implements Driver
                             throw new InvalidMappingException("Missing parameters on property - {$field}, field must be set on [change] trigger in class - {$meta->name}");
                         }
                         $trackedFieldAttribute = $mappingProperty['field'];
-                        $valueAttribute = isset($mappingProperty['value']) ? $mappingProperty['value'] : null;
+                        $valueAttribute = $mappingProperty['value'] ?? null;
                         if (is_array($trackedFieldAttribute) && null !== $valueAttribute) {
                             throw new InvalidMappingException('Blameable extension does not support multiple value changeset detection yet.');
                         }

--- a/src/IpTraceable/Mapping/Driver/Yaml.php
+++ b/src/IpTraceable/Mapping/Driver/Yaml.php
@@ -56,7 +56,7 @@ class Yaml extends File implements Driver
                             throw new InvalidMappingException("Missing parameters on property - {$field}, field must be set on [change] trigger in class - {$meta->name}");
                         }
                         $trackedFieldAttribute = $mappingProperty['field'];
-                        $valueAttribute = isset($mappingProperty['value']) ? $mappingProperty['value'] : null;
+                        $valueAttribute = $mappingProperty['value'] ?? null;
                         if (is_array($trackedFieldAttribute) && null !== $valueAttribute) {
                             throw new InvalidMappingException('IpTraceable extension does not support multiple value changeset detection yet.');
                         }
@@ -87,7 +87,7 @@ class Yaml extends File implements Driver
                             throw new InvalidMappingException("Missing parameters on property - {$field}, field must be set on [change] trigger in class - {$meta->name}");
                         }
                         $trackedFieldAttribute = $mappingProperty['field'];
-                        $valueAttribute = isset($mappingProperty['value']) ? $mappingProperty['value'] : null;
+                        $valueAttribute = $mappingProperty['value'] ?? null;
                         if (is_array($trackedFieldAttribute) && null !== $valueAttribute) {
                             throw new InvalidMappingException('IpTraceable extension does not support multiple value changeset detection yet.');
                         }

--- a/src/Loggable/Document/Repository/LogEntryRepository.php
+++ b/src/Loggable/Document/Repository/LogEntryRepository.php
@@ -74,7 +74,7 @@ class LogEntryRepository extends DocumentRepository
         $qb = $this->createQueryBuilder();
         $qb->field('objectId')->equals($objectId);
         $qb->field('objectClass')->equals($objectMeta->name);
-        $qb->field('version')->lte(intval($version));
+        $qb->field('version')->lte((int) $version);
         $qb->sort('version', 'ASC');
         $q = $qb->getQuery();
 

--- a/src/Loggable/Entity/Repository/LogEntryRepository.php
+++ b/src/Loggable/Entity/Repository/LogEntryRepository.php
@@ -107,7 +107,7 @@ class LogEntryRepository extends EntityRepository
                         }
                     }
                 }
-                $filled = 0 === count($fields);
+                $filled = 0 === (is_array($fields) || $fields instanceof \Countable ? count($fields) : 0);
             }
             /*if (count($fields)) {
                 throw new \Gedmo\Exception\UnexpectedValueException('Could not fully revert the entity to version: '.$version);

--- a/src/Loggable/LoggableListener.php
+++ b/src/Loggable/LoggableListener.php
@@ -98,9 +98,7 @@ class LoggableListener extends MappedEventSubscriber
      */
     protected function getLogEntryClass(LoggableAdapter $ea, $class)
     {
-        return isset(self::$configurations[$this->name][$class]['logEntryClass']) ?
-            self::$configurations[$this->name][$class]['logEntryClass'] :
-            $ea->getDefaultLogEntryClass();
+        return self::$configurations[$this->name][$class]['logEntryClass'] ?? $ea->getDefaultLogEntryClass();
     }
 
     /**

--- a/src/Loggable/Mapping/Driver/Xml.php
+++ b/src/Loggable/Mapping/Driver/Xml.php
@@ -31,20 +31,18 @@ class Xml extends BaseXml
 
         $xml = $xml->children(self::GEDMO_NAMESPACE_URI);
 
-        if ('entity' == $xmlDoctrine->getName() || 'document' == $xmlDoctrine->getName() || 'mapped-superclass' == $xmlDoctrine->getName()) {
-            if (isset($xml->loggable)) {
-                /**
-                 * @var \SimpleXMLElement;
-                 */
-                $data = $xml->loggable;
-                $config['loggable'] = true;
-                if ($this->_isAttributeSet($data, 'log-entry-class')) {
-                    $class = $this->_getAttribute($data, 'log-entry-class');
-                    if (!$cl = $this->getRelatedClassName($meta, $class)) {
-                        throw new InvalidMappingException("LogEntry class: {$class} does not exist.");
-                    }
-                    $config['logEntryClass'] = $cl;
+        if (('entity' == $xmlDoctrine->getName() || 'document' == $xmlDoctrine->getName() || 'mapped-superclass' == $xmlDoctrine->getName()) && isset($xml->loggable)) {
+            /**
+             * @var \SimpleXMLElement;
+             */
+            $data = $xml->loggable;
+            $config['loggable'] = true;
+            if ($this->_isAttributeSet($data, 'log-entry-class')) {
+                $class = $this->_getAttribute($data, 'log-entry-class');
+                if (!$cl = $this->getRelatedClassName($meta, $class)) {
+                    throw new InvalidMappingException("LogEntry class: {$class} does not exist.");
                 }
+                $config['logEntryClass'] = $cl;
             }
         }
 

--- a/src/Loggable/Mapping/Driver/Yaml.php
+++ b/src/Loggable/Mapping/Driver/Yaml.php
@@ -47,71 +47,61 @@ class Yaml extends File implements Driver
 
         if (isset($mapping['fields'])) {
             foreach ($mapping['fields'] as $field => $fieldMapping) {
-                if (isset($fieldMapping['gedmo'])) {
-                    if (in_array('versioned', $fieldMapping['gedmo'])) {
-                        if ($meta->isCollectionValuedAssociation($field)) {
-                            throw new InvalidMappingException("Cannot apply versioning to field [{$field}] as it is collection in object - {$meta->name}");
-                        }
-                        // fields cannot be overrided and throws mapping exception
-                        $config['versioned'][] = $field;
+                if (isset($fieldMapping['gedmo']) && in_array('versioned', $fieldMapping['gedmo'])) {
+                    if ($meta->isCollectionValuedAssociation($field)) {
+                        throw new InvalidMappingException("Cannot apply versioning to field [{$field}] as it is collection in object - {$meta->name}");
                     }
+                    // fields cannot be overrided and throws mapping exception
+                    $config['versioned'][] = $field;
                 }
             }
         }
 
         if (isset($mapping['attributeOverride'])) {
             foreach ($mapping['attributeOverride'] as $field => $fieldMapping) {
-                if (isset($fieldMapping['gedmo'])) {
-                    if (in_array('versioned', $fieldMapping['gedmo'])) {
-                        if ($meta->isCollectionValuedAssociation($field)) {
-                            throw new InvalidMappingException("Cannot apply versioning to field [{$field}] as it is collection in object - {$meta->name}");
-                        }
-                        // fields cannot be overrided and throws mapping exception
-                        $config['versioned'][] = $field;
+                if (isset($fieldMapping['gedmo']) && in_array('versioned', $fieldMapping['gedmo'])) {
+                    if ($meta->isCollectionValuedAssociation($field)) {
+                        throw new InvalidMappingException("Cannot apply versioning to field [{$field}] as it is collection in object - {$meta->name}");
                     }
+                    // fields cannot be overrided and throws mapping exception
+                    $config['versioned'][] = $field;
                 }
             }
         }
 
         if (isset($mapping['manyToOne'])) {
             foreach ($mapping['manyToOne'] as $field => $fieldMapping) {
-                if (isset($fieldMapping['gedmo'])) {
-                    if (in_array('versioned', $fieldMapping['gedmo'])) {
-                        if ($meta->isCollectionValuedAssociation($field)) {
-                            throw new InvalidMappingException("Cannot apply versioning to field [{$field}] as it is collection in object - {$meta->name}");
-                        }
-                        // fields cannot be overrided and throws mapping exception
-                        $config['versioned'][] = $field;
+                if (isset($fieldMapping['gedmo']) && in_array('versioned', $fieldMapping['gedmo'])) {
+                    if ($meta->isCollectionValuedAssociation($field)) {
+                        throw new InvalidMappingException("Cannot apply versioning to field [{$field}] as it is collection in object - {$meta->name}");
                     }
+                    // fields cannot be overrided and throws mapping exception
+                    $config['versioned'][] = $field;
                 }
             }
         }
 
         if (isset($mapping['oneToOne'])) {
             foreach ($mapping['oneToOne'] as $field => $fieldMapping) {
-                if (isset($fieldMapping['gedmo'])) {
-                    if (in_array('versioned', $fieldMapping['gedmo'])) {
-                        if ($meta->isCollectionValuedAssociation($field)) {
-                            throw new InvalidMappingException("Cannot apply versioning to field [{$field}] as it is collection in object - {$meta->name}");
-                        }
-                        // fields cannot be overrided and throws mapping exception
-                        $config['versioned'][] = $field;
+                if (isset($fieldMapping['gedmo']) && in_array('versioned', $fieldMapping['gedmo'])) {
+                    if ($meta->isCollectionValuedAssociation($field)) {
+                        throw new InvalidMappingException("Cannot apply versioning to field [{$field}] as it is collection in object - {$meta->name}");
                     }
+                    // fields cannot be overrided and throws mapping exception
+                    $config['versioned'][] = $field;
                 }
             }
         }
 
         if (isset($mapping['embedded'])) {
             foreach ($mapping['embedded'] as $field => $fieldMapping) {
-                if (isset($fieldMapping['gedmo'])) {
-                    if (in_array('versioned', $fieldMapping['gedmo'])) {
-                        if ($meta->isCollectionValuedAssociation($field)) {
-                            throw new InvalidMappingException("Cannot apply versioning to field [{$field}] as it is collection in object - {$meta->name}");
-                        }
-                        // fields cannot be overrided and throws mapping exception
-                        $mapping = $this->_getMapping($fieldMapping['class']);
-                        $this->inspectEmbeddedForVersioned($field, $mapping, $config);
+                if (isset($fieldMapping['gedmo']) && in_array('versioned', $fieldMapping['gedmo'])) {
+                    if ($meta->isCollectionValuedAssociation($field)) {
+                        throw new InvalidMappingException("Cannot apply versioning to field [{$field}] as it is collection in object - {$meta->name}");
                     }
+                    // fields cannot be overrided and throws mapping exception
+                    $mapping = $this->_getMapping($fieldMapping['class']);
+                    $this->inspectEmbeddedForVersioned($field, $mapping, $config);
                 }
             }
         }
@@ -140,7 +130,7 @@ class Yaml extends File implements Driver
     private function inspectEmbeddedForVersioned($field, array $mapping, array &$config)
     {
         if (isset($mapping['fields'])) {
-            foreach ($mapping['fields'] as $property => $fieldMapping) {
+            foreach (array_keys($mapping['fields']) as $property) {
                 $config['versioned'][] = $field.'.'.$property;
             }
         }

--- a/src/Mapping/Driver/File.php
+++ b/src/Mapping/Driver/File.php
@@ -19,6 +19,10 @@ use Gedmo\Mapping\Driver;
 abstract class File implements Driver
 {
     /**
+     * @var mixed[]
+     */
+    public $_paths;
+    /**
      * @var FileLocator
      */
     protected $locator;
@@ -85,10 +89,8 @@ abstract class File implements Driver
     {
         //try loading mapping from original driver first
         $mapping = null;
-        if (!is_null($this->_originalDriver)) {
-            if ($this->_originalDriver instanceof FileDriver || $this->_originalDriver instanceof AbstractFileDriver) {
-                $mapping = $this->_originalDriver->getElement($className);
-            }
+        if (!is_null($this->_originalDriver) && ($this->_originalDriver instanceof FileDriver || $this->_originalDriver instanceof AbstractFileDriver)) {
+            $mapping = $this->_originalDriver->getElement($className);
         }
 
         //if no mapping found try to load mapping file again

--- a/src/Mapping/MappedEventSubscriber.php
+++ b/src/Mapping/MappedEventSubscriber.php
@@ -134,7 +134,7 @@ abstract class MappedEventSubscriber implements EventSubscriber
                     }
                 }
 
-                $objectClass = isset($config['useObjectClass']) ? $config['useObjectClass'] : $class;
+                $objectClass = $config['useObjectClass'] ?? $class;
                 if ($objectClass !== $class) {
                     $this->getConfiguration($objectManager, $objectClass);
                 }

--- a/src/References/Mapping/Driver/Xml.php
+++ b/src/References/Mapping/Driver/Xml.php
@@ -46,54 +46,52 @@ class Xml extends BaseXml
 
         $xml = $xml->children(self::GEDMO_NAMESPACE_URI);
 
-        if ('entity' === $xmlDoctrine->getName() || 'document' === $xmlDoctrine->getName() || 'mapped-superclass' === $xmlDoctrine->getName()) {
-            if (isset($xml->reference)) {
-                /**
-                 * @var \SimpleXMLElement
-                 */
-                foreach ($xml->reference as $element) {
-                    if (!$this->_isAttributeSet($element, 'type')) {
-                        throw new InvalidMappingException("Reference type (document or entity) is not set in class - {$meta->name}");
-                    }
+        if (('entity' === $xmlDoctrine->getName() || 'document' === $xmlDoctrine->getName() || 'mapped-superclass' === $xmlDoctrine->getName()) && isset($xml->reference)) {
+            /**
+             * @var \SimpleXMLElement
+             */
+            foreach ($xml->reference as $element) {
+                if (!$this->_isAttributeSet($element, 'type')) {
+                    throw new InvalidMappingException("Reference type (document or entity) is not set in class - {$meta->name}");
+                }
 
-                    $type = $this->_getAttribute($element, 'type');
-                    if (!in_array($type, $this->validTypes)) {
-                        throw new InvalidMappingException($type.' is not a valid reference type, valid types are: '.implode(', ', $this->validTypes));
-                    }
+                $type = $this->_getAttribute($element, 'type');
+                if (!in_array($type, $this->validTypes)) {
+                    throw new InvalidMappingException($type.' is not a valid reference type, valid types are: '.implode(', ', $this->validTypes));
+                }
 
-                    $reference = $this->_getAttribute($element, 'reference');
-                    if (!in_array($reference, $this->validReferences)) {
-                        throw new InvalidMappingException($reference.' is not a valid reference, valid references are: '.implode(', ', $this->validReferences));
-                    }
+                $reference = $this->_getAttribute($element, 'reference');
+                if (!in_array($reference, $this->validReferences)) {
+                    throw new InvalidMappingException($reference.' is not a valid reference, valid references are: '.implode(', ', $this->validReferences));
+                }
 
-                    if (!$this->_isAttributeSet($element, 'field')) {
-                        throw new InvalidMappingException("Reference field is not set in class - {$meta->name}");
-                    }
-                    $field = $this->_getAttribute($element, 'field');
+                if (!$this->_isAttributeSet($element, 'field')) {
+                    throw new InvalidMappingException("Reference field is not set in class - {$meta->name}");
+                }
+                $field = $this->_getAttribute($element, 'field');
 
-                    if (!$this->_isAttributeSet($element, 'class')) {
-                        throw new InvalidMappingException("Reference field is not set in class - {$meta->name}");
-                    }
-                    $class = $this->_getAttribute($element, 'class');
+                if (!$this->_isAttributeSet($element, 'class')) {
+                    throw new InvalidMappingException("Reference field is not set in class - {$meta->name}");
+                }
+                $class = $this->_getAttribute($element, 'class');
 
-                    if (!$this->_isAttributeSet($element, 'identifier')) {
-                        throw new InvalidMappingException("Reference identifier is not set in class - {$meta->name}");
-                    }
-                    $identifier = $this->_getAttribute($element, 'identifier');
+                if (!$this->_isAttributeSet($element, 'identifier')) {
+                    throw new InvalidMappingException("Reference identifier is not set in class - {$meta->name}");
+                }
+                $identifier = $this->_getAttribute($element, 'identifier');
 
-                    $config[$reference][$field] = [
-                        'field' => $field,
-                        'type' => $type,
-                        'class' => $class,
-                        'identifier' => $identifier,
-                    ];
+                $config[$reference][$field] = [
+                    'field' => $field,
+                    'type' => $type,
+                    'class' => $class,
+                    'identifier' => $identifier,
+                ];
 
-                    if (!$this->_isAttributeSet($element, 'mappedBy')) {
-                        $config[$reference][$field]['mappedBy'] = $this->_getAttribute($element, 'mappedBy');
-                    }
-                    if (!$this->_isAttributeSet($element, 'inversedBy')) {
-                        $config[$reference][$field]['inversedBy'] = $this->_getAttribute($element, 'inversedBy');
-                    }
+                if (!$this->_isAttributeSet($element, 'mappedBy')) {
+                    $config[$reference][$field]['mappedBy'] = $this->_getAttribute($element, 'mappedBy');
+                }
+                if (!$this->_isAttributeSet($element, 'inversedBy')) {
+                    $config[$reference][$field]['inversedBy'] = $this->_getAttribute($element, 'inversedBy');
                 }
             }
         }

--- a/src/References/Mapping/Driver/Yaml.php
+++ b/src/References/Mapping/Driver/Yaml.php
@@ -35,7 +35,7 @@ class Yaml extends File implements Driver
             foreach ($mapping['gedmo']['reference'] as $field => $fieldMapping) {
                 $reference = $fieldMapping['reference'];
 
-                if (!in_array($reference, array_keys($this->validReferences))) {
+                if (!array_key_exists($reference, $this->validReferences)) {
                     throw new InvalidMappingException($reference.' is not a valid reference, valid references are: '.implode(', ', array_keys($this->validReferences)));
                 }
 

--- a/src/References/Mapping/Event/Adapter/ORM.php
+++ b/src/References/Mapping/Event/Adapter/ORM.php
@@ -65,10 +65,8 @@ final class ORM extends BaseAdapterORM implements ReferencesAdapter
         $this->throwIfNotDocumentManager($om);
         $meta = $om->getClassMetadata($class);
 
-        if ($om instanceof MongoDocumentManager) {
-            if (!$meta->isInheritanceTypeNone()) {
-                return $om->find($class, $identifier);
-            }
+        if ($om instanceof MongoDocumentManager && !$meta->isInheritanceTypeNone()) {
+            return $om->find($class, $identifier);
         }
 
         return $om->getReference($class, $identifier);

--- a/src/Sluggable/Handler/TreeSlugHandler.php
+++ b/src/Sluggable/Handler/TreeSlugHandler.php
@@ -79,9 +79,9 @@ class TreeSlugHandler implements SlugHandlerWithUniqueCallbackInterface
         $this->isInsert = $this->om->getUnitOfWork()->isScheduledForInsert($object);
         $options = $config['handlers'][get_called_class()];
 
-        $this->usedPathSeparator = isset($options['separator']) ? $options['separator'] : self::SEPARATOR;
-        $this->prefix = isset($options['prefix']) ? $options['prefix'] : '';
-        $this->suffix = isset($options['suffix']) ? $options['suffix'] : '';
+        $this->usedPathSeparator = $options['separator'] ?? self::SEPARATOR;
+        $this->prefix = $options['prefix'] ?? '';
+        $this->suffix = $options['suffix'] ?? '';
 
         if (!$this->isInsert && !$needToChangeSlug) {
             $changeSet = $ea->getObjectChangeSet($this->om->getUnitOfWork(), $object);

--- a/src/Sluggable/Handler/TreeSlugHandler.php
+++ b/src/Sluggable/Handler/TreeSlugHandler.php
@@ -181,14 +181,7 @@ class TreeSlugHandler implements SlugHandlerWithUniqueCallbackInterface
     {
         $slug = $text.$this->suffix;
 
-        if (strlen($this->parentSlug)) {
-            $slug = $this->parentSlug.$this->usedPathSeparator.$slug;
-        } else {
-            // if no parentSlug, apply our prefix
-            $slug = $this->prefix.$slug;
-        }
-
-        return $slug;
+        return strlen($this->parentSlug) ? $this->parentSlug.$this->usedPathSeparator.$slug : $this->prefix.$slug;
     }
 
     /**

--- a/src/Sluggable/Mapping/Driver/Annotation.php
+++ b/src/Sluggable/Mapping/Driver/Annotation.php
@@ -143,7 +143,7 @@ class Annotation extends AbstractAnnotationDriver
             if (!empty($meta->identifier) && $meta->isIdentifier($fieldName) && !(bool) $slug->unique) {
                 throw new InvalidMappingException("Identifier field - [{$fieldName}] slug must be unique in order to maintain primary key in class - {$meta->name}");
             }
-            if (false === $slug->unique && $slug->unique_base) {
+            if (!$slug->unique && $slug->unique_base) {
                 throw new InvalidMappingException("Slug annotation [unique_base] can not be set if unique is unset or 'false'");
             }
             if ($slug->unique_base && !$meta->hasField($slug->unique_base) && !$meta->hasAssociation($slug->unique_base)) {

--- a/src/Sluggable/Mapping/Driver/Xml.php
+++ b/src/Sluggable/Mapping/Driver/Xml.php
@@ -121,7 +121,7 @@ class Xml extends BaseXml
                 throw new InvalidMappingException("Identifier field - [{$field}] slug must be unique in order to maintain primary key in class - {$meta->name}");
             }
             $ubase = $config['slugs'][$field]['unique_base'];
-            if (false === $config['slugs'][$field]['unique'] && $ubase) {
+            if (!$config['slugs'][$field]['unique'] && $ubase) {
                 throw new InvalidMappingException("Slug annotation [unique_base] can not be set if unique is unset or 'false'");
             }
             if ($ubase && !$meta->hasField($ubase) && !$meta->hasAssociation($ubase)) {

--- a/src/Sluggable/Mapping/Driver/Yaml.php
+++ b/src/Sluggable/Mapping/Driver/Yaml.php
@@ -128,8 +128,7 @@ class Yaml extends File implements Driver
                 $config['slugs'][$field]['unique'] = isset($slug['unique']) ?
                     (bool) $slug['unique'] : true;
 
-                $config['slugs'][$field]['unique_base'] = isset($slug['unique_base']) ?
-                    $slug['unique_base'] : null;
+                $config['slugs'][$field]['unique_base'] = $slug['unique_base'] ?? null;
 
                 $config['slugs'][$field]['separator'] = isset($slug['separator']) ?
                     (string) $slug['separator'] : '-';

--- a/src/Sluggable/SluggableListener.php
+++ b/src/Sluggable/SluggableListener.php
@@ -269,7 +269,7 @@ class SluggableListener extends MappedEventSubscriber
         $config = $this->getConfiguration($om, $meta->name);
 
         foreach ($config['slugs'] as $slugField => $options) {
-            $hasHandlers = count($options['handlers']);
+            $hasHandlers = is_array($options['handlers']) || $options['handlers'] instanceof \Countable ? count($options['handlers']) : 0;
             $options['useObjectClass'] = $config['useObjectClass'];
             // collect the slug from fields
             $slug = $meta->getReflectionProperty($slugField)->getValue($object);

--- a/src/Sluggable/SluggableListener.php
+++ b/src/Sluggable/SluggableListener.php
@@ -179,7 +179,7 @@ class SluggableListener extends MappedEventSubscriber
         $meta = $om->getClassMetadata(get_class($object));
 
         if ($config = $this->getConfiguration($om, $meta->name)) {
-            foreach ($config['slugs'] as $slugField => $options) {
+            foreach (array_keys($config['slugs']) as $slugField) {
                 if ($meta->isIdentifier($slugField)) {
                     $meta->getReflectionProperty($slugField)->setValue($object, '__id__');
                 }
@@ -303,7 +303,7 @@ class SluggableListener extends MappedEventSubscriber
             }
             // notify slug handlers --> onChangeDecision
             if ($hasHandlers) {
-                foreach ($options['handlers'] as $class => $handlerOptions) {
+                foreach (array_keys($options['handlers']) as $class) {
                     $this->getHandler($class)->onChangeDecision($ea, $options, $object, $slug, $needToChangeSlug);
                 }
             }
@@ -314,7 +314,7 @@ class SluggableListener extends MappedEventSubscriber
                 $urlized = false;
 
                 if ($hasHandlers) {
-                    foreach ($options['handlers'] as $class => $handlerOptions) {
+                    foreach (array_keys($options['handlers']) as $class) {
                         $this->getHandler($class)->postSlugBuild($ea, $options, $object, $slug);
                         if ($this->getHandler($class)->handlesUrlization()) {
                             $urlized = true;
@@ -350,19 +350,11 @@ class SluggableListener extends MappedEventSubscriber
                         break;
 
                     case 'lower':
-                        if (function_exists('mb_strtolower')) {
-                            $slug = mb_strtolower($slug);
-                        } else {
-                            $slug = strtolower($slug);
-                        }
+                        $slug = function_exists('mb_strtolower') ? mb_strtolower($slug) : strtolower($slug);
                         break;
 
                     case 'upper':
-                        if (function_exists('mb_strtoupper')) {
-                            $slug = mb_strtoupper($slug);
-                        } else {
-                            $slug = strtoupper($slug);
-                        }
+                        $slug = function_exists('mb_strtoupper') ? mb_strtoupper($slug) : strtoupper($slug);
                         break;
 
                     default:
@@ -375,13 +367,13 @@ class SluggableListener extends MappedEventSubscriber
                     $slug = substr($slug, 0, $mapping['length']);
                 }
 
-                if (isset($mapping['nullable']) && $mapping['nullable'] && 0 === strlen($slug)) {
+                if (isset($mapping['nullable']) && $mapping['nullable'] && $slug === '') {
                     $slug = null;
                 }
 
                 // notify slug handlers --> beforeMakingUnique
                 if ($hasHandlers) {
-                    foreach ($options['handlers'] as $class => $handlerOptions) {
+                    foreach (array_keys($options['handlers']) as $class) {
                         $handler = $this->getHandler($class);
                         if ($handler instanceof SlugHandlerWithUniqueCallbackInterface) {
                             $handler->beforeMakingUnique($ea, $options, $object, $slug);
@@ -397,7 +389,7 @@ class SluggableListener extends MappedEventSubscriber
 
                 // notify slug handlers --> onSlugCompletion
                 if ($hasHandlers) {
-                    foreach ($options['handlers'] as $class => $handlerOptions) {
+                    foreach (array_keys($options['handlers']) as $class) {
                         $this->getHandler($class)->onSlugCompletion($ea, $options, $object, $slug);
                     }
                 }

--- a/src/SoftDeleteable/Mapping/Driver/Xml.php
+++ b/src/SoftDeleteable/Mapping/Driver/Xml.php
@@ -31,28 +31,21 @@ class Xml extends BaseXml
         $xmlDoctrine = $xml;
         $xml = $xml->children(self::GEDMO_NAMESPACE_URI);
 
-        if (in_array($xmlDoctrine->getName(), ['mapped-superclass', 'entity', 'document', 'embedded-document'])) {
-            if (isset($xml->{'soft-deleteable'})) {
-                $field = $this->_getAttribute($xml->{'soft-deleteable'}, 'field-name');
-
-                if (!$field) {
-                    throw new InvalidMappingException('Field name for SoftDeleteable class is mandatory.');
-                }
-
-                Validator::validateField($meta, $field);
-
-                $config['softDeleteable'] = true;
-                $config['fieldName'] = $field;
-
-                $config['timeAware'] = false;
-                if ($this->_isAttributeSet($xml->{'soft-deleteable'}, 'time-aware')) {
-                    $config['timeAware'] = $this->_getBooleanAttribute($xml->{'soft-deleteable'}, 'time-aware');
-                }
-
-                $config['hardDelete'] = true;
-                if ($this->_isAttributeSet($xml->{'soft-deleteable'}, 'hard-delete')) {
-                    $config['hardDelete'] = $this->_getBooleanAttribute($xml->{'soft-deleteable'}, 'hard-delete');
-                }
+        if (in_array($xmlDoctrine->getName(), ['mapped-superclass', 'entity', 'document', 'embedded-document']) && isset($xml->{'soft-deleteable'})) {
+            $field = $this->_getAttribute($xml->{'soft-deleteable'}, 'field-name');
+            if (!$field) {
+                throw new InvalidMappingException('Field name for SoftDeleteable class is mandatory.');
+            }
+            Validator::validateField($meta, $field);
+            $config['softDeleteable'] = true;
+            $config['fieldName'] = $field;
+            $config['timeAware'] = false;
+            if ($this->_isAttributeSet($xml->{'soft-deleteable'}, 'time-aware')) {
+                $config['timeAware'] = $this->_getBooleanAttribute($xml->{'soft-deleteable'}, 'time-aware');
+            }
+            $config['hardDelete'] = true;
+            if ($this->_isAttributeSet($xml->{'soft-deleteable'}, 'hard-delete')) {
+                $config['hardDelete'] = $this->_getBooleanAttribute($xml->{'soft-deleteable'}, 'hard-delete');
             }
         }
     }

--- a/src/SoftDeleteable/Query/TreeWalker/SoftDeleteableWalker.php
+++ b/src/SoftDeleteable/Query/TreeWalker/SoftDeleteableWalker.php
@@ -72,9 +72,7 @@ class SoftDeleteableWalker extends SqlWalker
         $quotedTableName = $class->getQuotedTableName($this->platform);
         $quotedColumnName = $class->getQuotedColumnName($this->deletedAtField, $this->platform);
 
-        $sql = 'UPDATE '.$quotedTableName.' SET '.$quotedColumnName.' = '.$this->platform->getCurrentTimestampSQL();
-
-        return $sql;
+        return 'UPDATE '.$quotedTableName.' SET '.$quotedColumnName.' = '.$this->platform->getCurrentTimestampSQL();
     }
 
     /**

--- a/src/SoftDeleteable/Traits/SoftDeleteable.php
+++ b/src/SoftDeleteable/Traits/SoftDeleteable.php
@@ -22,8 +22,9 @@ trait SoftDeleteable
      * Set or clear the deleted at timestamp.
      *
      * @return self
+     * @param \DateTime|\DateTimeImmutable $deletedAt
      */
-    public function setDeletedAt(DateTime $deletedAt = null)
+    public function setDeletedAt(\DateTimeInterface $deletedAt = null)
     {
         $this->deletedAt = $deletedAt;
 

--- a/src/SoftDeleteable/Traits/SoftDeleteableDocument.php
+++ b/src/SoftDeleteable/Traits/SoftDeleteableDocument.php
@@ -25,8 +25,9 @@ trait SoftDeleteableDocument
      * Set or clear the deleted at timestamp.
      *
      * @return self
+     * @param \DateTime|\DateTimeImmutable $deletedAt
      */
-    public function setDeletedAt(DateTime $deletedAt = null)
+    public function setDeletedAt(\DateTimeInterface $deletedAt = null)
     {
         $this->deletedAt = $deletedAt;
 

--- a/src/SoftDeleteable/Traits/SoftDeleteableEntity.php
+++ b/src/SoftDeleteable/Traits/SoftDeleteableEntity.php
@@ -25,8 +25,9 @@ trait SoftDeleteableEntity
      * Set or clear the deleted at timestamp.
      *
      * @return self
+     * @param \DateTime|\DateTimeImmutable $deletedAt
      */
-    public function setDeletedAt(DateTime $deletedAt = null)
+    public function setDeletedAt(\DateTimeInterface $deletedAt = null)
     {
         $this->deletedAt = $deletedAt;
 

--- a/src/Sortable/Entity/Repository/SortableRepository.php
+++ b/src/Sortable/Entity/Repository/SortableRepository.php
@@ -64,7 +64,7 @@ class SortableRepository extends EntityRepository
             }
             unset($groups[$name]);
         }
-        if (count($groups) > 0) {
+        if ((is_array($groups) || $groups instanceof \Countable ? count($groups) : 0) > 0) {
             throw new \InvalidArgumentException('You need to specify values for the following groups to select by sortable groups: '.implode(', ', array_keys($groups)));
         }
 

--- a/src/Sortable/Entity/Repository/SortableRepository.php
+++ b/src/Sortable/Entity/Repository/SortableRepository.php
@@ -58,7 +58,7 @@ class SortableRepository extends EntityRepository
     public function getBySortableGroupsQueryBuilder(array $groupValues = [])
     {
         $groups = isset($this->config['groups']) ? array_combine(array_values($this->config['groups']), array_keys($this->config['groups'])) : [];
-        foreach ($groupValues as $name => $value) {
+        foreach (array_keys($groupValues) as $name) {
             if (!in_array($name, $this->config['groups'])) {
                 throw new \InvalidArgumentException('Sortable group "'.$name.'" is not defined in Entity '.$this->meta->name);
             }

--- a/src/Sortable/Mapping/Driver/Annotation.php
+++ b/src/Sortable/Mapping/Driver/Annotation.php
@@ -79,10 +79,8 @@ class Annotation extends AbstractAnnotationDriver
             }
         }
 
-        if (!$meta->isMappedSuperclass && $config) {
-            if (!isset($config['position'])) {
-                throw new InvalidMappingException("Missing property: 'position' in class - {$meta->name}");
-            }
+        if (!$meta->isMappedSuperclass && $config && !isset($config['position'])) {
+            throw new InvalidMappingException("Missing property: 'position' in class - {$meta->name}");
         }
     }
 }

--- a/src/Sortable/Mapping/Driver/Xml.php
+++ b/src/Sortable/Mapping/Driver/Xml.php
@@ -63,10 +63,8 @@ class Xml extends BaseXml
             $this->readSortableGroups($xml->{'many-to-many'}, $config);
         }
 
-        if (!$meta->isMappedSuperclass && $config) {
-            if (!isset($config['position'])) {
-                throw new InvalidMappingException("Missing property: 'position' in class - {$meta->name}");
-            }
+        if (!$meta->isMappedSuperclass && $config && !isset($config['position'])) {
+            throw new InvalidMappingException("Missing property: 'position' in class - {$meta->name}");
         }
     }
 

--- a/src/Sortable/Mapping/Driver/Yaml.php
+++ b/src/Sortable/Mapping/Driver/Yaml.php
@@ -45,13 +45,11 @@ class Yaml extends File implements Driver
 
         if (isset($mapping['fields'])) {
             foreach ($mapping['fields'] as $field => $fieldMapping) {
-                if (isset($fieldMapping['gedmo'])) {
-                    if (in_array('sortablePosition', $fieldMapping['gedmo'])) {
-                        if (!$this->isValidField($meta, $field)) {
-                            throw new InvalidMappingException("Sortable position field - [{$field}] type is not valid and must be 'integer' in class - {$meta->name}");
-                        }
-                        $config['position'] = $field;
+                if (isset($fieldMapping['gedmo']) && in_array('sortablePosition', $fieldMapping['gedmo'])) {
+                    if (!$this->isValidField($meta, $field)) {
+                        throw new InvalidMappingException("Sortable position field - [{$field}] type is not valid and must be 'integer' in class - {$meta->name}");
                     }
+                    $config['position'] = $field;
                 }
             }
             $this->readSortableGroups($mapping['fields'], $config);
@@ -63,23 +61,19 @@ class Yaml extends File implements Driver
             $this->readSortableGroups($mapping['manyToMany'], $config);
         }
 
-        if (!$meta->isMappedSuperclass && $config) {
-            if (!isset($config['position'])) {
-                throw new InvalidMappingException("Missing property: 'position' in class - {$meta->name}");
-            }
+        if (!$meta->isMappedSuperclass && $config && !isset($config['position'])) {
+            throw new InvalidMappingException("Missing property: 'position' in class - {$meta->name}");
         }
     }
 
     private function readSortableGroups($mapping, array &$config)
     {
         foreach ($mapping as $field => $fieldMapping) {
-            if (isset($fieldMapping['gedmo'])) {
-                if (in_array('sortableGroup', $fieldMapping['gedmo'])) {
-                    if (!isset($config['groups'])) {
-                        $config['groups'] = [];
-                    }
-                    $config['groups'][] = $field;
+            if (isset($fieldMapping['gedmo']) && in_array('sortableGroup', $fieldMapping['gedmo'])) {
+                if (!isset($config['groups'])) {
+                    $config['groups'] = [];
                 }
+                $config['groups'][] = $field;
             }
         }
     }

--- a/src/Sortable/SortableListener.php
+++ b/src/Sortable/SortableListener.php
@@ -289,11 +289,7 @@ class SortableListener extends MappedEventSubscriber
                 $newPosition = 0;
             }
         } elseif ($newPosition > $this->maxPositions[$hash]) {
-            if ($groupHasChanged) {
-                $newPosition = $this->maxPositions[$hash] + 1;
-            } else {
-                $newPosition = $this->maxPositions[$hash];
-            }
+            $newPosition = $groupHasChanged ? $this->maxPositions[$hash] + 1 : $this->maxPositions[$hash];
         } else {
             $newPosition = min([$this->maxPositions[$hash], $newPosition]);
         }
@@ -451,11 +447,7 @@ class SortableListener extends MappedEventSubscriber
                                 // Special case for equal objects but different instances.
                                 // If the object implements Comparable interface we can use its compareTo method
                                 // Otherwise we fallback to normal object comparison
-                                if ($gr instanceof Comparable) {
-                                    $matches = $gr->compareTo($value);
-                                } else {
-                                    $matches = $gr == $value;
-                                }
+                                $matches = $gr instanceof Comparable ? $gr->compareTo($value) : $gr == $value;
                             } else {
                                 $matches = $gr === $value;
                             }
@@ -512,7 +504,7 @@ class SortableListener extends MappedEventSubscriber
         $maxPos = null;
 
         // Get groups
-        if (!sizeof($groups)) {
+        if (!count($groups)) {
             $groups = $this->getGroups($meta, $config, $object);
         }
 
@@ -538,7 +530,7 @@ class SortableListener extends MappedEventSubscriber
             $maxPos = -1;
         }
 
-        return intval($maxPos);
+        return (int) $maxPos;
     }
 
     /**

--- a/src/Timestampable/Mapping/Driver/Yaml.php
+++ b/src/Timestampable/Mapping/Driver/Yaml.php
@@ -66,7 +66,7 @@ class Yaml extends File implements Driver
                             throw new InvalidMappingException("Missing parameters on property - {$field}, field must be set on [change] trigger in class - {$meta->name}");
                         }
                         $trackedFieldAttribute = $mappingProperty['field'];
-                        $valueAttribute = isset($mappingProperty['value']) ? $mappingProperty['value'] : null;
+                        $valueAttribute = $mappingProperty['value'] ?? null;
                         if (is_array($trackedFieldAttribute) && null !== $valueAttribute) {
                             throw new InvalidMappingException('Timestampable extension does not support multiple value changeset detection yet.');
                         }

--- a/src/Timestampable/Traits/Timestampable.php
+++ b/src/Timestampable/Traits/Timestampable.php
@@ -24,8 +24,9 @@ trait Timestampable
      * Sets createdAt.
      *
      * @return $this
+     * @param \DateTime|\DateTimeImmutable $createdAt
      */
-    public function setCreatedAt(\DateTime $createdAt)
+    public function setCreatedAt(\DateTimeInterface $createdAt)
     {
         $this->createdAt = $createdAt;
 
@@ -46,8 +47,9 @@ trait Timestampable
      * Sets updatedAt.
      *
      * @return $this
+     * @param \DateTime|\DateTimeImmutable $updatedAt
      */
-    public function setUpdatedAt(\DateTime $updatedAt)
+    public function setUpdatedAt(\DateTimeInterface $updatedAt)
     {
         $this->updatedAt = $updatedAt;
 

--- a/src/Timestampable/Traits/TimestampableDocument.php
+++ b/src/Timestampable/Traits/TimestampableDocument.php
@@ -31,8 +31,9 @@ trait TimestampableDocument
      * Sets createdAt.
      *
      * @return $this
+     * @param \DateTime|\DateTimeImmutable $createdAt
      */
-    public function setCreatedAt(\DateTime $createdAt)
+    public function setCreatedAt(\DateTimeInterface $createdAt)
     {
         $this->createdAt = $createdAt;
 
@@ -53,8 +54,9 @@ trait TimestampableDocument
      * Sets updatedAt.
      *
      * @return $this
+     * @param \DateTime|\DateTimeImmutable $updatedAt
      */
-    public function setUpdatedAt(\DateTime $updatedAt)
+    public function setUpdatedAt(\DateTimeInterface $updatedAt)
     {
         $this->updatedAt = $updatedAt;
 

--- a/src/Timestampable/Traits/TimestampableEntity.php
+++ b/src/Timestampable/Traits/TimestampableEntity.php
@@ -31,8 +31,9 @@ trait TimestampableEntity
      * Sets createdAt.
      *
      * @return $this
+     * @param \DateTime|\DateTimeImmutable $createdAt
      */
-    public function setCreatedAt(\DateTime $createdAt)
+    public function setCreatedAt(\DateTimeInterface $createdAt)
     {
         $this->createdAt = $createdAt;
 
@@ -53,8 +54,9 @@ trait TimestampableEntity
      * Sets updatedAt.
      *
      * @return $this
+     * @param \DateTime|\DateTimeImmutable $updatedAt
      */
-    public function setUpdatedAt(\DateTime $updatedAt)
+    public function setUpdatedAt(\DateTimeInterface $updatedAt)
     {
         $this->updatedAt = $updatedAt;
 

--- a/src/Tool/Logging/DBAL/QueryAnalyzer.php
+++ b/src/Tool/Logging/DBAL/QueryAnalyzer.php
@@ -111,9 +111,8 @@ class QueryAnalyzer implements SQLLogger
             }
             $output .= $sql.';'.PHP_EOL;
         }
-        $output .= PHP_EOL;
 
-        return $output;
+        return $output . PHP_EOL;
     }
 
     /**
@@ -224,14 +223,11 @@ class QueryAnalyzer implements SQLLogger
                 if ($type instanceof Type) {
                     $value = $type->convertToDatabaseValue($value, $this->platform);
                 }
-            } else {
-                // Remove `$value instanceof \DateTime` check when PHP version is bumped to >=5.5
-                if (is_object($value) && ($value instanceof \DateTime || $value instanceof \DateTimeInterface)) {
-                    $value = $value->format($this->platform->getDateTimeFormatString());
-                } elseif (!is_null($value)) {
-                    $type = Type::getType(gettype($value));
-                    $value = $type->convertToDatabaseValue($value, $this->platform);
-                }
+            } elseif (is_object($value) && ($value instanceof \DateTime || $value instanceof \DateTimeInterface)) {
+                $value = $value->format($this->platform->getDateTimeFormatString());
+            } elseif (!is_null($value)) {
+                $type = Type::getType(gettype($value));
+                $value = $type->convertToDatabaseValue($value, $this->platform);
             }
             if (is_string($value)) {
                 $value = "'{$value}'";

--- a/src/Tool/Wrapper/EntityWrapper.php
+++ b/src/Tool/Wrapper/EntityWrapper.php
@@ -118,12 +118,8 @@ class EntityWrapper extends AbstractWrapper
      */
     protected function initialize()
     {
-        if (!$this->initialized) {
-            if ($this->object instanceof Proxy) {
-                if (!$this->object->__isInitialized__) {
-                    $this->object->__load();
-                }
-            }
+        if (!$this->initialized && $this->object instanceof Proxy && !$this->object->__isInitialized__) {
+            $this->object->__load();
         }
     }
 

--- a/src/Tool/Wrapper/MongoDocumentWrapper.php
+++ b/src/Tool/Wrapper/MongoDocumentWrapper.php
@@ -105,23 +105,21 @@ class MongoDocumentWrapper extends AbstractWrapper
      */
     protected function initialize()
     {
-        if (!$this->initialized) {
-            if ($this->object instanceof Proxy) {
-                $uow = $this->om->getUnitOfWork();
-                if (!$this->object->__isInitialized__) {
-                    $persister = $uow->getDocumentPersister($this->meta->name);
-                    $identifier = null;
-                    if ($uow->isInIdentityMap($this->object)) {
-                        $identifier = $this->getIdentifier();
-                    } else {
-                        // this may not happen but in case
-                        $reflProperty = new \ReflectionProperty($this->object, 'identifier');
-                        $reflProperty->setAccessible(true);
-                        $identifier = $reflProperty->getValue($this->object);
-                    }
-                    $this->object->__isInitialized__ = true;
-                    $persister->load($identifier, $this->object);
+        if (!$this->initialized && $this->object instanceof Proxy) {
+            $uow = $this->om->getUnitOfWork();
+            if (!$this->object->__isInitialized__) {
+                $persister = $uow->getDocumentPersister($this->meta->name);
+                $identifier = null;
+                if ($uow->isInIdentityMap($this->object)) {
+                    $identifier = $this->getIdentifier();
+                } else {
+                    // this may not happen but in case
+                    $reflProperty = new \ReflectionProperty($this->object, 'identifier');
+                    $reflProperty->setAccessible(true);
+                    $identifier = $reflProperty->getValue($this->object);
                 }
+                $this->object->__isInitialized__ = true;
+                $persister->load($identifier, $this->object);
             }
         }
     }

--- a/src/Translatable/Document/Repository/TranslationRepository.php
+++ b/src/Translatable/Document/Repository/TranslationRepository.php
@@ -124,9 +124,7 @@ class TranslationRepository extends DocumentRepository
 
             $documentClass = $config['useObjectClass'];
 
-            $translationClass = isset($config['translationClass']) ?
-                $config['translationClass'] :
-                $translationMeta->rootDocumentName;
+            $translationClass = $config['translationClass'] ?? $translationMeta->rootDocumentName;
 
             $qb = $this->dm->createQueryBuilder($translationClass);
             $q = $qb->field('foreignKey')->equals($documentId)

--- a/src/Translatable/Entity/Repository/TranslationRepository.php
+++ b/src/Translatable/Entity/Repository/TranslationRepository.php
@@ -128,9 +128,7 @@ class TranslationRepository extends EntityRepository
             $entityClass = $config['useObjectClass'];
             $translationMeta = $this->getClassMetadata(); // table inheritance support
 
-            $translationClass = isset($config['translationClass']) ?
-                $config['translationClass'] :
-                $translationMeta->rootEntityName;
+            $translationClass = $config['translationClass'] ?? $translationMeta->rootEntityName;
 
             $qb = $this->_em->createQueryBuilder();
             $qb->select('trans.content, trans.field, trans.locale')

--- a/src/Translatable/Entity/Repository/TranslationRepository.php
+++ b/src/Translatable/Entity/Repository/TranslationRepository.php
@@ -82,7 +82,7 @@ class TranslationRepository extends EntityRepository
                 $transMeta->getReflectionProperty('field')->setValue($trans, $field);
                 $transMeta->getReflectionProperty('locale')->setValue($trans, $locale);
             }
-            if ($listener->getDefaultLocale() != $listener->getTranslatableLocale($entity, $meta, $this->getEntityManager()) &&
+            if ($listener->getDefaultLocale() !== $listener->getTranslatableLocale($entity, $meta, $this->getEntityManager()) &&
                 $locale === $listener->getDefaultLocale()) {
                 $listener->setTranslationInDefaultLocale(spl_object_hash($entity), $field, $trans);
                 $needsPersist = $listener->getPersistDefaultLocaleTranslation();

--- a/src/Translatable/Hydrator/ORM/ObjectHydrator.php
+++ b/src/Translatable/Hydrator/ORM/ObjectHydrator.php
@@ -44,7 +44,7 @@ class ObjectHydrator extends BaseObjectHydrator
     {
         parent::cleanup();
         $listener = $this->getTranslatableListener();
-        $listener->setSkipOnLoad(null !== $this->savedSkipOnLoad ? $this->savedSkipOnLoad : false);
+        $listener->setSkipOnLoad($this->savedSkipOnLoad ?? false);
     }
 
     /**

--- a/src/Translatable/Hydrator/ORM/SimpleObjectHydrator.php
+++ b/src/Translatable/Hydrator/ORM/SimpleObjectHydrator.php
@@ -44,7 +44,7 @@ class SimpleObjectHydrator extends BaseSimpleObjectHydrator
     {
         parent::cleanup();
         $listener = $this->getTranslatableListener();
-        $listener->setSkipOnLoad(null !== $this->savedSkipOnLoad ? $this->savedSkipOnLoad : false);
+        $listener->setSkipOnLoad($this->savedSkipOnLoad ?? false);
     }
 
     /**

--- a/src/Translatable/Mapping/Driver/Annotation.php
+++ b/src/Translatable/Mapping/Driver/Annotation.php
@@ -108,10 +108,8 @@ class Annotation extends AbstractAnnotationDriver
             }
         }
 
-        if (!$meta->isMappedSuperclass && $config) {
-            if (is_array($meta->identifier) && count($meta->identifier) > 1) {
-                throw new InvalidMappingException("Translatable does not support composite identifiers in class - {$meta->name}");
-            }
+        if (!$meta->isMappedSuperclass && $config && (is_array($meta->identifier) && count($meta->identifier) > 1)) {
+            throw new InvalidMappingException("Translatable does not support composite identifiers in class - {$meta->name}");
         }
     }
 }

--- a/src/Translatable/Mapping/Driver/Xml.php
+++ b/src/Translatable/Mapping/Driver/Xml.php
@@ -30,24 +30,22 @@ class Xml extends BaseXml
 
         $xml = $xml->children(self::GEDMO_NAMESPACE_URI);
 
-        if (('entity' == $xmlDoctrine->getName() || 'mapped-superclass' == $xmlDoctrine->getName())) {
-            if ($xml->count() && isset($xml->translation)) {
-                /**
-                 * @var \SimpleXmlElement
-                 */
-                $data = $xml->translation;
-                if ($this->_isAttributeSet($data, 'locale')) {
-                    $config['locale'] = $this->_getAttribute($data, 'locale');
-                } elseif ($this->_isAttributeSet($data, 'language')) {
-                    $config['locale'] = $this->_getAttribute($data, 'language');
+        if (('entity' == $xmlDoctrine->getName() || 'mapped-superclass' == $xmlDoctrine->getName()) && ($xml->count() && isset($xml->translation))) {
+            /**
+             * @var \SimpleXmlElement
+             */
+            $data = $xml->translation;
+            if ($this->_isAttributeSet($data, 'locale')) {
+                $config['locale'] = $this->_getAttribute($data, 'locale');
+            } elseif ($this->_isAttributeSet($data, 'language')) {
+                $config['locale'] = $this->_getAttribute($data, 'language');
+            }
+            if ($this->_isAttributeSet($data, 'entity')) {
+                $entity = $this->_getAttribute($data, 'entity');
+                if (!$cl = $this->getRelatedClassName($meta, $entity)) {
+                    throw new InvalidMappingException("Translation entity class: {$entity} does not exist.");
                 }
-                if ($this->_isAttributeSet($data, 'entity')) {
-                    $entity = $this->_getAttribute($data, 'entity');
-                    if (!$cl = $this->getRelatedClassName($meta, $entity)) {
-                        throw new InvalidMappingException("Translation entity class: {$entity} does not exist.");
-                    }
-                    $config['translationClass'] = $cl;
-                }
+                $config['translationClass'] = $cl;
             }
         }
 
@@ -69,10 +67,8 @@ class Xml extends BaseXml
 
         $this->inspectElementsForTranslatableFields($xmlDoctrine, $config);
 
-        if (!$meta->isMappedSuperclass && $config) {
-            if (is_array($meta->identifier) && count($meta->identifier) > 1) {
-                throw new InvalidMappingException("Translatable does not support composite identifiers in class - {$meta->name}");
-            }
+        if (!$meta->isMappedSuperclass && $config && (is_array($meta->identifier) && count($meta->identifier) > 1)) {
+            throw new InvalidMappingException("Translatable does not support composite identifiers in class - {$meta->name}");
         }
     }
 
@@ -101,7 +97,7 @@ class Xml extends BaseXml
             /** @var \SimpleXmlElement $data */
             $data = $mapping->translatable;
             if ($this->_isAttributeSet($data, 'fallback')) {
-                $config['fallback'][$fieldName] = 'true' == $this->_getAttribute($data, 'fallback') ? true : false;
+                $config['fallback'][$fieldName] = 'true' == $this->_getAttribute($data, 'fallback');
             }
         }
     }

--- a/src/Translatable/Mapping/Driver/Yaml.php
+++ b/src/Translatable/Mapping/Driver/Yaml.php
@@ -59,10 +59,8 @@ class Yaml extends File implements Driver
             }
         }
 
-        if (!$meta->isMappedSuperclass && $config) {
-            if (is_array($meta->identifier) && count($meta->identifier) > 1) {
-                throw new InvalidMappingException("Translatable does not support composite identifiers in class - {$meta->name}");
-            }
+        if (!$meta->isMappedSuperclass && $config && (is_array($meta->identifier) && count($meta->identifier) > 1)) {
+            throw new InvalidMappingException("Translatable does not support composite identifiers in class - {$meta->name}");
         }
     }
 
@@ -76,13 +74,11 @@ class Yaml extends File implements Driver
 
     private function buildFieldConfiguration($field, $fieldMapping, array &$config)
     {
-        if (is_array($fieldMapping) && isset($fieldMapping['gedmo'])) {
-            if (in_array('translatable', $fieldMapping['gedmo']) || isset($fieldMapping['gedmo']['translatable'])) {
-                // fields cannot be overrided and throws mapping exception
-                $config['fields'][] = $field;
-                if (isset($fieldMapping['gedmo']['translatable']['fallback'])) {
-                    $config['fallback'][$field] = $fieldMapping['gedmo']['translatable']['fallback'];
-                }
+        if (is_array($fieldMapping) && isset($fieldMapping['gedmo']) && (in_array('translatable', $fieldMapping['gedmo']) || isset($fieldMapping['gedmo']['translatable']))) {
+            // fields cannot be overrided and throws mapping exception
+            $config['fields'][] = $field;
+            if (isset($fieldMapping['gedmo']['translatable']['fallback'])) {
+                $config['fallback'][$field] = $fieldMapping['gedmo']['translatable']['fallback'];
             }
         }
     }

--- a/src/Translatable/Mapping/Event/Adapter/ORM.php
+++ b/src/Translatable/Mapping/Event/Adapter/ORM.php
@@ -114,7 +114,7 @@ final class ORM extends BaseAdapterORM implements TranslatableAdapter
         case Type::BIGINT:
         case Type::INTEGER:
         case Type::SMALLINT:
-            return intval($key);
+            return (int) $key;
         default:
             return (string) $key;
         }

--- a/src/Translatable/Query/TreeWalker/TranslationWalker.php
+++ b/src/Translatable/Query/TreeWalker/TranslationWalker.php
@@ -31,6 +31,10 @@ use Gedmo\Translatable\TranslatableListener;
 class TranslationWalker extends SqlWalker
 {
     /**
+     * @var \Gedmo\Translatable\TranslatableListener|mixed
+     */
+    public $listener;
+    /**
      * Name for translation fallback hint
      *
      * @internal
@@ -150,9 +154,8 @@ class TranslationWalker extends SqlWalker
     public function walkSelectClause($selectClause)
     {
         $result = parent::walkSelectClause($selectClause);
-        $result = $this->replace($this->replacements, $result);
 
-        return $result;
+        return $this->replace($this->replacements, $result);
     }
 
     /**
@@ -161,9 +164,8 @@ class TranslationWalker extends SqlWalker
     public function walkFromClause($fromClause)
     {
         $result = parent::walkFromClause($fromClause);
-        $result .= $this->joinTranslations($fromClause);
 
-        return $result;
+        return $result . $this->joinTranslations($fromClause);
     }
 
     /**
@@ -201,9 +203,7 @@ class TranslationWalker extends SqlWalker
      */
     public function walkSubselect($subselect)
     {
-        $result = parent::walkSubselect($subselect);
-
-        return $result;
+        return parent::walkSubselect($subselect);
     }
 
     /**
@@ -212,9 +212,8 @@ class TranslationWalker extends SqlWalker
     public function walkSubselectFromClause($subselectFromClause)
     {
         $result = parent::walkSubselectFromClause($subselectFromClause);
-        $result .= $this->joinTranslations($subselectFromClause);
 
-        return $result;
+        return $result . $this->joinTranslations($subselectFromClause);
     }
 
     /**
@@ -249,26 +248,20 @@ class TranslationWalker extends SqlWalker
     {
         $result = '';
         foreach ($from->identificationVariableDeclarations as $decl) {
-            if ($decl->rangeVariableDeclaration instanceof RangeVariableDeclaration) {
-                if (isset($this->components[$decl->rangeVariableDeclaration->aliasIdentificationVariable])) {
-                    $result .= $this->components[$decl->rangeVariableDeclaration->aliasIdentificationVariable];
-                }
+            if ($decl->rangeVariableDeclaration instanceof RangeVariableDeclaration && isset($this->components[$decl->rangeVariableDeclaration->aliasIdentificationVariable])) {
+                $result .= $this->components[$decl->rangeVariableDeclaration->aliasIdentificationVariable];
             }
             if (isset($decl->joinVariableDeclarations)) {
                 foreach ($decl->joinVariableDeclarations as $joinDecl) {
-                    if ($joinDecl->join instanceof Join) {
-                        if (isset($this->components[$joinDecl->join->aliasIdentificationVariable])) {
-                            $result .= $this->components[$joinDecl->join->aliasIdentificationVariable];
-                        }
+                    if ($joinDecl->join instanceof Join && isset($this->components[$joinDecl->join->aliasIdentificationVariable])) {
+                        $result .= $this->components[$joinDecl->join->aliasIdentificationVariable];
                     }
                 }
             } else {
                 // based on new changes
                 foreach ($decl->joins as $join) {
-                    if ($join instanceof Join) {
-                        if (isset($this->components[$join->joinAssociationDeclaration->aliasIdentificationVariable])) {
-                            $result .= $this->components[$join->joinAssociationDeclaration->aliasIdentificationVariable];
-                        }
+                    if ($join instanceof Join && isset($this->components[$join->joinAssociationDeclaration->aliasIdentificationVariable])) {
+                        $result .= $this->components[$join->joinAssociationDeclaration->aliasIdentificationVariable];
                     }
                 }
             }
@@ -342,7 +335,7 @@ class TranslationWalker extends SqlWalker
                 // Treat translation as original field type
                 $fieldMapping = $meta->getFieldMapping($field);
                 if ((($this->platform instanceof MySqlPlatform) &&
-                    in_array($fieldMapping['type'], ['decimal'])) ||
+                    $fieldMapping['type'] == 'decimal') ||
                     (!($this->platform instanceof MySqlPlatform) &&
                     !in_array($fieldMapping['type'], ['datetime', 'datetimetz', 'date', 'time']))) {
                     $type = Type::getType($fieldMapping['type']);
@@ -461,7 +454,7 @@ class TranslationWalker extends SqlWalker
             case 'string':
             case 'guid':
                 // need to cast to VARCHAR
-                $component = $component.'::VARCHAR';
+                $component .= '::VARCHAR';
                 break;
             }
         }

--- a/src/Translatable/TranslatableListener.php
+++ b/src/Translatable/TranslatableListener.php
@@ -314,7 +314,7 @@ class TranslatableListener extends MappedEventSubscriber
                 $locale = $value;
             }
         } elseif ($om instanceof DocumentManager) {
-            list($mapping, $parentObject) = $om->getUnitOfWork()->getParentAssociation($object);
+            [$mapping, $parentObject] = $om->getUnitOfWork()->getParentAssociation($object);
             if (null != $parentObject) {
                 $parentMeta = $om->getClassMetadata(get_class($parentObject));
                 $locale = $this->getTranslatableLocale($parentObject, $parentMeta, $om);

--- a/src/Translatable/TranslatableListener.php
+++ b/src/Translatable/TranslatableListener.php
@@ -198,9 +198,7 @@ class TranslatableListener extends MappedEventSubscriber
      */
     public function getTranslationClass(TranslatableAdapter $ea, $class)
     {
-        return isset(self::$configurations[$this->name][$class]['translationClass']) ?
-            self::$configurations[$this->name][$class]['translationClass'] :
-            $ea->getDefaultTranslationClass()
+        return self::$configurations[$this->name][$class]['translationClass'] ?? $ea->getDefaultTranslationClass()
         ;
     }
 
@@ -463,7 +461,7 @@ class TranslatableListener extends MappedEventSubscriber
                 $translated = null;
                 foreach ($result as $entry) {
                     if ($entry['field'] == $field) {
-                        $translated = isset($entry['content']) ? $entry['content'] : null;
+                        $translated = $entry['content'] ?? null;
                         break;
                     }
                 }

--- a/src/Tree/Entity/Repository/ClosureTreeRepository.php
+++ b/src/Tree/Entity/Repository/ClosureTreeRepository.php
@@ -413,7 +413,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
           WHERE c.id IS NULL
         ");
 
-        if ($missingSelfRefsCount = intval($q->getSingleScalarResult())) {
+        if ($missingSelfRefsCount = (int) $q->getSingleScalarResult()) {
             $errors[] = "Missing $missingSelfRefsCount self referencing closures";
         }
 
@@ -425,7 +425,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
           WHERE c2.id IS NULL AND node.$nodeIdField <> c1.ancestor
         ");
 
-        if ($missingClosuresCount = intval($q->getSingleScalarResult())) {
+        if ($missingClosuresCount = (int) $q->getSingleScalarResult()) {
             $errors[] = "Missing $missingClosuresCount closures";
         }
 
@@ -437,7 +437,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
             WHERE c2.id IS NULL AND c1.descendant <> c1.ancestor
         ");
 
-        if ($invalidClosuresCount = intval($q->getSingleScalarResult())) {
+        if ($invalidClosuresCount = (int) $q->getSingleScalarResult()) {
             $errors[] = "Found $invalidClosuresCount invalid closures";
         }
 
@@ -513,15 +513,14 @@ class ClosureTreeRepository extends AbstractTreeRepository
           LEFT JOIN {$closureMeta->name} AS c WITH c.ancestor = node AND c.depth = 0
           WHERE c.id IS NULL
         ");
-        $newClosuresCount += $buildClosures("
+
+        return $newClosuresCount + $buildClosures("
           SELECT IDENTITY(c1.ancestor) AS ancestor, node.$nodeIdField AS descendant, c1.depth + 1 AS depth
           FROM {$nodeMeta->name} AS node
           INNER JOIN {$closureMeta->name} AS c1 WITH c1.descendant = node.{$config['parent']}
           LEFT  JOIN {$closureMeta->name} AS c2 WITH c2.descendant = node.$nodeIdField AND c2.ancestor = c1.ancestor
           WHERE c2.id IS NULL AND node.$nodeIdField <> c1.ancestor
         ");
-
-        return $newClosuresCount;
     }
 
     public function cleanUpClosure()

--- a/src/Tree/Entity/Repository/ClosureTreeRepository.php
+++ b/src/Tree/Entity/Repository/ClosureTreeRepository.php
@@ -315,7 +315,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
                     $tmp = &$refs[$n['parent_id']][$childrenIndex];
                 }
 
-                $key = count($tmp);
+                $key = is_array($tmp) || $tmp instanceof \Countable ? count($tmp) : 0;
                 $tmp[$key] = $node;
                 $refs[$node[$idField]] = &$tmp[$key];
             }
@@ -597,7 +597,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
 
     protected function getJoinColumnFieldName($association)
     {
-        if (count($association['joinColumnFieldNames']) > 1) {
+        if ((is_array($association['joinColumnFieldNames']) || $association['joinColumnFieldNames'] instanceof \Countable ? count($association['joinColumnFieldNames']) : 0) > 1) {
             throw new \RuntimeException('More association on field '.$association['fieldName']);
         }
 

--- a/src/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/src/Tree/Entity/Repository/NestedTreeRepository.php
@@ -235,10 +235,8 @@ class NestedTreeRepository extends AbstractTreeRepository
             } else {
                 throw new \InvalidArgumentException('Node is not related to this repository');
             }
-        } else {
-            if ($direct) {
-                $qb->where($qb->expr()->isNull('node.'.$config['parent']));
-            }
+        } elseif ($direct) {
+            $qb->where($qb->expr()->isNull('node.'.$config['parent']));
         }
         if (!$sortByField) {
             $qb->orderBy('node.'.$config['left'], 'ASC');
@@ -249,12 +247,10 @@ class NestedTreeRepository extends AbstractTreeRepository
             }
             $fields = rtrim($fields, ',');
             $qb->orderBy($fields, $direction);
+        } elseif ($meta->hasField($sortByField) && in_array(strtolower($direction), ['asc', 'desc'])) {
+            $qb->orderBy('node.'.$sortByField, $direction);
         } else {
-            if ($meta->hasField($sortByField) && in_array(strtolower($direction), ['asc', 'desc'])) {
-                $qb->orderBy('node.'.$sortByField, $direction);
-            } else {
-                throw new InvalidArgumentException("Invalid sort options specified: field - {$sortByField}, direction - {$direction}");
-            }
+            throw new InvalidArgumentException("Invalid sort options specified: field - {$sortByField}, direction - {$direction}");
         }
 
         return $qb;
@@ -318,10 +314,8 @@ class NestedTreeRepository extends AbstractTreeRepository
         $meta = $this->getClassMetadata();
         $config = $this->listener->getConfiguration($this->_em, $meta->name);
 
-        if (isset($config['root']) && is_null($root)) {
-            if (is_null($root)) {
-                throw new InvalidArgumentException('If tree has root, getLeafs method requires any node of this tree');
-            }
+        if (isset($config['root']) && is_null($root) && is_null($root)) {
+            throw new InvalidArgumentException('If tree has root, getLeafs method requires any node of this tree');
         }
 
         $qb = $this->getQueryBuilder();
@@ -347,12 +341,10 @@ class NestedTreeRepository extends AbstractTreeRepository
                 $qb->addOrderBy('node.'.$config['root'], 'ASC');
             }
             $qb->addOrderBy('node.'.$config['left'], 'ASC', true);
+        } elseif ($meta->hasField($sortByField) && in_array(strtolower($direction), ['asc', 'desc'])) {
+            $qb->orderBy('node.'.$sortByField, $direction);
         } else {
-            if ($meta->hasField($sortByField) && in_array(strtolower($direction), ['asc', 'desc'])) {
-                $qb->orderBy('node.'.$sortByField, $direction);
-            } else {
-                throw new InvalidArgumentException("Invalid sort options specified: field - {$sortByField}, direction - {$direction}");
-            }
+            throw new InvalidArgumentException("Invalid sort options specified: field - {$sortByField}, direction - {$direction}");
         }
 
         return $qb;
@@ -754,7 +746,7 @@ class NestedTreeRepository extends AbstractTreeRepository
                 $right = $wrapped->getPropertyValue($config['right']);
                 $left = $wrapped->getPropertyValue($config['left']);
                 $this->moveDown($node, true);
-                if ($left != ($right - 1)) {
+                if ($left != $right - 1) {
                     $this->reorder($node, $sortByField, $direction, false);
                 }
             }
@@ -925,7 +917,7 @@ class NestedTreeRepository extends AbstractTreeRepository
             $qb->where($qb->expr()->eq('node.'.$config['root'], ':rid'));
             $qb->setParameter('rid', $rootId);
         }
-        $min = intval($qb->getQuery()->getSingleScalarResult());
+        $min = (int) $qb->getQuery()->getSingleScalarResult();
         $edge = $this->listener->getStrategy($this->_em, $meta->name)->max($this->_em, $config['useObjectClass'], $rootId);
         // check duplicate right and left values
         for ($i = $min; $i <= $edge; ++$i) {
@@ -941,7 +933,7 @@ class NestedTreeRepository extends AbstractTreeRepository
                 $qb->andWhere($qb->expr()->eq('node.'.$config['root'], ':rid'));
                 $qb->setParameter('rid', $rootId);
             }
-            $count = intval($qb->getQuery()->getSingleScalarResult());
+            $count = (int) $qb->getQuery()->getSingleScalarResult();
             if (1 !== $count) {
                 if (0 === $count) {
                     $errors[] = "index [{$i}], missing".($root ? ' on tree root: '.$rootId : '');
@@ -1032,7 +1024,7 @@ class NestedTreeRepository extends AbstractTreeRepository
                     $qb->andWhere($qb->expr()->eq('node.'.$config['root'], ':rid'));
                     $qb->setParameter('rid', $rootId);
                 }
-                if ($count = intval($qb->getQuery()->getSingleScalarResult())) {
+                if ($count = (int) $qb->getQuery()->getSingleScalarResult()) {
                     $errors[] = "node [{$id}] parent field is blank, but it has a parent";
                 }
             }

--- a/src/Tree/Hydrator/ORM/TreeObjectHydrator.php
+++ b/src/Tree/Hydrator/ORM/TreeObjectHydrator.php
@@ -146,7 +146,7 @@ class TreeObjectHydrator extends ObjectHydrator
                 $parentId = $this->getPropertyValue($parentProxy, $this->idField);
             }
 
-            if (null === $parentId || !key_exists($parentId, $idHashmap)) {
+            if (null === $parentId || !array_key_exists($parentId, $idHashmap)) {
                 $rootNodes[] = $node;
             }
         }

--- a/src/Tree/Mapping/Driver/Xml.php
+++ b/src/Tree/Mapping/Driver/Xml.php
@@ -49,7 +49,7 @@ class Xml extends BaseXml
                 throw new InvalidMappingException("Tree type: $strategy is not available.");
             }
             $config['strategy'] = $strategy;
-            $config['activate_locking'] = 'true' === $this->_getAttribute($xml->tree, 'activate-locking') ? true : false;
+            $config['activate_locking'] = 'true' === $this->_getAttribute($xml->tree, 'activate-locking');
 
             if ($lockingTimeout = $this->_getAttribute($xml->tree, 'locking-timeout')) {
                 $config['locking_timeout'] = (int) $lockingTimeout;
@@ -107,27 +107,15 @@ class Xml extends BaseXml
 
                     $appendId = $this->_getAttribute($mapping->{'tree-path'}, 'append_id');
 
-                    if (!$appendId) {
-                        $appendId = true;
-                    } else {
-                        $appendId = 'false' == strtolower($appendId) ? false : true;
-                    }
+                    $appendId = $appendId ? 'false' != strtolower($appendId) : true;
 
                     $startsWithSeparator = $this->_getAttribute($mapping->{'tree-path'}, 'starts_with_separator');
 
-                    if (!$startsWithSeparator) {
-                        $startsWithSeparator = false;
-                    } else {
-                        $startsWithSeparator = 'false' == strtolower($startsWithSeparator) ? false : true;
-                    }
+                    $startsWithSeparator = $startsWithSeparator ? 'false' != strtolower($startsWithSeparator) : false;
 
                     $endsWithSeparator = $this->_getAttribute($mapping->{'tree-path'}, 'ends_with_separator');
 
-                    if (!$endsWithSeparator) {
-                        $endsWithSeparator = true;
-                    } else {
-                        $endsWithSeparator = 'false' == strtolower($endsWithSeparator) ? false : true;
-                    }
+                    $endsWithSeparator = $endsWithSeparator ? 'false' != strtolower($endsWithSeparator) : true;
 
                     $config['path'] = $field;
                     $config['path_separator'] = $separator;

--- a/src/Tree/Mapping/Driver/Yaml.php
+++ b/src/Tree/Mapping/Driver/Yaml.php
@@ -52,8 +52,7 @@ class Yaml extends File implements Driver
                     throw new InvalidMappingException("Tree type: $strategy is not available.");
                 }
                 $config['strategy'] = $strategy;
-                $config['activate_locking'] = isset($classMapping['tree']['activateLocking']) ?
-                    $classMapping['tree']['activateLocking'] : false;
+                $config['activate_locking'] = $classMapping['tree']['activateLocking'] ?? false;
                 $config['locking_timeout'] = isset($classMapping['tree']['lockingTimeout']) ?
                     (int) $classMapping['tree']['lockingTimeout'] : 3;
 
@@ -110,8 +109,7 @@ class Yaml extends File implements Driver
                             throw new InvalidMappingException("Tree Path field - [{$field}] type is not valid. It must be string or text in class - {$meta->name}");
                         }
 
-                        $treePathInfo = isset($fieldMapping['gedmo']['treePath']) ? $fieldMapping['gedmo']['treePath'] :
-                            $fieldMapping['gedmo'][array_search('treePath', $fieldMapping['gedmo'])];
+                        $treePathInfo = $fieldMapping['gedmo']['treePath'] ?? $fieldMapping['gedmo'][array_search('treePath', $fieldMapping['gedmo'])];
 
                         if (is_array($treePathInfo) && isset($treePathInfo['separator'])) {
                             $separator = $treePathInfo['separator'];

--- a/src/Tree/Mapping/Driver/Yaml.php
+++ b/src/Tree/Mapping/Driver/Yaml.php
@@ -70,13 +70,11 @@ class Yaml extends File implements Driver
 
         if (isset($mapping['id'])) {
             foreach ($mapping['id'] as $field => $fieldMapping) {
-                if (isset($fieldMapping['gedmo'])) {
-                    if (in_array('treePathSource', $fieldMapping['gedmo'])) {
-                        if (!$validator->isValidFieldForPathSource($meta, $field)) {
-                            throw new InvalidMappingException("Tree PathSource field - [{$field}] type is not valid. It can be any of the integer variants, double, float or string in class - {$meta->name}");
-                        }
-                        $config['path_source'] = $field;
+                if (isset($fieldMapping['gedmo']) && in_array('treePathSource', $fieldMapping['gedmo'])) {
+                    if (!$validator->isValidFieldForPathSource($meta, $field)) {
+                        throw new InvalidMappingException("Tree PathSource field - [{$field}] type is not valid. It can be any of the integer variants, double, float or string in class - {$meta->name}");
                     }
+                    $config['path_source'] = $field;
                 }
             }
         }
@@ -111,21 +109,13 @@ class Yaml extends File implements Driver
 
                         $treePathInfo = $fieldMapping['gedmo']['treePath'] ?? $fieldMapping['gedmo'][array_search('treePath', $fieldMapping['gedmo'])];
 
-                        if (is_array($treePathInfo) && isset($treePathInfo['separator'])) {
-                            $separator = $treePathInfo['separator'];
-                        } else {
-                            $separator = '|';
-                        }
+                        $separator = is_array($treePathInfo) && isset($treePathInfo['separator']) ? $treePathInfo['separator'] : '|';
 
                         if (strlen($separator) > 1) {
                             throw new InvalidMappingException("Tree Path field - [{$field}] Separator {$separator} is invalid. It must be only one character long.");
                         }
 
-                        if (is_array($treePathInfo) && isset($treePathInfo['appendId'])) {
-                            $appendId = $treePathInfo['appendId'];
-                        } else {
-                            $appendId = null;
-                        }
+                        $appendId = is_array($treePathInfo) && isset($treePathInfo['appendId']) ? $treePathInfo['appendId'] : null;
 
                         if (is_array($treePathInfo) && isset($treePathInfo['startsWithSeparator'])) {
                             $startsWithSeparator = $treePathInfo['startsWithSeparator'];

--- a/src/Tree/RepositoryUtils.php
+++ b/src/Tree/RepositoryUtils.php
@@ -112,7 +112,7 @@ class RepositoryUtils implements RepositoryUtilsInterface
             foreach ($tree as $node) {
                 $output .= is_string($options['childOpen']) ? $options['childOpen'] : $options['childOpen']($node);
                 $output .= $options['nodeDecorator']($node);
-                if (count($node[$childrenIndex]) > 0) {
+                if ((is_array($node[$childrenIndex]) || $node[$childrenIndex] instanceof \Countable ? count($node[$childrenIndex]) : 0) > 0) {
                     $output .= $build($node[$childrenIndex]);
                 }
                 $output .= is_string($options['childClose']) ? $options['childClose'] : $options['childClose']($node);
@@ -155,7 +155,7 @@ class RepositoryUtils implements RepositoryUtilsInterface
                     $stack[] = &$nestedTree[$i];
                 } else {
                     // Add child to parent
-                    $i = count($stack[$l - 1][$this->childrenIndex]);
+                    $i = is_array($stack[$l - 1][$this->childrenIndex]) || $stack[$l - 1][$this->childrenIndex] instanceof \Countable ? count($stack[$l - 1][$this->childrenIndex]) : 0;
                     $stack[$l - 1][$this->childrenIndex][$i] = $item;
                     $stack[] = &$stack[$l - 1][$this->childrenIndex][$i];
                 }

--- a/src/Tree/Strategy/ORM/Closure.php
+++ b/src/Tree/Strategy/ORM/Closure.php
@@ -207,7 +207,7 @@ class Closure implements Strategy
 
     protected function getJoinColumnFieldName($association)
     {
-        if (count($association['joinColumnFieldNames']) > 1) {
+        if ((is_array($association['joinColumnFieldNames']) || $association['joinColumnFieldNames'] instanceof \Countable ? count($association['joinColumnFieldNames']) : 0) > 1) {
             throw new RuntimeException('More association on field '.$association['fieldName']);
         }
 

--- a/src/Tree/Strategy/ORM/Nested.php
+++ b/src/Tree/Strategy/ORM/Nested.php
@@ -554,7 +554,7 @@ class Nested implements Strategy
         $query = $qb->getQuery();
         $right = $query->getSingleScalarResult();
 
-        return intval($right);
+        return (int) $right;
     }
 
     /**

--- a/src/Tree/Strategy/ORM/Nested.php
+++ b/src/Tree/Strategy/ORM/Nested.php
@@ -607,7 +607,7 @@ class Nested implements Strategy
                     continue;
                 }
 
-                $nodeMeta = $em->getClassMetadata(get_class($node));
+                $nodeMeta = $em->getClassMetadata($node !== null ? get_class($node) : self::class);
 
                 if (!array_key_exists($config['left'], $nodeMeta->getReflectionProperties())) {
                     continue;
@@ -678,7 +678,7 @@ class Nested implements Strategy
                     continue;
                 }
 
-                $nodeMeta = $em->getClassMetadata(get_class($node));
+                $nodeMeta = $em->getClassMetadata($node !== null ? get_class($node) : self::class);
 
                 if (!array_key_exists($config['left'], $nodeMeta->getReflectionProperties())) {
                     continue;

--- a/src/Tree/TreeListener.php
+++ b/src/Tree/TreeListener.php
@@ -255,7 +255,7 @@ class TreeListener extends MappedEventSubscriber
     protected function getStrategiesUsedForObjects(array $classes)
     {
         $strategies = [];
-        foreach ($classes as $name => $opt) {
+        foreach (array_keys($classes) as $name) {
             if (isset($this->strategies[$name]) && !isset($strategies[$this->strategies[$name]])) {
                 $strategies[$this->strategies[$name]] = $this->strategyInstances[$this->strategies[$name]];
             }

--- a/src/Uploadable/Event/UploadableBaseEventArgs.php
+++ b/src/Uploadable/Event/UploadableBaseEventArgs.php
@@ -17,6 +17,10 @@ use Gedmo\Uploadable\UploadableListener;
 abstract class UploadableBaseEventArgs extends EventArgs
 {
     /**
+     * @var mixed[]
+     */
+    public $config;
+    /**
      * The instance of the Uploadable listener that fired this event
      *
      * @var \Gedmo\Uploadable\UploadableListener

--- a/src/Uploadable/Mapping/Driver/Xml.php
+++ b/src/Uploadable/Mapping/Driver/Xml.php
@@ -30,58 +30,54 @@ class Xml extends BaseXml
         $xmlDoctrine = $xml;
         $xml = $xml->children(self::GEDMO_NAMESPACE_URI);
 
-        if ('entity' == $xmlDoctrine->getName() || 'mapped-superclass' == $xmlDoctrine->getName()) {
-            if (isset($xml->uploadable)) {
-                $xmlUploadable = $xml->uploadable;
-                $config['uploadable'] = true;
-                $config['allowOverwrite'] = $this->_isAttributeSet($xmlUploadable, 'allow-overwrite') ?
-                    (bool) $this->_getAttribute($xmlUploadable, 'allow-overwrite') : false;
-                $config['appendNumber'] = $this->_isAttributeSet($xmlUploadable, 'append-number') ?
-                    (bool) $this->_getAttribute($xmlUploadable, 'append-number') : false;
-                $config['path'] = $this->_isAttributeSet($xmlUploadable, 'path') ?
-                    $this->_getAttribute($xml->{'uploadable'}, 'path') : '';
-                $config['pathMethod'] = $this->_isAttributeSet($xmlUploadable, 'path-method') ?
-                    $this->_getAttribute($xml->{'uploadable'}, 'path-method') : '';
-                $config['callback'] = $this->_isAttributeSet($xmlUploadable, 'callback') ?
-                    $this->_getAttribute($xml->{'uploadable'}, 'callback') : '';
-                $config['fileMimeTypeField'] = false;
-                $config['fileNameField'] = false;
-                $config['filePathField'] = false;
-                $config['fileSizeField'] = false;
-                $config['filenameGenerator'] = $this->_isAttributeSet($xmlUploadable, 'filename-generator') ?
-                    $this->_getAttribute($xml->{'uploadable'}, 'filename-generator') :
-                    Validator::FILENAME_GENERATOR_NONE;
-                $config['maxSize'] = $this->_isAttributeSet($xmlUploadable, 'max-size') ?
-                    (float) $this->_getAttribute($xml->{'uploadable'}, 'max-size') :
-                    (float) 0;
-                $config['allowedTypes'] = $this->_isAttributeSet($xmlUploadable, 'allowed-types') ?
-                    $this->_getAttribute($xml->{'uploadable'}, 'allowed-types') :
-                    '';
-                $config['disallowedTypes'] = $this->_isAttributeSet($xmlUploadable, 'disallowed-types') ?
-                    $this->_getAttribute($xml->{'uploadable'}, 'disallowed-types') :
-                    '';
+        if (('entity' == $xmlDoctrine->getName() || 'mapped-superclass' == $xmlDoctrine->getName()) && isset($xml->uploadable)) {
+            $xmlUploadable = $xml->uploadable;
+            $config['uploadable'] = true;
+            $config['allowOverwrite'] = $this->_isAttributeSet($xmlUploadable, 'allow-overwrite') ?
+                (bool) $this->_getAttribute($xmlUploadable, 'allow-overwrite') : false;
+            $config['appendNumber'] = $this->_isAttributeSet($xmlUploadable, 'append-number') ?
+                (bool) $this->_getAttribute($xmlUploadable, 'append-number') : false;
+            $config['path'] = $this->_isAttributeSet($xmlUploadable, 'path') ?
+                $this->_getAttribute($xml->{'uploadable'}, 'path') : '';
+            $config['pathMethod'] = $this->_isAttributeSet($xmlUploadable, 'path-method') ?
+                $this->_getAttribute($xml->{'uploadable'}, 'path-method') : '';
+            $config['callback'] = $this->_isAttributeSet($xmlUploadable, 'callback') ?
+                $this->_getAttribute($xml->{'uploadable'}, 'callback') : '';
+            $config['fileMimeTypeField'] = false;
+            $config['fileNameField'] = false;
+            $config['filePathField'] = false;
+            $config['fileSizeField'] = false;
+            $config['filenameGenerator'] = $this->_isAttributeSet($xmlUploadable, 'filename-generator') ?
+                $this->_getAttribute($xml->{'uploadable'}, 'filename-generator') :
+                Validator::FILENAME_GENERATOR_NONE;
+            $config['maxSize'] = $this->_isAttributeSet($xmlUploadable, 'max-size') ?
+                (float) $this->_getAttribute($xml->{'uploadable'}, 'max-size') :
+                (float) 0;
+            $config['allowedTypes'] = $this->_isAttributeSet($xmlUploadable, 'allowed-types') ?
+                $this->_getAttribute($xml->{'uploadable'}, 'allowed-types') :
+                '';
+            $config['disallowedTypes'] = $this->_isAttributeSet($xmlUploadable, 'disallowed-types') ?
+                $this->_getAttribute($xml->{'uploadable'}, 'disallowed-types') :
+                '';
+            if (isset($xmlDoctrine->field)) {
+                foreach ($xmlDoctrine->field as $mapping) {
+                    $mappingDoctrine = $mapping;
+                    $mapping = $mapping->children(self::GEDMO_NAMESPACE_URI);
 
-                if (isset($xmlDoctrine->field)) {
-                    foreach ($xmlDoctrine->field as $mapping) {
-                        $mappingDoctrine = $mapping;
-                        $mapping = $mapping->children(self::GEDMO_NAMESPACE_URI);
+                    $field = $this->_getAttribute($mappingDoctrine, 'name');
 
-                        $field = $this->_getAttribute($mappingDoctrine, 'name');
-
-                        if (isset($mapping->{'uploadable-file-mime-type'})) {
-                            $config['fileMimeTypeField'] = $field;
-                        } elseif (isset($mapping->{'uploadable-file-size'})) {
-                            $config['fileSizeField'] = $field;
-                        } elseif (isset($mapping->{'uploadable-file-name'})) {
-                            $config['fileNameField'] = $field;
-                        } elseif (isset($mapping->{'uploadable-file-path'})) {
-                            $config['filePathField'] = $field;
-                        }
+                    if (isset($mapping->{'uploadable-file-mime-type'})) {
+                        $config['fileMimeTypeField'] = $field;
+                    } elseif (isset($mapping->{'uploadable-file-size'})) {
+                        $config['fileSizeField'] = $field;
+                    } elseif (isset($mapping->{'uploadable-file-name'})) {
+                        $config['fileNameField'] = $field;
+                    } elseif (isset($mapping->{'uploadable-file-path'})) {
+                        $config['filePathField'] = $field;
                     }
                 }
-
-                Validator::validateConfiguration($meta, $config);
             }
+            Validator::validateConfiguration($meta, $config);
         }
     }
 }

--- a/src/Uploadable/Mapping/Driver/Yaml.php
+++ b/src/Uploadable/Mapping/Driver/Yaml.php
@@ -43,25 +43,19 @@ class Yaml extends File implements Driver
                     (bool) $uploadable['allowOverwrite'] : false;
                 $config['appendNumber'] = isset($uploadable['appendNumber']) ?
                     (bool) $uploadable['appendNumber'] : false;
-                $config['path'] = isset($uploadable['path']) ? $uploadable['path'] : '';
-                $config['pathMethod'] = isset($uploadable['pathMethod']) ? $uploadable['pathMethod'] : '';
-                $config['callback'] = isset($uploadable['callback']) ? $uploadable['callback'] : '';
+                $config['path'] = $uploadable['path'] ?? '';
+                $config['pathMethod'] = $uploadable['pathMethod'] ?? '';
+                $config['callback'] = $uploadable['callback'] ?? '';
                 $config['fileMimeTypeField'] = false;
                 $config['fileNameField'] = false;
                 $config['filePathField'] = false;
                 $config['fileSizeField'] = false;
-                $config['filenameGenerator'] = isset($uploadable['filenameGenerator']) ?
-                    $uploadable['filenameGenerator'] :
-                    Validator::FILENAME_GENERATOR_NONE;
+                $config['filenameGenerator'] = $uploadable['filenameGenerator'] ?? Validator::FILENAME_GENERATOR_NONE;
                 $config['maxSize'] = isset($uploadable['maxSize']) ?
                     (float) $uploadable['maxSize'] :
                     (float) 0;
-                $config['allowedTypes'] = isset($uploadable['allowedTypes']) ?
-                    $uploadable['allowedTypes'] :
-                    '';
-                $config['disallowedTypes'] = isset($uploadable['disallowedTypes']) ?
-                    $uploadable['disallowedTypes'] :
-                    '';
+                $config['allowedTypes'] = $uploadable['allowedTypes'] ?? '';
+                $config['disallowedTypes'] = $uploadable['disallowedTypes'] ?? '';
 
                 if (isset($mapping['fields'])) {
                     foreach ($mapping['fields'] as $field => $info) {

--- a/src/Uploadable/UploadableListener.php
+++ b/src/Uploadable/UploadableListener.php
@@ -163,10 +163,8 @@ class UploadableListener extends MappedEventSubscriber
         foreach ($ea->getScheduledObjectDeletions($uow) as $object) {
             $meta = $om->getClassMetadata(get_class($object));
 
-            if ($config = $this->getConfiguration($om, $meta->name)) {
-                if (isset($config['uploadable']) && $config['uploadable']) {
-                    $this->addFileRemoval($meta, $config, $object);
-                }
+            if (($config = $this->getConfiguration($om, $meta->name)) && (isset($config['uploadable']) && $config['uploadable'])) {
+                $this->addFileRemoval($meta, $config, $object);
             }
         }
     }
@@ -241,12 +239,12 @@ class UploadableListener extends MappedEventSubscriber
         }
 
         if ($config['allowedTypes'] || $config['disallowedTypes']) {
-            $ok = $config['allowedTypes'] ? false : true;
+            $ok = !(bool) $config['allowedTypes'];
             $mimes = $config['allowedTypes'] ? $config['allowedTypes'] : $config['disallowedTypes'];
 
             foreach ($mimes as $m) {
                 if ($mime === $m) {
-                    $ok = $config['allowedTypes'] ? true : false;
+                    $ok = (bool) $config['allowedTypes'];
 
                     break;
                 }
@@ -355,9 +353,8 @@ class UploadableListener extends MappedEventSubscriber
         }
 
         Validator::validatePath($path);
-        $path = rtrim($path, '\/');
 
-        return $path;
+        return rtrim($path, '\/');
     }
 
     /**
@@ -401,9 +398,8 @@ class UploadableListener extends MappedEventSubscriber
         $refl = $meta->getReflectionClass();
         $filePathField = $refl->getProperty($propertyName);
         $filePathField->setAccessible(true);
-        $filePath = $filePathField->getValue($object);
 
-        return $filePath;
+        return $filePathField->getValue($object);
     }
 
     /**

--- a/tests/Gedmo/Mapping/Fixture/Compatibility/Article.php
+++ b/tests/Gedmo/Mapping/Fixture/Compatibility/Article.php
@@ -56,7 +56,10 @@ class Article
         return $this->created;
     }
 
-    public function setCreated(\DateTime $created)
+    /**
+     * @param \DateTime|\DateTimeImmutable $created
+     */
+    public function setCreated(\DateTimeInterface $created)
     {
         $this->created = $created;
     }
@@ -71,7 +74,10 @@ class Article
         return $this->updated;
     }
 
-    public function setUpdated(\DateTime $updated)
+    /**
+     * @param \DateTime|\DateTimeImmutable $updated
+     */
+    public function setUpdated(\DateTimeInterface $updated)
     {
         $this->updated = $updated;
     }

--- a/tests/Gedmo/Mapping/Fixture/SoftDeleteable.php
+++ b/tests/Gedmo/Mapping/Fixture/SoftDeleteable.php
@@ -11,6 +11,9 @@ use Gedmo\Mapping\Annotation as Gedmo;
  */
 class SoftDeleteable
 {
+    public $title;
+    public $code;
+    public $slug;
     /**
      * @ORM\Id
      * @ORM\GeneratedValue

--- a/tests/Gedmo/Mapping/Fixture/Yaml/BaseCategory.php
+++ b/tests/Gedmo/Mapping/Fixture/Yaml/BaseCategory.php
@@ -46,7 +46,7 @@ class BaseCategory
      *
      * @param dateTime $created
      */
-    public function setCreated(\dateTime $created)
+    public function setCreated(\DateTimeInterface $created)
     {
         $this->created = $created;
     }

--- a/tests/Gedmo/Mapping/MetadataFactory/CustomDriverTest.php
+++ b/tests/Gedmo/Mapping/MetadataFactory/CustomDriverTest.php
@@ -15,6 +15,14 @@ use Mapping\Fixture\Unmapped\Timestampable;
  */
 class CustomDriverTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * @var \Gedmo\Timestampable\TimestampableListener|mixed
+     */
+    public $timestampable;
+    /**
+     * @var \Doctrine\ORM\EntityManager|mixed
+     */
+    public $em;
     public function setUp(): void
     {
         $config = new \Doctrine\ORM\Configuration();

--- a/tests/Gedmo/Mapping/MetadataFactory/ForcedMetadataTest.php
+++ b/tests/Gedmo/Mapping/MetadataFactory/ForcedMetadataTest.php
@@ -15,6 +15,14 @@ use Mapping\Fixture\Unmapped\Timestampable;
  */
 class ForcedMetadataTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * @var \Gedmo\Timestampable\TimestampableListener|mixed
+     */
+    public $timestampable;
+    /**
+     * @var \Doctrine\ORM\EntityManager|mixed
+     */
+    public $em;
     public function setUp(): void
     {
         $config = new \Doctrine\ORM\Configuration();

--- a/tests/Gedmo/Mapping/Mock/Extension/Encoder/Mapping/Driver/Annotation.php
+++ b/tests/Gedmo/Mapping/Mock/Extension/Encoder/Mapping/Driver/Annotation.php
@@ -33,7 +33,7 @@ class Annotation implements Driver
                 continue;
             }
             // now lets check if property has our annotation
-            if ($encode = $reader->getPropertyAnnotation($property, 'Gedmo\Mapping\Mock\Extension\Encoder\Mapping\Encode')) {
+            if (($encode = $reader->getPropertyAnnotation($property, 'Gedmo\Mapping\Mock\Extension\Encoder\Mapping\Encode')) !== null) {
                 $field = $property->getName();
                 // check if field is mapped
                 if (!$meta->hasField($field)) {

--- a/tests/Gedmo/Mapping/SluggableMappingTest.php
+++ b/tests/Gedmo/Mapping/SluggableMappingTest.php
@@ -84,19 +84,19 @@ class SluggableMappingTest extends \PHPUnit\Framework\TestCase
 
         $this->assertArrayHasKey('handlers', $config['slugs']['slug']);
         $handlers = $config['slugs']['slug']['handlers'];
-        $this->assertEquals(2, count($handlers));
+        $this->assertEquals(2, is_array($handlers) || $handlers instanceof \Countable ? count($handlers) : 0);
         $this->assertArrayHasKey('Gedmo\Sluggable\Handler\TreeSlugHandler', $handlers);
         $this->assertArrayHasKey('Gedmo\Sluggable\Handler\RelativeSlugHandler', $handlers);
 
         $first = $handlers['Gedmo\Sluggable\Handler\TreeSlugHandler'];
-        $this->assertEquals(2, count($first));
+        $this->assertEquals(2, is_array($first) || $first instanceof \Countable ? count($first) : 0);
         $this->assertArrayHasKey('parentRelationField', $first);
         $this->assertArrayHasKey('separator', $first);
         $this->assertEquals('parent', $first['parentRelationField']);
         $this->assertEquals('/', $first['separator']);
 
         $second = $handlers['Gedmo\Sluggable\Handler\RelativeSlugHandler'];
-        $this->assertEquals(3, count($second));
+        $this->assertEquals(3, is_array($second) || $second instanceof \Countable ? count($second) : 0);
         $this->assertArrayHasKey('relationField', $second);
         $this->assertArrayHasKey('relationSlugField', $second);
         $this->assertArrayHasKey('separator', $second);
@@ -119,19 +119,19 @@ class SluggableMappingTest extends \PHPUnit\Framework\TestCase
 
         $this->assertArrayHasKey('handlers', $config['slugs']['slug']);
         $handlers = $config['slugs']['slug']['handlers'];
-        $this->assertEquals(2, count($handlers));
+        $this->assertEquals(2, is_array($handlers) || $handlers instanceof \Countable ? count($handlers) : 0);
         $this->assertArrayHasKey('Gedmo\Sluggable\Handler\TreeSlugHandler', $handlers);
         $this->assertArrayHasKey('Gedmo\Sluggable\Handler\RelativeSlugHandler', $handlers);
 
         $first = $handlers['Gedmo\Sluggable\Handler\TreeSlugHandler'];
-        $this->assertEquals(2, count($first));
+        $this->assertEquals(2, is_array($first) || $first instanceof \Countable ? count($first) : 0);
         $this->assertArrayHasKey('parentRelationField', $first);
         $this->assertArrayHasKey('separator', $first);
         $this->assertEquals('parent', $first['parentRelationField']);
         $this->assertEquals('/', $first['separator']);
 
         $second = $handlers['Gedmo\Sluggable\Handler\RelativeSlugHandler'];
-        $this->assertEquals(3, count($second));
+        $this->assertEquals(3, is_array($second) || $second instanceof \Countable ? count($second) : 0);
         $this->assertArrayHasKey('relationField', $second);
         $this->assertArrayHasKey('relationSlugField', $second);
         $this->assertArrayHasKey('separator', $second);

--- a/tests/Gedmo/Mapping/TranslatableMappingTest.php
+++ b/tests/Gedmo/Mapping/TranslatableMappingTest.php
@@ -17,6 +17,10 @@ use Gedmo\Mapping\ExtensionMetadataFactory;
  */
 class TranslatableMappingTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * @var \Gedmo\Translatable\TranslatableListener|mixed
+     */
+    public $translatableListener;
     const TEST_YAML_ENTITY_CLASS = 'Mapping\Fixture\Yaml\User';
     private $em;
 

--- a/tests/Gedmo/Mapping/Xml/SluggableMappingTest.php
+++ b/tests/Gedmo/Mapping/Xml/SluggableMappingTest.php
@@ -81,21 +81,21 @@ class SluggableMappingTest extends BaseTestCaseORM
         $this->assertEquals('code', $fields[2]);
 
         $this->assertArrayHasKey('handlers', $config);
-        $this->assertEquals(2, count($config['handlers']));
+        $this->assertEquals(2, is_array($config['handlers']) || $config['handlers'] instanceof \Countable ? count($config['handlers']) : 0);
         $handlers = $config['handlers'];
 
         $this->assertArrayHasKey('Gedmo\Sluggable\Handler\TreeSlugHandler', $handlers);
         $this->assertArrayHasKey('Gedmo\Sluggable\Handler\RelativeSlugHandler', $handlers);
 
         $first = $handlers['Gedmo\Sluggable\Handler\TreeSlugHandler'];
-        $this->assertEquals(2, count($first));
+        $this->assertEquals(2, is_array($first) || $first instanceof \Countable ? count($first) : 0);
         $this->assertArrayHasKey('parentRelationField', $first);
         $this->assertArrayHasKey('separator', $first);
         $this->assertEquals('parent', $first['parentRelationField']);
         $this->assertEquals('/', $first['separator']);
 
         $second = $handlers['Gedmo\Sluggable\Handler\RelativeSlugHandler'];
-        $this->assertEquals(3, count($second));
+        $this->assertEquals(3, is_array($second) || $second instanceof \Countable ? count($second) : 0);
         $this->assertArrayHasKey('relationField', $second);
         $this->assertArrayHasKey('relationSlugField', $second);
         $this->assertArrayHasKey('separator', $second);

--- a/tests/Gedmo/ReferenceIntegrity/ReferenceIntegrityDocumentTest.php
+++ b/tests/Gedmo/ReferenceIntegrity/ReferenceIntegrityDocumentTest.php
@@ -120,7 +120,7 @@ class ReferenceIntegrityDocumentTest extends BaseTestCaseMongoODM
             ->findOneBy(['title' => 'One Pull Article']);
 
         $types = $article->getTypes();
-        $this->assertTrue(1 === count($types));
+        $this->assertTrue(1 === (is_array($types) || $types instanceof \Countable ? count($types) : 0));
         $this->assertEquals('One Pull Type 1', $types[0]->getTitle());
 
         $this->dm->clear();
@@ -150,7 +150,7 @@ class ReferenceIntegrityDocumentTest extends BaseTestCaseMongoODM
             ->findOneBy(['title' => 'Many Pull Article']);
 
         $types = $article->getTypes();
-        $this->assertTrue(1 === count($types));
+        $this->assertTrue(1 === (is_array($types) || $types instanceof \Countable ? count($types) : 0));
         $this->assertEquals('Many Pull Type 1', $types[0]->getTitle());
 
         $this->dm->clear();

--- a/tests/Gedmo/Sluggable/Fixture/Handler/People/Occupation.php
+++ b/tests/Gedmo/Sluggable/Fixture/Handler/People/Occupation.php
@@ -11,6 +11,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
  */
 class Occupation
 {
+    public $children;
     /**
      * @ORM\Id
      * @ORM\GeneratedValue

--- a/tests/Gedmo/Sluggable/Fixture/Handler/TreeSlug.php
+++ b/tests/Gedmo/Sluggable/Fixture/Handler/TreeSlug.php
@@ -11,6 +11,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
  */
 class TreeSlug
 {
+    public $children;
     /**
      * @ORM\Id
      * @ORM\GeneratedValue

--- a/tests/Gedmo/Sluggable/Fixture/Handler/TreeSlugPrefixSuffix.php
+++ b/tests/Gedmo/Sluggable/Fixture/Handler/TreeSlugPrefixSuffix.php
@@ -11,6 +11,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
  */
 class TreeSlugPrefixSuffix
 {
+    public $children;
     /**
      * @ORM\Id
      * @ORM\GeneratedValue

--- a/tests/Gedmo/Sluggable/Fixture/Issue939/SluggableListener.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue939/SluggableListener.php
@@ -14,8 +14,12 @@ class SluggableListener extends BaseSluggableListener
         $this->originalTransliterator = $this->getTransliterator();
         $this->originalUrlizer = $this->getUrlizer();
 
-        $this->setTransliterator([$this, 'transliterator']);
-        $this->setUrlizer([$this, 'urlizer']);
+        $this->setTransliterator(function ($slug, $separator, $object) {
+            return $this->transliterator($slug, $separator, $object);
+        });
+        $this->setUrlizer(function ($slug, $separator, $object) {
+            return $this->urlizer($slug, $separator, $object);
+        });
     }
 
     public function transliterator($slug, $separator = '-', $object = null)

--- a/tests/Gedmo/Sluggable/Fixture/MappedSuperclass/Vehicle.php
+++ b/tests/Gedmo/Sluggable/Fixture/MappedSuperclass/Vehicle.php
@@ -10,6 +10,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
  */
 class Vehicle
 {
+    public $id;
     /**
      * @ORM\Column(length=128)
      */

--- a/tests/Gedmo/Sluggable/Fixture/TransArticleManySlug.php
+++ b/tests/Gedmo/Sluggable/Fixture/TransArticleManySlug.php
@@ -13,6 +13,11 @@ use Gedmo\Translatable\Translatable;
 class TransArticleManySlug implements Sluggable, Translatable
 {
     /**
+     * @var \Sluggable\Fixture\Comment[]|mixed
+     */
+    public $comments;
+    public $page;
+    /**
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")

--- a/tests/Gedmo/SoftDeleteable/Fixture/Document/User.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Document/User.php
@@ -27,7 +27,7 @@ class User
      *
      * @return $this
      */
-    public function setDeletedAt(\DateTime $deletedAt)
+    public function setDeletedAt(\DateTimeInterface $deletedAt)
     {
         $this->deletedAt = $deletedAt;
 

--- a/tests/Gedmo/SoftDeleteable/Fixture/Document/UserTimeAware.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Document/UserTimeAware.php
@@ -27,7 +27,7 @@ class UserTimeAware
      *
      * @return $this
      */
-    public function setDeletedAt(\DateTime $deletedAt)
+    public function setDeletedAt(\DateTimeInterface $deletedAt)
     {
         $this->deletedAt = $deletedAt;
 

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/OtherComment.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/OtherComment.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class OtherComment
 {
+    public $deletedAt;
     /**
      * @ORM\Column(name="id", type="integer")
      * @ORM\Id

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/Page.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/Page.php
@@ -16,6 +16,10 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Page
 {
     /**
+     * @var \SoftDeleteable\Fixture\Entity\Module[]
+     */
+    public $module;
+    /**
      * @ORM\Column(name="id", type="integer")
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="IDENTITY")

--- a/tests/Gedmo/Sortable/Fixture/Document/Kid.php
+++ b/tests/Gedmo/Sortable/Fixture/Document/Kid.php
@@ -55,7 +55,10 @@ class Kid
         return $this->position;
     }
 
-    public function setBirthdate(\DateTime $birthdate)
+    /**
+     * @param \DateTime|\DateTimeImmutable $birthdate
+     */
+    public function setBirthdate(\DateTimeInterface $birthdate)
     {
         $this->birthdate = $birthdate;
     }

--- a/tests/Gedmo/Sortable/Fixture/Event.php
+++ b/tests/Gedmo/Sortable/Fixture/Event.php
@@ -47,7 +47,10 @@ class Event
         return $this->id;
     }
 
-    public function setDateTime(\DateTime $date)
+    /**
+     * @param \DateTime|\DateTimeImmutable $date
+     */
+    public function setDateTime(\DateTimeInterface $date)
     {
         $this->dateTime = $date;
     }

--- a/tests/Gedmo/Sortable/Fixture/Transport/Reservation.php
+++ b/tests/Gedmo/Sortable/Fixture/Transport/Reservation.php
@@ -72,7 +72,10 @@ class Reservation
         return $this->destination;
     }
 
-    public function setTravelDate(\DateTime $date)
+    /**
+     * @param \DateTime|\DateTimeImmutable $date
+     */
+    public function setTravelDate(\DateTimeInterface $date)
     {
         $this->travelDate = $date;
     }

--- a/tests/Gedmo/Sortable/SortableTest.php
+++ b/tests/Gedmo/Sortable/SortableTest.php
@@ -160,8 +160,9 @@ class SortableTest extends BaseTestCaseORM
         $this->assertEquals('Node4', $nodes[2]->getName());
         $this->assertEquals('Node2', $nodes[3]->getName());
         $this->assertEquals('Node5', $nodes[4]->getName());
+        $nodesCount = is_array($nodes) || $nodes instanceof \Countable ? count($nodes) : 0;
 
-        for ($i = 0; $i < (is_array($nodes) || $nodes instanceof \Countable ? count($nodes) : 0); ++$i) {
+        for ($i = 0; $i < (is_array($nodes) || $nodes instanceof \Countable ? $nodesCount : 0); ++$i) {
             $this->assertSame($i, $nodes[$i]->getPosition());
         }
     }
@@ -207,8 +208,9 @@ class SortableTest extends BaseTestCaseORM
         $this->assertEquals('Node2', $nodes[2]->getName());
         $this->assertEquals('Node3', $nodes[3]->getName());
         $this->assertEquals('Node5', $nodes[4]->getName());
+        $nodesCount = is_array($nodes) || $nodes instanceof \Countable ? count($nodes) : 0;
 
-        for ($i = 0; $i < (is_array($nodes) || $nodes instanceof \Countable ? count($nodes) : 0); ++$i) {
+        for ($i = 0; $i < (is_array($nodes) || $nodes instanceof \Countable ? $nodesCount : 0); ++$i) {
             $this->assertSame($i, $nodes[$i]->getPosition());
         }
     }

--- a/tests/Gedmo/Sortable/SortableTest.php
+++ b/tests/Gedmo/Sortable/SortableTest.php
@@ -161,7 +161,7 @@ class SortableTest extends BaseTestCaseORM
         $this->assertEquals('Node2', $nodes[3]->getName());
         $this->assertEquals('Node5', $nodes[4]->getName());
 
-        for ($i = 0; $i < count($nodes); ++$i) {
+        for ($i = 0; $i < (is_array($nodes) || $nodes instanceof \Countable ? count($nodes) : 0); ++$i) {
             $this->assertSame($i, $nodes[$i]->getPosition());
         }
     }
@@ -208,7 +208,7 @@ class SortableTest extends BaseTestCaseORM
         $this->assertEquals('Node3', $nodes[3]->getName());
         $this->assertEquals('Node5', $nodes[4]->getName());
 
-        for ($i = 0; $i < count($nodes); ++$i) {
+        for ($i = 0; $i < (is_array($nodes) || $nodes instanceof \Countable ? count($nodes) : 0); ++$i) {
             $this->assertSame($i, $nodes[$i]->getPosition());
         }
     }

--- a/tests/Gedmo/Timestampable/ChangeTest.php
+++ b/tests/Gedmo/Timestampable/ChangeTest.php
@@ -110,7 +110,10 @@ class EventAdapterORMStub extends BaseAdapterORM implements TimestampableAdapter
 {
     protected $dateTime;
 
-    public function setDateValue(\DateTime $dateTime)
+    /**
+     * @param \DateTime|\DateTimeImmutable $dateTime
+     */
+    public function setDateValue(\DateTimeInterface $dateTime)
     {
         $this->dateTime = $dateTime;
     }

--- a/tests/Gedmo/Timestampable/Fixture/Article.php
+++ b/tests/Gedmo/Timestampable/Fixture/Article.php
@@ -139,7 +139,10 @@ class Article implements Timestampable
         return $this->created;
     }
 
-    public function setCreated(\DateTime $created)
+    /**
+     * @param \DateTime|\DateTimeImmutable $created
+     */
+    public function setCreated(\DateTimeInterface $created)
     {
         $this->created = $created;
     }
@@ -149,7 +152,10 @@ class Article implements Timestampable
         return $this->published;
     }
 
-    public function setPublished(\DateTime $published)
+    /**
+     * @param \DateTime|\DateTimeImmutable $published
+     */
+    public function setPublished(\DateTimeInterface $published)
     {
         $this->published = $published;
     }
@@ -164,12 +170,18 @@ class Article implements Timestampable
         return $this->updated;
     }
 
-    public function setUpdated(\DateTime $updated)
+    /**
+     * @param \DateTime|\DateTimeImmutable $updated
+     */
+    public function setUpdated(\DateTimeInterface $updated)
     {
         $this->updated = $updated;
     }
 
-    public function setContentChanged(\DateTime $contentChanged)
+    /**
+     * @param \DateTime|\DateTimeImmutable $contentChanged
+     */
+    public function setContentChanged(\DateTimeInterface $contentChanged)
     {
         $this->contentChanged = $contentChanged;
     }

--- a/tests/Gedmo/Timestampable/Fixture/Document/Article.php
+++ b/tests/Gedmo/Timestampable/Fixture/Document/Article.php
@@ -107,12 +107,18 @@ class Article
         $this->created = $created;
     }
 
-    public function setPublished(\DateTime $published)
+    /**
+     * @param \DateTime|\DateTimeImmutable $published
+     */
+    public function setPublished(\DateTimeInterface $published)
     {
         $this->published = $published;
     }
 
-    public function setUpdated(\DateTime $updated)
+    /**
+     * @param \DateTime|\DateTimeImmutable $updated
+     */
+    public function setUpdated(\DateTimeInterface $updated)
     {
         $this->updated = $updated;
     }

--- a/tests/Gedmo/Timestampable/Fixture/Document/Tag.php
+++ b/tests/Gedmo/Timestampable/Fixture/Document/Tag.php
@@ -57,7 +57,10 @@ class Tag
         return $this->created;
     }
 
-    public function setCreated(\DateTime $created)
+    /**
+     * @param \DateTime|\DateTimeImmutable $created
+     */
+    public function setCreated(\DateTimeInterface $created)
     {
         $this->created = $created;
     }
@@ -70,7 +73,10 @@ class Tag
         return $this->updated;
     }
 
-    public function setUpdated(\DateTime $updated)
+    /**
+     * @param \DateTime|\DateTimeImmutable $updated
+     */
+    public function setUpdated(\DateTimeInterface $updated)
     {
         $this->updated = $updated;
     }

--- a/tests/Gedmo/Timestampable/Fixture/TitledArticle.php
+++ b/tests/Gedmo/Timestampable/Fixture/TitledArticle.php
@@ -60,7 +60,7 @@ class TitledArticle implements Timestampable
     /**
      * @param \DateTime $chtext
      */
-    public function setChtext($chtext)
+    public function setChtext(\DateTimeInterface $chtext)
     {
         $this->chtext = $chtext;
     }
@@ -76,7 +76,7 @@ class TitledArticle implements Timestampable
     /**
      * @param \DateTime $chtitle
      */
-    public function setChtitle($chtitle)
+    public function setChtitle(\DateTimeInterface $chtitle)
     {
         $this->chtitle = $chtitle;
     }
@@ -92,7 +92,7 @@ class TitledArticle implements Timestampable
     /**
      * @param \DateTime $closed
      */
-    public function setClosed($closed)
+    public function setClosed(\DateTimeInterface $closed)
     {
         $this->closed = $closed;
     }

--- a/tests/Gedmo/Tool/BaseTestCaseOM.php
+++ b/tests/Gedmo/Tool/BaseTestCaseOM.php
@@ -103,9 +103,7 @@ abstract class BaseTestCaseOM extends \PHPUnit\Framework\TestCase
         $conn = $this->getMockBuilder('Doctrine\\MongoDB\\Connection')->getMock();
         $config = $this->getMockAnnotatedODMMongoDBConfig($dbName, $mappingDriver);
 
-        $dm = DocumentManager::create($conn, $config, $this->getEventManager());
-
-        return $dm;
+        return DocumentManager::create($conn, $config, $this->getEventManager());
     }
 
     /**

--- a/tests/Gedmo/Tool/BaseTestCaseORM.php
+++ b/tests/Gedmo/Tool/BaseTestCaseORM.php
@@ -61,7 +61,7 @@ abstract class BaseTestCaseORM extends \PHPUnit\Framework\TestCase
             'memory' => true,
         ];
 
-        $config = null === $config ? $this->getMockAnnotatedConfig() : $config;
+        $config = $config ?? $this->getMockAnnotatedConfig();
         $em = EntityManager::create($conn, $config, $evm ?: $this->getEventManager());
 
         $schema = array_map(function ($class) use ($em) {

--- a/tests/Gedmo/Translatable/Fixture/Document/Personal/Article.php
+++ b/tests/Gedmo/Translatable/Fixture/Document/Personal/Article.php
@@ -11,6 +11,8 @@ use Gedmo\Mapping\Annotation as Gedmo;
  */
 class Article
 {
+    public $code;
+    public $slug;
     /** @MongoODM\Id */
     private $id;
 

--- a/tests/Gedmo/Translatable/Issue/Issue109Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue109Test.php
@@ -61,7 +61,7 @@ class Issue109Test extends BaseTestCaseORM
         $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, self::TREE_WALKER_TRANSLATION);
 
         $result = $query->getResult();
-        $this->assertEquals(3, count($result));
+        $this->assertEquals(3, is_array($result) || $result instanceof \Countable ? count($result) : 0);
     }
 
     protected function getUsedEntityFixtures()

--- a/tests/Gedmo/Translatable/Issue/Issue1123Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue1123Test.php
@@ -8,6 +8,10 @@ use Translatable\Fixture\Issue1123\ChildEntity;
 
 class Issue1123Test extends BaseTestCaseORM
 {
+    /**
+     * @var \Gedmo\Translatable\TranslatableListener|mixed
+     */
+    public $translatableListener;
     const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
     const BASE_ENTITY = 'Translatable\\Fixture\\Issue1123\\BaseEntity';
     const CHILD_ENTITY = 'Translatable\\Fixture\\Issue1123\\ChildEntity';

--- a/tests/Gedmo/Translatable/Issue/Issue114Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue114Test.php
@@ -99,13 +99,13 @@ class Issue114Test extends BaseTestCaseORM
         $this->em->flush();
 
         $trans = $repo->findTranslations($article2);
-        $this->assertEquals(1, count($trans));
+        $this->assertEquals(1, is_array($trans) || $trans instanceof \Countable ? count($trans) : 0);
 
         $trans = $repo->findTranslations($article3);
-        $this->assertEquals(1, count($trans));
+        $this->assertEquals(1, is_array($trans) || $trans instanceof \Countable ? count($trans) : 0);
 
         $trans = $repo->findTranslations($article1);
-        $this->assertEquals(1, count($trans));
+        $this->assertEquals(1, is_array($trans) || $trans instanceof \Countable ? count($trans) : 0);
     }
 
     protected function getUsedEntityFixtures()

--- a/tests/Gedmo/Translatable/Issue/Issue173Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue173Test.php
@@ -51,7 +51,7 @@ class Issue173Test extends BaseTestCaseORM
         );
 
         $categories = $this->getCategoriesThatHasNoAssociations();
-        $this->assertEquals(count($categories), 1, '$category3 has no associations');
+        $this->assertEquals(is_array($categories) || $categories instanceof \Countable ? count($categories) : 0, 1, '$category3 has no associations');
     }
 
     public function getCategoriesThatHasNoAssociations()

--- a/tests/Gedmo/Translatable/Issue/Issue84Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue84Test.php
@@ -49,7 +49,7 @@ class Issue84Test extends BaseTestCaseORM
         $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $article);
 
         $trans = $repo->findTranslations($article);
-        $this->assertEquals(1, count($trans));
+        $this->assertEquals(1, is_array($trans) || $trans instanceof \Countable ? count($trans) : 0);
     }
 
     protected function getUsedEntityFixtures()

--- a/tests/Gedmo/Translatable/TranslatableEntityDefaultTranslationTest.php
+++ b/tests/Gedmo/Translatable/TranslatableEntityDefaultTranslationTest.php
@@ -17,6 +17,10 @@ use Translatable\Fixture\Article;
  */
 class TranslatableEntityDefaultTranslationTest extends BaseTestCaseORM
 {
+    /**
+     * @var \Doctrine\ORM\EntityRepository<\Gedmo\Translatable\Entity\Translation>|mixed
+     */
+    public $repo;
     const ARTICLE = 'Translatable\\Fixture\\Article';
     const COMMENT = 'Translatable\\Fixture\\Comment';
     const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';

--- a/tests/Gedmo/Tree/ClosureTreeRepositoryTest.php
+++ b/tests/Gedmo/Tree/ClosureTreeRepositoryTest.php
@@ -394,7 +394,7 @@ class ClosureTreeRepositoryTest extends BaseTestCaseORM
 
         $food = $tree[0];
         $this->assertEquals('Food', $food['title']);
-        $this->assertEquals(3, count($food['__children']));
+        $this->assertEquals(3, is_array($food['__children']) || $food['__children'] instanceof \Countable ? count($food['__children']) : 0);
         $this->assertEquals('Boring Food', $food['__children'][0]['title']);
         $this->assertEquals('Fruits', $food['__children'][1]['title']);
         $this->assertEquals('Milk', $food['__children'][2]['title']);
@@ -406,7 +406,7 @@ class ClosureTreeRepositoryTest extends BaseTestCaseORM
             $sortOption
         );
 
-        $this->assertEquals(3, count($tree));
+        $this->assertEquals(3, is_array($tree) || $tree instanceof \Countable ? count($tree) : 0);
         $this->assertEquals('Boring Food', $tree[0]['title']);
         $this->assertEquals('Fruits', $tree[1]['title']);
         $this->assertEquals('Milk', $tree[2]['title']);

--- a/tests/Gedmo/Tree/Fixture/CategoryUuid.php
+++ b/tests/Gedmo/Tree/Fixture/CategoryUuid.php
@@ -76,7 +76,7 @@ class CategoryUuid implements NodeInterface
      */
     public function createId()
     {
-        $this->id = bin2hex(pack('N2', mt_rand(), mt_rand()));
+        $this->id = bin2hex(pack('N2', random_int(0, mt_getrandmax()), random_int(0, mt_getrandmax())));
     }
 
     public function getId()

--- a/tests/Gedmo/Tree/Fixture/Closure/Category.php
+++ b/tests/Gedmo/Tree/Fixture/Closure/Category.php
@@ -13,6 +13,10 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Category
 {
     /**
+     * @var \Tree\Fixture\Closure\CategoryClosure[]
+     */
+    public $closures;
+    /**
      * @ORM\Column(name="id", type="integer")
      * @ORM\Id
      * @ORM\GeneratedValue

--- a/tests/Gedmo/Tree/Fixture/Closure/CategoryWithoutLevel.php
+++ b/tests/Gedmo/Tree/Fixture/Closure/CategoryWithoutLevel.php
@@ -13,6 +13,10 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class CategoryWithoutLevel
 {
     /**
+     * @var \Tree\Fixture\Closure\CategoryWithoutLevelClosure[]
+     */
+    public $closures;
+    /**
      * @ORM\Column(name="id", type="integer")
      * @ORM\Id
      * @ORM\GeneratedValue

--- a/tests/Gedmo/Tree/Fixture/Closure/Person.php
+++ b/tests/Gedmo/Tree/Fixture/Closure/Person.php
@@ -17,6 +17,11 @@ use Gedmo\Mapping\Annotation as Gedmo;
  */
 abstract class Person
 {
+    public $name;
+    /**
+     * @var \Tree\Fixture\Closure\CategoryClosure[]
+     */
+    public $closures;
     /**
      * @ORM\Column(name="id", type="integer")
      * @ORM\Id

--- a/tests/Gedmo/Tree/Fixture/User.php
+++ b/tests/Gedmo/Tree/Fixture/User.php
@@ -67,7 +67,7 @@ class User extends Role
         $num = strlen($set);
         $ret = '';
         for ($i = 0; $i < $length; ++$i) {
-            $ret .= $set[rand(0, $num - 1)];
+            $ret .= $set[random_int(0, $num - 1)];
         }
 
         return $ret;

--- a/tests/Gedmo/Tree/MaterializedPathODMMongoDBRepositoryTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathODMMongoDBRepositoryTest.php
@@ -238,15 +238,15 @@ class MaterializedPathODMMongoDBRepositoryTest extends BaseTestCaseMongoODM
         $roots = $this->repo->getRootNodes();
         $tree = $this->repo->childrenHierarchy($food, true);
 
-        $this->assertEquals(2, count($tree));
+        $this->assertEquals(2, is_array($tree) || $tree instanceof \Countable ? count($tree) : 0);
         $this->assertEquals('Fruits', $tree[0]['title']);
         $this->assertEquals('Vegitables', $tree[1]['title']);
 
         // Tree of one specific root only with direct children, with the root node
         $tree = $this->repo->childrenHierarchy($food, true, [], true);
 
-        $this->assertEquals(1, count($tree));
-        $this->assertEquals(2, count($tree[0]['__children']));
+        $this->assertEquals(1, is_array($tree) || $tree instanceof \Countable ? count($tree) : 0);
+        $this->assertEquals(2, is_array($tree[0]['__children']) || $tree[0]['__children'] instanceof \Countable ? count($tree[0]['__children']) : 0);
         $this->assertEquals('Food', $tree[0]['title']);
         $this->assertEquals('Fruits', $tree[0]['__children'][0]['title']);
         $this->assertEquals('Vegitables', $tree[0]['__children'][1]['title']);

--- a/tests/Gedmo/Tree/MaterializedPathORMFeaturesTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathORMFeaturesTest.php
@@ -98,7 +98,7 @@ class MaterializedPathORMFeaturesTest extends BaseTestCaseORM
     public function generatePath(array $sources)
     {
         $path = '';
-        foreach ($sources as $p => $id) {
+        foreach (array_keys($sources) as $p) {
             $path .= $this->config['path_separator'].$p;
         }
 

--- a/tests/Gedmo/Tree/MaterializedPathORMRepositoryTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathORMRepositoryTest.php
@@ -268,15 +268,15 @@ class MaterializedPathORMRepositoryTest extends BaseTestCaseORM
         $roots = $this->repo->getRootNodes();
         $tree = $this->repo->childrenHierarchy($roots[1], true);
 
-        $this->assertEquals(2, count($tree));
+        $this->assertEquals(2, is_array($tree) || $tree instanceof \Countable ? count($tree) : 0);
         $this->assertEquals('Fruits', $tree[0]['title']);
         $this->assertEquals('Vegitables', $tree[1]['title']);
 
         // Tree of one specific root only with direct children, with the root node
         $tree = $this->repo->childrenHierarchy($roots[1], true, [], true);
 
-        $this->assertEquals(1, count($tree));
-        $this->assertEquals(2, count($tree[0]['__children']));
+        $this->assertEquals(1, is_array($tree) || $tree instanceof \Countable ? count($tree) : 0);
+        $this->assertEquals(2, is_array($tree[0]['__children']) || $tree[0]['__children'] instanceof \Countable ? count($tree[0]['__children']) : 0);
         $this->assertEquals('Food', $tree[0]['title']);
         $this->assertEquals('Fruits', $tree[0]['__children'][0]['title']);
         $this->assertEquals('Vegitables', $tree[0]['__children'][1]['title']);

--- a/tests/Gedmo/Tree/MaterializedPathORMRepositoryTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathORMRepositoryTest.php
@@ -17,6 +17,14 @@ use Tool\BaseTestCaseORM;
  */
 class MaterializedPathORMRepositoryTest extends BaseTestCaseORM
 {
+    /**
+     * @var \Gedmo\Tree\TreeListener|mixed
+     */
+    public $listener;
+    /**
+     * @var mixed[]
+     */
+    public $config;
     const CATEGORY = 'Tree\\Fixture\\MPCategory';
     const CATEGORY_WITH_TRIMMED_SEPARATOR = 'Tree\\Fixture\\MPCategoryWithTrimmedSeparator';
 

--- a/tests/Gedmo/Tree/MultInheritanceWithJoinedTableTest.php
+++ b/tests/Gedmo/Tree/MultInheritanceWithJoinedTableTest.php
@@ -18,6 +18,10 @@ use Tool\BaseTestCaseORM;
  */
 class MultInheritanceWithJoinedTableTest extends BaseTestCaseORM
 {
+    /**
+     * @var \Gedmo\Tree\TreeListener|mixed
+     */
+    public $tree;
     const USER = 'Tree\\Fixture\\User';
     const GROUP = 'Tree\\Fixture\\UserGroup';
     const ROLE = 'Tree\\Fixture\\Role';

--- a/tests/Gedmo/Tree/NestedTreeRootRepositoryTest.php
+++ b/tests/Gedmo/Tree/NestedTreeRootRepositoryTest.php
@@ -78,7 +78,7 @@ class NestedTreeRootRepositoryTest extends BaseTestCaseORM
         $roots = $repo->getRootNodes();
         $tree = $repo->childrenHierarchy();
 
-        $this->assertEquals(2, count($tree));     // Count roots
+        $this->assertEquals(2, is_array($tree) || $tree instanceof \Countable ? count($tree) : 0);     // Count roots
         $this->assertEquals('Food', $tree[0]['title']);
         $this->assertEquals('Sports', $tree[1]['title']);
         $this->assertEquals('Fruits', $tree[0]['__children'][0]['title']);
@@ -90,7 +90,7 @@ class NestedTreeRootRepositoryTest extends BaseTestCaseORM
         $roots = $repo->getRootNodes();
         $tree = $repo->childrenHierarchy($roots[0]);
 
-        $this->assertEquals(2, count($tree));     // Count roots
+        $this->assertEquals(2, is_array($tree) || $tree instanceof \Countable ? count($tree) : 0);     // Count roots
         $this->assertEquals('Fruits', $tree[0]['title']);
         $this->assertEquals('Vegitables', $tree[1]['title']);
         $this->assertEquals('Carrots', $tree[1]['__children'][0]['title']);
@@ -99,7 +99,7 @@ class NestedTreeRootRepositoryTest extends BaseTestCaseORM
         // Tree of one specific root, with the root node
         $tree = $repo->childrenHierarchy($roots[0], false, [], true);
 
-        $this->assertEquals(1, count($tree));     // Count roots
+        $this->assertEquals(1, is_array($tree) || $tree instanceof \Countable ? count($tree) : 0);     // Count roots
         $this->assertEquals('Food', $tree[0]['title']);
         $this->assertEquals('Fruits', $tree[0]['__children'][0]['title']);
         $this->assertEquals('Vegitables', $tree[0]['__children'][1]['title']);
@@ -110,14 +110,14 @@ class NestedTreeRootRepositoryTest extends BaseTestCaseORM
         $roots = $repo->getRootNodes();
         $tree = $repo->childrenHierarchy($roots[0], true);
 
-        $this->assertEquals(2, count($tree));
+        $this->assertEquals(2, is_array($tree) || $tree instanceof \Countable ? count($tree) : 0);
         $this->assertEquals('Fruits', $tree[0]['title']);
         $this->assertEquals('Vegitables', $tree[1]['title']);
 
         // Tree of one specific root only with direct children, with the root node
         $tree = $repo->childrenHierarchy($roots[0], true, [], true);
 
-        $this->assertEquals(1, count($tree));
+        $this->assertEquals(1, is_array($tree) || $tree instanceof \Countable ? count($tree) : 0);
         $this->assertEquals('Food', $tree[0]['title']);
         $this->assertEquals('Fruits', $tree[0]['__children'][0]['title']);
         $this->assertEquals('Vegitables', $tree[0]['__children'][1]['title']);
@@ -416,14 +416,14 @@ class NestedTreeRootRepositoryTest extends BaseTestCaseORM
         // Test getRootNodes without custom ordering
         $roots = $repo->getRootNodes();
 
-        $this->assertEquals(2, count($roots));
+        $this->assertEquals(2, is_array($roots) || $roots instanceof \Countable ? count($roots) : 0);
         $this->assertEquals('Food', $roots[0]->getTitle());
         $this->assertEquals('Sports', $roots[1]->getTitle());
 
         // Test getRootNodes with custom ordering
         $roots = $repo->getRootNodes('title', 'desc');
 
-        $this->assertEquals(2, count($roots));
+        $this->assertEquals(2, is_array($roots) || $roots instanceof \Countable ? count($roots) : 0);
         $this->assertEquals('Sports', $roots[0]->getTitle());
         $this->assertEquals('Food', $roots[1]->getTitle());
     }

--- a/tests/Gedmo/Tree/TreeObjectHydratorTest.php
+++ b/tests/Gedmo/Tree/TreeObjectHydratorTest.php
@@ -51,35 +51,35 @@ class TreeObjectHydratorTest extends BaseTestCaseORM
             ->setHint(Query::HINT_INCLUDE_META_COLUMNS, true)
             ->getResult('tree');
 
-        $this->assertEquals(count($result), 1);
+        $this->assertEquals(is_array($result) || $result instanceof \Countable ? count($result) : 0, 1);
 
         $food = $result[0];
         $this->assertEquals($food->getTitle(), 'Food');
-        $this->assertEquals(count($food->getChildren()), 4);
+        $this->assertEquals(is_array($food->getChildren()) || $food->getChildren() instanceof \Countable ? count($food->getChildren()) : 0, 4);
 
         $fruits = $food->getChildren()->get(0);
         $this->assertEquals($fruits->getTitle(), 'Fruits');
-        $this->assertEquals(count($fruits->getChildren()), 2);
+        $this->assertEquals(is_array($fruits->getChildren()) || $fruits->getChildren() instanceof \Countable ? count($fruits->getChildren()) : 0, 2);
 
         $vegetables = $food->getChildren()->get(1);
         $this->assertEquals($vegetables->getTitle(), 'Vegetables');
-        $this->assertEquals(count($vegetables->getChildren()), 0);
+        $this->assertEquals(is_array($vegetables->getChildren()) || $vegetables->getChildren() instanceof \Countable ? count($vegetables->getChildren()) : 0, 0);
 
         $milk = $food->getChildren()->get(2);
         $this->assertEquals($milk->getTitle(), 'Milk');
-        $this->assertEquals(count($milk->getChildren()), 0);
+        $this->assertEquals(is_array($milk->getChildren()) || $milk->getChildren() instanceof \Countable ? count($milk->getChildren()) : 0, 0);
 
         $meat = $food->getChildren()->get(3);
         $this->assertEquals($meat->getTitle(), 'Meat');
-        $this->assertEquals(count($meat->getChildren()), 0);
+        $this->assertEquals(is_array($meat->getChildren()) || $meat->getChildren() instanceof \Countable ? count($meat->getChildren()) : 0, 0);
 
         $oranges = $fruits->getChildren()->get(0);
         $this->assertEquals($oranges->getTitle(), 'Oranges');
-        $this->assertEquals(count($oranges->getChildren()), 0);
+        $this->assertEquals(is_array($oranges->getChildren()) || $oranges->getChildren() instanceof \Countable ? count($oranges->getChildren()) : 0, 0);
 
         $citrons = $fruits->getChildren()->get(1);
         $this->assertEquals($citrons->getTitle(), 'Citrons');
-        $this->assertEquals(count($citrons->getChildren()), 0);
+        $this->assertEquals(is_array($citrons->getChildren()) || $citrons->getChildren() instanceof \Countable ? count($citrons->getChildren()) : 0, 0);
 
         // Make sure only one query was executed
         $this->assertEquals(count($stack->queries), 1);
@@ -102,19 +102,19 @@ class TreeObjectHydratorTest extends BaseTestCaseORM
             ->setHint(Query::HINT_INCLUDE_META_COLUMNS, true)
             ->getResult('tree');
 
-        $this->assertEquals(count($result), 1);
+        $this->assertEquals(is_array($result) || $result instanceof \Countable ? count($result) : 0, 1);
 
         $fruits = $result[0];
         $this->assertEquals($fruits->getTitle(), 'Fruits');
-        $this->assertEquals(count($fruits->getChildren()), 2);
+        $this->assertEquals(is_array($fruits->getChildren()) || $fruits->getChildren() instanceof \Countable ? count($fruits->getChildren()) : 0, 2);
 
         $oranges = $fruits->getChildren()->get(0);
         $this->assertEquals($oranges->getTitle(), 'Oranges');
-        $this->assertEquals(count($oranges->getChildren()), 0);
+        $this->assertEquals(is_array($oranges->getChildren()) || $oranges->getChildren() instanceof \Countable ? count($oranges->getChildren()) : 0, 0);
 
         $citrons = $fruits->getChildren()->get(1);
         $this->assertEquals($citrons->getTitle(), 'Citrons');
-        $this->assertEquals(count($citrons->getChildren()), 0);
+        $this->assertEquals(is_array($citrons->getChildren()) || $citrons->getChildren() instanceof \Countable ? count($citrons->getChildren()) : 0, 0);
 
         $this->assertEquals(count($stack->queries), 2);
     }
@@ -136,31 +136,31 @@ class TreeObjectHydratorTest extends BaseTestCaseORM
             ->setHint(Query::HINT_INCLUDE_META_COLUMNS, true)
             ->getResult('tree');
 
-        $this->assertEquals(count($result), 4);
+        $this->assertEquals(is_array($result) || $result instanceof \Countable ? count($result) : 0, 4);
 
         $fruits = $result[0];
         $this->assertEquals($fruits->getTitle(), 'Fruits');
-        $this->assertEquals(count($fruits->getChildren()), 2);
+        $this->assertEquals(is_array($fruits->getChildren()) || $fruits->getChildren() instanceof \Countable ? count($fruits->getChildren()) : 0, 2);
 
         $vegetables = $result[1];
         $this->assertEquals($vegetables->getTitle(), 'Vegetables');
-        $this->assertEquals(count($vegetables->getChildren()), 0);
+        $this->assertEquals(is_array($vegetables->getChildren()) || $vegetables->getChildren() instanceof \Countable ? count($vegetables->getChildren()) : 0, 0);
 
         $milk = $result[2];
         $this->assertEquals($milk->getTitle(), 'Milk');
-        $this->assertEquals(count($milk->getChildren()), 0);
+        $this->assertEquals(is_array($milk->getChildren()) || $milk->getChildren() instanceof \Countable ? count($milk->getChildren()) : 0, 0);
 
         $meat = $result[3];
         $this->assertEquals($meat->getTitle(), 'Meat');
-        $this->assertEquals(count($meat->getChildren()), 0);
+        $this->assertEquals(is_array($meat->getChildren()) || $meat->getChildren() instanceof \Countable ? count($meat->getChildren()) : 0, 0);
 
         $oranges = $fruits->getChildren()->get(0);
         $this->assertEquals($oranges->getTitle(), 'Oranges');
-        $this->assertEquals(count($oranges->getChildren()), 0);
+        $this->assertEquals(is_array($oranges->getChildren()) || $oranges->getChildren() instanceof \Countable ? count($oranges->getChildren()) : 0, 0);
 
         $citrons = $fruits->getChildren()->get(1);
         $this->assertEquals($citrons->getTitle(), 'Citrons');
-        $this->assertEquals(count($citrons->getChildren()), 0);
+        $this->assertEquals(is_array($citrons->getChildren()) || $citrons->getChildren() instanceof \Countable ? count($citrons->getChildren()) : 0, 0);
 
         $this->assertEquals(count($stack->queries), 2);
     }

--- a/tests/Gedmo/Uploadable/Fixture/Entity/Article.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/Article.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class Article
 {
+    public $filePath;
     /**
      * @ORM\Column(name="id", type="integer")
      * @ORM\Id

--- a/tests/Gedmo/Uploadable/UploadableEntityTest.php
+++ b/tests/Gedmo/Uploadable/UploadableEntityTest.php
@@ -674,16 +674,14 @@ class UploadableEntityTest extends BaseTestCaseORM
     private function generateUploadedFile($index = 'image', $filePath = false, $filename = false, array $info = [])
     {
         $defaultInfo = [
-            'tmp_name' => !$filePath ? $this->testFile : $filePath,
-            'name' => !$filename ? $this->testFilename : $filename,
+            'tmp_name' => $filePath ? $filePath : $this->testFile,
+            'name' => $filename ? $filename : $this->testFilename,
             'size' => $this->testFileSize,
             'type' => $this->testFileMimeType,
             'error' => 0,
         ];
 
-        $info = array_merge($defaultInfo, $info);
-
-        return $info;
+        return array_merge($defaultInfo, $info);
     }
 
     protected function getUsedEntityFixtures()


### PR DESCRIPTION
Thanks to [Rector](https://github.com/rectorphp/rector) I was able to make some improvements.

Some of the rectors caused some trouble, so I blacklisted those for now. We can look after those at a later moment.

I've added the rector configuration file and added it to the dev dependencies, so we can use Rector to upgrade to a newer version of PHP when supports end. Security Support for PHP 7.3 ends this year (6 Dec 2021)