### PR TITLE
Allow ORM 2.10.2 and later

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
     "conflict": {
         "doctrine/mongodb": "<1.3",
         "doctrine/mongodb-odm": "<2.0",
-        "doctrine/orm": ">=2.10",
+        "doctrine/orm": ">=2.10,<2.10.2",
         "sebastian/comparator": "<2.0"
     },
     "suggest": {


### PR DESCRIPTION
Follows #2255 and doctrine/orm#9136.

Can you please verify that reverting that change unblocked the upgrade to ORM 2.10 for you?