### PR TITLE
Fix `Gedmo\Mapping\Driver\Xml::_loadMappingFile()` behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ a release.
 
 ## [Unreleased]
 ### Fixed
+- `Gedmo\Mapping\Driver\Xml::_loadMappingFile()` behavior in scenarios where `libxml_disable_entity_loader(true)` was previously
+  called.
 - Loggable: Missing support for `versioned` fields at `attribute-override` in XML mapping.
 
 ## [3.3.0] - 2021-11-15

--- a/src/Mapping/Driver/Xml.php
+++ b/src/Mapping/Driver/Xml.php
@@ -84,7 +84,11 @@ abstract class Xml extends File
     protected function _loadMappingFile($file)
     {
         $result = [];
-        $xmlElement = simplexml_load_file($file);
+        // We avoid calling `simplexml_load_file()` in order to prevent file operations in libXML.
+        // If `libxml_disable_entity_loader(true)` is called before, `simplexml_load_file()` fails,
+        // that's why we use `simplexml_load_string()` instead.
+        // @see https://bugs.php.net/bug.php?id=62577.
+        $xmlElement = simplexml_load_string(file_get_contents($file));
         $xmlElement = $xmlElement->children(self::DOCTRINE_NAMESPACE_URI);
 
         if (isset($xmlElement->entity)) {


### PR DESCRIPTION
Fixes `Gedmo\Mapping\Driver\Xml::_loadMappingFile()` behavior in scenarios where `libxml_disable_entity_loader(true)` was previously called.

Closes #1945,