### PR TITLE
DBAL 3 compatibility, misc. replacements of deprecated API uses

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   phpunit:
-    name: "PHPUnit"
+    name: "PHPUnit ${{ matrix.php-version }} (${{ matrix.deps }})${{ matrix.dbal-version && format(' - DBAL {0}', matrix.dbal-version) || '' }}"
     runs-on: "ubuntu-20.04"
 
     services:
@@ -26,9 +26,17 @@ jobs:
           - "8.0"
         deps:
           - "highest"
+        dbal-version:
+          - ""
         include:
           - deps: "lowest"
             php-version: "7.2"
+          - deps: "highest"
+            php-version: "8.0"
+            dbal-version: "^2.13.1"
+          - deps: "highest"
+            php-version: "8.0"
+            dbal-version: "^3.1"
 
     steps:
       - name: "Checkout"
@@ -41,6 +49,10 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           extensions: mongodb
+
+      - name: "Restrict DBAL version"
+        if: "${{ matrix.dbal-version }}"
+        run: "composer require --dev --no-update doctrine/dbal:${{ matrix.dbal-version }}"
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,12 @@ a release.
 
 ## [Unreleased]
 ### Added
+- Support for doctrine/dbal 3.x
 - Timestampable: Support to use annotations as attributes on PHP >= 8.0.
+
+### Changes
+- Dropped support for doctrine/dbal < 2.13.1
+- The third argument of `Gedmo\SoftDeleteable\Query\TreeWalker\Exec\MultiTableDeleteExecutor::__construct()` requires a `Doctrine\ORM\Mapping\ClassMetadata` instance.
 
 ## [3.3.1] - 2021-11-18
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -40,17 +40,18 @@
         "doctrine/collections": "^1.0",
         "doctrine/common": "^2.13 || ^3.0",
         "doctrine/event-manager": "^1.0",
-        "doctrine/persistence": "^1.3.4 || ^2.0"
+        "doctrine/persistence": "^1.3.3 || ^2.0"
     },
     "conflict": {
-        "doctrine/mongodb": "<1.3",
+        "doctrine/cache": "<1.11",
+        "doctrine/dbal": "<2.13.1 || ~3.0.0",
         "doctrine/mongodb-odm": "<2.0",
         "doctrine/orm": "<2.10.2",
         "sebastian/comparator": "<2.0"
     },
     "require-dev": {
         "doctrine/cache": "^1.11 || ^2.0",
-        "doctrine/dbal": "^2.13",
+        "doctrine/dbal": "^2.13.1 || ^3.1",
         "doctrine/doctrine-bundle": "^2.3",
         "doctrine/mongodb-odm": "^2.0",
         "doctrine/orm": "^2.10.2",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,11 +1,17 @@
 parameters:
-    ignoreErrors:
-        -
-            message: "#^Class Doctrine\\\\ODM\\\\PHPCR\\\\DocumentManager not found\\.$#"
-            count: 2
-            path: src/References/Mapping/Event/Adapter/ORM.php
+	ignoreErrors:
+		-
+			message: "#^Class Doctrine\\\\ODM\\\\PHPCR\\\\DocumentManager not found\\.$#"
+			count: 2
+			path: src/References/Mapping/Event/Adapter/ORM.php
 
-        -
-            message: "#^Access to an undefined property ProxyManager\\\\Proxy\\\\GhostObjectInterface\\:\\:\\$identifier\\.$#"
-            count: 1
-            path: src/Tool/Wrapper/MongoDocumentWrapper.php
+		-
+			message: "#^Access to an undefined property ProxyManager\\\\Proxy\\\\GhostObjectInterface\\:\\:\\$identifier\\.$#"
+			count: 1
+			path: src/Tool/Wrapper/MongoDocumentWrapper.php
+
+		-
+			message: "#^Class Doctrine\\\\DBAL\\\\Platforms\\\\PostgreSQLPlatform not found\\.$#"
+			count: 1
+			path: src/Translatable/Query/TreeWalker/TranslationWalker.php
+

--- a/src/SoftDeleteable/Filter/SoftDeleteableFilter.php
+++ b/src/SoftDeleteable/Filter/SoftDeleteableFilter.php
@@ -30,6 +30,7 @@ class SoftDeleteableFilter extends SQLFilter
 
     /**
      * @var array<string, bool>
+     * @phpstan-var array<class-string, bool>
      */
     protected $disabled = [];
 
@@ -57,7 +58,9 @@ class SoftDeleteableFilter extends SQLFilter
         }
 
         $platform = $this->getConnection()->getDatabasePlatform();
-        $column = $targetEntity->getQuotedColumnName($config['fieldName'], $platform);
+        $quoteStrategy = $this->getEntityManager()->getConfiguration()->getQuoteStrategy();
+
+        $column = $quoteStrategy->getColumnName($config['fieldName'], $targetEntity, $platform);
 
         $addCondSql = $platform->getIsNullExpression($targetTableAlias.'.'.$column);
         if (isset($config['timeAware']) && $config['timeAware']) {

--- a/src/SoftDeleteable/Query/TreeWalker/SoftDeleteableWalker.php
+++ b/src/SoftDeleteable/Query/TreeWalker/SoftDeleteableWalker.php
@@ -27,7 +27,7 @@ class SoftDeleteableWalker extends SqlWalker
     /**
      * @var Connection
      *
-     * @deprecated to be removed in 4.0, use the getConnection method instead
+     * @deprecated to be removed in 4.0, use the `getConnection()` method instead.
      */
     protected $conn;
 

--- a/src/Sortable/Mapping/Event/Adapter/ORM.php
+++ b/src/Sortable/Mapping/Event/Adapter/ORM.php
@@ -25,7 +25,7 @@ final class ORM extends BaseAdapterORM implements SortableAdapter
         $this->addGroupWhere($qb, $groups);
         $query = $qb->getQuery();
         $query->useQueryCache(false);
-        $query->useResultCache(false);
+        $query->disableResultCache();
         $res = $query->getResult();
 
         return $res[0][1];

--- a/src/Translatable/Query/TreeWalker/TranslationWalker.php
+++ b/src/Translatable/Query/TreeWalker/TranslationWalker.php
@@ -3,7 +3,8 @@
 namespace Gedmo\Translatable\Query\TreeWalker;
 
 use Doctrine\DBAL\Platforms\MySqlPlatform;
-use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query;
@@ -460,8 +461,12 @@ class TranslationWalker extends SqlWalker
             return $component;
         }
 
+        // @todo: remove the `PostgreSQL94Platform` check when dropping doctrine/dbal 3.1.x support
+        // the below check prefers the `PostgreSQLPlatform` class for doctrine/dbal 2.13.x or 3.2
+        // and later and falls back to the `PostgreSQL94Platform` class for compatibility with 3.1
+        // where `PostgreSQLPlatform` does not exist
         // try to look at postgres casting
-        if ($this->platform instanceof PostgreSqlPlatform) {
+        if ($this->platform instanceof PostgreSQLPlatform || $this->platform instanceof PostgreSQL94Platform) {
             switch ($typeFK) {
                 case 'string':
                 case 'guid':

--- a/src/Translatable/Query/TreeWalker/TranslationWalker.php
+++ b/src/Translatable/Query/TreeWalker/TranslationWalker.php
@@ -2,7 +2,7 @@
 
 namespace Gedmo\Translatable\Query\TreeWalker;
 
-use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Types\Type;
@@ -347,9 +347,9 @@ class TranslationWalker extends SqlWalker
 
                 // Treat translation as original field type
                 $fieldMapping = $meta->getFieldMapping($field);
-                if ((($this->platform instanceof MySqlPlatform) &&
+                if ((($this->platform instanceof MySQLPlatform) &&
                     in_array($fieldMapping['type'], ['decimal'])) ||
-                    (!($this->platform instanceof MySqlPlatform) &&
+                    (!($this->platform instanceof MySQLPlatform) &&
                     !in_array($fieldMapping['type'], ['datetime', 'datetimetz', 'date', 'time']))) {
                     $type = Type::getType($fieldMapping['type']);
                     $substituteField = 'CAST('.$substituteField.' AS '.$type->getSQLDeclaration($fieldMapping, $this->platform).')';

--- a/src/Tree/Strategy/ORM/Closure.php
+++ b/src/Tree/Strategy/ORM/Closure.php
@@ -6,7 +6,6 @@ use Doctrine\Common\Cache\Cache;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
-use Doctrine\ORM\Version;
 use Doctrine\Persistence\ObjectManager;
 use Gedmo\Exception\RuntimeException;
 use Gedmo\Mapping\Event\AdapterInterface;
@@ -104,12 +103,10 @@ class Closure implements Strategy
                 'fetch' => ClassMetadataInfo::FETCH_LAZY,
             ];
             $closureMetadata->mapManyToOne($ancestorMapping);
-            if (Version::compare('2.3.0-dev') <= 0) {
-                $closureMetadata->reflFields['ancestor'] = $cmf
-                    ->getReflectionService()
-                    ->getAccessibleProperty($closureMetadata->name, 'ancestor')
-                ;
-            }
+            $closureMetadata->reflFields['ancestor'] = $cmf
+                ->getReflectionService()
+                ->getAccessibleProperty($closureMetadata->name, 'ancestor')
+            ;
         }
 
         if (!$closureMetadata->hasAssociation('descendant')) {
@@ -134,12 +131,10 @@ class Closure implements Strategy
                 'fetch' => ClassMetadataInfo::FETCH_LAZY,
             ];
             $closureMetadata->mapManyToOne($descendantMapping);
-            if (Version::compare('2.3.0-dev') <= 0) {
-                $closureMetadata->reflFields['descendant'] = $cmf
-                    ->getReflectionService()
-                    ->getAccessibleProperty($closureMetadata->name, 'descendant')
-                ;
-            }
+            $closureMetadata->reflFields['descendant'] = $cmf
+                ->getReflectionService()
+                ->getAccessibleProperty($closureMetadata->name, 'descendant')
+            ;
         }
         // create unique index on ancestor and descendant
         $indexName = substr(strtoupper('IDX_'.md5($closureMetadata->name)), 0, 20);

--- a/tests/Gedmo/Loggable/Fixture/Entity/Address.php
+++ b/tests/Gedmo/Loggable/Fixture/Entity/Address.php
@@ -16,7 +16,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Address
 {
     /**
-     * @var int
+     * @var int|null
      * @ORM\Id()
      * @ORM\Column(name="id", type="integer")
      * @ORM\GeneratedValue(strategy="AUTO")
@@ -45,7 +45,7 @@ class Address
     protected $geo;
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getId()
     {

--- a/tests/Gedmo/Loggable/Fixture/Entity/Address.php
+++ b/tests/Gedmo/Loggable/Fixture/Entity/Address.php
@@ -16,10 +16,10 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Address
 {
     /**
-     * @var string
+     * @var int
      * @ORM\Id()
-     * @ORM\Column(type="string", length=36)
-     * @ORM\GeneratedValue(strategy="UUID")
+     * @ORM\Column(name="id", type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
      */
     protected $id;
 
@@ -45,7 +45,7 @@ class Address
     protected $geo;
 
     /**
-     * @return string
+     * @return int
      */
     public function getId()
     {

--- a/tests/Gedmo/Mapping/LoggableMappingTest.php
+++ b/tests/Gedmo/Mapping/LoggableMappingTest.php
@@ -2,12 +2,13 @@
 
 namespace Gedmo\Tests\Loggable;
 
-use Doctrine\ORM\Mapping\Driver\DriverChain;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Gedmo\Loggable\Entity\LogEntry;
 use Gedmo\Loggable\LoggableListener;
 use Gedmo\Mapping\ExtensionMetadataFactory;
 use Gedmo\Tests\Mapping\Fixture\Yaml\Category;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 /**
  * These are mapping tests for tree extension
@@ -26,11 +27,11 @@ final class LoggableMappingTest extends \PHPUnit\Framework\TestCase
     protected function setUp(): void
     {
         $config = new \Doctrine\ORM\Configuration();
-        $config->setMetadataCacheImpl(new \Doctrine\Common\Cache\ArrayCache());
-        $config->setQueryCacheImpl(new \Doctrine\Common\Cache\ArrayCache());
+        $config->setMetadataCache(new ArrayAdapter());
+        $config->setQueryCache(new ArrayAdapter());
         $config->setProxyDir(TESTS_TEMP_DIR);
         $config->setProxyNamespace('Gedmo\Mapping\Proxy');
-        $chainDriverImpl = new DriverChain();
+        $chainDriverImpl = new MappingDriverChain();
         $chainDriverImpl->addDriver(
             new YamlDriver([__DIR__.'/Driver/Yaml']),
             'Gedmo\Tests\Mapping\Fixture\Yaml'

--- a/tests/Gedmo/Mapping/MetadataFactory/ForcedMetadataTest.php
+++ b/tests/Gedmo/Mapping/MetadataFactory/ForcedMetadataTest.php
@@ -4,7 +4,6 @@ namespace Gedmo\Tests\Mapping\MetadataFactory;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Version;
 use Gedmo\Tests\Mapping\Fixture\Unmapped\Timestampable;
 
 /**
@@ -79,9 +78,7 @@ final class ForcedMetadataTest extends \PHPUnit\Framework\TestCase
         $eventArgs = new \Doctrine\ORM\Event\LoadClassMetadataEventArgs($metadata, $this->em);
         $evm->dispatchEvent(\Doctrine\ORM\Events::loadClassMetadata, $eventArgs);
 
-        if (Version::compare('2.3.0-dev') <= 0) {
-            $metadata->wakeupReflection($cmf->getReflectionService());
-        }
+        $metadata->wakeupReflection($cmf->getReflectionService());
         $schemaTool = new \Doctrine\ORM\Tools\SchemaTool($this->em);
         $schemaTool->dropSchema([]);
         $schemaTool->createSchema([

--- a/tests/Gedmo/Mapping/MultiManagerMappingTest.php
+++ b/tests/Gedmo/Mapping/MultiManagerMappingTest.php
@@ -4,8 +4,8 @@ namespace Gedmo\Tests\Mapping;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
-use Doctrine\ORM\Mapping\Driver\DriverChain;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Gedmo\Tests\Mapping\Fixture\Yaml\User;
 use Gedmo\Tests\Sluggable\Fixture\Document\Article;
 use Gedmo\Tests\Tool\BaseTestCaseOM;
@@ -53,7 +53,7 @@ final class MultiManagerMappingTest extends BaseTestCaseOM
 
         $yamlDriver = new YamlDriver(__DIR__.'/Driver/Yaml');
 
-        $chain = new DriverChain();
+        $chain = new MappingDriverChain();
         $chain->addDriver($annotationDriver, 'Gedmo\Tests\Translatable\Fixture');
         $chain->addDriver($yamlDriver, 'Gedmo\Tests\Mapping\Fixture\Yaml');
         $chain->addDriver($annotationDriver2, 'Gedmo\Translatable');

--- a/tests/Gedmo/Mapping/SluggableMappingTest.php
+++ b/tests/Gedmo/Mapping/SluggableMappingTest.php
@@ -2,14 +2,15 @@
 
 namespace Gedmo\Tests\Sluggable;
 
-use Doctrine\ORM\Mapping\Driver\DriverChain;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Gedmo\Mapping\ExtensionMetadataFactory;
 use Gedmo\Sluggable\Handler\RelativeSlugHandler;
 use Gedmo\Sluggable\Handler\TreeSlugHandler;
 use Gedmo\Sluggable\SluggableListener;
 use Gedmo\Tests\Mapping\Fixture\Sluggable;
 use Gedmo\Tests\Mapping\Fixture\Yaml\Category;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 /**
  * These are mapping tests for sluggable extension
@@ -29,11 +30,11 @@ final class SluggableMappingTest extends \PHPUnit\Framework\TestCase
     protected function setUp(): void
     {
         $config = new \Doctrine\ORM\Configuration();
-        $config->setMetadataCacheImpl(new \Doctrine\Common\Cache\ArrayCache());
-        $config->setQueryCacheImpl(new \Doctrine\Common\Cache\ArrayCache());
+        $config->setMetadataCache(new ArrayAdapter());
+        $config->setQueryCache(new ArrayAdapter());
         $config->setProxyDir(TESTS_TEMP_DIR);
         $config->setProxyNamespace('Gedmo\Mapping\Proxy');
-        $chainDriverImpl = new DriverChain();
+        $chainDriverImpl = new MappingDriverChain();
         $chainDriverImpl->addDriver(
             new YamlDriver([__DIR__.'/Driver/Yaml']),
             'Gedmo\Tests\Mapping\Fixture\Yaml'

--- a/tests/Gedmo/Mapping/SoftDeleteableMappingTest.php
+++ b/tests/Gedmo/Mapping/SoftDeleteableMappingTest.php
@@ -5,8 +5,8 @@ namespace Gedmo\Tests\Mapping;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\EventManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
-use Doctrine\ORM\Mapping\Driver\DriverChain;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Gedmo\SoftDeleteable\SoftDeleteableListener;
 use Gedmo\Tests\Mapping\Fixture\Yaml\SoftDeleteable;
 use Gedmo\Tests\Tool\BaseTestCaseOM;
@@ -42,7 +42,7 @@ final class SoftDeleteableMappingTest extends BaseTestCaseOM
 
         $yamlDriver = new YamlDriver(__DIR__.'/Driver/Yaml');
 
-        $chain = new DriverChain();
+        $chain = new MappingDriverChain();
         $chain->addDriver($yamlDriver, 'Gedmo\Tests\Mapping\Fixture\Yaml');
         $chain->addDriver($annotationDriver, 'Gedmo\Tests\Mapping\Fixture');
 

--- a/tests/Gedmo/Mapping/SortableMappingTest.php
+++ b/tests/Gedmo/Mapping/SortableMappingTest.php
@@ -5,8 +5,8 @@ namespace Gedmo\Tests\Sluggable;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\EventManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
-use Doctrine\ORM\Mapping\Driver\DriverChain;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Gedmo\Sortable\SortableListener;
 use Gedmo\Tests\Mapping\Fixture\SortableGroup;
 use Gedmo\Tests\Mapping\Fixture\Yaml\Sortable;
@@ -42,7 +42,7 @@ final class SortableMappingTest extends BaseTestCaseOM
 
         $yamlDriver = new YamlDriver(__DIR__.'/Driver/Yaml');
 
-        $chain = new DriverChain();
+        $chain = new MappingDriverChain();
         $chain->addDriver($yamlDriver, 'Gedmo\Tests\Mapping\Fixture\Yaml');
         $chain->addDriver($annotationDriver, 'Gedmo\Tests\Mapping\Fixture');
 

--- a/tests/Gedmo/Mapping/TimestampableMappingTest.php
+++ b/tests/Gedmo/Mapping/TimestampableMappingTest.php
@@ -2,11 +2,12 @@
 
 namespace Gedmo\Tests\Timestampable;
 
-use Doctrine\ORM\Mapping\Driver\DriverChain;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Gedmo\Mapping\ExtensionMetadataFactory;
 use Gedmo\Tests\Mapping\Fixture\Yaml\Category;
 use Gedmo\Timestampable\TimestampableListener;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 /**
  * These are mapping tests for timestampable extension
@@ -25,11 +26,11 @@ final class TimestampableMappingTest extends \PHPUnit\Framework\TestCase
     protected function setUp(): void
     {
         $config = new \Doctrine\ORM\Configuration();
-        $config->setMetadataCacheImpl(new \Doctrine\Common\Cache\ArrayCache());
-        $config->setQueryCacheImpl(new \Doctrine\Common\Cache\ArrayCache());
+        $config->setMetadataCache(new ArrayAdapter());
+        $config->setQueryCache(new ArrayAdapter());
         $config->setProxyDir(TESTS_TEMP_DIR);
         $config->setProxyNamespace('Gedmo\Mapping\Proxy');
-        $chainDriverImpl = new DriverChain();
+        $chainDriverImpl = new MappingDriverChain();
         $chainDriverImpl->addDriver(
             new YamlDriver([__DIR__.'/Driver/Yaml']),
             'Gedmo\Tests\Mapping\Fixture\Yaml'

--- a/tests/Gedmo/Mapping/TranslatableMappingTest.php
+++ b/tests/Gedmo/Mapping/TranslatableMappingTest.php
@@ -3,12 +3,13 @@
 namespace Gedmo\Tests\Translatable;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Mapping\Driver\DriverChain;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Gedmo\Mapping\ExtensionMetadataFactory;
 use Gedmo\Tests\Mapping\Fixture\Yaml\User;
 use Gedmo\Tests\Translatable\Fixture\PersonTranslation;
 use Gedmo\Translatable\TranslatableListener;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 /**
  * These are mapping tests for translatable behavior
@@ -36,11 +37,11 @@ final class TranslatableMappingTest extends \PHPUnit\Framework\TestCase
     protected function setUp(): void
     {
         $config = new \Doctrine\ORM\Configuration();
-        $config->setMetadataCacheImpl(new \Doctrine\Common\Cache\ArrayCache());
-        $config->setQueryCacheImpl(new \Doctrine\Common\Cache\ArrayCache());
+        $config->setMetadataCache(new ArrayAdapter());
+        $config->setQueryCache(new ArrayAdapter());
         $config->setProxyDir(TESTS_TEMP_DIR);
         $config->setProxyNamespace('Gedmo\Mapping\Proxy');
-        $chainDriverImpl = new DriverChain();
+        $chainDriverImpl = new MappingDriverChain();
         $chainDriverImpl->addDriver(
             new YamlDriver([__DIR__.'/Driver/Yaml']),
             'Gedmo\Tests\Mapping\Fixture\Yaml'

--- a/tests/Gedmo/Mapping/TreeMappingTest.php
+++ b/tests/Gedmo/Mapping/TreeMappingTest.php
@@ -2,14 +2,15 @@
 
 namespace Gedmo\Tests\Tree;
 
-use Doctrine\ORM\Mapping\Driver\DriverChain;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Gedmo\Mapping\ExtensionMetadataFactory;
 use Gedmo\Tests\Mapping\Fixture\Yaml\Category;
 use Gedmo\Tests\Mapping\Fixture\Yaml\ClosureCategory;
 use Gedmo\Tests\Mapping\Fixture\Yaml\MaterializedPathCategory;
 use Gedmo\Tests\Tree\Fixture\Closure\CategoryClosure;
 use Gedmo\Tree\TreeListener;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 /**
  * These are mapping tests for tree extension
@@ -39,11 +40,11 @@ final class TreeMappingTest extends \PHPUnit\Framework\TestCase
     protected function setUp(): void
     {
         $config = new \Doctrine\ORM\Configuration();
-        $config->setMetadataCacheImpl(new \Doctrine\Common\Cache\ArrayCache());
-        $config->setQueryCacheImpl(new \Doctrine\Common\Cache\ArrayCache());
+        $config->setMetadataCache(new ArrayAdapter());
+        $config->setQueryCache(new ArrayAdapter());
         $config->setProxyDir(TESTS_TEMP_DIR);
         $config->setProxyNamespace('Gedmo\Mapping\Proxy');
-        $chainDriverImpl = new DriverChain();
+        $chainDriverImpl = new MappingDriverChain();
         $chainDriverImpl->addDriver(
             new YamlDriver([__DIR__.'/Driver/Yaml']),
             'Gedmo\Tests\Mapping\Fixture\Yaml'

--- a/tests/Gedmo/Mapping/UploadableMappingTest.php
+++ b/tests/Gedmo/Mapping/UploadableMappingTest.php
@@ -5,8 +5,8 @@ namespace Gedmo\Tests\Mapping;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\EventManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
-use Doctrine\ORM\Mapping\Driver\DriverChain;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Gedmo\Tests\Mapping\Fixture\Yaml\Uploadable;
 use Gedmo\Tests\Tool\BaseTestCaseOM;
 use Gedmo\Uploadable\Mapping\Validator;
@@ -45,7 +45,7 @@ final class UploadableMappingTest extends BaseTestCaseOM
 
         $yamlDriver = new YamlDriver(__DIR__.'/Driver/Yaml');
 
-        $chain = new DriverChain();
+        $chain = new MappingDriverChain();
         $chain->addDriver($yamlDriver, 'Gedmo\Tests\Mapping\Fixture\Yaml');
         $chain->addDriver($annotationDriver, 'Gedmo\Tests\Mapping\Fixture');
 

--- a/tests/Gedmo/Mapping/Xml/ClosureTreeMappingTest.php
+++ b/tests/Gedmo/Mapping/Xml/ClosureTreeMappingTest.php
@@ -5,8 +5,8 @@ namespace Gedmo\Tests\Mapping\Xml;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\EventManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
-use Doctrine\ORM\Mapping\Driver\DriverChain;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Gedmo\Tests\Mapping\Fixture\ClosureTreeClosure;
 use Gedmo\Tests\Mapping\Fixture\Xml\ClosureTree;
 use Gedmo\Tests\Tool\BaseTestCaseOM;
@@ -42,7 +42,7 @@ final class ClosureTreeMappingTest extends BaseTestCaseOM
 
         $xmlDriver = new XmlDriver(__DIR__.'/../Driver/Xml');
 
-        $chain = new DriverChain();
+        $chain = new MappingDriverChain();
         $chain->addDriver($xmlDriver, 'Gedmo\Tests\Mapping\Fixture\Xml');
         $chain->addDriver($annotationDriver, 'Gedmo\Tests\Mapping\Fixture');
         $chain->addDriver($annotationDriver, 'Gedmo\Tree');

--- a/tests/Gedmo/Mapping/Xml/LoggableMappingTest.php
+++ b/tests/Gedmo/Mapping/Xml/LoggableMappingTest.php
@@ -5,8 +5,8 @@ namespace Gedmo\Tests\Mapping\Xml;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\EventManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
-use Doctrine\ORM\Mapping\Driver\DriverChain;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Gedmo\Loggable\Entity\LogEntry;
 use Gedmo\Loggable\LoggableListener;
 use Gedmo\Tests\Mapping\Fixture\Xml\Embedded;
@@ -45,7 +45,7 @@ final class LoggableMappingTest extends BaseTestCaseOM
 
         $xmlDriver = new XmlDriver(__DIR__.'/../Driver/Xml');
 
-        $chain = new DriverChain();
+        $chain = new MappingDriverChain();
         $chain->addDriver($annotationDriver, 'Gedmo\Loggable');
         $chain->addDriver($xmlDriver, 'Gedmo\Tests\Mapping\Fixture\Xml');
 

--- a/tests/Gedmo/Mapping/Xml/MaterializedPathTreeMappingTest.php
+++ b/tests/Gedmo/Mapping/Xml/MaterializedPathTreeMappingTest.php
@@ -5,8 +5,8 @@ namespace Gedmo\Tests\Mapping\Xml;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\EventManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
-use Doctrine\ORM\Mapping\Driver\DriverChain;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Gedmo\Tests\Mapping\Fixture\Xml\MaterializedPathTree;
 use Gedmo\Tests\Tool\BaseTestCaseOM;
 use Gedmo\Tree\TreeListener;
@@ -42,7 +42,7 @@ final class MaterializedPathTreeMappingTest extends BaseTestCaseOM
 
         $xmlDriver = new XmlDriver(__DIR__.'/../Driver/Xml');
 
-        $chain = new DriverChain();
+        $chain = new MappingDriverChain();
         $chain->addDriver($xmlDriver, 'Gedmo\Tests\Mapping\Fixture\Xml');
         $chain->addDriver($annotationDriver, 'Gedmo\Tests\Mapping\Fixture');
         $chain->addDriver($annotationDriver, 'Gedmo\Tree');

--- a/tests/Gedmo/Mapping/Xml/NestedTreeMappingTest.php
+++ b/tests/Gedmo/Mapping/Xml/NestedTreeMappingTest.php
@@ -3,8 +3,8 @@
 namespace Gedmo\Tests\Mapping\Xml;
 
 use Doctrine\Common\EventManager;
-use Doctrine\ORM\Mapping\Driver\DriverChain;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Gedmo\Tests\Mapping\Fixture\Xml\NestedTree;
 use Gedmo\Tests\Tool\BaseTestCaseOM;
 use Gedmo\Tree\TreeListener;
@@ -36,7 +36,7 @@ final class NestedTreeMappingTest extends BaseTestCaseOM
 
         $xmlDriver = new XmlDriver(__DIR__.'/../Driver/Xml');
 
-        $chain = new DriverChain();
+        $chain = new MappingDriverChain();
         $chain->addDriver($xmlDriver, 'Gedmo\Tests\Mapping\Fixture\Xml');
 
         $this->tree = new TreeListener();

--- a/tests/Gedmo/Mapping/Xml/Simplified/TimestampableMappingTest.php
+++ b/tests/Gedmo/Mapping/Xml/Simplified/TimestampableMappingTest.php
@@ -3,8 +3,8 @@
 namespace Gedmo\Tests\Mapping\Xml\Simplified;
 
 use Doctrine\Common\EventManager;
-use Doctrine\ORM\Mapping\Driver\DriverChain;
 use Doctrine\ORM\Mapping\Driver\SimplifiedXmlDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Gedmo\Tests\Mapping\Fixture\Xml\Status;
 use Gedmo\Tests\Mapping\Fixture\Xml\Timestampable;
 use Gedmo\Tests\Tool\BaseTestCaseORM;
@@ -43,7 +43,7 @@ final class TimestampableMappingTest extends BaseTestCaseORM
             __DIR__.'/../../Driver/Xml' => 'Gedmo\Tests\Mapping\Fixture\Xml',
         ]);
 
-        $chain = new DriverChain();
+        $chain = new MappingDriverChain();
         $chain->addDriver($xmlDriver, 'Gedmo\Tests\Mapping\Fixture\Xml');
 
         return $chain;

--- a/tests/Gedmo/Mapping/Xml/SluggableMappingTest.php
+++ b/tests/Gedmo/Mapping/Xml/SluggableMappingTest.php
@@ -3,8 +3,8 @@
 namespace Gedmo\Tests\Mapping\Xml;
 
 use Doctrine\Common\EventManager;
-use Doctrine\ORM\Mapping\Driver\DriverChain;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Gedmo\Sluggable\Handler\RelativeSlugHandler;
 use Gedmo\Sluggable\Handler\TreeSlugHandler;
 use Gedmo\Sluggable\SluggableListener;
@@ -47,7 +47,7 @@ final class SluggableMappingTest extends BaseTestCaseORM
     {
         $xmlDriver = new XmlDriver(__DIR__.'/../Driver/Xml');
 
-        $chain = new DriverChain();
+        $chain = new MappingDriverChain();
         $chain->addDriver($xmlDriver, 'Gedmo\Tests\Mapping\Fixture\Xml');
 
         return $chain;

--- a/tests/Gedmo/Mapping/Xml/SoftDeleteableMappingTest.php
+++ b/tests/Gedmo/Mapping/Xml/SoftDeleteableMappingTest.php
@@ -5,8 +5,8 @@ namespace Gedmo\Tests\Mapping\Xml;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\EventManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
-use Doctrine\ORM\Mapping\Driver\DriverChain;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Gedmo\SoftDeleteable\SoftDeleteableListener;
 use Gedmo\Tests\Mapping\Fixture\Xml\SoftDeleteable;
 use Gedmo\Tests\Tool\BaseTestCaseOM;
@@ -42,7 +42,7 @@ final class SoftDeleteableMappingTest extends BaseTestCaseOM
 
         $xmlDriver = new XmlDriver(__DIR__.'/../Driver/Xml');
 
-        $chain = new DriverChain();
+        $chain = new MappingDriverChain();
         $chain->addDriver($xmlDriver, 'Gedmo\Tests\Mapping\Fixture\Xml');
         $chain->addDriver($annotationDriver, 'Gedmo\Tests\Mapping\Fixture');
 

--- a/tests/Gedmo/Mapping/Xml/SortableMappingTest.php
+++ b/tests/Gedmo/Mapping/Xml/SortableMappingTest.php
@@ -5,8 +5,8 @@ namespace Gedmo\Tests\Mapping\Xml;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\EventManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
-use Doctrine\ORM\Mapping\Driver\DriverChain;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Gedmo\Sortable\SortableListener;
 use Gedmo\Tests\Mapping\Fixture\SortableGroup;
 use Gedmo\Tests\Mapping\Fixture\Xml\Sortable;
@@ -42,7 +42,7 @@ final class SortableMappingTest extends BaseTestCaseOM
 
         $xmlDriver = new XmlDriver(__DIR__.'/../Driver/Xml');
 
-        $chain = new DriverChain();
+        $chain = new MappingDriverChain();
         $chain->addDriver($xmlDriver, 'Gedmo\Tests\Mapping\Fixture\Xml');
         $chain->addDriver($annotationDriver, 'Gedmo\Tests\Mapping\Fixture');
 

--- a/tests/Gedmo/Mapping/Xml/TimestampableMappingTest.php
+++ b/tests/Gedmo/Mapping/Xml/TimestampableMappingTest.php
@@ -3,8 +3,8 @@
 namespace Gedmo\Tests\Mapping\Xml;
 
 use Doctrine\Common\EventManager;
-use Doctrine\ORM\Mapping\Driver\DriverChain;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Gedmo\Tests\Mapping\Fixture\Xml\Status;
 use Gedmo\Tests\Mapping\Fixture\Xml\Timestampable;
 use Gedmo\Tests\Tool\BaseTestCaseOM;
@@ -37,7 +37,7 @@ final class TimestampableMappingTest extends BaseTestCaseOM
 
         $xmlDriver = new XmlDriver(__DIR__.'/../Driver/Xml');
 
-        $chain = new DriverChain();
+        $chain = new MappingDriverChain();
         $chain->addDriver($xmlDriver, 'Gedmo\Tests\Mapping\Fixture\Xml');
 
         $this->timestampable = new TimestampableListener();

--- a/tests/Gedmo/Mapping/Xml/TranslatableMappingTest.php
+++ b/tests/Gedmo/Mapping/Xml/TranslatableMappingTest.php
@@ -5,8 +5,8 @@ namespace Gedmo\Tests\Mapping\Xml;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\EventManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
-use Doctrine\ORM\Mapping\Driver\DriverChain;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Gedmo\Tests\Mapping\Fixture\Xml\Translatable;
 use Gedmo\Tests\Mapping\Fixture\Xml\TranslatableWithEmbedded;
 use Gedmo\Tests\Tool\BaseTestCaseOM;
@@ -43,7 +43,7 @@ final class TranslatableMappingTest extends BaseTestCaseOM
 
         $xmlDriver = new XmlDriver(__DIR__.'/../Driver/Xml');
 
-        $chain = new DriverChain();
+        $chain = new MappingDriverChain();
         $chain->addDriver($annotationDriver, 'Gedmo\Translatable');
         $chain->addDriver($xmlDriver, 'Gedmo\Tests\Mapping\Fixture\Xml');
 

--- a/tests/Gedmo/Mapping/Xml/UploadableMappingTest.php
+++ b/tests/Gedmo/Mapping/Xml/UploadableMappingTest.php
@@ -5,8 +5,8 @@ namespace Gedmo\Tests\Mapping\Xml;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\EventManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
-use Doctrine\ORM\Mapping\Driver\DriverChain;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Gedmo\Tests\Mapping\Fixture\Xml\Uploadable;
 use Gedmo\Tests\Tool\BaseTestCaseOM;
 use Gedmo\Uploadable\Mapping\Validator;
@@ -45,7 +45,7 @@ final class UploadableMappingTest extends BaseTestCaseOM
 
         $xmlDriver = new XmlDriver(__DIR__.'/../Driver/Xml');
 
-        $chain = new DriverChain();
+        $chain = new MappingDriverChain();
         $chain->addDriver($xmlDriver, 'Gedmo\Tests\Mapping\Fixture\Xml');
         $chain->addDriver($annotationDriver, 'Gedmo\Tests\Mapping\Fixture');
 

--- a/tests/Gedmo/Mapping/Yaml/LoggableMappingTest.php
+++ b/tests/Gedmo/Mapping/Yaml/LoggableMappingTest.php
@@ -5,8 +5,8 @@ namespace Gedmo\Tests\Mapping\Yaml;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\EventManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
-use Doctrine\ORM\Mapping\Driver\DriverChain;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Gedmo\Loggable\Entity\LogEntry;
 use Gedmo\Loggable\LoggableListener;
 use Gedmo\Tests\Mapping\Fixture\Yaml\Embedded;
@@ -43,7 +43,7 @@ final class LoggableMappingTest extends BaseTestCaseOM
 
         $yamlDriver = new YamlDriver(__DIR__.'/../Driver/Yaml');
 
-        $chain = new DriverChain();
+        $chain = new MappingDriverChain();
         $chain->addDriver($annotationDriver, 'Gedmo\Loggable');
         $chain->addDriver($yamlDriver, 'Gedmo\Tests\Mapping\Fixture\Yaml');
 

--- a/tests/Gedmo/Sluggable/Issue/Issue116Test.php
+++ b/tests/Gedmo/Sluggable/Issue/Issue116Test.php
@@ -3,8 +3,8 @@
 namespace Gedmo\Tests\Sluggable;
 
 use Doctrine\Common\EventManager;
-use Doctrine\ORM\Mapping\Driver\DriverChain;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Gedmo\Sluggable\SluggableListener;
 use Gedmo\Tests\Sluggable\Fixture\Issue116\Country;
 use Gedmo\Tests\Tool\BaseTestCaseORM;
@@ -34,7 +34,7 @@ final class Issue116Test extends BaseTestCaseORM
 
     protected function getMetadataDriverImplementation()
     {
-        $chain = new DriverChain();
+        $chain = new MappingDriverChain();
         $chain->addDriver(
             new YamlDriver([__DIR__.'/../Fixture/Issue116/Mapping']),
             'Gedmo\Tests\Sluggable\Fixture\Issue116'

--- a/tests/Gedmo/SoftDeleteable/SoftDeleteableEntityTest.php
+++ b/tests/Gedmo/SoftDeleteable/SoftDeleteableEntityTest.php
@@ -4,6 +4,7 @@ namespace Gedmo\Tests\SoftDeleteable;
 
 use function class_exists;
 use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\Common\Cache\Psr6\CacheAdapter;
 use Doctrine\Common\EventManager;
 use Doctrine\Common\EventSubscriber;
 use Gedmo\SoftDeleteable\Filter\SoftDeleteableFilter;
@@ -493,8 +494,7 @@ final class SoftDeleteableEntityTest extends BaseTestCaseORM
             static::markTestSkipped('Test only applies when doctrine/cache 1.x is installed');
         }
 
-        $cache = new ArrayCache();
-        $this->em->getConfiguration()->setQueryCacheImpl($cache);
+        $this->em->getConfiguration()->setQueryCache(CacheAdapter::wrap(new ArrayCache()));
 
         $filter = $this->em->getFilters()->enable(self::SOFT_DELETEABLE_FILTER_NAME);
         $filter->disableForEntity(self::USER_CLASS);

--- a/tests/Gedmo/Sortable/Fixture/CustomerType.php
+++ b/tests/Gedmo/Sortable/Fixture/CustomerType.php
@@ -3,7 +3,8 @@
 namespace Gedmo\Tests\Sortable\Fixture;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\DBAL\Driver\PDOException;
+use Doctrine\DBAL\Driver\PDO\Exception as PDODriverException;
+use Doctrine\DBAL\Driver\PDOException as LegacyPDOException;
 use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
@@ -88,11 +89,17 @@ class CustomerType
     public function postRemove()
     {
         if ($this->getCustomers()->count() > 0) {
-            // we imitate an foreign key constraint exception, because doctrine
-            // does not support sqlite constraints, which must be tested, too.
+            // we imitate a foreign key constraint exception because Doctrine
+            // does not support SQLite constraints, which must be tested, too.
+
             $pdoException = new \PDOException('SQLSTATE[23000]: Integrity constraint violation: 1451 Cannot delete or update a parent row: a foreign key constraint fails', '23000');
 
-            throw new ForeignKeyConstraintViolationException(sprintf('An exception occurred while deleting the customer type with id %s.', $this->getId()), new PDOException($pdoException));
+            // @todo: This check can be removed when dropping support for doctrine/dbal 2.x.
+            if (class_exists(LegacyPDOException::class)) {
+                throw new ForeignKeyConstraintViolationException(sprintf('An exception occurred while deleting the customer type with id %s.', $this->getId()), new LegacyPDOException($pdoException));
+            }
+
+            throw new ForeignKeyConstraintViolationException(PDODriverException::new($pdoException), null);
         }
     }
 }

--- a/tests/Gedmo/Tool/BaseTestCaseOM.php
+++ b/tests/Gedmo/Tool/BaseTestCaseOM.php
@@ -7,7 +7,7 @@ use Doctrine\Common\EventManager;
 // orm specific
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver as AnnotationDriverODM;
@@ -157,7 +157,7 @@ abstract class BaseTestCaseOM extends \PHPUnit\Framework\TestCase
         $driver = $this->getMockBuilder(Driver::class)->getMock();
         $driver->expects(static::once())
             ->method('getDatabasePlatform')
-            ->willReturn($this->getMockBuilder(MySqlPlatform::class)->getMock());
+            ->willReturn($this->getMockBuilder(MySQLPlatform::class)->getMock());
 
         $conn = $this->getMockBuilder(Connection::class)
             ->setConstructorArgs([], $driver)

--- a/tests/Gedmo/Tool/BaseTestCaseORM.php
+++ b/tests/Gedmo/Tool/BaseTestCaseORM.php
@@ -5,7 +5,7 @@ namespace Gedmo\Tests\Tool;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
@@ -142,7 +142,7 @@ abstract class BaseTestCaseORM extends \PHPUnit\Framework\TestCase
         $driver = $this->getMockBuilder(Driver::class)->getMock();
         $driver->expects(static::once())
             ->method('getDatabasePlatform')
-            ->willReturn($this->getMockBuilder(MySqlPlatform::class)->getMock());
+            ->willReturn($this->getMockBuilder(MySQLPlatform::class)->getMock());
 
         $conn = $this->getMockBuilder(Connection::class)
             ->setConstructorArgs([], $driver)

--- a/tests/Gedmo/Translatable/TranslatableIdentifierTest.php
+++ b/tests/Gedmo/Translatable/TranslatableIdentifierTest.php
@@ -96,7 +96,7 @@ final class TranslatableIdentifierTest extends BaseTestCaseORM
         $q = $this->em
             ->createQuery('SELECT si FROM '.self::FIXTURE.' si WHERE si.uid = :id')
             ->setParameter('id', $this->testObjectId)
-            ->useResultCache(false)
+            ->disableResultCache()
         ;
         $data = $q->getResult();
         static::assertCount(1, $data);

--- a/tests/Gedmo/Translatable/TranslationQueryWalkerTest.php
+++ b/tests/Gedmo/Translatable/TranslationQueryWalkerTest.php
@@ -12,6 +12,7 @@ use Gedmo\Translatable\Hydrator\ORM\ObjectHydrator;
 use Gedmo\Translatable\Hydrator\ORM\SimpleObjectHydrator;
 use Gedmo\Translatable\Query\TreeWalker\TranslationWalker;
 use Gedmo\Translatable\TranslatableListener;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 /**
  * These are tests for translation query walker
@@ -54,8 +55,7 @@ final class TranslationQueryWalkerTest extends BaseTestCaseORM
      */
     public function shouldHandleQueryCache()
     {
-        $cache = new \Doctrine\Common\Cache\ArrayCache();
-        $this->em->getConfiguration()->setQueryCacheImpl($cache);
+        $this->em->getConfiguration()->setQueryCache(new ArrayAdapter());
         $dql = 'SELECT a FROM '.self::ARTICLE.' a';
         $q = $this->em->createQuery($dql);
         $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, self::TREE_WALKER_TRANSLATION);


### PR DESCRIPTION
This adds full DBAL 3 compatibility and does a minor API cleanup to avoid uses of deprecated symbols.

A CI build is also added to make sure there is at least one run on each major DBAL branch.