### PR TITLE
[Translatable] fix Type error for non-nullable getter upon a missing translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ a release.
 ---
 
 ## [Unreleased]
+### Added
+- Translatable: Add defaultTranslationValue option to allow null or string value (#2167). TranslatableListener can hydrate object properties with null value, but it may cause a Type error for non-nullable getter upon a missing translation.
+
 ### Fixed
 - Uploadable: `FileInfoInterface::getSize()` return type declaration (#2413).
 - Tree: Setting a new Tree Root when Tree Parent is `null`.

--- a/doc/translatable.md
+++ b/doc/translatable.md
@@ -609,6 +609,15 @@ $translatableListener->setPersistDefaultLocaleTranslation(true); // default is f
 This would always store translations in all locales, also keeping original record
 translated field values in default locale set.
 
+To set a default translation value upon a missing translation:
+
+``` php
+<?php
+$translatableListener->setDefaultTranslationValue(''); // default is null
+```
+
+**Note**: By default the value is null, but it may cause a Type error for non-nullable getter upon a missing translation.
+
 ### Translation Entity
 
 In some cases if there are thousands of records or even more.. we would like to

--- a/src/Translatable/TranslatableListener.php
+++ b/src/Translatable/TranslatableListener.php
@@ -120,6 +120,13 @@ class TranslatableListener extends MappedEventSubscriber
     private $translationInDefaultLocale = [];
 
     /**
+     * Default translation value upon missing translation
+     *
+     * @var string|null
+     */
+    private $defaultTranslationValue;
+
+    /**
      * Specifies the list of events to listen
      *
      * @return string[]
@@ -255,6 +262,17 @@ class TranslatableListener extends MappedEventSubscriber
         $this->locale = $locale;
 
         return $this;
+    }
+
+    /**
+     * Set the default translation value on missing translation
+     *
+     * @deprecated usage of a non nullable value for defaultTranslationValue is deprecated
+     * and will be removed on the next major release which will rely on the expected types
+     */
+    public function setDefaultTranslationValue(?string $defaultTranslationValue): void
+    {
+        $this->defaultTranslationValue = $defaultTranslationValue;
     }
 
     /**
@@ -483,7 +501,8 @@ class TranslatableListener extends MappedEventSubscriber
             );
             // translate object's translatable properties
             foreach ($config['fields'] as $field) {
-                $translated = null;
+                $translated = $this->defaultTranslationValue;
+
                 foreach ($result as $entry) {
                     if ($entry['field'] == $field) {
                         $translated = $entry['content'] ?? null;
@@ -491,8 +510,9 @@ class TranslatableListener extends MappedEventSubscriber
                         break;
                     }
                 }
+
                 // update translation
-                if (null !== $translated
+                if ($this->defaultTranslationValue !== $translated
                     || (!$this->translationFallback && (!isset($config['fallback'][$field]) || !$config['fallback'][$field]))
                     || ($this->translationFallback && isset($config['fallback'][$field]) && !$config['fallback'][$field])
                 ) {

--- a/tests/Gedmo/Translatable/Fixture/Issue2167/Article.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue2167/Article.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Translatable\Fixture\Issue2167;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * @ORM\Entity
+ */
+#[ORM\Entity]
+class Article
+{
+    /**
+     * @var int
+     *
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    private $id;
+
+    /**
+     * @var string
+     *
+     * @Gedmo\Translatable
+     * @ORM\Column(name="title", type="string", length=128)
+     */
+    #[Gedmo\Translatable]
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
+    private $title;
+
+    /**
+     * @var string
+     *
+     * @Gedmo\Locale()
+     */
+    #[Gedmo\Locale]
+    private $locale;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getLocale(): string
+    {
+        return $this->locale;
+    }
+
+    public function setLocale(string $locale): void
+    {
+        $this->locale = $locale;
+    }
+}

--- a/tests/Gedmo/Translatable/Issue/Issue2167Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue2167Test.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Translatable\Issue;
+
+use Doctrine\Common\EventManager;
+use Gedmo\Tests\Tool\BaseTestCaseORM;
+use Gedmo\Tests\Translatable\Fixture\Issue2167\Article;
+use Gedmo\Translatable\Entity\Translation;
+use Gedmo\Translatable\TranslatableListener;
+
+class Issue2167Test extends BaseTestCaseORM
+{
+    private const TRANSLATION = Translation::class;
+    private const ENTITY = Article::class;
+
+    /**
+     * @var TranslatableListener
+     */
+    private $translatableListener;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $evm = new EventManager();
+
+        $this->translatableListener = new TranslatableListener();
+        $this->translatableListener->setTranslatableLocale('en');
+        $this->translatableListener->setDefaultLocale('en');
+        $this->translatableListener->setTranslationFallback(false);
+        $evm->addEventSubscriber($this->translatableListener);
+
+        $this->getDefaultMockSqliteEntityManager($evm);
+    }
+
+    public function testShouldFindInheritedClassTranslations(): void
+    {
+        $enTitle = 'My english title';
+        $deTitle = 'My german title';
+
+        // English
+        $entity = new Article();
+        $entity->setTitle($enTitle);
+        $entity->setLocale('en');
+        $this->em->persist($entity);
+        $this->em->flush();
+
+        // German
+        $entity->setLocale('de');
+        $entity->setTitle($deTitle);
+        $this->em->flush();
+
+        // Find with default translation value as null value (default setting)
+        $entityInEn = $this->findUsingQueryBuilder('en');
+        $entityInDe = $this->findUsingQueryBuilder('de');
+        $entityInFr = $this->findUsingQueryBuilder('fr');
+
+        static::assertSame($enTitle, $entityInEn->getTitle());
+        static::assertSame($deTitle, $entityInDe->getTitle());
+        static::assertNull($entityInFr->getTitle());
+
+        // Find with default translation value as empty string
+        $this->translatableListener->setDefaultTranslationValue('');
+
+        $entityInEn = $this->findUsingQueryBuilder('en');
+        $entityInDe = $this->findUsingQueryBuilder('de');
+        $entityInFr = $this->findUsingQueryBuilder('fr');
+
+        static::assertSame($enTitle, $entityInEn->getTitle());
+        static::assertSame($deTitle, $entityInDe->getTitle());
+        static::assertSame('', $entityInFr->getTitle());
+
+        // Find with default translation value as not empty string
+        $this->translatableListener->setDefaultTranslationValue('no_translated');
+
+        $entityInEn = $this->findUsingQueryBuilder('en');
+        $entityInDe = $this->findUsingQueryBuilder('de');
+        $entityInFr = $this->findUsingQueryBuilder('fr');
+
+        static::assertSame($enTitle, $entityInEn->getTitle());
+        static::assertSame($deTitle, $entityInDe->getTitle());
+        static::assertSame('no_translated', $entityInFr->getTitle());
+    }
+
+    protected function getUsedEntityFixtures(): array
+    {
+        return [
+            self::TRANSLATION,
+            self::ENTITY,
+        ];
+    }
+
+    private function findUsingQueryBuilder(string $locale): ?Article
+    {
+        $this->em->clear();
+        $this->translatableListener->setTranslatableLocale($locale);
+
+        $qb = $this->em->createQueryBuilder()->select('e')->from(self::ENTITY, 'e');
+
+        return $qb->getQuery()->getSingleResult();
+    }
+}


### PR DESCRIPTION
Since https://github.com/doctrine-extensions/DoctrineExtensions/pull/2153 the TranslatableListener can hydrate object properties with `null` value instead of empty `''`.
But it may cause a Type error for non-nullable getter upon a missing translation.(see https://github.com/doctrine-extensions/DoctrineExtensions/issues/2167).

We use the Translatable component for a very strategic product with a high level of code quality. We have a large number of translatable entities therefore the proposed workaround (https://github.com/doctrine-extensions/DoctrineExtensions/issues/2167) is not acceptable for us, so we are stuck in 2.4.41 

The solution proposed here allows to have a real solution allowing to define the value of the untranslated property. 

The value remains `null` by default but the `setDefaultTranslationValue(?string $defaultTranslationValue)` allows to define another value `string|null`.