### PR TITLE
Add missing XSD definitions

### DIFF
--- a/schemas/orm/doctrine-extensions-mapping-2-2.xsd
+++ b/schemas/orm/doctrine-extensions-mapping-2-2.xsd
@@ -25,6 +25,7 @@
   <xs:element name="translation" type="gedmo:translation"/>
   <xs:element name="tree" type="gedmo:tree"/>
   <xs:element name="tree-closure" type="gedmo:tree-closure"/>
+  <xs:element name="tree-path" type="gedmo:tree-path"/>
   <xs:element name="loggable" type="gedmo:loggable"/>
   <xs:element name="soft-deleteable" type="gedmo:soft-deleteable"/>
   <xs:element name="uploadable" type="gedmo:uploadable"/>

--- a/schemas/orm/doctrine-extensions-mapping-2-2.xsd
+++ b/schemas/orm/doctrine-extensions-mapping-2-2.xsd
@@ -104,6 +104,8 @@
 
   <xs:complexType name="soft-deleteable">
     <xs:attribute name="field-name" type="xs:string" use="required" />
+    <xs:attribute name="hard-delete" type="xs:boolean" use="optional" />
+    <xs:attribute name="time-aware" type="xs:boolean" use="optional" />
   </xs:complexType>
 
   <xs:complexType name="handler">

--- a/tests/Gedmo/Mapping/Driver/Xml/Mapping.Fixture.Xml.SoftDeleteable.dcm.xml
+++ b/tests/Gedmo/Mapping/Driver/Xml/Mapping.Fixture.Xml.SoftDeleteable.dcm.xml
@@ -9,6 +9,6 @@
 
         <field name="deletedAt" type="datetime" nullable="true"/>
 
-        <gedmo:soft-deleteable field-name="deletedAt"/>
+        <gedmo:soft-deleteable field-name="deletedAt" time-aware="false" hard-delete="true"/>
     </entity>
 </doctrine-mapping>


### PR DESCRIPTION
Update XSD in order to add missing definitions:
* `tree-path` type;
* `hard-delete` and `time-aware` attributes to "soft-deleteable" type;

See
https://github.com/doctrine-extensions/DoctrineExtensions/blob/b26ed3b92091e5aa14d9fa1382d8c370084aa422/src/SoftDeleteable/Mapping/Driver/Xml.php#L47-L55

https://github.com/doctrine-extensions/DoctrineExtensions/blob/b26ed3b92091e5aa14d9fa1382d8c370084aa422/src/Tree/Mapping/Driver/Xml.php#L97