### PR TITLE
Tweak Doctrine dependencies and add a DBAL 3 compat fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,23 +40,24 @@
         "doctrine/collections": "^1.0",
         "doctrine/common": "^2.13 || ^3.0",
         "doctrine/event-manager": "^1.0",
-        "doctrine/persistence": "^1.3.4 || ^2.0"
+        "doctrine/persistence": "^1.3.3 || ^2.0"
     },
     "require-dev": {
         "doctrine/cache": "^1.11 || ^2.0",
-        "doctrine/dbal": "^2.13",
+        "doctrine/dbal": "^2.13.1 || ^3.1",
         "doctrine/doctrine-bundle": "^2.3",
         "doctrine/mongodb-odm": "^2.0",
-        "doctrine/orm": "^2.9.6",
+        "doctrine/orm": "^2.9",
         "friendsofphp/php-cs-fixer": "^3.0",
         "phpunit/phpunit": "^8.5 || ^9.5",
         "symfony/cache": "^4.4 || ^5.0",
         "symfony/yaml": "^4.1"
     },
     "conflict": {
-        "doctrine/mongodb": "<1.3",
+        "doctrine/cache": "<1.11",
+        "doctrine/dbal": "<2.13.1 || ~3.0.0",
         "doctrine/mongodb-odm": "<2.0",
-        "doctrine/orm": ">=2.10",
+        "doctrine/orm": "<2.9 || >=2.10",
         "sebastian/comparator": "<2.0"
     },
     "suggest": {

--- a/src/Translatable/Query/TreeWalker/TranslationWalker.php
+++ b/src/Translatable/Query/TreeWalker/TranslationWalker.php
@@ -3,6 +3,7 @@
 namespace Gedmo\Translatable\Query\TreeWalker;
 
 use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -455,8 +456,13 @@ class TranslationWalker extends SqlWalker
             return $component;
         }
 
+        /*
+         * DBAL 3.x drops support of PostgreSQL 9.3 and earlier,
+         * the below check prefers the `PostgreSQL94Platform` class as it is available in both major DBAL versions
+         * and falls back to the deprecated `PostgreSqlPlatform` class to account for older PostgreSQL versions with DBAL 2.x
+         */
         // try to look at postgres casting
-        if ($this->platform instanceof PostgreSqlPlatform) {
+        if ($this->platform instanceof PostgreSQL94Platform || $this->platform instanceof PostgreSqlPlatform) {
             switch ($typeFK) {
             case 'string':
             case 'guid':


### PR DESCRIPTION
`doctrine/persistence` wasn't declared in the dependencies, added it with versions including the `Doctrine\Persistence` namespace

There isn't a big reason for `doctrine/orm` to be pinned to the last 2.9 patch release that I'm aware of (the XML linting should always be done on a setup with the latest supported version installed, so closing down the range just for that step is a little too strict).  I've also added a conflict to older ORM versions since effectively whatever is in dev is the minimum supported version for an optional dependency.

A conflict to `doctrine/cache:<1.11` is added to make sure that only versions of that library with the 2.0 compatibility layer are usable.

DBAL 3 compatibility is improved with this PR, and generally, projects supporting both DBAL 2 and 3 are locking to 2.13 thanks to the forward compatibility layer.

There's no need to conflict against `doctrine/mongodb` anymore.  That library is abandoned anyway and this library realistically doesn't support it anymore to begin with (with https://github.com/doctrine-extensions/DoctrineExtensions/pull/2260 removing the last remnants of references to it).