### PR TITLE
fix reserved indicator

### DIFF
--- a/doc/symfony4.md
+++ b/doc/symfony4.md
@@ -164,7 +164,7 @@ services:
             - { name: doctrine.event_subscriber, connection: default }
         calls:
             - [ setAnnotationReader, [ "@annotation_reader" ] ]
-            - [ setDefaultLocale, [ %locale% ] ]
+            - [ setDefaultLocale, [ "%locale%" ] ]
             - [ setTranslationFallback, [ false ] ]
 
     gedmo.listener.timestampable:


### PR DESCRIPTION
When using the yaml config template this lead to : 
``` 
The reserved indicator "%" cannot start a plain scalar.

```

If apply, this commit will fix that.