### PR TITLE
Deprecate the annotation reader being allowed to be any object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ a release.
 - In order to close the API, `@final` and `@internal` annotations were added to all non base classes, which means that extending
   these classes is deprecated and can not be inherited in version 4.0.
 - Sortable: Accepting a return type other than "integer" from `Comparable::compareTo()` is deprecated in `SortableListener::postFlush()`. This will not be accepted in version 4.0.
+- Deprecate the annotation reader being allowed to be any object.
+  In 4.0, a `Doctrine\Common\Annotations\Reader` or `Gedmo\Mapping\Driver\AttributeReader` instance will be required.
 
 ## [3.10.0] - 2022-11-14
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,8 @@
         "doctrine/event-manager": "^1.2",
         "doctrine/persistence": "^2.2 || ^3.0",
         "psr/cache": "^1 || ^2 || ^3",
-        "symfony/cache": "^4.4 || ^5.3 || ^6.0"
+        "symfony/cache": "^4.4 || ^5.3 || ^6.0",
+        "symfony/deprecation-contracts": "^2.1 || ^3.0"
     },
     "require-dev": {
         "doctrine/cache": "^1.11 || ^2.0",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -441,11 +441,6 @@ parameters:
 			path: src/Sortable/Mapping/Driver/Yaml.php
 
 		-
-			message: "#^Else branch is unreachable because previous condition is always true\\.$#"
-			count: 1
-			path: src/Sortable/SortableListener.php
-
-		-
 			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:getFieldMapping\\(\\)\\.$#"
 			count: 1
 			path: src/Sortable/Mapping/Driver/Yaml.php
@@ -472,6 +467,11 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method Gedmo\\\\Sortable\\\\Mapping\\\\Event\\\\SortableAdapter\\:\\:updatePositions\\(\\)\\.$#"
+			count: 1
+			path: src/Sortable/SortableListener.php
+
+		-
+			message: "#^Else branch is unreachable because previous condition is always true\\.$#"
 			count: 1
 			path: src/Sortable/SortableListener.php
 

--- a/src/Mapping/Driver/AbstractAnnotationDriver.php
+++ b/src/Mapping/Driver/AbstractAnnotationDriver.php
@@ -9,6 +9,7 @@
 
 namespace Gedmo\Mapping\Driver;
 
+use Doctrine\Common\Annotations\Reader;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 
@@ -23,7 +24,9 @@ abstract class AbstractAnnotationDriver implements AnnotationDriverInterface
     /**
      * Annotation reader instance
      *
-     * @var object
+     * @var Reader|AttributeReader|object
+     *
+     * @todo Remove the support for the `object` type in the next major release.
      */
     protected $reader;
 
@@ -43,6 +46,20 @@ abstract class AbstractAnnotationDriver implements AnnotationDriverInterface
 
     public function setAnnotationReader($reader)
     {
+        if (!$reader instanceof Reader && !$reader instanceof AttributeReader) {
+            trigger_deprecation(
+                'gedmo/doctrine-extensions',
+                '3.11',
+                'Passing an object not implementing "%s" or "%s" as argument 1 to "%s()" is deprecated and'
+                .' will throw an "%s" error in version 4.0. Instance of "%s" given.',
+                Reader::class,
+                AttributeReader::class,
+                __METHOD__,
+                \TypeError::class,
+                get_class($reader)
+            );
+        }
+
         $this->reader = $reader;
     }
 

--- a/src/Mapping/Driver/AnnotationDriverInterface.php
+++ b/src/Mapping/Driver/AnnotationDriverInterface.php
@@ -9,6 +9,7 @@
 
 namespace Gedmo\Mapping\Driver;
 
+use Doctrine\Common\Annotations\Reader;
 use Gedmo\Mapping\Driver;
 
 /**
@@ -20,17 +21,21 @@ use Gedmo\Mapping\Driver;
 interface AnnotationDriverInterface extends Driver
 {
     /**
-     * Set annotation reader class
-     * since older doctrine versions do not provide an interface
-     * it must provide these methods:
+     * Set the annotation reader instance
+     *
+     * When originally implemented, `Doctrine\Common\Annotations\Reader` was not available,
+     * therefore this method may accept any object implementing these methods from the interface:
+     *
      *     getClassAnnotations([reflectionClass])
      *     getClassAnnotation([reflectionClass], [name])
      *     getPropertyAnnotations([reflectionProperty])
      *     getPropertyAnnotation([reflectionProperty], [name])
      *
-     * @param object $reader annotation reader class
+     * @param Reader|AttributeReader|object $reader
      *
      * @return void
+     *
+     * @note Providing any object is deprecated, as of 4.0 a `Doctrine\Common\Annotations\Reader` or `Gedmo\Mapping\Driver\AttributeReader` will be required
      */
     public function setAnnotationReader($reader);
 }

--- a/src/Mapping/ExtensionMetadataFactory.php
+++ b/src/Mapping/ExtensionMetadataFactory.php
@@ -10,6 +10,8 @@
 namespace Gedmo\Mapping;
 
 use Doctrine\Bundle\DoctrineBundle\Mapping\MappingDriver as DoctrineBundleMappingDriver;
+use Doctrine\Common\Annotations\Reader;
+use Doctrine\Common\Cache\Cache;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\Driver\DefaultFileLocator;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
@@ -58,6 +60,7 @@ class ExtensionMetadataFactory
      * Custom annotation reader
      *
      * @var object
+     * @phpstan-var Reader|AttributeReader
      */
     protected $annotationReader;
 
@@ -66,8 +69,22 @@ class ExtensionMetadataFactory
      */
     private $cacheItemPool;
 
+    /**
+     * @param Reader|AttributeReader|object $annotationReader
+     */
     public function __construct(ObjectManager $objectManager, string $extensionNamespace, object $annotationReader, ?CacheItemPoolInterface $cacheItemPool = null)
     {
+        if (!$annotationReader instanceof Reader && !$annotationReader instanceof AttributeReader) {
+            trigger_deprecation(
+                'gedmo/doctrine-extensions',
+                '3.11',
+                'Providing an annotation reader which does not implement %s or is not an instance of %s to %s is deprecated.',
+                Reader::class,
+                AttributeReader::class,
+                static::class
+            );
+        }
+
         $this->objectManager = $objectManager;
         $this->annotationReader = $annotationReader;
         $this->extensionNamespace = $extensionNamespace;

--- a/src/Mapping/MappedEventSubscriber.php
+++ b/src/Mapping/MappedEventSubscriber.php
@@ -24,6 +24,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\Mapping\AbstractClassMetadataFactory;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\ObjectManager;
+use Gedmo\Mapping\Driver\AttributeReader;
 use Gedmo\Mapping\Event\AdapterInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
@@ -76,7 +77,7 @@ abstract class MappedEventSubscriber implements EventSubscriber
     /**
      * Custom annotation reader
      *
-     * @var object
+     * @var Reader|AttributeReader|object|null
      */
     private $annotationReader;
 
@@ -162,20 +163,36 @@ abstract class MappedEventSubscriber implements EventSubscriber
     }
 
     /**
-     * Set annotation reader class
-     * since older doctrine versions do not provide an interface
-     * it must provide these methods:
+     * Set the annotation reader instance
+     *
+     * When originally implemented, `Doctrine\Common\Annotations\Reader` was not available,
+     * therefore this method may accept any object implementing these methods from the interface:
+     *
      *     getClassAnnotations([reflectionClass])
      *     getClassAnnotation([reflectionClass], [name])
      *     getPropertyAnnotations([reflectionProperty])
      *     getPropertyAnnotation([reflectionProperty], [name])
      *
-     * @param Reader $reader annotation reader class
+     * @param object $reader
+     * @phpstan-param Reader|AttributeReader $reader
      *
      * @return void
+     *
+     * @note Providing any object is deprecated, as of 4.0 a `Doctrine\Common\Annotations\Reader` or `Gedmo\Mapping\Driver\AttributeReader` will be required
      */
     public function setAnnotationReader($reader)
     {
+        if (!$reader instanceof Reader && !$reader instanceof AttributeReader) {
+            trigger_deprecation(
+                'gedmo/doctrine-extensions',
+                '3.11',
+                'Providing an annotation reader which does not implement %s or is not an instance of %s to %s() is deprecated.',
+                Reader::class,
+                AttributeReader::class,
+                __METHOD__
+            );
+        }
+
         $this->annotationReader = $reader;
     }
 


### PR DESCRIPTION
The annotation reader references in this package look to predate the `Doctrine\Common\Annotations\Reader` interface, and right now any place accepting a reader essentially allows any arbitrary object that mostly implements that interface (only the class and property readers are required, the method readers aren't).  This proposes tightening up the API by documenting that a `Doctrine\Common\Annotations\Reader` should be provided and deprecating support for any arbitrary object with 4.0 changing to require the interface.