### PR TITLE
Replace EntityRepository with ServiceEntityRepository

### DIFF
--- a/src/Loggable/Entity/Repository/LogEntryRepository.php
+++ b/src/Loggable/Entity/Repository/LogEntryRepository.php
@@ -2,7 +2,7 @@
 
 namespace Gedmo\Loggable\Entity\Repository;
 
-use Doctrine\ORM\EntityRepository;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query;
 use Gedmo\Loggable\Entity\MappedSuperclass\AbstractLogEntry;
@@ -16,7 +16,7 @@ use Gedmo\Tool\Wrapper\EntityWrapper;
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
-class LogEntryRepository extends EntityRepository
+class LogEntryRepository extends ServiceEntityRepository
 {
     /**
      * Currently used loggable listener

--- a/src/Sortable/Entity/Repository/SortableRepository.php
+++ b/src/Sortable/Entity/Repository/SortableRepository.php
@@ -2,9 +2,8 @@
 
 namespace Gedmo\Sortable\Entity\Repository;
 
-use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\EntityRepository;
-use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
 use Gedmo\Sortable\SortableListener;
 
 /**
@@ -13,7 +12,7 @@ use Gedmo\Sortable\SortableListener;
  * @author Lukas Botsch <lukas.botsch@gmail.com>
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
-class SortableRepository extends EntityRepository
+class SortableRepository extends ServiceEntityRepository
 {
     /**
      * Sortable listener on event manager
@@ -25,11 +24,12 @@ class SortableRepository extends EntityRepository
     protected $config = null;
     protected $meta = null;
 
-    public function __construct(EntityManagerInterface $em, ClassMetadata $class)
+    public function __construct(ManagerRegistry $registry, string $entityClass)
     {
-        parent::__construct($em, $class);
+        parent::__construct($registry, $entityClass);
+
         $sortableListener = null;
-        foreach ($em->getEventManager()->getListeners() as $event => $listeners) {
+        foreach ($this->_em->getEventManager()->getListeners() as $event => $listeners) {
             foreach ($listeners as $hash => $listener) {
                 if ($listener instanceof SortableListener) {
                     $sortableListener = $listener;

--- a/src/Translatable/Entity/Repository/TranslationRepository.php
+++ b/src/Translatable/Entity/Repository/TranslationRepository.php
@@ -2,11 +2,10 @@
 
 namespace Gedmo\Translatable\Entity\Repository;
 
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\DBAL\Types\Type;
-use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\EntityRepository;
-use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query;
+use Doctrine\Persistence\ManagerRegistry;
 use Gedmo\Tool\Wrapper\EntityWrapper;
 use Gedmo\Translatable\Mapping\Event\Adapter\ORM as TranslatableAdapterORM;
 use Gedmo\Translatable\TranslatableListener;
@@ -18,7 +17,7 @@ use Gedmo\Translatable\TranslatableListener;
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
-class TranslationRepository extends EntityRepository
+class TranslationRepository extends ServiceEntityRepository
 {
     /**
      * Current TranslatableListener instance used
@@ -31,12 +30,13 @@ class TranslationRepository extends EntityRepository
     /**
      * {@inheritdoc}
      */
-    public function __construct(EntityManagerInterface $em, ClassMetadata $class)
+    public function __construct(ManagerRegistry $registry, string $entityClass)
     {
-        if ($class->getReflectionClass()->isSubclassOf('Gedmo\Translatable\Entity\MappedSuperclass\AbstractPersonalTranslation')) {
+        parent::__construct($registry, $entityClass);
+
+        if ($this->_class->getReflectionClass()->isSubclassOf('Gedmo\Translatable\Entity\MappedSuperclass\AbstractPersonalTranslation')) {
             throw new \Gedmo\Exception\UnexpectedValueException('This repository is useless for personal translations');
         }
-        parent::__construct($em, $class);
     }
 
     /**

--- a/src/Tree/Entity/Repository/AbstractTreeRepository.php
+++ b/src/Tree/Entity/Repository/AbstractTreeRepository.php
@@ -2,9 +2,8 @@
 
 namespace Gedmo\Tree\Entity\Repository;
 
-use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\EntityRepository;
-use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
 use Gedmo\Exception\InvalidArgumentException;
 use Gedmo\Tool\Wrapper\EntityWrapper;
 use Gedmo\Tree\RepositoryInterface;
@@ -12,7 +11,7 @@ use Gedmo\Tree\RepositoryUtils;
 use Gedmo\Tree\RepositoryUtilsInterface;
 use Gedmo\Tree\TreeListener;
 
-abstract class AbstractTreeRepository extends EntityRepository implements RepositoryInterface
+abstract class AbstractTreeRepository extends ServiceEntityRepository implements RepositoryInterface
 {
     /**
      * Tree listener on event manager
@@ -29,11 +28,12 @@ abstract class AbstractTreeRepository extends EntityRepository implements Reposi
     /**
      * {@inheritdoc}
      */
-    public function __construct(EntityManagerInterface $em, ClassMetadata $class)
+    public function __construct(ManagerRegistry $registry, string $entityClass)
     {
-        parent::__construct($em, $class);
+        parent::__construct($registry, $entityClass);
+
         $treeListener = null;
-        foreach ($em->getEventManager()->getListeners() as $listeners) {
+        foreach ($this->_em->getEventManager()->getListeners() as $listeners) {
             foreach ($listeners as $listener) {
                 if ($listener instanceof TreeListener) {
                     $treeListener = $listener;


### PR DESCRIPTION
Before:

```php
class CourseCategoryRepository extends SortableRepository
{
    public function __construct(EntityManagerInterface $em)
    {
        parent::__construct($em, $em->getClassMetadata(CourseCategory::class));
    }

    // ...
}
```

After:

```php
class CourseCategoryRepository extends SortableRepository
{
    public function __construct(ManagerRegistry $registry)
    {
        parent::__construct($registry, CourseCategory::class);
    }

    // ...
}
```