### PR TITLE
Allow installation of doctrine 2.10.2 and newer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
     "conflict": {
         "doctrine/mongodb": "<1.3",
         "doctrine/mongodb-odm": "<2.0",
-        "doctrine/orm": ">=2.10",
+        "doctrine/orm": "2.10.0 || 2.10.1",
         "sebastian/comparator": "<2.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
     "conflict": {
         "doctrine/mongodb": "<1.3",
         "doctrine/mongodb-odm": "<2.0",
-        "doctrine/orm": "2.10.0 || 2.10.1",
+        "doctrine/orm": ">=2.10",
         "sebastian/comparator": "<2.0"
     },
     "suggest": {


### PR DESCRIPTION
The conflict was resolved in https://github.com/doctrine/orm/commit/12babcc1c24759002605057b79e5bc6f93e3bf0a#diff-5d251e7137bb3f96c0e8924dd898e75cdabaee0aca204879b649520b2e49a630 on the doctrine/orm side by @greg0ire. And so it is not longer required to conflict >=2.10.0 just the version 2.10.1 and 2.10.2

Currently my project did install `doctrine/orm: 2.10.2` but an older version of `gedmo/doctrine-extensions: 3.1.0`.