### PR TITLE
Allow to install `doctrine/orm` 2.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ a release.
 
 ## [Unreleased]
 
+### Fixed
+- Restored compatibility with doctrine/orm >= 2.10.2 (#2272).
+  Since doctrine/orm 2.10, `Doctrine\ORM\UnitOfWork` relies on SPL object IDs instead of hashes, thus we need to adapt our codebase in order to be compatible with this change.
+  As `Doctrine\ODM\MongoDB\UnitOfWork` from doctrine/mongodb-odm still uses `spl_object_hash()`, all `spl_object_hash()` calls were replaced by `spl_object_id()` to make it work with both ORM and ODM managers.
+
 ## [3.2.0] - 2021-10-05
 ### Added
 - PHP 8 Attributes for Doctrine ORM to entities & traits (#2251) 

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "doctrine/dbal": "^2.13",
         "doctrine/doctrine-bundle": "^2.3",
         "doctrine/mongodb-odm": "^2.0",
-        "doctrine/orm": "^2.9.6",
+        "doctrine/orm": "^2.10.2",
         "friendsofphp/php-cs-fixer": "^3.0",
         "phpunit/phpunit": "^8.5 || ^9.5",
         "symfony/cache": "^4.4 || ^5.0",
@@ -56,7 +56,7 @@
     "conflict": {
         "doctrine/mongodb": "<1.3",
         "doctrine/mongodb-odm": "<2.0",
-        "doctrine/orm": ">=2.10",
+        "doctrine/orm": "<2.10.2",
         "sebastian/comparator": "<2.0"
     },
     "suggest": {

--- a/src/Loggable/LoggableListener.php
+++ b/src/Loggable/LoggableListener.php
@@ -123,7 +123,7 @@ class LoggableListener extends MappedEventSubscriber
         $ea = $this->getEventAdapter($args);
         $object = $ea->getObject();
         $om = $ea->getObjectManager();
-        $oid = spl_object_hash($object);
+        $oid = spl_object_id($object);
         $uow = $om->getUnitOfWork();
         if ($this->pendingLogEntryInserts && array_key_exists($oid, $this->pendingLogEntryInserts)) {
             $wrapped = AbstractWrapper::wrap($object, $om);
@@ -136,7 +136,7 @@ class LoggableListener extends MappedEventSubscriber
             $uow->scheduleExtraUpdate($logEntry, [
                 'objectId' => [null, $id],
             ]);
-            $ea->setOriginalObjectProperty($uow, spl_object_hash($logEntry), 'objectId', $id);
+            $ea->setOriginalObjectProperty($uow, $logEntry, 'objectId', $id);
             unset($this->pendingLogEntryInserts[$oid]);
         }
         if ($this->pendingRelatedObjects && array_key_exists($oid, $this->pendingRelatedObjects)) {
@@ -153,7 +153,7 @@ class LoggableListener extends MappedEventSubscriber
                 $uow->scheduleExtraUpdate($logEntry, [
                     'data' => [$oldData, $data],
                 ]);
-                $ea->setOriginalObjectProperty($uow, spl_object_hash($logEntry), 'data', $data);
+                $ea->setOriginalObjectProperty($uow, $logEntry, 'data', $data);
             }
             unset($this->pendingRelatedObjects[$oid]);
         }
@@ -228,7 +228,7 @@ class LoggableListener extends MappedEventSubscriber
                 if ($wrapped->isEmbeddedAssociation($field)) {
                     $value = $this->getObjectChangeSetData($ea, $value, $logEntry);
                 } else {
-                    $oid = spl_object_hash($value);
+                    $oid = spl_object_id($value);
                     $wrappedAssoc = AbstractWrapper::wrap($value, $om);
                     $value = $wrappedAssoc->getIdentifier(false);
                     if (!is_array($value) && !$value) {
@@ -278,7 +278,7 @@ class LoggableListener extends MappedEventSubscriber
             // check for the availability of the primary key
             $uow = $om->getUnitOfWork();
             if (self::ACTION_CREATE === $action && $ea->isPostInsertGenerator($meta)) {
-                $this->pendingLogEntryInserts[spl_object_hash($object)] = $logEntry;
+                $this->pendingLogEntryInserts[spl_object_id($object)] = $logEntry;
             } else {
                 $logEntry->setObjectId($wrapped->getIdentifier());
             }

--- a/src/Mapping/Event/Adapter/ODM.php
+++ b/src/Mapping/Event/Adapter/ODM.php
@@ -154,17 +154,17 @@ class ODM implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function setOriginalObjectProperty($uow, $oid, $property, $value)
+    public function setOriginalObjectProperty($uow, $object, $property, $value)
     {
-        $uow->setOriginalDocumentProperty($oid, $property, $value);
+        $uow->setOriginalDocumentProperty(spl_object_hash($object), $property, $value);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function clearObjectChangeSet($uow, $oid)
+    public function clearObjectChangeSet($uow, $object)
     {
-        $uow->clearDocumentChangeSet($oid);
+        $uow->clearDocumentChangeSet(spl_object_hash($object));
     }
 
     /**

--- a/src/Mapping/Event/Adapter/ORM.php
+++ b/src/Mapping/Event/Adapter/ORM.php
@@ -151,17 +151,17 @@ class ORM implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function setOriginalObjectProperty($uow, $oid, $property, $value)
+    public function setOriginalObjectProperty($uow, $object, $property, $value)
     {
-        $uow->setOriginalEntityProperty($oid, $property, $value);
+        $uow->setOriginalEntityProperty(spl_object_id($object), $property, $value);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function clearObjectChangeSet($uow, $oid)
+    public function clearObjectChangeSet($uow, $object)
     {
-        $uow->clearEntityChangeSet($oid);
+        $uow->clearEntityChangeSet(spl_object_id($object));
     }
 
     /**

--- a/src/Mapping/Event/AdapterInterface.php
+++ b/src/Mapping/Event/AdapterInterface.php
@@ -3,6 +3,7 @@
 namespace Gedmo\Mapping\Event;
 
 use Doctrine\Common\EventArgs;
+use Doctrine\ODM\MongoDB\UnitOfWork as MongoDBUnitOfWork;
 use Doctrine\ORM\UnitOfWork;
 use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Doctrine\Persistence\ObjectManager;
@@ -135,20 +136,20 @@ interface AdapterInterface
     /**
      * Sets a property value of the original data array of an object
      *
-     * @param UnitOfWork $uow
-     * @param string     $oid
-     * @param string     $property
-     * @param mixed      $value
+     * @param UnitOfWork|MongoDBUnitOfWork $uow
+     * @param object                       $object
+     * @param string                       $property
+     * @param mixed                        $value
      *
      * @return void
      */
-    public function setOriginalObjectProperty($uow, $oid, $property, $value);
+    public function setOriginalObjectProperty($uow, $object, $property, $value);
 
     /**
      * Clears the property changeset of the object with the given OID.
      *
-     * @param UnitOfWork $uow
-     * @param string     $oid the object's OID
+     * @param UnitOfWork|MongoDBUnitOfWork $uow
+     * @param object                       $object
      */
-    public function clearObjectChangeSet($uow, $oid);
+    public function clearObjectChangeSet($uow, $object);
 }

--- a/src/Mapping/MappedEventSubscriber.php
+++ b/src/Mapping/MappedEventSubscriber.php
@@ -153,7 +153,7 @@ abstract class MappedEventSubscriber implements EventSubscriber
      */
     public function getExtensionMetadataFactory(ObjectManager $objectManager)
     {
-        $oid = spl_object_hash($objectManager);
+        $oid = spl_object_id($objectManager);
         if (!isset($this->extensionMetadataFactory[$oid])) {
             if (null === $this->annotationReader) {
                 // create default annotation reader for extensions

--- a/src/Sluggable/Handler/InversedRelativeSlugHandler.php
+++ b/src/Sluggable/Handler/InversedRelativeSlugHandler.php
@@ -109,12 +109,12 @@ class InversedRelativeSlugHandler implements SlugHandlerInterface
                         if (property_exists($object, '__isInitialized__') && !$object->__isInitialized__) {
                             continue;
                         }
-                        $oid = spl_object_hash($object);
+
                         $objectSlug = $meta->getReflectionProperty($mappedByConfig['slug'])->getValue($object);
                         if (preg_match("@^{$oldSlug}@smi", $objectSlug)) {
                             $objectSlug = str_replace($oldSlug, $slug, $objectSlug);
                             $meta->getReflectionProperty($mappedByConfig['slug'])->setValue($object, $objectSlug);
-                            $ea->setOriginalObjectProperty($uow, $oid, $mappedByConfig['slug'], $objectSlug);
+                            $ea->setOriginalObjectProperty($uow, $object, $mappedByConfig['slug'], $objectSlug);
                         }
                     }
                 }

--- a/src/Sluggable/Handler/TreeSlugHandler.php
+++ b/src/Sluggable/Handler/TreeSlugHandler.php
@@ -155,12 +155,12 @@ class TreeSlugHandler implements SlugHandlerWithUniqueCallbackInterface
                     if (property_exists($object, '__isInitialized__') && !$object->__isInitialized__) {
                         continue;
                     }
-                    $oid = spl_object_hash($object);
+
                     $objectSlug = $meta->getReflectionProperty($config['slug'])->getValue($object);
                     if (preg_match("@^{$target}{$config['pathSeparator']}@smi", $objectSlug)) {
                         $objectSlug = str_replace($target, $slug, $objectSlug);
                         $meta->getReflectionProperty($config['slug'])->setValue($object, $objectSlug);
-                        $ea->setOriginalObjectProperty($uow, $oid, $config['slug'], $objectSlug);
+                        $ea->setOriginalObjectProperty($uow, $object, $config['slug'], $objectSlug);
                     }
                 }
             }

--- a/src/Sortable/SortableListener.php
+++ b/src/Sortable/SortableListener.php
@@ -438,7 +438,7 @@ class SortableListener extends MappedEventSubscriber
                             }
                         }
 
-                        $oid = spl_object_hash($object);
+                        $oid = spl_object_id($object);
                         $pos = $meta->getReflectionProperty($config['position'])->getValue($object);
                         $matches = $pos >= $delta['start'];
                         $matches = $matches && ($delta['stop'] <= 0 || $pos < $delta['stop']);
@@ -497,7 +497,7 @@ class SortableListener extends MappedEventSubscriber
             if ($val instanceof \DateTime) {
                 $val = $val->format('c');
             } elseif (is_object($val)) {
-                $val = spl_object_hash($val);
+                $val = spl_object_id($val);
             }
             $data .= $group.$val;
         }

--- a/src/Translatable/Document/Repository/TranslationRepository.php
+++ b/src/Translatable/Document/Repository/TranslationRepository.php
@@ -90,7 +90,7 @@ class TranslationRepository extends DocumentRepository
             if ($this->dm->getUnitOfWork()->isInIdentityMap($document)) {
                 $this->dm->persist($trans);
             } else {
-                $oid = spl_object_hash($document);
+                $oid = spl_object_id($document);
                 $listener->addPendingTranslationInsert($oid, $trans);
             }
         }

--- a/src/Translatable/Entity/Repository/TranslationRepository.php
+++ b/src/Translatable/Entity/Repository/TranslationRepository.php
@@ -84,7 +84,7 @@ class TranslationRepository extends EntityRepository
             }
             if ($listener->getDefaultLocale() != $listener->getTranslatableLocale($entity, $meta, $this->getEntityManager()) &&
                 $locale === $listener->getDefaultLocale()) {
-                $listener->setTranslationInDefaultLocale(spl_object_hash($entity), $field, $trans);
+                $listener->setTranslationInDefaultLocale(spl_object_id($entity), $field, $trans);
                 $needsPersist = $listener->getPersistDefaultLocaleTranslation();
             }
             $type = Type::getType($meta->getTypeOfField($field));
@@ -94,7 +94,7 @@ class TranslationRepository extends EntityRepository
                 if ($this->_em->getUnitOfWork()->isInIdentityMap($entity)) {
                     $this->_em->persist($trans);
                 } else {
-                    $oid = spl_object_hash($entity);
+                    $oid = spl_object_id($entity);
                     $listener->addPendingTranslationInsert($oid, $trans);
                 }
             }

--- a/src/Tree/Entity/Repository/ClosureTreeRepository.php
+++ b/src/Tree/Entity/Repository/ClosureTreeRepository.php
@@ -256,7 +256,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
                     ->getStrategy($this->_em, $meta->name)
                     ->updateNode($this->_em, $nodeToReparent, $node);
 
-                $oid = spl_object_hash($nodeToReparent);
+                $oid = spl_object_id($nodeToReparent);
                 $this->_em->getUnitOfWork()->setOriginalEntityProperty($oid, $config['parent'], $parent);
             }
 

--- a/src/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/src/Tree/Entity/Repository/NestedTreeRepository.php
@@ -118,7 +118,7 @@ class NestedTreeRepository extends AbstractTreeRepository
                 $position = substr($position, 0, -2);
             }
             $wrapped->setPropertyValue($config['left'], 0); // simulate changeset
-            $oid = spl_object_hash($node);
+            $oid = spl_object_id($node);
             $this->listener
                 ->getStrategy($this->_em, $meta->name)
                 ->setNodePosition($oid, $position)

--- a/src/Tree/Strategy/AbstractMaterializedPath.php
+++ b/src/Tree/Strategy/AbstractMaterializedPath.php
@@ -103,7 +103,7 @@ abstract class AbstractMaterializedPath implements Strategy
         $fieldMapping = $meta->getFieldMapping($config['path_source']);
 
         if ($meta->isIdentifier($config['path_source']) || 'string' === $fieldMapping['type']) {
-            $this->scheduledForPathProcess[spl_object_hash($node)] = $node;
+            $this->scheduledForPathProcess[spl_object_id($node)] = $node;
         } else {
             $this->updateNode($om, $node, $ea);
         }
@@ -138,7 +138,7 @@ abstract class AbstractMaterializedPath implements Strategy
      */
     public function processPostPersist($om, $node, AdapterInterface $ea)
     {
-        $oid = spl_object_hash($node);
+        $oid = spl_object_id($node);
 
         if ($this->scheduledForPathProcess && array_key_exists($oid, $this->scheduledForPathProcess)) {
             $this->scheduledForPathProcessWithIdSet[$oid] = $node;
@@ -233,7 +233,6 @@ abstract class AbstractMaterializedPath implements Strategy
      */
     public function updateNode(ObjectManager $om, $node, AdapterInterface $ea)
     {
-        $oid = spl_object_hash($node);
         $meta = $om->getClassMetadata(get_class($node));
         $config = $this->listener->getConfiguration($om, $meta->name);
         $uow = $om->getUnitOfWork();
@@ -343,13 +342,13 @@ abstract class AbstractMaterializedPath implements Strategy
         }
 
         if (!$uow instanceof MongoDBUnitOfWork) {
-            $ea->setOriginalObjectProperty($uow, $oid, $config['path'], $path);
+            $ea->setOriginalObjectProperty($uow, $node, $config['path'], $path);
             $uow->scheduleExtraUpdate($node, $changes);
         } else {
             $ea->recomputeSingleObjectChangeSet($uow, $meta, $node);
         }
         if (isset($config['path_hash'])) {
-            $ea->setOriginalObjectProperty($uow, $oid, $config['path_hash'], $pathHash);
+            $ea->setOriginalObjectProperty($uow, $node, $config['path_hash'], $pathHash);
         }
     }
 
@@ -418,9 +417,9 @@ abstract class AbstractMaterializedPath implements Strategy
                 throw new TreeLockingException(sprintf($msg, $id));
             }
 
-            $this->rootsOfTreesWhichNeedsLocking[spl_object_hash($parentNode)] = $parentNode;
+            $this->rootsOfTreesWhichNeedsLocking[spl_object_id($parentNode)] = $parentNode;
 
-            $oid = spl_object_hash($node);
+            $oid = spl_object_id($node);
 
             switch ($action) {
                 case self::ACTION_INSERT:
@@ -457,15 +456,15 @@ abstract class AbstractMaterializedPath implements Strategy
         if ($config['activate_locking']) {
             switch ($action) {
                 case self::ACTION_INSERT:
-                    unset($this->pendingObjectsToInsert[spl_object_hash($node)]);
+                    unset($this->pendingObjectsToInsert[spl_object_id($node)]);
 
                     break;
                 case self::ACTION_UPDATE:
-                    unset($this->pendingObjectsToUpdate[spl_object_hash($node)]);
+                    unset($this->pendingObjectsToUpdate[spl_object_id($node)]);
 
                     break;
                 case self::ACTION_REMOVE:
-                    unset($this->pendingObjectsToRemove[spl_object_hash($node)]);
+                    unset($this->pendingObjectsToRemove[spl_object_id($node)]);
 
                     break;
                 default:

--- a/src/Tree/Strategy/ORM/Closure.php
+++ b/src/Tree/Strategy/ORM/Closure.php
@@ -174,7 +174,7 @@ class Closure implements Strategy
      */
     public function processPrePersist($em, $node)
     {
-        $this->pendingChildNodeInserts[spl_object_hash($em)][spl_object_hash($node)] = $node;
+        $this->pendingChildNodeInserts[spl_object_id($em)][spl_object_id($node)] = $node;
     }
 
     /**
@@ -241,7 +241,7 @@ class Closure implements Strategy
     public function processPostPersist($em, $entity, AdapterInterface $ea)
     {
         $uow = $em->getUnitOfWork();
-        $emHash = spl_object_hash($em);
+        $emHash = spl_object_id($em);
 
         while ($node = array_shift($this->pendingChildNodeInserts[$emHash])) {
             $meta = $em->getClassMetadata(get_class($node));
@@ -288,7 +288,7 @@ class Closure implements Strategy
                 }
             } elseif (isset($config['level'])) {
                 $uow->scheduleExtraUpdate($node, [$config['level'] => [null, 1]]);
-                $ea->setOriginalObjectProperty($uow, spl_object_hash($node), $config['level'], 1);
+                $ea->setOriginalObjectProperty($uow, $node, $config['level'], 1);
                 $levelProp = $meta->getReflectionProperty($config['level']);
                 $levelProp->setValue($node, 1);
             }
@@ -368,7 +368,7 @@ class Closure implements Strategy
                     ]]
                 );
                 $levelProp->setValue($node, $level);
-                $uow->setOriginalEntityProperty(spl_object_hash($node), $config['level'], $level);
+                $uow->setOriginalEntityProperty(spl_object_id($node), $config['level'], $level);
             }
 
             $this->pendingNodesLevelProcess = [];
@@ -391,7 +391,7 @@ class Closure implements Strategy
             $parent = $changeSet[$config['parent']][1] ? AbstractWrapper::wrap($changeSet[$config['parent']][1], $em) : null;
 
             if ($parent && !$parent->getIdentifier()) {
-                $this->pendingNodeUpdates[spl_object_hash($node)] = [
+                $this->pendingNodeUpdates[spl_object_id($node)] = [
                     'node' => $node,
                     'oldParent' => $changeSet[$config['parent']][0],
                 ];

--- a/src/Tree/Strategy/ORM/Nested.php
+++ b/src/Tree/Strategy/ORM/Nested.php
@@ -61,7 +61,7 @@ class Nested implements Strategy
 
     /**
      * Stores a list of node position strategies
-     * for each node by object hash
+     * for each node by object id
      *
      * @var array
      */
@@ -147,7 +147,7 @@ class Nested implements Strategy
             throw new \Gedmo\Exception\UnexpectedValueException('Root cannot be changed manually, change parent instead');
         }
 
-        $oid = spl_object_hash($node);
+        $oid = spl_object_id($node);
         if (isset($changeSet[$config['left']]) && isset($this->nodePositions[$oid])) {
             $wrapped = AbstractWrapper::wrap($node, $em);
             $parent = $wrapped->getPropertyValue($config['parent']);
@@ -307,7 +307,7 @@ class Nested implements Strategy
             $right = 2;
         }
 
-        $oid = spl_object_hash($node);
+        $oid = spl_object_id($node);
         if (isset($this->nodePositions[$oid])) {
             $position = $this->nodePositions[$oid];
         }
@@ -318,7 +318,7 @@ class Nested implements Strategy
             $wrappedParent = AbstractWrapper::wrap($parent, $em);
 
             $parentRoot = isset($config['root']) ? $wrappedParent->getPropertyValue($config['root']) : null;
-            $parentOid = spl_object_hash($parent);
+            $parentOid = spl_object_id($parent);
             $parentLeft = $wrappedParent->getPropertyValue($config['left']);
             $parentRight = $wrappedParent->getPropertyValue($config['right']);
             if (empty($parentLeft) && empty($parentRight)) {
@@ -615,7 +615,7 @@ class Nested implements Strategy
                     continue;
                 }
 
-                $oid = spl_object_hash($node);
+                $oid = spl_object_id($node);
                 $left = $meta->getReflectionProperty($config['left'])->getValue($node);
                 $currentRoot = isset($config['root']) ? $meta->getReflectionProperty($config['root'])->getValue($node) : null;
                 if ($currentRoot === $root && $left >= $first) {
@@ -690,7 +690,7 @@ class Nested implements Strategy
                 $right = $meta->getReflectionProperty($config['right'])->getValue($node);
                 $currentRoot = isset($config['root']) ? $meta->getReflectionProperty($config['root'])->getValue($node) : null;
                 if ($currentRoot === $root && $left >= $first && $right <= $last) {
-                    $oid = spl_object_hash($node);
+                    $oid = spl_object_id($node);
                     $uow = $em->getUnitOfWork();
 
                     $meta->getReflectionProperty($config['left'])->setValue($node, $left + $delta);

--- a/src/Uploadable/UploadableListener.php
+++ b/src/Uploadable/UploadableListener.php
@@ -201,7 +201,7 @@ class UploadableListener extends MappedEventSubscriber
      */
     public function processFile(AdapterInterface $ea, $object, $action)
     {
-        $oid = spl_object_hash($object);
+        $oid = spl_object_id($object);
         $om = $ea->getObjectManager();
         $uow = $om->getUnitOfWork();
         $meta = $om->getClassMetadata(get_class($object));
@@ -676,7 +676,7 @@ class UploadableListener extends MappedEventSubscriber
             throw new \RuntimeException(sprintf($msg, get_class($entity)));
         }
 
-        $this->fileInfoObjects[spl_object_hash($entity)] = [
+        $this->fileInfoObjects[spl_object_id($entity)] = [
             'entity' => $entity,
             'fileInfo' => $fileInfo,
         ];
@@ -689,7 +689,7 @@ class UploadableListener extends MappedEventSubscriber
      */
     public function getEntityFileInfo($entity)
     {
-        $oid = spl_object_hash($entity);
+        $oid = spl_object_id($entity);
 
         if (!isset($this->fileInfoObjects[$oid])) {
             throw new \RuntimeException(sprintf('There\'s no FileInfoInterface object for entity of class "%s".', get_class($entity)));


### PR DESCRIPTION
For some context: https://github.com/doctrine/orm/issues/9141 and https://github.com/doctrine-extensions/DoctrineExtensions/pull/2271

Since version `doctrine/orm` 2.10, `UnitOfWork` relies on SPL object IDs, not hashes, so in order to be able to use newer versions we need to adapt to this change.

The problem here is that `UnitOfWork` from ODM still uses `spl_object_hash`, so this PR changes all `spl_object_hash` calls to `spl_object_id` and to make it work with both ORM and ODM, these methods have been changed:

https://github.com/doctrine-extensions/DoctrineExtensions/blob/8c02cee09e3dd43799ec3b84b619b19982c47f43/src/Mapping/Event/AdapterInterface.php#L131-L149

To accept an object instead of the OID, that way how the OID is calculated is delegated to the implementation,

ORM:

https://github.com/franmomu/DoctrineExtensions/blob/c23fd27d3d4859b459aee12c11d481de483638bc/src/Mapping/Event/Adapter/ORM.php#L154-L165

ODM:

https://github.com/franmomu/DoctrineExtensions/blob/c23fd27d3d4859b459aee12c11d481de483638bc/src/Mapping/Event/Adapter/ODM.php#L157-L168

This is BC break, but since `doctrine/orm` did it, not sure how many people would be affected by this.

Fixes #2261.