### PR TITLE
Add annotation for createLifecycleEventArgsInstance method

### DIFF
--- a/src/Mapping/Event/AdapterInterface.php
+++ b/src/Mapping/Event/AdapterInterface.php
@@ -4,6 +4,8 @@ namespace Gedmo\Mapping\Event;
 
 use Doctrine\Common\EventArgs;
 use Doctrine\ORM\UnitOfWork;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
+use Doctrine\Persistence\ObjectManager;
 
 /**
  * Doctrine event adapter interface is used
@@ -12,6 +14,8 @@ use Doctrine\ORM\UnitOfWork;
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
+ *
+ * @method LifecycleEventArgs createLifecycleEventArgsInstance(object $object, ObjectManager $manager)
  */
 interface AdapterInterface
 {


### PR DESCRIPTION
The `SoftDeleteableListener` makes calls to `Gedmo\Mapping\Event\AdapterInterface::createLifecycleEventArgsInstance()`, but the method doesn't actually exist on the interface (the two concrete implementations in this package do provide it though).  This PR annotates the method as being soft-required, and at 4.0, the method should be required on the interface.