### PR TITLE
Replace removed constants from `Doctrine\DBAL\Types\Type`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ a release.
 ### Fixed
 - Removed legacy checks targeting older versions of PHP (#2201)
 - Added missing XSD definitions (#2244)
+- Replaced undefined constants from `Doctrine\DBAL\Types\Type` at `Gedmo\Translatable\Mapping\Event\Adapter\ORM::foreignKey()` (#2250)
 - Add conflict against "doctrine/orm" >=2.10 in order to guarantee the schema extension (see https://github.com/doctrine/orm/pull/8852) (#2255)
 
 ## [3.1.0] - 2021-06-22

--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
     "require-dev": {
         "alcaeus/mongo-php-adapter": "^1.1",
         "doctrine/cache": "^1.11 || ^2.0",
+        "doctrine/dbal": "^2.13",
         "doctrine/doctrine-bundle": "^2.3",
         "doctrine/mongodb-odm": "^2.0",
         "doctrine/orm": "^2.6.3",

--- a/src/Translatable/Mapping/Event/Adapter/ORM.php
+++ b/src/Translatable/Mapping/Event/Adapter/ORM.php
@@ -4,6 +4,7 @@ namespace Gedmo\Translatable\Mapping\Event\Adapter;
 
 use Doctrine\Common\Proxy\Proxy;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Gedmo\Mapping\Event\Adapter\ORM as BaseAdapterORM;
 use Gedmo\Tool\Wrapper\AbstractWrapper;
@@ -111,9 +112,9 @@ final class ORM extends BaseAdapterORM implements TranslatableAdapter
         $meta = $em->getClassMetadata($className);
         $type = Type::getType($meta->getTypeOfField('foreignKey'));
         switch ($type->getName()) {
-        case Type::BIGINT:
-        case Type::INTEGER:
-        case Type::SMALLINT:
+        case Types::BIGINT:
+        case Types::INTEGER:
+        case Types::SMALLINT:
             return intval($key);
         default:
             return (string) $key;


### PR DESCRIPTION
* Fixed accessing undefined constants from `Doctrine\DBAL\Types\Type`.
* Added missing dev dependency for "doctrine/dbal".

See [this failed action](https://github.com/doctrine-extensions/DoctrineExtensions/pull/2246/checks?check_run_id=3576379821#step:6:22) in #2246.