### PR TITLE
Declare conflict against "doctrine/orm" >= 2.10 in order to guarantee the schema extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ a release.
 ### Fixed
 - Removed legacy checks targeting older versions of PHP (#2201)
 - Added missing XSD definitions (#2244)
+- Add conflict against "doctrine/orm" >=2.10 in order to guarantee the schema extension (see https://github.com/doctrine/orm/pull/8852) (#2255)
 
 ## [3.1.0] - 2021-06-22
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,7 @@
     "conflict": {
         "doctrine/mongodb": "<1.3",
         "doctrine/mongodb-odm": "<2.0",
+        "doctrine/orm": ">=2.10",
         "sebastian/comparator": "<2.0"
     },
     "suggest": {


### PR DESCRIPTION
"doctrine/orm" 2.10.0 removes the possibility to extend the mapping schema, so we must provide our own validation schema in order to support this version.
See doctrine/orm#8852.