### PR TITLE
[Loggable] Fix missinig support for `versioned` fields at `attribute-override` in XML mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ a release.
 ---
 
 ## [Unreleased]
+### Fixed
+- Loggable: Missing support for `versioned` fields at `attribute-override` in XML mapping.
 
 ## [3.3.0] - 2021-11-15
 ### Added

--- a/src/Loggable/Mapping/Driver/Xml.php
+++ b/src/Loggable/Mapping/Driver/Xml.php
@@ -51,6 +51,9 @@ class Xml extends BaseXml
         if (isset($xmlDoctrine->field)) {
             $this->inspectElementForVersioned($xmlDoctrine->field, $config, $meta);
         }
+        foreach ($xmlDoctrine->{'attribute-overrides'}->{'attribute-override'} ?? [] as $overrideMapping) {
+            $this->inspectElementForVersioned($overrideMapping, $config, $meta);
+        }
         if (isset($xmlDoctrine->{'many-to-one'})) {
             $this->inspectElementForVersioned($xmlDoctrine->{'many-to-one'}, $config, $meta);
         }


### PR DESCRIPTION
Closes #1976.