### PR TITLE
Add support for attributes to Translatable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ a release.
 
 ## [Unreleased]
 
+### Added
+- Support to use Translatable annotations as attributes on PHP >= 8.0.
+
 ### Fixed
 - Return value for `replaceRelative()` and `replaceInverseRelative()` at `Gedmo\Sluggable\Mapping\Event\Adapter\ODM` if the
   query result does not implement `Doctrine\ODM\MongoDB\Iterator\Iterator`.

--- a/doc/translatable.md
+++ b/doc/translatable.md
@@ -89,9 +89,15 @@ on how to setup and use the extensions in most optimized way.
 
 ### Translatable annotations:
 - **@Gedmo\Mapping\Annotation\Translatable** it will **translate** this field
-- **@Gedmo\Mapping\Annotation\TranslationEntity(class="my\class")** it will use this class to store **translations** generated
-- **@Gedmo\Mapping\Annotation\Locale or @Gedmo\Mapping\Annotation\Language** this will identify this column as **locale** or **language**
+- **@Gedmo\Mapping\Annotation\TranslationEntity(class="my\class")** it will use this class to store the generated **translations**
+- **@Gedmo\Mapping\Annotation\Locale** or **@Gedmo\Mapping\Annotation\Language** these will identify this column as **locale** or **language**
 used to override the global locale
+
+### Translatable attributes:
+- **Gedmo\Mapping\Annotation\Translatable** it will **translate** this field
+- **Gedmo\Mapping\Annotation\TranslationEntity(class: MyClass::class)** it will use this class to store the generated **translations**
+- **Gedmo\Mapping\Annotation\Locale** or **Gedmo\Mapping\Annotation\Language** these will identify this column as **locale** or **language**
+  used to override the global locale
 
 <a name="entity-domain-object"></a>
 
@@ -100,6 +106,8 @@ used to override the global locale
 **Note:** that Translatable interface is not necessary, except in cases where
 you need to identify an entity as being Translatable. The metadata is loaded only once when
 cache is activated
+
+### Annotations
 
 ``` php
 <?php
@@ -169,6 +177,72 @@ class Article implements Translatable
 }
 ```
 
+### Attributes
+
+``` php
+<?php
+namespace Entity;
+
+use Gedmo\Mapping\Annotation as Gedmo;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Translatable\Translatable;
+
+ #[ORM\Table(name: 'articles')]
+ #[ORM\Entity]
+class Article implements Translatable
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private $id;
+
+    #[Gedmo\Translatable]
+    #[ORM\Column(name: 'title', type: 'string', length: 128)]
+    private $title;
+
+    #[Gedmo\Translatable]
+    #[ORM\Column(name: 'content', type: 'text')]
+    private $content;
+
+    /**
+     * Used locale to override Translation listener`s locale
+     * this is not a mapped field of entity metadata, just a simple property
+     */
+    #[Gedmo\Locale]
+    private $locale;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    public function setContent($content)
+    {
+        $this->content = $content;
+    }
+
+    public function getContent()
+    {
+        return $this->content;
+    }
+
+    public function setTranslatableLocale($locale)
+    {
+        $this->locale = $locale;
+    }
+}
+```
+
 <a name="document-domain-object"></a>
 
 ## Translatable Document example:
@@ -193,12 +267,14 @@ class Article implements Translatable
      * @Gedmo\Translatable
      * @ODM\Field(type="string")
      */
+    #[Gedmo\Translatable]
     private $title;
 
     /**
      * @Gedmo\Translatable
      * @ODM\Field(type="string")
      */
+    #[Gedmo\Translatable]
     private $content;
 
     /**
@@ -206,6 +282,7 @@ class Article implements Translatable
      * Used locale to override Translation listener`s locale
      * this is not a mapped field of entity metadata, just a simple property
      */
+    #[Gedmo\Locale]
     private $locale;
 
     public function getId()
@@ -619,12 +696,16 @@ your translations by extending the mapped superclass.
 
 ArticleTranslation Entity:
 
+**Note:** this example is using annotations and attributes for mapping, you should use
+one of them, not both.
+
 ``` php
 <?php
 namespace Entity\Translation;
 
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Translatable\Entity\MappedSuperclass\AbstractTranslation;
+use Gedmo\Translatable\Entity\Repository\TranslationRepository;
 
 /**
  * @ORM\Table(name="article_translations", indexes={
@@ -632,6 +713,9 @@ use Gedmo\Translatable\Entity\MappedSuperclass\AbstractTranslation;
  * })
  * @ORM\Entity(repositoryClass="Gedmo\Translatable\Entity\Repository\TranslationRepository")
  */
+ #[ORM\Table(name: 'article_translations')]
+ #[ORM\Index(name: 'article_translation_idx', columns: ['locale', 'object_class', 'field', 'foreign_key'])]
+ #[ORM\Entity(repositoryClass: TranslationRepository::class)]
 class ArticleTranslation extends AbstractTranslation
 {
     /**
@@ -644,17 +728,23 @@ class ArticleTranslation extends AbstractTranslation
 It is handy for specific methods common to the Translation Entity
 
 **Note:** This Entity will be used instead of default Translation Entity
-only if we specify a class annotation @Gedmo\TranslationEntity(class="my\translation\entity"):
+only if we specify a class annotation `@Gedmo\TranslationEntity(class="my\translation\entity")`
+or a class attribute `#[Gedmo\TranslationEntity(class: ArticleTranslation::class)]`
 
 ``` php
 <?php
+
 use Doctrine\ORM\Mapping as ORM;
+use Entity\Translation\ArticleTranslation;
 
 /**
  * @ORM\Table(name="articles")
  * @ORM\Entity
  * @Gedmo\TranslationEntity(class="Entity\Translation\ArticleTranslation")
  */
+#[ORM\Table(name: 'articles')]
+#[ORM\Entity]
+#[Gedmo\TranslationEntity(class: ArticleTranslation::class)]
 class Article
 {
     // ...
@@ -678,7 +768,7 @@ implementing array access on entity, using left join to fill collection and so o
 Note: that [query hint](#orm-query-hint) will work on personal translations the same way.
 You can always use a left join like for standard doctrine collections.
 
-Usage example:
+Usage example (using both annotations and attributes, you should only use one of them):
 
 ``` php
 <?php
@@ -687,11 +777,14 @@ namespace Entity;
 use Doctrine\Common\Collections\ArrayCollection;
 use Gedmo\Mapping\Annotation as Gedmo;
 use Doctrine\ORM\Mapping as ORM;
+use Entity\CategoryTranslation;
 
 /**
  * @ORM\Entity
  * @Gedmo\TranslationEntity(class="Entity\CategoryTranslation")
  */
+ #[ORM\Entity]
+ #[Gedmo\TranslationEntity(class: CategoryTranslation::class)]
 class Category
 {
     /**
@@ -699,18 +792,25 @@ class Category
      * @ORM\Id
      * @ORM\GeneratedValue
      */
+    #[ORM\Column(type: 'integer')]
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
     private $id;
 
     /**
      * @Gedmo\Translatable
      * @ORM\Column(length=64)
      */
+    #[ORM\Column(length: 64)]
+    #[Gedmo\Translatable]
     private $title;
 
     /**
      * @Gedmo\Translatable
      * @ORM\Column(type="text", nullable=true)
      */
+    #[ORM\Column(type: 'text', nullable: true)]
+    #[Gedmo\Translatable]
     private $description;
 
     /**
@@ -720,6 +820,7 @@ class Category
      *   cascade={"persist", "remove"}
      * )
      */
+    #[ORM\OneToMany(targetEntity: CategoryTranslation::class, mappedBy: 'object', cascade: ['persist', 'remove'])]
     private $translations;
 
     public function __construct()
@@ -789,6 +890,9 @@ use Gedmo\Translatable\Entity\MappedSuperclass\AbstractPersonalTranslation;
  *     })}
  * )
  */
+#[ORM\Entity]
+#[ORM\Table(name: 'category_translations')]
+#[ORM\UniqueConstraint(name: 'lookup_unique_idx', columns: ['locale', 'object_id', 'field'])]
 class CategoryTranslation extends AbstractPersonalTranslation
 {
     /**
@@ -809,6 +913,8 @@ class CategoryTranslation extends AbstractPersonalTranslation
      * @ORM\ManyToOne(targetEntity="Category", inversedBy="translations")
      * @ORM\JoinColumn(name="object_id", referencedColumnName="id", onDelete="CASCADE")
      */
+    #[ORM\ManyToOne(targetEntity: Category::class, inversedBy: 'translations')]
+    #[ORM\JoinColumn(name: 'object_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
     protected $object;
 }
 ```

--- a/src/Mapping/Annotation/Annotation.php
+++ b/src/Mapping/Annotation/Annotation.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gedmo\Mapping\Annotation;
+
+/**
+ * @internal
+ */
+interface Annotation
+{
+}

--- a/src/Mapping/Annotation/Language.php
+++ b/src/Mapping/Annotation/Language.php
@@ -2,7 +2,9 @@
 
 namespace Gedmo\Mapping\Annotation;
 
+use Attribute;
 use Doctrine\Common\Annotations\Annotation;
+use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 
 /**
  * Language annotation for Translatable behavioral extension
@@ -13,6 +15,7 @@ use Doctrine\Common\Annotations\Annotation;
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
-final class Language extends Annotation
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class Language implements GedmoAnnotation
 {
 }

--- a/src/Mapping/Annotation/Locale.php
+++ b/src/Mapping/Annotation/Locale.php
@@ -2,7 +2,9 @@
 
 namespace Gedmo\Mapping\Annotation;
 
+use Attribute;
 use Doctrine\Common\Annotations\Annotation;
+use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 
 /**
  * Locale annotation for Translatable behavioral extension
@@ -13,6 +15,7 @@ use Doctrine\Common\Annotations\Annotation;
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
-final class Locale extends Annotation
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class Locale implements GedmoAnnotation
 {
 }

--- a/src/Mapping/Annotation/Translatable.php
+++ b/src/Mapping/Annotation/Translatable.php
@@ -2,19 +2,28 @@
 
 namespace Gedmo\Mapping\Annotation;
 
+use Attribute;
 use Doctrine\Common\Annotations\Annotation;
+use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 
 /**
  * Translatable annotation for Translatable behavioral extension
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("PROPERTY")
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
-final class Translatable extends Annotation
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class Translatable implements GedmoAnnotation
 {
-    /** @var bool */
+    /** @var bool|null */
     public $fallback;
+
+    public function __construct(?bool $fallback = null)
+    {
+        $this->fallback = $fallback;
+    }
 }

--- a/src/Mapping/Annotation/Translatable.php
+++ b/src/Mapping/Annotation/Translatable.php
@@ -22,8 +22,15 @@ final class Translatable implements GedmoAnnotation
     /** @var bool|null */
     public $fallback;
 
-    public function __construct(?bool $fallback = null)
+    public function __construct(array $data = [], ?bool $fallback = null)
     {
-        $this->fallback = $fallback;
+        if ([] !== $data) {
+            trigger_error(sprintf(
+                'Passing an array as first argument to "%s" is deprecated. Use named arguments instead.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
+        $this->fallback = $data['fallback'] ?? $fallback;
     }
 }

--- a/src/Mapping/Annotation/Translatable.php
+++ b/src/Mapping/Annotation/Translatable.php
@@ -26,7 +26,7 @@ final class Translatable implements GedmoAnnotation
     {
         if ([] !== $data) {
             trigger_error(sprintf(
-                'Passing an array as first argument to "%s" is deprecated. Use named arguments instead.',
+                'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
                 __METHOD__
             ), E_USER_DEPRECATED);
         }

--- a/src/Mapping/Annotation/TranslationEntity.php
+++ b/src/Mapping/Annotation/TranslationEntity.php
@@ -2,19 +2,28 @@
 
 namespace Gedmo\Mapping\Annotation;
 
+use Attribute;
 use Doctrine\Common\Annotations\Annotation;
+use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 
 /**
  * TranslationEntity annotation for Translatable behavioral extension
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("CLASS")
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
-final class TranslationEntity extends Annotation
+#[Attribute(Attribute::TARGET_CLASS)]
+final class TranslationEntity implements GedmoAnnotation
 {
     /** @var string @Required */
     public $class;
+
+    public function __construct(string $class)
+    {
+        $this->class = $class;
+    }
 }

--- a/src/Mapping/Annotation/TranslationEntity.php
+++ b/src/Mapping/Annotation/TranslationEntity.php
@@ -26,7 +26,7 @@ final class TranslationEntity implements GedmoAnnotation
     {
         if ([] !== $data) {
             trigger_error(sprintf(
-                'Passing an array as first argument to "%s" is deprecated. Use named arguments instead.',
+                'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
                 __METHOD__
             ), E_USER_DEPRECATED);
         }

--- a/src/Mapping/Annotation/TranslationEntity.php
+++ b/src/Mapping/Annotation/TranslationEntity.php
@@ -22,8 +22,15 @@ final class TranslationEntity implements GedmoAnnotation
     /** @var string @Required */
     public $class;
 
-    public function __construct(string $class)
+    public function __construct(array $data = [], string $class = '')
     {
-        $this->class = $class;
+        if ([] !== $data) {
+            trigger_error(sprintf(
+                'Passing an array as first argument to "%s" is deprecated. Use named arguments instead.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
+        $this->class = $data['class'] ?? $class;
     }
 }

--- a/src/Mapping/Driver/AttributeDriverInterface.php
+++ b/src/Mapping/Driver/AttributeDriverInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Gedmo\Mapping\Driver;
+
+/**
+ * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
+ *
+ * @internal
+ */
+interface AttributeDriverInterface extends AnnotationDriverInterface
+{
+}

--- a/src/Mapping/Driver/AttributeReader.php
+++ b/src/Mapping/Driver/AttributeReader.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Gedmo\Mapping\Driver;
+
+use Gedmo\Mapping\Annotation\Annotation;
+use ReflectionClass;
+
+/**
+ * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
+ *
+ * @internal
+ */
+final class AttributeReader
+{
+    /** @return array<Annotation> */
+    public function getClassAnnotations(ReflectionClass $class): array
+    {
+        return $this->convertToAttributeInstances($class->getAttributes());
+    }
+
+    public function getClassAnnotation(ReflectionClass $class, $annotationName): ?Annotation
+    {
+        return $this->getClassAnnotations($class)[$annotationName] ?? null;
+    }
+
+    /** @return array<Annotation> */
+    public function getPropertyAnnotations(\ReflectionProperty $property): array
+    {
+        return $this->convertToAttributeInstances($property->getAttributes());
+    }
+
+    public function getPropertyAnnotation(\ReflectionProperty $property, $annotationName): ?Annotation
+    {
+        return $this->getPropertyAnnotations($property)[$annotationName] ?? null;
+    }
+
+    /**
+     * @param array<\ReflectionAttribute> $attributes
+     *
+     * @return array<Annotation>
+     */
+    private function convertToAttributeInstances(array $attributes): array
+    {
+        $instances = [];
+
+        foreach ($attributes as $attribute) {
+            $attributeName = $attribute->getName();
+            assert(is_string($attributeName));
+            // Make sure we only get Gedmo Annotations
+            if (!is_subclass_of($attributeName, Annotation::class)) {
+                continue;
+            }
+
+            $instance = $attribute->newInstance();
+            assert($instance instanceof Annotation);
+
+            $instances[$attributeName] = $instance;
+        }
+
+        return $instances;
+    }
+}

--- a/src/Mapping/ExtensionMetadataFactory.php
+++ b/src/Mapping/ExtensionMetadataFactory.php
@@ -10,6 +10,8 @@ use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Doctrine\Persistence\Mapping\Driver\SymfonyFileLocator;
 use Doctrine\Persistence\ObjectManager;
 use Gedmo\Mapping\Driver\AnnotationDriverInterface;
+use Gedmo\Mapping\Driver\AttributeDriverInterface;
+use Gedmo\Mapping\Driver\AttributeReader;
 use Gedmo\Mapping\Driver\File as FileDriver;
 
 /**
@@ -186,7 +188,10 @@ class ExtensionMetadataFactory
                     $driver->setLocator(new DefaultFileLocator($omDriver->getPaths(), $omDriver->getFileExtension()));
                 }
             }
-            if ($driver instanceof AnnotationDriverInterface) {
+
+            if ($driver instanceof AttributeDriverInterface) {
+                $driver->setAnnotationReader(new AttributeReader());
+            } elseif ($driver instanceof AnnotationDriverInterface) {
                 $driver->setAnnotationReader($this->annotationReader);
             }
         }

--- a/src/Translatable/Mapping/Driver/Attribute.php
+++ b/src/Translatable/Mapping/Driver/Attribute.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Gedmo\Translatable\Mapping\Driver;
+
+use Gedmo\Mapping\Annotation\Translatable;
+use Gedmo\Mapping\Driver\AttributeDriverInterface;
+
+/**
+ * This is an attribute mapping driver for Translatable
+ * behavioral extension. Used for extraction of extended
+ * metadata from Annotations specifically for Translatable
+ * extension.
+ *
+ * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
+ *
+ * @internal
+ */
+final class Attribute extends Annotation implements AttributeDriverInterface
+{
+}

--- a/tests/Gedmo/Mapping/Annotation/BaseClassAnnotationTestCase.php
+++ b/tests/Gedmo/Mapping/Annotation/BaseClassAnnotationTestCase.php
@@ -1,29 +1,29 @@
 <?php
 
-namespace Tool;
+namespace Gedmo\Tests\Mapping\Annotation;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use Gedmo\Mapping\Annotation\Annotation;
 use PHPUnit\Framework\TestCase;
 
-abstract class BaseTestAnnotation extends TestCase
+abstract class BaseClassAnnotationTestCase extends TestCase
 {
     /**
      * @requires PHP 8
      * @dataProvider getValidParameters
      */
-    public function testLoadFromAttribute(string $annotationProperty, string $classProperty, $expectedReturn)
+    public function testLoadFromAttribute(string $annotationProperty, $expectedReturn): void
     {
-        $annotation = $this->getMethodAnnotation($classProperty, true);
+        $annotation = $this->getClassAnnotation(true);
         static::assertEquals($annotation->$annotationProperty, $expectedReturn);
     }
 
     /**
      * @dataProvider getValidParameters
      */
-    public function testLoadFromDoctrineAnnotation(string $annotationProperty, string $classProperty, $expectedReturn)
+    public function testLoadFromDoctrineAnnotation(string $annotationProperty, $expectedReturn): void
     {
-        $annotation = $this->getMethodAnnotation($classProperty, false);
+        $annotation = $this->getClassAnnotation(false);
         static::assertEquals($annotation->$annotationProperty, $expectedReturn);
     }
 
@@ -35,10 +35,10 @@ abstract class BaseTestAnnotation extends TestCase
 
     abstract protected function getAnnotationModelClass(): string;
 
-    private function getMethodAnnotation(string $property, bool $attributes): Annotation
+    private function getClassAnnotation(bool $attributes): Annotation
     {
         $class = $attributes ? $this->getAttributeModelClass() : $this->getAnnotationModelClass();
-        $reflection = new \ReflectionProperty($class, $property);
+        $reflection = new \ReflectionClass($class);
         $annotationClass = $this->getAnnotationClass();
 
         if ($attributes) {
@@ -46,11 +46,11 @@ abstract class BaseTestAnnotation extends TestCase
             $annotation = $attributes[0]->newInstance();
         } else {
             $reader = new AnnotationReader();
-            $annotation = $reader->getPropertyAnnotation($reflection, $annotationClass);
+            $annotation = $reader->getClassAnnotation($reflection, $annotationClass);
         }
 
         if (!$annotation instanceof $annotationClass) {
-            throw new \Exception('Can\'t parse annotation');
+            throw new \LogicException('Can\'t parse annotation.');
         }
 
         return $annotation;

--- a/tests/Gedmo/Mapping/Annotation/BasePropertyAnnotationTestCase.php
+++ b/tests/Gedmo/Mapping/Annotation/BasePropertyAnnotationTestCase.php
@@ -1,29 +1,29 @@
 <?php
 
-namespace Tool;
+namespace Gedmo\Tests\Mapping\Annotation;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use Gedmo\Mapping\Annotation\Annotation;
 use PHPUnit\Framework\TestCase;
 
-abstract class BaseTestClassAnnotation extends TestCase
+abstract class BasePropertyAnnotationTestCase extends TestCase
 {
     /**
      * @requires PHP 8
      * @dataProvider getValidParameters
      */
-    public function testLoadFromAttribute(string $annotationProperty, $expectedReturn)
+    public function testLoadFromAttribute(string $annotationProperty, string $classProperty, $expectedReturn): void
     {
-        $annotation = $this->getClassAnnotation(true);
+        $annotation = $this->getMethodAnnotation($classProperty, true);
         static::assertEquals($annotation->$annotationProperty, $expectedReturn);
     }
 
     /**
      * @dataProvider getValidParameters
      */
-    public function testLoadFromDoctrineAnnotation(string $annotationProperty, $expectedReturn)
+    public function testLoadFromDoctrineAnnotation(string $annotationProperty, string $classProperty, $expectedReturn): void
     {
-        $annotation = $this->getClassAnnotation(false);
+        $annotation = $this->getMethodAnnotation($classProperty, false);
         static::assertEquals($annotation->$annotationProperty, $expectedReturn);
     }
 
@@ -35,10 +35,10 @@ abstract class BaseTestClassAnnotation extends TestCase
 
     abstract protected function getAnnotationModelClass(): string;
 
-    private function getClassAnnotation(bool $attributes): Annotation
+    private function getMethodAnnotation(string $property, bool $attributes): Annotation
     {
         $class = $attributes ? $this->getAttributeModelClass() : $this->getAnnotationModelClass();
-        $reflection = new \ReflectionClass($class);
+        $reflection = new \ReflectionProperty($class, $property);
         $annotationClass = $this->getAnnotationClass();
 
         if ($attributes) {
@@ -46,11 +46,11 @@ abstract class BaseTestClassAnnotation extends TestCase
             $annotation = $attributes[0]->newInstance();
         } else {
             $reader = new AnnotationReader();
-            $annotation = $reader->getClassAnnotation($reflection, $annotationClass);
+            $annotation = $reader->getPropertyAnnotation($reflection, $annotationClass);
         }
 
         if (!$annotation instanceof $annotationClass) {
-            throw new \Exception('Can\'t parse annotation');
+            throw new \LogicException('Can\'t parse annotation.');
         }
 
         return $annotation;

--- a/tests/Gedmo/Mapping/Annotation/TranslatablePropertyTestCase.php
+++ b/tests/Gedmo/Mapping/Annotation/TranslatablePropertyTestCase.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Gedmo\Mapping\Annotation;
+namespace Gedmo\Tests\Mapping\Annotation;
 
-use Mapping\Fixture\Annotation\TranslatableModel as AnnotationTranslatableModel;
-use Mapping\Fixture\Attribute\TranslatableModel as AttributeTranslatableModel;
-use Tool\BaseTestAnnotation;
+use Gedmo\Mapping\Annotation\Translatable;
+use Gedmo\Tests\Mapping\Fixture\Annotation\TranslatableModel as AnnotationTranslatableModel;
+use Gedmo\Tests\Mapping\Fixture\Attribute\TranslatableModel as AttributeTranslatableModel;
 
-class TranslatableTest extends BaseTestAnnotation
+final class TranslatablePropertyTestCase extends BasePropertyAnnotationTestCase
 {
     public function getValidParameters(): iterable
     {

--- a/tests/Gedmo/Mapping/Annotation/TranslatableTest.php
+++ b/tests/Gedmo/Mapping/Annotation/TranslatableTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gedmo\Mapping\Annotation;
+
+use Mapping\Fixture\Annotation\TranslatableModel as AnnotationTranslatableModel;
+use Mapping\Fixture\Attribute\TranslatableModel as AttributeTranslatableModel;
+use Tool\BaseTestAnnotation;
+
+class TranslatableTest extends BaseTestAnnotation
+{
+    public function getValidParameters(): iterable
+    {
+        return [
+            ['fallback', 'title', null],
+            ['fallback', 'titleFallbackTrue', true],
+            ['fallback', 'titleFallbackFalse', false],
+        ];
+    }
+
+    protected function getAnnotationClass(): string
+    {
+        return Translatable::class;
+    }
+
+    protected function getAttributeModelClass(): string
+    {
+        return AttributeTranslatableModel::class;
+    }
+
+    protected function getAnnotationModelClass(): string
+    {
+        return AnnotationTranslatableModel::class;
+    }
+}

--- a/tests/Gedmo/Mapping/Annotation/TranslationEntityTest.php
+++ b/tests/Gedmo/Mapping/Annotation/TranslationEntityTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gedmo\Mapping\Annotation;
+
+use Mapping\Fixture\Annotation\TranslationEntityModel as AnnotationTranslationEntityModel;
+use Mapping\Fixture\Attribute\TranslationEntityModel as AttributeTranslationEntityModel;
+use Tool\BaseTestClassAnnotation;
+
+class TranslationEntityTest extends BaseTestClassAnnotation
+{
+    public function getValidParameters(): iterable
+    {
+        return [
+            ['class', \stdClass::class],
+        ];
+    }
+
+    protected function getAnnotationClass(): string
+    {
+        return TranslationEntity::class;
+    }
+
+    protected function getAttributeModelClass(): string
+    {
+        return AttributeTranslationEntityModel::class;
+    }
+
+    protected function getAnnotationModelClass(): string
+    {
+        return AnnotationTranslationEntityModel::class;
+    }
+}

--- a/tests/Gedmo/Mapping/Annotation/TranslationEntityTestCase.php
+++ b/tests/Gedmo/Mapping/Annotation/TranslationEntityTestCase.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Gedmo\Mapping\Annotation;
+namespace Gedmo\Tests\Mapping\Annotation;
 
-use Mapping\Fixture\Annotation\TranslationEntityModel as AnnotationTranslationEntityModel;
-use Mapping\Fixture\Attribute\TranslationEntityModel as AttributeTranslationEntityModel;
-use Tool\BaseTestClassAnnotation;
+use Gedmo\Mapping\Annotation\TranslationEntity;
+use Gedmo\Tests\Mapping\Fixture\Annotation\TranslationEntityModel as AnnotationTranslationEntityModel;
+use Gedmo\Tests\Mapping\Fixture\Attribute\TranslationEntityModel as AttributeTranslationEntityModel;
 
-class TranslationEntityTest extends BaseTestClassAnnotation
+final class TranslationEntityTestCase extends BaseClassAnnotationTestCase
 {
     public function getValidParameters(): iterable
     {

--- a/tests/Gedmo/Mapping/Fixture/Annotation/TranslatableModel.php
+++ b/tests/Gedmo/Mapping/Fixture/Annotation/TranslatableModel.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mapping\Fixture\Annotation;
+
+use Gedmo\Mapping\Annotation as Gedmo;
+
+class TranslatableModel
+{
+    /**
+     * @Gedmo\Translatable()
+     */
+    private $title;
+
+    /**
+     * @Gedmo\Translatable(fallback=true)
+     */
+    private $titleFallbackTrue;
+
+    /**
+     * @Gedmo\Translatable(fallback=false)
+     */
+    private $titleFallbackFalse;
+}

--- a/tests/Gedmo/Mapping/Fixture/Annotation/TranslatableModel.php
+++ b/tests/Gedmo/Mapping/Fixture/Annotation/TranslatableModel.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Mapping\Fixture\Annotation;
+namespace Gedmo\Tests\Mapping\Fixture\Annotation;
 
 use Gedmo\Mapping\Annotation as Gedmo;
 

--- a/tests/Gedmo/Mapping/Fixture/Annotation/TranslationEntityModel.php
+++ b/tests/Gedmo/Mapping/Fixture/Annotation/TranslationEntityModel.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mapping\Fixture\Annotation;
+
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * @Gedmo\TranslationEntity(class="stdClass")
+ */
+class TranslationEntityModel
+{
+}

--- a/tests/Gedmo/Mapping/Fixture/Annotation/TranslationEntityModel.php
+++ b/tests/Gedmo/Mapping/Fixture/Annotation/TranslationEntityModel.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Mapping\Fixture\Annotation;
+namespace Gedmo\Tests\Mapping\Fixture\Annotation;
 
 use Gedmo\Mapping\Annotation as Gedmo;
 

--- a/tests/Gedmo/Mapping/Fixture/Attribute/TranslatableModel.php
+++ b/tests/Gedmo/Mapping/Fixture/Attribute/TranslatableModel.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Mapping\Fixture\Attribute;
+namespace Gedmo\Tests\Mapping\Fixture\Attribute;
 
 use Gedmo\Mapping\Annotation as Gedmo;
 

--- a/tests/Gedmo/Mapping/Fixture/Attribute/TranslatableModel.php
+++ b/tests/Gedmo/Mapping/Fixture/Attribute/TranslatableModel.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mapping\Fixture\Attribute;
+
+use Gedmo\Mapping\Annotation as Gedmo;
+
+class TranslatableModel
+{
+    #[Gedmo\Translatable]
+    private $title;
+
+    #[Gedmo\Translatable(fallback: true)]
+    private $titleFallbackTrue;
+
+    #[Gedmo\Translatable(fallback: false)]
+    private $titleFallbackFalse;
+}

--- a/tests/Gedmo/Mapping/Fixture/Attribute/TranslationEntityModel.php
+++ b/tests/Gedmo/Mapping/Fixture/Attribute/TranslationEntityModel.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mapping\Fixture\Attribute;
+
+use Gedmo\Mapping\Annotation as Gedmo;
+
+#[Gedmo\TranslationEntity(class: \stdClass::class)]
+class TranslationEntityModel
+{
+}

--- a/tests/Gedmo/Mapping/Fixture/Attribute/TranslationEntityModel.php
+++ b/tests/Gedmo/Mapping/Fixture/Attribute/TranslationEntityModel.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Mapping\Fixture\Attribute;
+namespace Gedmo\Tests\Mapping\Fixture\Attribute;
 
 use Gedmo\Mapping\Annotation as Gedmo;
 

--- a/tests/Gedmo/Tool/BaseTestAnnotation.php
+++ b/tests/Gedmo/Tool/BaseTestAnnotation.php
@@ -15,7 +15,7 @@ abstract class BaseTestAnnotation extends TestCase
     public function testLoadFromAttribute(string $annotationProperty, string $classProperty, $expectedReturn)
     {
         $annotation = $this->getMethodAnnotation($classProperty, true);
-        $this->assertEquals($annotation->$annotationProperty, $expectedReturn);
+        static::assertEquals($annotation->$annotationProperty, $expectedReturn);
     }
 
     /**
@@ -24,7 +24,7 @@ abstract class BaseTestAnnotation extends TestCase
     public function testLoadFromDoctrineAnnotation(string $annotationProperty, string $classProperty, $expectedReturn)
     {
         $annotation = $this->getMethodAnnotation($classProperty, false);
-        $this->assertEquals($annotation->$annotationProperty, $expectedReturn);
+        static::assertEquals($annotation->$annotationProperty, $expectedReturn);
     }
 
     abstract public function getValidParameters(): iterable;

--- a/tests/Gedmo/Tool/BaseTestAnnotation.php
+++ b/tests/Gedmo/Tool/BaseTestAnnotation.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tool;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Gedmo\Mapping\Annotation\Annotation;
+use PHPUnit\Framework\TestCase;
+
+abstract class BaseTestAnnotation extends TestCase
+{
+    /**
+     * @requires PHP 8
+     * @dataProvider getValidParameters
+     */
+    public function testLoadFromAttribute(string $annotationProperty, string $classProperty, $expectedReturn)
+    {
+        $annotation = $this->getMethodAnnotation($classProperty, true);
+        $this->assertEquals($annotation->$annotationProperty, $expectedReturn);
+    }
+
+    /**
+     * @dataProvider getValidParameters
+     */
+    public function testLoadFromDoctrineAnnotation(string $annotationProperty, string $classProperty, $expectedReturn)
+    {
+        $annotation = $this->getMethodAnnotation($classProperty, false);
+        $this->assertEquals($annotation->$annotationProperty, $expectedReturn);
+    }
+
+    abstract public function getValidParameters(): iterable;
+
+    abstract protected function getAnnotationClass(): string;
+
+    abstract protected function getAttributeModelClass(): string;
+
+    abstract protected function getAnnotationModelClass(): string;
+
+    private function getMethodAnnotation(string $property, bool $attributes): Annotation
+    {
+        $class = $attributes ? $this->getAttributeModelClass() : $this->getAnnotationModelClass();
+        $reflection = new \ReflectionProperty($class, $property);
+        $annotationClass = $this->getAnnotationClass();
+
+        if ($attributes) {
+            $attributes = $reflection->getAttributes($annotationClass);
+            $annotation = $attributes[0]->newInstance();
+        } else {
+            $reader = new AnnotationReader();
+            $annotation = $reader->getPropertyAnnotation($reflection, $annotationClass);
+        }
+
+        if (!$annotation instanceof $annotationClass) {
+            throw new \Exception('Can\'t parse annotation');
+        }
+
+        return $annotation;
+    }
+}

--- a/tests/Gedmo/Tool/BaseTestCaseORM.php
+++ b/tests/Gedmo/Tool/BaseTestCaseORM.php
@@ -9,7 +9,9 @@ use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Gedmo\Loggable\LoggableListener;
 use Gedmo\Sluggable\SluggableListener;
 use Gedmo\SoftDeleteable\SoftDeleteableListener;
@@ -76,6 +78,30 @@ abstract class BaseTestCaseORM extends \PHPUnit\Framework\TestCase
         $schemaTool->createSchema($schema);
 
         return $this->em = $em;
+    }
+
+    protected function getDefaultMockSqliteEntityManager(EventManager $evm = null): EntityManager
+    {
+        return $this->getMockSqliteEntityManager($evm, $this->getDefaultConfiguration());
+    }
+
+    private function getDefaultConfiguration(): Configuration
+    {
+        $config = new Configuration();
+        $config->setProxyDir(__DIR__.'/../../temp');
+        $config->setProxyNamespace('Proxy');
+        $config->setMetadataDriverImpl($this->getMetadataDefaultDriverImplementation());
+
+        return $config;
+    }
+
+    private function getMetadataDefaultDriverImplementation(): MappingDriver
+    {
+        if (PHP_VERSION_ID >= 80000) {
+            return new AttributeDriver([]);
+        }
+
+        return new AnnotationDriver($_ENV['annotation_reader']);
     }
 
     /**

--- a/tests/Gedmo/Tool/BaseTestClassAnnotation.php
+++ b/tests/Gedmo/Tool/BaseTestClassAnnotation.php
@@ -15,7 +15,7 @@ abstract class BaseTestClassAnnotation extends TestCase
     public function testLoadFromAttribute(string $annotationProperty, $expectedReturn)
     {
         $annotation = $this->getClassAnnotation(true);
-        $this->assertEquals($annotation->$annotationProperty, $expectedReturn);
+        static::assertEquals($annotation->$annotationProperty, $expectedReturn);
     }
 
     /**
@@ -24,7 +24,7 @@ abstract class BaseTestClassAnnotation extends TestCase
     public function testLoadFromDoctrineAnnotation(string $annotationProperty, $expectedReturn)
     {
         $annotation = $this->getClassAnnotation(false);
-        $this->assertEquals($annotation->$annotationProperty, $expectedReturn);
+        static::assertEquals($annotation->$annotationProperty, $expectedReturn);
     }
 
     abstract public function getValidParameters(): iterable;

--- a/tests/Gedmo/Tool/BaseTestClassAnnotation.php
+++ b/tests/Gedmo/Tool/BaseTestClassAnnotation.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tool;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Gedmo\Mapping\Annotation\Annotation;
+use PHPUnit\Framework\TestCase;
+
+abstract class BaseTestClassAnnotation extends TestCase
+{
+    /**
+     * @requires PHP 8
+     * @dataProvider getValidParameters
+     */
+    public function testLoadFromAttribute(string $annotationProperty, $expectedReturn)
+    {
+        $annotation = $this->getClassAnnotation(true);
+        $this->assertEquals($annotation->$annotationProperty, $expectedReturn);
+    }
+
+    /**
+     * @dataProvider getValidParameters
+     */
+    public function testLoadFromDoctrineAnnotation(string $annotationProperty, $expectedReturn)
+    {
+        $annotation = $this->getClassAnnotation(false);
+        $this->assertEquals($annotation->$annotationProperty, $expectedReturn);
+    }
+
+    abstract public function getValidParameters(): iterable;
+
+    abstract protected function getAnnotationClass(): string;
+
+    abstract protected function getAttributeModelClass(): string;
+
+    abstract protected function getAnnotationModelClass(): string;
+
+    private function getClassAnnotation(bool $attributes): Annotation
+    {
+        $class = $attributes ? $this->getAttributeModelClass() : $this->getAnnotationModelClass();
+        $reflection = new \ReflectionClass($class);
+        $annotationClass = $this->getAnnotationClass();
+
+        if ($attributes) {
+            $attributes = $reflection->getAttributes($annotationClass);
+            $annotation = $attributes[0]->newInstance();
+        } else {
+            $reader = new AnnotationReader();
+            $annotation = $reader->getClassAnnotation($reflection, $annotationClass);
+        }
+
+        if (!$annotation instanceof $annotationClass) {
+            throw new \Exception('Can\'t parse annotation');
+        }
+
+        return $annotation;
+    }
+}

--- a/tests/Gedmo/Translatable/AttributeEntityTranslationTableTest.php
+++ b/tests/Gedmo/Translatable/AttributeEntityTranslationTableTest.php
@@ -1,11 +1,13 @@
 <?php
 
-namespace Gedmo\Translatable;
+namespace Gedmo\Tests\Translatable;
 
 use Doctrine\Common\EventManager;
-use Tool\BaseTestCaseORM;
-use Translatable\Fixture\Attribute\Person;
-use Translatable\Fixture\Attribute\PersonTranslation;
+use Gedmo\Tests\Tool\BaseTestCaseORM;
+use Gedmo\Tests\Translatable\Fixture\Attribute\Person;
+use Gedmo\Tests\Translatable\Fixture\Attribute\PersonTranslation;
+use Gedmo\Translatable\Entity\Repository\TranslationRepository;
+use Gedmo\Translatable\TranslatableListener;
 
 /**
  * These are tests for translatable behavior
@@ -18,7 +20,7 @@ use Translatable\Fixture\Attribute\PersonTranslation;
  *
  * @requires PHP >= 8.0
  */
-class AttributeEntityTranslationTableTest extends BaseTestCaseORM
+final class AttributeEntityTranslationTableTest extends BaseTestCaseORM
 {
     public const PERSON = Person::class;
     public const TRANSLATION = PersonTranslation::class;
@@ -38,7 +40,7 @@ class AttributeEntityTranslationTableTest extends BaseTestCaseORM
         $this->getDefaultMockSqliteEntityManager($evm);
     }
 
-    public function testFixtureGeneratedTranslations()
+    public function testFixtureGeneratedTranslations(): void
     {
         $person = new Person();
         $person->setName('name in en');
@@ -48,10 +50,10 @@ class AttributeEntityTranslationTableTest extends BaseTestCaseORM
         $this->em->clear();
 
         $repo = $this->em->getRepository(self::TRANSLATION);
-        static::assertTrue($repo instanceof Entity\Repository\TranslationRepository);
+        static::assertTrue($repo instanceof TranslationRepository);
 
         $translations = $repo->findTranslations($person);
-        //As Translate locale and Default locale are the same, no records should be present in translations table
+        // As Translate locale and Default locale are the same, no records should be present in translations table
         static::assertCount(0, $translations);
 
         // test second translations
@@ -64,7 +66,7 @@ class AttributeEntityTranslationTableTest extends BaseTestCaseORM
         $this->em->clear();
 
         $translations = $repo->findTranslations($person);
-        //Only one translation should be present
+        // Only one translation should be present
         static::assertCount(1, $translations);
         static::assertArrayHasKey('de_de', $translations);
 

--- a/tests/Gedmo/Translatable/AttributeEntityTranslationTableTest.php
+++ b/tests/Gedmo/Translatable/AttributeEntityTranslationTableTest.php
@@ -48,11 +48,11 @@ class AttributeEntityTranslationTableTest extends BaseTestCaseORM
         $this->em->clear();
 
         $repo = $this->em->getRepository(self::TRANSLATION);
-        $this->assertTrue($repo instanceof Entity\Repository\TranslationRepository);
+        static::assertTrue($repo instanceof Entity\Repository\TranslationRepository);
 
         $translations = $repo->findTranslations($person);
         //As Translate locale and Default locale are the same, no records should be present in translations table
-        $this->assertCount(0, $translations);
+        static::assertCount(0, $translations);
 
         // test second translations
         $person = $this->em->find(self::PERSON, $person->getId());
@@ -65,11 +65,11 @@ class AttributeEntityTranslationTableTest extends BaseTestCaseORM
 
         $translations = $repo->findTranslations($person);
         //Only one translation should be present
-        $this->assertCount(1, $translations);
-        $this->assertArrayHasKey('de_de', $translations);
+        static::assertCount(1, $translations);
+        static::assertArrayHasKey('de_de', $translations);
 
-        $this->assertArrayHasKey('name', $translations['de_de']);
-        $this->assertEquals('name in de', $translations['de_de']['name']);
+        static::assertArrayHasKey('name', $translations['de_de']);
+        static::assertEquals('name in de', $translations['de_de']['name']);
 
         $this->translatableListener->setTranslatableLocale('en_us');
     }

--- a/tests/Gedmo/Translatable/Fixture/Article.php
+++ b/tests/Gedmo/Translatable/Fixture/Article.php
@@ -2,6 +2,7 @@
 
 namespace Gedmo\Tests\Translatable\Fixture;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 use Gedmo\Translatable\Translatable;
@@ -9,33 +10,49 @@ use Gedmo\Translatable\Translatable;
 /**
  * @ORM\Entity
  */
+#[ORM\Entity]
 class Article implements Translatable
 {
-    /** @ORM\Id @ORM\GeneratedValue @ORM\Column(type="integer") */
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     /**
      * @Gedmo\Translatable
      * @ORM\Column(name="title", type="string", length=128)
      */
+    #[Gedmo\Translatable]
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
     private $title;
 
     /**
      * @Gedmo\Translatable
      * @ORM\Column(name="content", type="text", nullable=true)
      */
+    #[Gedmo\Translatable]
+    #[ORM\Column(name: 'content', type: Types::TEXT, nullable: true)]
     private $content;
 
     /**
      * @Gedmo\Translatable(fallback=false)
      * @ORM\Column(name="views", type="integer", nullable=true)
      */
+    #[Gedmo\Translatable(fallback: false)]
+    #[ORM\Column(name: 'views', type: Types::INTEGER, nullable: true)]
     private $views;
 
     /**
      * @Gedmo\Translatable(fallback=true)
      * @ORM\Column(name="author", type="string", nullable=true)
      */
+    #[Gedmo\Translatable(fallback: true)]
+    #[ORM\Column(name: 'author', type: Types::STRING, nullable: true)]
     private $author;
 
     /**
@@ -43,11 +60,13 @@ class Article implements Translatable
      *
      * @Gedmo\Locale
      */
+    #[Gedmo\Locale]
     private $locale;
 
     /**
      * @ORM\OneToMany(targetEntity="Comment", mappedBy="article")
      */
+    #[ORM\OneToMany(targetEntity: Comment::class, mappedBy: 'article')]
     private $comments;
 
     public function getId()

--- a/tests/Gedmo/Translatable/Fixture/Attribute/Person.php
+++ b/tests/Gedmo/Translatable/Fixture/Attribute/Person.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Translatable\Fixture\Attribute;
+namespace Gedmo\Tests\Translatable\Fixture\Attribute;
 
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;

--- a/tests/Gedmo/Translatable/Fixture/Attribute/Person.php
+++ b/tests/Gedmo/Translatable/Fixture/Attribute/Person.php
@@ -1,33 +1,20 @@
 <?php
 
-namespace Gedmo\Tests\Translatable\Fixture;
+namespace Translatable\Fixture\Attribute;
 
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
-/**
- * @ORM\Entity
- * @Gedmo\TranslationEntity(class="PersonTranslation")
- */
 #[ORM\Entity]
 #[Gedmo\TranslationEntity(class: PersonTranslation::class)]
 class Person
 {
-    /**
-     * @ORM\Id
-     * @ORM\GeneratedValue
-     * @ORM\Column(type="integer")
-     */
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
-    /**
-     * @Gedmo\Translatable
-     * @ORM\Column(name="name", type="string", length=128)
-     */
     #[Gedmo\Translatable]
     #[ORM\Column(name: 'name', type: Types::STRING, length: 128)]
     private $name;

--- a/tests/Gedmo/Translatable/Fixture/Attribute/PersonTranslation.php
+++ b/tests/Gedmo/Translatable/Fixture/Attribute/PersonTranslation.php
@@ -1,23 +1,11 @@
 <?php
 
-namespace Gedmo\Tests\Translatable\Fixture;
+namespace Translatable\Fixture\Attribute;
 
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Translatable\Entity\MappedSuperclass\AbstractTranslation;
 use Gedmo\Translatable\Entity\Repository\TranslationRepository;
 
-/**
- * @ORM\Table(
- *         name="ext_translations",
- *         indexes={@ORM\Index(name="translations_lookup_idx", columns={
- *             "locale", "object_class", "foreign_key"
- *         })},
- *         uniqueConstraints={@ORM\UniqueConstraint(name="lookup_unique_idx", columns={
- *             "locale", "object_class", "foreign_key", "field"
- *         })}
- * )
- * @ORM\Entity(repositoryClass="Gedmo\Translatable\Entity\Repository\TranslationRepository")
- */
 #[ORM\Entity(repositoryClass: TranslationRepository::class)]
 #[ORM\Table(name: 'ext_translations')]
 #[ORM\Index(name: 'translations_lookup_idx', columns: ['locale', 'object_Class', 'foreign_key'])]

--- a/tests/Gedmo/Translatable/Fixture/Attribute/PersonTranslation.php
+++ b/tests/Gedmo/Translatable/Fixture/Attribute/PersonTranslation.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Translatable\Fixture\Attribute;
+namespace Gedmo\Tests\Translatable\Fixture\Attribute;
 
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Translatable\Entity\MappedSuperclass\AbstractTranslation;

--- a/tests/Gedmo/Translatable/Fixture/Comment.php
+++ b/tests/Gedmo/Translatable/Fixture/Comment.php
@@ -2,32 +2,46 @@
 
 namespace Gedmo\Tests\Translatable\Fixture;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
  */
+#[ORM\Entity]
 class Comment
 {
-    /** @ORM\Id @ORM\GeneratedValue @ORM\Column(type="integer") */
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     /**
      * @Gedmo\Translatable
      * @ORM\Column(name="subject", type="string", length=128)
      */
+    #[Gedmo\Translatable]
+    #[ORM\Column(name: 'subject', type: Types::STRING, length: 128)]
     private $subject;
 
     /**
      * @Gedmo\Translatable
      * @ORM\Column(name="message", type="text")
      */
+    #[Gedmo\Translatable]
+    #[ORM\Column(name: 'message', type: Types::TEXT)]
     private $message;
 
     /**
      * @ORM\ManyToOne(targetEntity="Article", inversedBy="comments")
      */
+    #[ORM\ManyToOne(targetEntity: Article::class, inversedBy: 'comments')]
     private $article;
 
     /**
@@ -35,6 +49,7 @@ class Comment
      *
      * @Gedmo\Language
      */
+    #[Gedmo\Language]
     private $locale;
 
     public function setArticle($article)

--- a/tests/Gedmo/Translatable/Fixture/Company.php
+++ b/tests/Gedmo/Translatable/Fixture/Company.php
@@ -2,6 +2,7 @@
 
 namespace Gedmo\Tests\Translatable\Fixture;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 use Gedmo\Translatable\Translatable;
@@ -9,21 +10,32 @@ use Gedmo\Translatable\Translatable;
 /**
  * @ORM\Entity
  */
+#[ORM\Entity]
 class Company implements Translatable
 {
-    /** @ORM\Id @ORM\GeneratedValue @ORM\Column(type="integer") */
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     /**
      * @ORM\Column(name="title", type="string", length=128)
      * @Gedmo\Translatable
      */
+    #[Gedmo\Translatable]
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
     private $title;
 
     /**
      * @var CompanyEmbedLink
      * @ORM\Embedded(class="Gedmo\Tests\Translatable\Fixture\CompanyEmbedLink")
      */
+    #[ORM\Embedded(class: CompanyEmbedLink::class)]
     private $link;
 
     /**
@@ -31,6 +43,7 @@ class Company implements Translatable
      *
      * @Gedmo\Locale
      */
+    #[Gedmo\Locale]
     private $locale;
 
     public function __construct()

--- a/tests/Gedmo/Translatable/Fixture/CompanyEmbedLink.php
+++ b/tests/Gedmo/Translatable/Fixture/CompanyEmbedLink.php
@@ -2,12 +2,14 @@
 
 namespace Gedmo\Tests\Translatable\Fixture;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Embeddable
  */
+#[ORM\Embeddable]
 class CompanyEmbedLink
 {
     /**
@@ -16,6 +18,8 @@ class CompanyEmbedLink
      * @ORM\Column(name="website", type="string", length=191, nullable=true)
      * @Gedmo\Translatable
      */
+    #[Gedmo\Translatable]
+    #[ORM\Column(name: 'website', type: Types::STRING, length: 191, nullable: true)]
     protected $website;
 
     /**
@@ -24,6 +28,8 @@ class CompanyEmbedLink
      * @ORM\Column(name="facebook", type="string", length=191, nullable=true)
      * @Gedmo\Translatable
      */
+    #[Gedmo\Translatable]
+    #[ORM\Column(name: 'facebook', type: Types::STRING, length: 191, nullable: true)]
     protected $facebook;
 
     /**

--- a/tests/Gedmo/Translatable/Fixture/File.php
+++ b/tests/Gedmo/Translatable/Fixture/File.php
@@ -2,6 +2,7 @@
 
 namespace Gedmo\Tests\Translatable\Fixture;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
@@ -11,6 +12,10 @@ use Gedmo\Mapping\Annotation as Gedmo;
  * @ORM\DiscriminatorColumn(name="discriminator", type="string")
  * @ORM\DiscriminatorMap({"file" = "File", "image" = "Image"})
  */
+#[ORM\Entity]
+#[ORM\InheritanceType('JOINED')]
+#[ORM\DiscriminatorColumn(name: 'discriminator', type: Types::STRING)]
+#[ORM\DiscriminatorMap(['file' => File::class, 'image' => Image::class])]
 class File
 {
     /**
@@ -18,17 +23,23 @@ class File
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
      */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     /**
      * @Gedmo\Translatable
      * @ORM\Column(length=128)
      */
+    #[Gedmo\Translatable]
+    #[ORM\Column(length: 128)]
     private $name;
 
     /**
      * @ORM\Column(type="integer")
      */
+    #[ORM\Column(type: Types::INTEGER)]
     private $size;
 
     public function setName($name)

--- a/tests/Gedmo/Translatable/Fixture/Image.php
+++ b/tests/Gedmo/Translatable/Fixture/Image.php
@@ -8,12 +8,15 @@ use Gedmo\Mapping\Annotation as Gedmo;
 /**
  * @ORM\Entity
  */
+#[ORM\Entity]
 class Image extends File
 {
     /**
      * @Gedmo\Translatable
      * @ORM\Column(length=128)
      */
+    #[Gedmo\Translatable]
+    #[ORM\Column(length: 128)]
     private $mime;
 
     public function setMime($mime)

--- a/tests/Gedmo/Translatable/Fixture/Issue1123/BaseEntity.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue1123/BaseEntity.php
@@ -2,6 +2,7 @@
 
 namespace Gedmo\Tests\Translatable\Fixture\Issue1123;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -15,6 +16,11 @@ use Doctrine\ORM\Mapping as ORM;
  * "child" = "ChildEntity"
  * })
  */
+#[ORM\Entity]
+#[ORM\Table(name: 'base_entity')]
+#[ORM\InheritanceType('JOINED')]
+#[ORM\DiscriminatorColumn(name: 'discr', type: Types::STRING)]
+#[ORM\DiscriminatorMap(['base' => BaseEntity::class, 'child' => ChildEntity::class])]
 abstract class BaseEntity
 {
     /**
@@ -22,5 +28,8 @@ abstract class BaseEntity
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
      */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
     protected $id;
 }

--- a/tests/Gedmo/Translatable/Fixture/Issue1123/ChildEntity.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue1123/ChildEntity.php
@@ -2,6 +2,7 @@
 
 namespace Gedmo\Tests\Translatable\Fixture\Issue1123;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 use Gedmo\Translatable\Translatable;
@@ -10,12 +11,16 @@ use Gedmo\Translatable\Translatable;
  * @ORM\Entity
  * @ORM\Table("child_entity")
  */
+#[ORM\Entity]
+#[ORM\Table(name: 'child_entity')]
 class ChildEntity extends BaseEntity implements Translatable
 {
     /**
      * @Gedmo\Translatable
      * @ORM\Column(name="childTitle", type="string", length=128, nullable=true)
      */
+    #[ORM\Column(name: 'childTitle', type: Types::STRING, length: 128, nullable: true)]
+    #[Gedmo\Translatable]
     private $childTitle;
 
     /**
@@ -23,6 +28,7 @@ class ChildEntity extends BaseEntity implements Translatable
      * Used locale to override Translation listener`s locale
      * this is not a mapped field of entity metadata, just a simple property
      */
+    #[Gedmo\Locale]
     private $locale = 'en';
 
     public function getChildTitle()

--- a/tests/Gedmo/Translatable/Fixture/Issue114/Article.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue114/Article.php
@@ -2,12 +2,14 @@
 
 namespace Gedmo\Tests\Translatable\Fixture\Issue114;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
  */
+#[ORM\Entity]
 class Article
 {
     /**
@@ -15,17 +17,23 @@ class Article
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
      */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     /**
      * @Gedmo\Translatable
      * @ORM\Column(name="title", type="string", length=128)
      */
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
+    #[Gedmo\Translatable]
     private $title;
 
     /**
      * @ORM\ManyToOne(targetEntity="Category", inversedBy="articles")
      */
+    #[ORM\ManyToOne(targetEntity: Category::class, inversedBy: 'articles')]
     private $category;
 
     public function getId()

--- a/tests/Gedmo/Translatable/Fixture/Issue114/Category.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue114/Category.php
@@ -2,12 +2,14 @@
 
 namespace Gedmo\Tests\Translatable\Fixture\Issue114;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
  */
+#[ORM\Entity]
 class Category
 {
     /**
@@ -15,17 +17,23 @@ class Category
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
      */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     /**
      * @Gedmo\Translatable
      * @ORM\Column(name="title", type="string", length=128)
      */
+    #[Gedmo\Translatable]
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
     private $title;
 
     /**
      * @ORM\OneToMany(targetEntity="Article", mappedBy="category", cascade={"persist", "remove"})
      */
+    #[ORM\OneToMany(targetEntity: Article::class, mappedBy: 'category', cascade: ['persist', 'remove'])]
     private $articles;
 
     public function getId()

--- a/tests/Gedmo/Translatable/Fixture/Issue138/Article.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue138/Article.php
@@ -2,12 +2,14 @@
 
 namespace Gedmo\Tests\Translatable\Fixture\Issue138;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
  */
+#[ORM\Entity]
 class Article
 {
     /**
@@ -15,18 +17,25 @@ class Article
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
      */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     /**
      * @Gedmo\Translatable
      * @ORM\Column(length=128)
      */
+    #[Gedmo\Translatable]
+    #[ORM\Column(length: 128)]
     private $title;
 
     /**
      * @Gedmo\Translatable
      * @ORM\Column(length=128)
      */
+    #[Gedmo\Translatable]
+    #[ORM\Column(length: 128)]
     private $titleTest;
 
     public function getId()

--- a/tests/Gedmo/Translatable/Fixture/Issue173/Article.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue173/Article.php
@@ -2,12 +2,14 @@
 
 namespace Gedmo\Tests\Translatable\Fixture\Issue173;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
  */
+#[ORM\Entity]
 class Article
 {
     /**
@@ -15,17 +17,23 @@ class Article
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
      */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     /**
      * @Gedmo\Translatable
      * @ORM\Column(name="title", type="string", length=128)
      */
+    #[Gedmo\Translatable]
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
     private $title;
 
     /**
      * @ORM\ManyToOne(targetEntity="Category", inversedBy="articles")
      */
+    #[ORM\ManyToOne(targetEntity: Category::class, inversedBy: 'articles')]
     private $category;
 
     public function getId()

--- a/tests/Gedmo/Translatable/Fixture/Issue173/Category.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue173/Category.php
@@ -2,12 +2,14 @@
 
 namespace Gedmo\Tests\Translatable\Fixture\Issue173;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
  */
+#[ORM\Entity]
 class Category
 {
     /**
@@ -15,22 +17,29 @@ class Category
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
      */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     /**
      * @Gedmo\Translatable
      * @ORM\Column(name="title", type="string", length=128)
      */
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
+    #[Gedmo\Translatable]
     private $title;
 
     /**
      * @ORM\OneToMany(targetEntity="Article", mappedBy="category", cascade={"persist", "remove"})
      */
+    #[ORM\OneToMany(targetEntity: Article::class, mappedBy: 'category', cascade: ['persist', 'remove'])]
     private $articles;
 
     /**
      * @ORM\OneToMany(targetEntity="Product", mappedBy="category", cascade={"persist", "remove"})
      */
+    #[ORM\OneToMany(targetEntity: Product::class, mappedBy: 'category', cascade: ['persist', 'remove'])]
     private $products;
 
     public function getId()

--- a/tests/Gedmo/Translatable/Fixture/Issue173/Product.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue173/Product.php
@@ -2,12 +2,14 @@
 
 namespace Gedmo\Tests\Translatable\Fixture\Issue173;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
  */
+#[ORM\Entity]
 class Product
 {
     /**
@@ -15,17 +17,23 @@ class Product
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
      */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     /**
      * @Gedmo\Translatable
      * @ORM\Column(name="title", type="string", length=128)
      */
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
+    #[Gedmo\Translatable]
     private $title;
 
     /**
      * @ORM\ManyToOne(targetEntity="Category", inversedBy="products")
      */
+    #[ORM\ManyToOne(targetEntity: Category::class, inversedBy: 'products')]
     private $category;
 
     public function getId()

--- a/tests/Gedmo/Translatable/Fixture/Issue2152/EntityWithTranslatableBoolean.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue2152/EntityWithTranslatableBoolean.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Gedmo\Tests\Translatable\Fixture\Issue2152;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
@@ -11,6 +12,8 @@ use Gedmo\Mapping\Annotation as Gedmo;
  * @ORM\Entity
  * @ORM\Table("entity")
  */
+#[ORM\Entity]
+#[ORM\Table(name: 'entity')]
 class EntityWithTranslatableBoolean
 {
     /**
@@ -20,6 +23,9 @@ class EntityWithTranslatableBoolean
      *
      * @var int
      */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     /**
@@ -28,6 +34,8 @@ class EntityWithTranslatableBoolean
      *
      * @var string|null
      */
+    #[ORM\Column(type: Types::STRING, nullable: true)]
+    #[Gedmo\Translatable]
     private $title;
 
     /**
@@ -36,6 +44,8 @@ class EntityWithTranslatableBoolean
      *
      * @var string|null
      */
+    #[ORM\Column(type: Types::STRING, nullable: true)]
+    #[Gedmo\Translatable]
     private $isOperating;
 
     /**
@@ -43,6 +53,7 @@ class EntityWithTranslatableBoolean
      *
      * @Gedmo\Locale()
      */
+    #[Gedmo\Locale]
     private $locale;
 
     public function __construct(string $title, string $isOperating = '0')

--- a/tests/Gedmo/Translatable/Fixture/Issue75/Article.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue75/Article.php
@@ -2,12 +2,14 @@
 
 namespace Gedmo\Tests\Translatable\Fixture\Issue75;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
  */
+#[ORM\Entity]
 class Article
 {
     /**
@@ -15,12 +17,17 @@ class Article
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
      */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     /**
      * @Gedmo\Translatable
      * @ORM\Column(name="title", type="string", length=128)
      */
+    #[Gedmo\Translatable]
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
     private $title;
 
     /**
@@ -30,11 +37,16 @@ class Article
      *      inverseJoinColumns={@ORM\JoinColumn(name="article_id", referencedColumnName="id")}
      * )
      */
+    #[ORM\ManyToMany(targetEntity: Image::class, inversedBy: 'articles')]
+    #[ORM\JoinTable(name: 'article_images')]
+    #[ORM\JoinColumn(name: 'image_id', referencedColumnName: 'id')]
+    #[ORM\InverseJoinColumn(name: 'article_id', referencedColumnName: 'id')]
     private $images;
 
     /**
      * @ORM\ManyToMany(targetEntity="File")
      */
+    #[ORM\ManyToMany(targetEntity: File::class)]
     private $files;
 
     public function __construct()

--- a/tests/Gedmo/Translatable/Fixture/Issue75/File.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue75/File.php
@@ -2,12 +2,14 @@
 
 namespace Gedmo\Tests\Translatable\Fixture\Issue75;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
  */
+#[ORM\Entity]
 class File
 {
     /**
@@ -15,12 +17,17 @@ class File
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
      */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     /**
      * @Gedmo\Translatable
      * @ORM\Column(name="title", type="string", length=128)
      */
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
+    #[Gedmo\Translatable]
     private $title;
 
     public function getId()

--- a/tests/Gedmo/Translatable/Fixture/Issue75/Image.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue75/Image.php
@@ -2,12 +2,14 @@
 
 namespace Gedmo\Tests\Translatable\Fixture\Issue75;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
  */
+#[ORM\Entity]
 class Image
 {
     /**
@@ -15,17 +17,23 @@ class Image
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
      */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     /**
      * @Gedmo\Translatable
      * @ORM\Column(name="title", type="string", length=128)
      */
+    #[Gedmo\Translatable]
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
     private $title;
 
     /**
      * @ORM\ManyToMany(targetEntity="Article", mappedBy="images")
      */
+    #[ORM\ManyToMany(targetEntity: Article::class, mappedBy: 'images')]
     private $articles;
 
     public function getId()

--- a/tests/Gedmo/Translatable/Fixture/Issue922/Post.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue922/Post.php
@@ -2,12 +2,14 @@
 
 namespace Gedmo\Tests\Translatable\Fixture\Issue922;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
  */
+#[ORM\Entity]
 class Post
 {
     /**
@@ -15,30 +17,41 @@ class Post
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
      */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     /**
      * @Gedmo\Translatable
      * @ORM\Column(type="datetime", nullable=true)
      */
+    #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
+    #[Gedmo\Translatable]
     private $publishedAt;
 
     /**
      * @Gedmo\Translatable
      * @ORM\Column(type="time")
      */
+    #[ORM\Column(type: Types::TIME_MUTABLE)]
+    #[Gedmo\Translatable]
     private $timestampAt;
 
     /**
      * @Gedmo\Translatable
      * @ORM\Column(type="date")
      */
+    #[ORM\Column(type: Types::DATE_MUTABLE)]
+    #[Gedmo\Translatable]
     private $dateAt;
 
     /**
      * @Gedmo\Translatable
      * @ORM\Column(type="boolean")
      */
+    #[ORM\Column(type: Types::BOOLEAN)]
+    #[Gedmo\Translatable]
     private $boolean;
 
     public function getId()

--- a/tests/Gedmo/Translatable/Fixture/MixedValue.php
+++ b/tests/Gedmo/Translatable/Fixture/MixedValue.php
@@ -2,12 +2,14 @@
 
 namespace Gedmo\Tests\Translatable\Fixture;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
  */
+#[ORM\Entity]
 class MixedValue
 {
     /**
@@ -15,18 +17,25 @@ class MixedValue
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
      */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     /**
      * @Gedmo\Translatable
      * @ORM\Column(type="datetime")
      */
+    #[Gedmo\Translatable]
+    #[ORM\Column(type: Types::DATETIME_MUTABLE)]
     private $date;
 
     /**
      * @Gedmo\Translatable
      * @ORM\Column(type="custom")
      */
+    #[Gedmo\Translatable]
+    #[ORM\Column(type: 'custom')]
     private $cust;
 
     public function getId()

--- a/tests/Gedmo/Translatable/Fixture/Personal/Article.php
+++ b/tests/Gedmo/Translatable/Fixture/Personal/Article.php
@@ -2,6 +2,7 @@
 
 namespace Gedmo\Tests\Translatable\Fixture\Personal;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
@@ -9,6 +10,8 @@ use Gedmo\Mapping\Annotation as Gedmo;
  * @Gedmo\TranslationEntity(class="Gedmo\Tests\Translatable\Fixture\Personal\PersonalArticleTranslation")
  * @ORM\Entity
  */
+#[ORM\Entity]
+#[Gedmo\TranslationEntity(class: PersonalArticleTranslation::class)]
 class Article
 {
     /**
@@ -16,17 +19,23 @@ class Article
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
      */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     /**
      * @Gedmo\Translatable
      * @ORM\Column(length=128)
      */
+    #[ORM\Column(length: 128)]
+    #[Gedmo\Translatable]
     private $title;
 
     /**
      * @ORM\OneToMany(targetEntity="PersonalArticleTranslation", mappedBy="object")
      */
+    #[ORM\OneToMany(targetEntity: PersonalArticleTranslation::class, mappedBy: 'object')]
     private $translations;
 
     public function getTranslations()

--- a/tests/Gedmo/Translatable/Fixture/Personal/PersonalArticleTranslation.php
+++ b/tests/Gedmo/Translatable/Fixture/Personal/PersonalArticleTranslation.php
@@ -9,11 +9,15 @@ use Gedmo\Translatable\Entity\MappedSuperclass\AbstractPersonalTranslation;
  * @ORM\Table(name="article_translations")
  * @ORM\Entity
  */
+#[ORM\Table(name: 'article_translations')]
+#[ORM\Entity]
 class PersonalArticleTranslation extends AbstractPersonalTranslation
 {
     /**
      * @ORM\ManyToOne(targetEntity="Article", inversedBy="translations")
      * @ORM\JoinColumn(name="object_id", referencedColumnName="id", onDelete="CASCADE")
      */
+    #[ORM\ManyToOne(targetEntity: 'Article', inversedBy: 'translations')]
+    #[ORM\JoinColumn(name: 'object_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
     protected $object;
 }

--- a/tests/Gedmo/Translatable/Fixture/Sport.php
+++ b/tests/Gedmo/Translatable/Fixture/Sport.php
@@ -2,12 +2,14 @@
 
 namespace Gedmo\Tests\Translatable\Fixture;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
  */
+#[ORM\Entity]
 class Sport
 {
     /**
@@ -15,17 +17,23 @@ class Sport
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
      */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     /**
      * @Gedmo\Translatable
      * @ORM\Column(length=128)
      */
+    #[Gedmo\Translatable]
+    #[ORM\Column(length: 128)]
     private $title;
 
     /**
      * @ORM\Column(type="text", nullable=true)
      */
+    #[ORM\Column(type: Types::TEXT, nullable: true)]
     private $description;
 
     public function getId()

--- a/tests/Gedmo/Translatable/Fixture/StringIdentifier.php
+++ b/tests/Gedmo/Translatable/Fixture/StringIdentifier.php
@@ -2,24 +2,30 @@
 
 namespace Gedmo\Tests\Translatable\Fixture;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
  */
+#[ORM\Entity]
 class StringIdentifier
 {
     /**
      * @ORM\Id
      * @ORM\Column(name="uid", type="string", length=32)
      */
+    #[ORM\Id]
+    #[ORM\Column(name: 'uid', type: Types::STRING, length: 32)]
     private $uid;
 
     /**
      * @Gedmo\Translatable
      * @ORM\Column(name="title", type="string", length=128)
      */
+    #[Gedmo\Translatable]
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
     private $title;
 
     /**
@@ -27,6 +33,7 @@ class StringIdentifier
      *
      * @Gedmo\Locale
      */
+    #[Gedmo\Locale]
     private $locale;
 
     public function getUid()

--- a/tests/Gedmo/Translatable/Fixture/Template/ArticleTemplate.php
+++ b/tests/Gedmo/Translatable/Fixture/Template/ArticleTemplate.php
@@ -2,24 +2,30 @@
 
 namespace Gedmo\Tests\Translatable\Fixture\Template;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\MappedSuperclass
  */
+#[ORM\MappedSuperclass]
 class ArticleTemplate
 {
     /**
      * @Gedmo\Translatable
      * @ORM\Column(name="title", type="string", length=128)
      */
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
+    #[Gedmo\Translatable]
     private $title;
 
     /**
      * @Gedmo\Translatable
      * @ORM\Column(name="content", type="text")
      */
+    #[ORM\Column(name: 'content', type: Types::TEXT)]
+    #[Gedmo\Translatable]
     private $content;
 
     /**
@@ -27,6 +33,7 @@ class ArticleTemplate
      *
      * @Gedmo\Locale
      */
+    #[Gedmo\Locale]
     protected $locale;
 
     public function setTitle($title)

--- a/tests/Gedmo/Translatable/Fixture/TemplatedArticle.php
+++ b/tests/Gedmo/Translatable/Fixture/TemplatedArticle.php
@@ -2,6 +2,7 @@
 
 namespace Gedmo\Tests\Translatable\Fixture;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 use Gedmo\Tests\Translatable\Fixture\Template\ArticleTemplate;
@@ -9,6 +10,7 @@ use Gedmo\Tests\Translatable\Fixture\Template\ArticleTemplate;
 /**
  * @ORM\Entity
  */
+#[ORM\Entity]
 class TemplatedArticle extends ArticleTemplate
 {
     /**
@@ -16,12 +18,17 @@ class TemplatedArticle extends ArticleTemplate
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
      */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     /**
      * @Gedmo\Translatable
      * @ORM\Column(type="string", length=128)
      */
+    #[Gedmo\Translatable]
+    #[ORM\Column(type: Types::STRING, length: 128)]
     private $name;
 
     public function setName($name)

--- a/tests/Gedmo/Translatable/InheritanceTest.php
+++ b/tests/Gedmo/Translatable/InheritanceTest.php
@@ -43,7 +43,7 @@ class InheritanceTest extends BaseTestCaseORM
         $this->translatableListener->setDefaultLocale('en');
         $evm->addEventSubscriber($this->translatableListener);
 
-        $this->getMockSqliteEntityManager($evm);
+        $this->getDefaultMockSqliteEntityManager($evm);
     }
 
     /**

--- a/tests/Gedmo/Translatable/Issue/Issue109Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue109Test.php
@@ -41,7 +41,7 @@ class Issue109Test extends BaseTestCaseORM
         $this->translatableListener->setDefaultLocale('en');
         $evm->addEventSubscriber($this->translatableListener);
 
-        $this->getMockSqliteEntityManager($evm);
+        $this->getDefaultMockSqliteEntityManager($evm);
         $this->populate();
     }
 

--- a/tests/Gedmo/Translatable/Issue/Issue1123Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue1123Test.php
@@ -27,7 +27,7 @@ class Issue1123Test extends BaseTestCaseORM
         $this->translatableListener->setTranslationFallback(true);
         $evm->addEventSubscriber($this->translatableListener);
 
-        $this->getMockSqliteEntityManager($evm);
+        $this->getDefaultMockSqliteEntityManager($evm);
     }
 
     /**

--- a/tests/Gedmo/Translatable/Issue/Issue114Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue114Test.php
@@ -36,7 +36,7 @@ class Issue114Test extends BaseTestCaseORM
         $this->translatableListener->setDefaultLocale('en');
         $evm->addEventSubscriber($this->translatableListener);
 
-        $this->getMockSqliteEntityManager($evm);
+        $this->getDefaultMockSqliteEntityManager($evm);
     }
 
     public function testIssue114()

--- a/tests/Gedmo/Translatable/Issue/Issue135Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue135Test.php
@@ -40,7 +40,7 @@ class Issue135Test extends BaseTestCaseORM
         $this->translatableListener->setDefaultLocale('en_us');
         $evm->addEventSubscriber($this->translatableListener);
 
-        $this->getMockSqliteEntityManager($evm);
+        $this->getDefaultMockSqliteEntityManager($evm);
         $this->populate();
     }
 

--- a/tests/Gedmo/Translatable/Issue/Issue138Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue138Test.php
@@ -38,7 +38,7 @@ class Issue138Test extends BaseTestCaseORM
         $this->translatableListener->setTranslationFallback(true);
         $evm->addEventSubscriber($this->translatableListener);
 
-        $this->getMockSqliteEntityManager($evm);
+        $this->getDefaultMockSqliteEntityManager($evm);
     }
 
     public function testIssue138()

--- a/tests/Gedmo/Translatable/Issue/Issue173Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue173Test.php
@@ -41,7 +41,7 @@ class Issue173Test extends BaseTestCaseORM
         $this->translatableListener->setDefaultLocale('en');
         $evm->addEventSubscriber($this->translatableListener);
 
-        $this->getMockSqliteEntityManager($evm);
+        $this->getDefaultMockSqliteEntityManager($evm);
 
         $this->populate();
     }

--- a/tests/Gedmo/Translatable/Issue/Issue2152Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue2152Test.php
@@ -32,7 +32,7 @@ class Issue2152Test extends BaseTestCaseORM
         $this->translatableListener->setTranslationFallback(true);
         $evm->addEventSubscriber($this->translatableListener);
 
-        $this->getMockSqliteEntityManager($evm);
+        $this->getDefaultMockSqliteEntityManager($evm);
     }
 
     /**

--- a/tests/Gedmo/Translatable/Issue/Issue84Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue84Test.php
@@ -34,7 +34,7 @@ class Issue84Test extends BaseTestCaseORM
         $this->translatableListener->setTranslatableLocale('en');
         $evm->addEventSubscriber($this->translatableListener);
 
-        $this->getMockSqliteEntityManager($evm);
+        $this->getDefaultMockSqliteEntityManager($evm);
     }
 
     public function testIssue84()

--- a/tests/Gedmo/Translatable/Issue/Issue922Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue922Test.php
@@ -31,7 +31,7 @@ class Issue922Test extends BaseTestCaseORM
         $this->translatableListener->setPersistDefaultLocaleTranslation(true);
         $evm->addEventSubscriber($this->translatableListener);
 
-        $this->getMockSqliteEntityManager($evm);
+        $this->getDefaultMockSqliteEntityManager($evm);
     }
 
     /**

--- a/tests/Gedmo/Translatable/MixedValueTranslationTest.php
+++ b/tests/Gedmo/Translatable/MixedValueTranslationTest.php
@@ -40,7 +40,7 @@ class MixedValueTranslationTest extends BaseTestCaseORM
         $this->translatableListener->setDefaultLocale('en_us');
         $evm->addEventSubscriber($this->translatableListener);
 
-        $this->getMockSqliteEntityManager($evm);
+        $this->getDefaultMockSqliteEntityManager($evm);
         $this->populate();
     }
 

--- a/tests/Gedmo/Translatable/PersonalTranslationTest.php
+++ b/tests/Gedmo/Translatable/PersonalTranslationTest.php
@@ -45,7 +45,7 @@ class PersonalTranslationTest extends BaseTestCaseORM
             'password' => 'nimda',
         ];
         //$this->getMockCustomEntityManager($conn, $evm);
-        $this->getMockSqliteEntityManager($evm);
+        $this->getDefaultMockSqliteEntityManager($evm);
     }
 
     /**

--- a/tests/Gedmo/Translatable/TranslatableEntityCollectionTest.php
+++ b/tests/Gedmo/Translatable/TranslatableEntityCollectionTest.php
@@ -44,7 +44,7 @@ class TranslatableEntityCollectionTest extends BaseTestCaseORM
             'password' => 'nimda',
         ];
         //$this->getMockCustomEntityManager($conn, $evm);
-        $this->getMockSqliteEntityManager($evm);
+        $this->getDefaultMockSqliteEntityManager($evm);
     }
 
     /**

--- a/tests/Gedmo/Translatable/TranslatableEntityDefaultTranslationTest.php
+++ b/tests/Gedmo/Translatable/TranslatableEntityDefaultTranslationTest.php
@@ -44,7 +44,7 @@ class TranslatableEntityDefaultTranslationTest extends BaseTestCaseORM
             'password' => 'nimda',
         ];
         //$this->getMockCustomEntityManager($conn, $evm);
-        $this->getMockSqliteEntityManager($evm);
+        $this->getDefaultMockSqliteEntityManager($evm);
 
         $this->repo = $this->em->getRepository(self::TRANSLATION);
     }

--- a/tests/Gedmo/Translatable/TranslatableIdentifierTest.php
+++ b/tests/Gedmo/Translatable/TranslatableIdentifierTest.php
@@ -43,7 +43,7 @@ class TranslatableIdentifierTest extends BaseTestCaseORM
                     'password' => 'nimda',
         ];
         //$this->getMockCustomEntityManager($conn, $evm);
-        $this->getMockSqliteEntityManager($evm);
+        $this->getDefaultMockSqliteEntityManager($evm);
     }
 
     /**

--- a/tests/Gedmo/Translatable/TranslatableTest.php
+++ b/tests/Gedmo/Translatable/TranslatableTest.php
@@ -41,7 +41,7 @@ class TranslatableTest extends BaseTestCaseORM
         $this->translatableListener->setDefaultLocale('en_us');
         $evm->addEventSubscriber($this->translatableListener);
 
-        $this->getMockSqliteEntityManager($evm);
+        $this->getDefaultMockSqliteEntityManager($evm);
     }
 
     /**

--- a/tests/Gedmo/Translatable/TranslatableWithEmbeddedTest.php
+++ b/tests/Gedmo/Translatable/TranslatableWithEmbeddedTest.php
@@ -33,7 +33,7 @@ class TranslatableWithEmbeddedTest extends BaseTestCaseORM
         $this->translatableListener->setDefaultLocale('en_us');
         $evm->addEventSubscriber($this->translatableListener);
 
-        $this->getMockSqliteEntityManager($evm);
+        $this->getDefaultMockSqliteEntityManager($evm);
         $this->populate();
     }
 

--- a/tests/Gedmo/Translatable/TranslationQueryWalkerTest.php
+++ b/tests/Gedmo/Translatable/TranslationQueryWalkerTest.php
@@ -45,7 +45,7 @@ class TranslationQueryWalkerTest extends BaseTestCaseORM
         $this->translatableListener->setDefaultLocale('en_us');
         $evm->addEventSubscriber($this->translatableListener);
 
-        $this->getMockSqliteEntityManager($evm);
+        $this->getDefaultMockSqliteEntityManager($evm);
         $this->populate();
     }
 


### PR DESCRIPTION
I think it's easier if we do this by extension and once we have one ready we can do the same for the others.

 So what this PR does:

**Annotations**:

Annotations no longer extend from `Annotation` from Doctrine, it uses [`NamedArgumentConstructor` annotation](https://www.doctrine-project.org/projects/doctrine-annotations/en/1.13/custom.html#optional-constructors-with-named-parameters) to be compatible with PHP 8.

There is a new `Annotation` interface that is used as a marker to parse the attributes from this package.

**Attribute Driver**

There is a `AttributeReader` class which is [from Doctrine ORM](https://github.com/doctrine/orm/blob/c0f70204d1680d8d804cfcbf91df23668807cd74/lib/Doctrine/ORM/Mapping/Driver/AttributeReader.php), but removing the parts not used here. 

All these new classes are marked as internal since we would probably change them as we add attributes to more extensions.

**Tests**

In order to test attributes, when using PHP 8, it reads attributes instead of annotations.