### PR TITLE
Remove code referencing non-existing classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
         "doctrine/annotations": "^1.13",
         "doctrine/collections": "^1.0",
         "doctrine/common": "^2.13 || ^3.0",
-        "doctrine/event-manager": "^1.0"
+        "doctrine/event-manager": "^1.0",
+        "doctrine/persistence": "^1.3.4 || ^2.0"
     },
     "provide": {
         "ext-mongo": "1.6.12"

--- a/src/AbstractTrackingListener.php
+++ b/src/AbstractTrackingListener.php
@@ -3,9 +3,9 @@
 namespace Gedmo;
 
 use Doctrine\Common\EventArgs;
-use Doctrine\Common\NotifyPropertyChanged;
 use Doctrine\ORM\UnitOfWork;
 use Doctrine\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\NotifyPropertyChanged;
 use Gedmo\Exception\UnexpectedValueException;
 use Gedmo\Mapping\Event\AdapterInterface;
 use Gedmo\Mapping\MappedEventSubscriber;

--- a/src/Loggable/Document/Repository/LogEntryRepository.php
+++ b/src/Loggable/Document/Repository/LogEntryRepository.php
@@ -2,7 +2,6 @@
 
 namespace Gedmo\Loggable\Document\Repository;
 
-use Doctrine\MongoDB\Cursor;
 use Doctrine\ODM\MongoDB\Iterator\Iterator;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
 use Gedmo\Loggable\Document\LogEntry;
@@ -45,7 +44,7 @@ class LogEntryRepository extends DocumentRepository
         $q = $qb->getQuery();
 
         $result = $q->execute();
-        if ($result instanceof Cursor || $result instanceof Iterator) {
+        if ($result instanceof Iterator) {
             $result = $result->toArray();
         }
 
@@ -79,7 +78,7 @@ class LogEntryRepository extends DocumentRepository
         $q = $qb->getQuery();
 
         $logs = $q->execute();
-        if ($logs instanceof Cursor || $logs instanceof Iterator) {
+        if ($logs instanceof Iterator) {
             $logs = $logs->toArray();
         }
         if ($logs) {

--- a/src/References/Mapping/Event/Adapter/ORM.php
+++ b/src/References/Mapping/Event/Adapter/ORM.php
@@ -3,13 +3,13 @@
 namespace Gedmo\References\Mapping\Event\Adapter;
 
 use Doctrine\ODM\MongoDB\DocumentManager as MongoDocumentManager;
-use Doctrine\ODM\MongoDB\Proxy\Proxy as MongoDBProxy;
 use Doctrine\ODM\PHPCR\DocumentManager as PhpcrDocumentManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Proxy\Proxy as ORMProxy;
 use Gedmo\Exception\InvalidArgumentException;
 use Gedmo\Mapping\Event\Adapter\ORM as BaseAdapterORM;
 use Gedmo\References\Mapping\Event\ReferencesAdapter;
+use ProxyManager\Proxy\GhostObjectInterface;
 
 /**
  * Doctrine event adapter for ORM references behavior
@@ -32,7 +32,7 @@ final class ORM extends BaseAdapterORM implements ReferencesAdapter
 
         if ($om instanceof MongoDocumentManager) {
             $meta = $om->getClassMetadata(get_class($object));
-            if ($object instanceof MongoDBProxy) {
+            if ($object instanceof GhostObjectInterface) {
                 $id = $om->getUnitOfWork()->getDocumentIdentifier($object);
             } else {
                 $id = $meta->getReflectionProperty($meta->identifier)->getValue($object);

--- a/src/Sluggable/Mapping/Event/Adapter/ODM.php
+++ b/src/Sluggable/Mapping/Event/Adapter/ODM.php
@@ -2,7 +2,6 @@
 
 namespace Gedmo\Sluggable\Mapping\Event\Adapter;
 
-use Doctrine\MongoDB\Cursor;
 use Doctrine\ODM\MongoDB\Iterator\Iterator;
 use Gedmo\Mapping\Event\Adapter\ODM as BaseAdapterODM;
 use Gedmo\Sluggable\Mapping\Event\SluggableAdapter;
@@ -46,7 +45,7 @@ final class ODM extends BaseAdapterODM implements SluggableAdapter
         $q->setHydrate(false);
 
         $result = $q->execute();
-        if ($result instanceof Cursor || $result instanceof Iterator) {
+        if ($result instanceof Iterator) {
             $result = $result->toArray();
         }
 
@@ -73,13 +72,13 @@ final class ODM extends BaseAdapterODM implements SluggableAdapter
         ;
         $q->setHydrate(false);
         $result = $q->execute();
-        if ($result instanceof Cursor) {
+        if ($result instanceof Iterator) {
             $result = $result->toArray();
             foreach ($result as $targetObject) {
                 $slug = preg_replace("@^{$target}@smi", $replacement.$config['pathSeparator'], $targetObject[$config['slug']]);
                 $dm
                     ->createQueryBuilder()
-                    ->update($config['useObjectClass'])
+                    ->updateMany($config['useObjectClass'])
                     ->field($config['slug'])->set($slug)
                     ->field($meta->identifier)->equals($targetObject['_id'])
                     ->getQuery()
@@ -107,13 +106,13 @@ final class ODM extends BaseAdapterODM implements SluggableAdapter
         ;
         $q->setHydrate(false);
         $result = $q->execute();
-        if ($result instanceof Cursor) {
+        if ($result instanceof Iterator) {
             $result = $result->toArray();
             foreach ($result as $targetObject) {
                 $slug = preg_replace("@^{$replacement}@smi", $target, $targetObject[$config['slug']]);
                 $dm
                     ->createQueryBuilder()
-                    ->update($config['useObjectClass'])
+                    ->updateMany($config['useObjectClass'])
                     ->field($config['slug'])->set($slug)
                     ->field($meta->identifier)->equals($targetObject['_id'])
                     ->getQuery()

--- a/src/Sortable/SortableListener.php
+++ b/src/Sortable/SortableListener.php
@@ -6,9 +6,9 @@ use Doctrine\Common\Comparable;
 use Doctrine\Common\EventArgs;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\Persistence\Mapping\ClassMetadata;
-use Doctrine\Persistence\Proxy;
 use Gedmo\Mapping\MappedEventSubscriber;
 use Gedmo\Sortable\Mapping\Event\SortableAdapter;
+use ProxyManager\Proxy\GhostObjectInterface;
 
 /**
  * The SortableListener maintains a sort index on your entities
@@ -419,7 +419,7 @@ class SortableListener extends MappedEventSubscriber
                         continue;
                     }
                     foreach ($objects as $object) {
-                        if ($object instanceof Proxy && !$object->__isInitialized__) {
+                        if ($object instanceof GhostObjectInterface && !$object->isProxyInitialized()) {
                             continue;
                         }
 

--- a/src/Tool/Wrapper/MongoDocumentWrapper.php
+++ b/src/Tool/Wrapper/MongoDocumentWrapper.php
@@ -3,7 +3,7 @@
 namespace Gedmo\Tool\Wrapper;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
-use Doctrine\ODM\MongoDB\Proxy\Proxy;
+use ProxyManager\Proxy\GhostObjectInterface;
 
 /**
  * Wraps document or proxy for more convenient
@@ -83,7 +83,7 @@ class MongoDocumentWrapper extends AbstractWrapper
     public function getIdentifier($single = true)
     {
         if (!$this->identifier) {
-            if ($this->object instanceof Proxy) {
+            if ($this->object instanceof GhostObjectInterface) {
                 $uow = $this->om->getUnitOfWork();
                 if ($uow->isInIdentityMap($this->object)) {
                     $this->identifier = (string) $uow->getDocumentIdentifier($this->object);
@@ -106,9 +106,9 @@ class MongoDocumentWrapper extends AbstractWrapper
     protected function initialize()
     {
         if (!$this->initialized) {
-            if ($this->object instanceof Proxy) {
+            if ($this->object instanceof GhostObjectInterface) {
                 $uow = $this->om->getUnitOfWork();
-                if (!$this->object->__isInitialized__) {
+                if (!$this->object->isProxyInitialized()) {
                     $persister = $uow->getDocumentPersister($this->meta->name);
                     $identifier = null;
                     if ($uow->isInIdentityMap($this->object)) {
@@ -119,7 +119,7 @@ class MongoDocumentWrapper extends AbstractWrapper
                         $reflProperty->setAccessible(true);
                         $identifier = $reflProperty->getValue($this->object);
                     }
-                    $this->object->__isInitialized__ = true;
+                    $this->object->initializeProxy();
                     $persister->load($identifier, $this->object);
                 }
             }

--- a/src/Translatable/Document/Repository/TranslationRepository.php
+++ b/src/Translatable/Document/Repository/TranslationRepository.php
@@ -6,6 +6,7 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Iterator\Iterator;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
+use Doctrine\ODM\MongoDB\Types\Type;
 use Doctrine\ODM\MongoDB\UnitOfWork;
 use Gedmo\Tool\Wrapper\MongoDocumentWrapper;
 use Gedmo\Translatable\Mapping\Event\Adapter\ODM as TranslatableAdapterODM;
@@ -175,7 +176,7 @@ class TranslationRepository extends DocumentRepository
 
             $q->setHydrate(false);
             $result = $q->execute();
-            if ($result instanceof Cursor) {
+            if ($result instanceof Iterator) {
                 $result = $result->toArray();
             }
             $id = count($result) ? $result[0]['foreignKey'] : null;
@@ -208,7 +209,7 @@ class TranslationRepository extends DocumentRepository
             $q->setHydrate(false);
             $data = $q->execute();
 
-            if ($data instanceof Cursor) {
+            if ($data instanceof Iterator) {
                 $data = $data->toArray();
             }
             if ($data && is_array($data) && count($data)) {
@@ -247,8 +248,6 @@ class TranslationRepository extends DocumentRepository
 
     private function getType($type)
     {
-        // due to change in ODM beta 9
-        return class_exists('Doctrine\ODM\MongoDB\Types\Type') ? \Doctrine\ODM\MongoDB\Types\Type::getType($type)
-            : \Doctrine\ODM\MongoDB\Mapping\Types\Type::getType($type);
+        return Type::getType($type);
     }
 }

--- a/src/Translatable/Mapping/Event/Adapter/ODM.php
+++ b/src/Translatable/Mapping/Event/Adapter/ODM.php
@@ -2,8 +2,9 @@
 
 namespace Gedmo\Translatable\Mapping\Event\Adapter;
 
-use Doctrine\MongoDB\Cursor;
+use Doctrine\ODM\MongoDB\Iterator\Iterator;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Types\Type;
 use Gedmo\Mapping\Event\Adapter\ODM as BaseAdapterODM;
 use Gedmo\Tool\Wrapper\AbstractWrapper;
 use Gedmo\Translatable\Mapping\Event\TranslatableAdapter;
@@ -88,7 +89,7 @@ final class ODM extends BaseAdapterODM implements TranslatableAdapter
         }
         $q->setHydrate(false);
         $result = $q->execute();
-        if ($result instanceof Cursor) {
+        if ($result instanceof Iterator) {
             $result = $result->toArray();
         }
 
@@ -196,8 +197,6 @@ final class ODM extends BaseAdapterODM implements TranslatableAdapter
 
     private function getType($type)
     {
-        // due to change in ODM beta 9
-        return class_exists('Doctrine\ODM\MongoDB\Types\Type') ? \Doctrine\ODM\MongoDB\Types\Type::getType($type)
-            : \Doctrine\ODM\MongoDB\Mapping\Types\Type::getType($type);
+        return Type::getType($type);
     }
 }

--- a/src/Tree/Strategy/AbstractMaterializedPath.php
+++ b/src/Tree/Strategy/AbstractMaterializedPath.php
@@ -10,6 +10,7 @@ use Gedmo\Mapping\Event\AdapterInterface;
 use Gedmo\Tree\Strategy;
 use Gedmo\Tree\TreeListener;
 use MongoDB\BSON\UTCDateTime;
+use ProxyManager\Proxy\GhostObjectInterface;
 
 /**
  * This strategy makes tree using materialized path strategy
@@ -397,11 +398,8 @@ abstract class AbstractMaterializedPath implements Strategy
             // In some cases, the parent could be a not initialized proxy. In this case, the
             // "lockTime" field may NOT be loaded yet and have null instead of the date.
             // We need to be sure that this field has its real value
-            if ($parentNode !== $node && $parentNode instanceof \Doctrine\ODM\MongoDB\Proxy\Proxy) {
-                $reflMethod = new \ReflectionMethod(get_class($parentNode), '__load');
-                $reflMethod->setAccessible(true);
-
-                $reflMethod->invoke($parentNode);
+            if ($parentNode !== $node && $parentNode instanceof GhostObjectInterface) {
+                $parentNode->initializeProxy();
             }
 
             // If tree is already locked, we throw an exception

--- a/src/Uploadable/Mapping/Validator.php
+++ b/src/Uploadable/Mapping/Validator.php
@@ -102,11 +102,7 @@ class Validator
 
     public static function validateFileSizeField(ClassMetadata $meta, $field)
     {
-        if ($meta instanceof \Doctrine\ODM\MongoDB\Mapping\ClassMetadataInfo) {
-            self::validateField($meta, $field, self::UPLOADABLE_FILE_SIZE, self::$validFileSizeTypesODM);
-        } else {
-            self::validateField($meta, $field, self::UPLOADABLE_FILE_SIZE, self::$validFileSizeTypes);
-        }
+        self::validateField($meta, $field, self::UPLOADABLE_FILE_SIZE, self::$validFileSizeTypes);
     }
 
     public static function validateField($meta, $field, $uploadableField, $validFieldTypes)

--- a/src/Uploadable/UploadableListener.php
+++ b/src/Uploadable/UploadableListener.php
@@ -3,8 +3,8 @@
 namespace Gedmo\Uploadable;
 
 use Doctrine\Common\EventArgs;
-use Doctrine\Common\NotifyPropertyChanged;
 use Doctrine\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\NotifyPropertyChanged;
 use Gedmo\Exception\UploadableCantWriteException;
 use Gedmo\Exception\UploadableCouldntGuessMimeTypeException;
 use Gedmo\Exception\UploadableExtensionException;


### PR DESCRIPTION
Follow-up of https://github.com/doctrine-extensions/DoctrineExtensions/pull/2213

`NotifyPropertyChanged` was moved [in `doctrine/common` `2.2`](https://github.com/doctrine/common/releases/tag/v2.10.0).

And for mongodb we have a conflict with `"doctrine/mongodb-odm": "<2.0"`, so `Cursor`, `Proxy` and `ClassMetadataInfo` do not exist in version 2.