### PR TITLE
[Translatable] Fix mixing attributes and annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ a release.
 
 ## [Unreleased]
 ### Fixed
+- Translatable: Using ORM/ODM attribute mapping and translatable annotations.
 - Tree: Missing support for `tree-path-hash` fields in XML mapping.
 - Tree: Check for affected rows at `ClosureTreeRepository::cleanUpClosure()` and `Closure::updateNode()`.
 - `Gedmo\Mapping\Driver\Xml::_loadMappingFile()` behavior in scenarios where `libxml_disable_entity_loader(true)` was previously

--- a/src/Mapping/Driver/AttributeAnnotationReader.php
+++ b/src/Mapping/Driver/AttributeAnnotationReader.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Gedmo\Mapping\Driver;
+
+use Doctrine\Common\Annotations\Reader;
+use Gedmo\Mapping\Annotation\Annotation;
+use ReflectionClass;
+use ReflectionMethod;
+
+/**
+ * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
+ *
+ * @internal
+ */
+final class AttributeAnnotationReader implements Reader
+{
+    /**
+     * @var Reader
+     */
+    private $annotationReader;
+
+    /**
+     * @var AttributeReader
+     */
+    private $attributeReader;
+
+    public function __construct(AttributeReader $attributeReader, Reader $annotationReader)
+    {
+        $this->attributeReader = $attributeReader;
+        $this->annotationReader = $annotationReader;
+    }
+
+    /**
+     * @return Annotation[]
+     */
+    public function getClassAnnotations(ReflectionClass $class): array
+    {
+        $annotations = $this->attributeReader->getClassAnnotations($class);
+
+        if ([] !== $annotations) {
+            return $annotations;
+        }
+
+        return $this->annotationReader->getClassAnnotations($class);
+    }
+
+    public function getClassAnnotation(ReflectionClass $class, $annotationName): ?Annotation
+    {
+        $annotation = $this->attributeReader->getClassAnnotation($class, $annotationName);
+
+        if (null !== $annotation) {
+            return $annotation;
+        }
+
+        return $this->annotationReader->getClassAnnotation($class, $annotationName);
+    }
+
+    /**
+     * @return Annotation[]
+     */
+    public function getPropertyAnnotations(\ReflectionProperty $property): array
+    {
+        $propertyAnnotations = $this->attributeReader->getPropertyAnnotations($property);
+
+        if ([] !== $propertyAnnotations) {
+            return $propertyAnnotations;
+        }
+
+        return $this->annotationReader->getPropertyAnnotations($property);
+    }
+
+    public function getPropertyAnnotation(\ReflectionProperty $property, $annotationName): ?Annotation
+    {
+        $annotation = $this->attributeReader->getPropertyAnnotation($property, $annotationName);
+
+        if (null !== $annotation) {
+            return $annotation;
+        }
+
+        return $this->annotationReader->getPropertyAnnotation($property, $annotationName);
+    }
+
+    public function getMethodAnnotations(ReflectionMethod $method)
+    {
+        throw new \BadMethodCallException('Not implemented');
+    }
+
+    public function getMethodAnnotation(ReflectionMethod $method, $annotationName)
+    {
+        throw new \BadMethodCallException('Not implemented');
+    }
+}

--- a/src/Mapping/Driver/AttributeReader.php
+++ b/src/Mapping/Driver/AttributeReader.php
@@ -13,7 +13,9 @@ use ReflectionClass;
  */
 final class AttributeReader
 {
-    /** @return array<Annotation> */
+    /**
+     * @return Annotation[]
+     */
     public function getClassAnnotations(ReflectionClass $class): array
     {
         return $this->convertToAttributeInstances($class->getAttributes());
@@ -24,7 +26,9 @@ final class AttributeReader
         return $this->getClassAnnotations($class)[$annotationName] ?? null;
     }
 
-    /** @return array<Annotation> */
+    /**
+     * @return Annotation[]
+     */
     public function getPropertyAnnotations(\ReflectionProperty $property): array
     {
         return $this->convertToAttributeInstances($property->getAttributes());
@@ -38,7 +42,7 @@ final class AttributeReader
     /**
      * @param array<\ReflectionAttribute> $attributes
      *
-     * @return array<Annotation>
+     * @return Annotation[]
      */
     private function convertToAttributeInstances(array $attributes): array
     {

--- a/src/Mapping/ExtensionMetadataFactory.php
+++ b/src/Mapping/ExtensionMetadataFactory.php
@@ -10,6 +10,7 @@ use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Doctrine\Persistence\Mapping\Driver\SymfonyFileLocator;
 use Doctrine\Persistence\ObjectManager;
 use Gedmo\Mapping\Driver\AnnotationDriverInterface;
+use Gedmo\Mapping\Driver\AttributeAnnotationReader;
 use Gedmo\Mapping\Driver\AttributeDriverInterface;
 use Gedmo\Mapping\Driver\AttributeReader;
 use Gedmo\Mapping\Driver\File as FileDriver;
@@ -186,7 +187,7 @@ class ExtensionMetadataFactory
             }
 
             if ($driver instanceof AttributeDriverInterface) {
-                $driver->setAnnotationReader(new AttributeReader());
+                $driver->setAnnotationReader(new AttributeAnnotationReader(new AttributeReader(), $this->annotationReader));
             } elseif ($driver instanceof AnnotationDriverInterface) {
                 $driver->setAnnotationReader($this->annotationReader);
             }

--- a/src/Translatable/Mapping/Driver/Attribute.php
+++ b/src/Translatable/Mapping/Driver/Attribute.php
@@ -8,7 +8,7 @@ use Gedmo\Mapping\Driver\AttributeDriverInterface;
 /**
  * This is an attribute mapping driver for Translatable
  * behavioral extension. Used for extraction of extended
- * metadata from Annotations specifically for Translatable
+ * metadata from attributes specifically for Translatable
  * extension.
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>

--- a/tests/Gedmo/Translatable/AttributeEntityTranslationTableTest.php
+++ b/tests/Gedmo/Translatable/AttributeEntityTranslationTableTest.php
@@ -4,6 +4,7 @@ namespace Gedmo\Tests\Translatable;
 
 use Doctrine\Common\EventManager;
 use Gedmo\Tests\Tool\BaseTestCaseORM;
+use Gedmo\Tests\Translatable\Fixture\Attribute\File;
 use Gedmo\Tests\Translatable\Fixture\Attribute\Person;
 use Gedmo\Tests\Translatable\Fixture\Attribute\PersonTranslation;
 use Gedmo\Translatable\Entity\Repository\TranslationRepository;
@@ -24,6 +25,7 @@ final class AttributeEntityTranslationTableTest extends BaseTestCaseORM
 {
     public const PERSON = Person::class;
     public const TRANSLATION = PersonTranslation::class;
+    public const FILE = File::class;
 
     private $translatableListener;
 
@@ -76,11 +78,37 @@ final class AttributeEntityTranslationTableTest extends BaseTestCaseORM
         $this->translatableListener->setTranslatableLocale('en_us');
     }
 
+    public function testFixtureWithAttributeMappingAndAnnotations(): void
+    {
+        $file = new File();
+        $file->setTitle('title in en');
+
+        $this->em->persist($file);
+        $this->em->flush();
+        $this->em->clear();
+
+        $file = $this->em->find(self::FILE, $file->getId());
+
+        $file->locale = 'de';
+        $file->setTitle('title in de');
+
+        $this->em->flush();
+        $this->em->clear();
+
+        $file = $this->em->find(self::FILE, $file->getId());
+
+        static::assertEquals('title in en', $file->getTitle());
+        $file->locale = 'de';
+        $this->em->refresh($file);
+        static::assertEquals('title in de', $file->getTitle());
+    }
+
     protected function getUsedEntityFixtures()
     {
         return [
             self::PERSON,
             self::TRANSLATION,
+            self::FILE,
         ];
     }
 }

--- a/tests/Gedmo/Translatable/Fixture/Attribute/File.php
+++ b/tests/Gedmo/Translatable/Fixture/Attribute/File.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Gedmo\Tests\Translatable\Fixture\Attribute;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+#[ORM\Entity]
+class File
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    private $id;
+
+    /**
+     * @Gedmo\Translatable
+     */
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
+    private $title;
+
+    /**
+     * @Gedmo\Locale
+     */
+    public $locale;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+}


### PR DESCRIPTION
Fixes #2321

It adds a new `AttributeAnnotationReader` which tries to read attributes and if it fails, it reads annotations.