### PR TITLE
Add phpstan-doctrine extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,7 @@
         "doctrine/orm": "^2.10.2",
         "friendsofphp/php-cs-fixer": "^3.0",
         "phpstan/phpstan": "^1.1",
+        "phpstan/phpstan-doctrine": "^1.0",
         "phpunit/phpunit": "^8.5 || ^9.5",
         "symfony/cache": "^4.4 || ^5.3",
         "symfony/yaml": "^4.4 || ^5.3"

--- a/doc/ip_traceable.md
+++ b/doc/ip_traceable.md
@@ -109,7 +109,7 @@ class Article
     private $updatedFromIp;
 
     /**
-     * @var datetime $contentChangedFromIp
+     * @var \DateTime $contentChangedFromIp
      *
      * @ORM\Column(name="content_changed_by", type="string", nullable=true, length=45)
      * @Gedmo\IpTraceable(on="change", field={"title", "body"})

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,6 @@
 includes:
     - phpstan-baseline.neon
+    - vendor/phpstan/phpstan-doctrine/extension.neon
 
 parameters:
     level: 1
@@ -8,3 +9,5 @@ parameters:
         - tests
     bootstrapFiles:
         - tests/bootstrap.php
+    doctrine:
+        objectManagerLoader: tests/object-manager.php

--- a/tests/Gedmo/Mapping/Fixture/Compatibility/Article.php
+++ b/tests/Gedmo/Mapping/Fixture/Compatibility/Article.php
@@ -16,7 +16,7 @@ class Article
     private $title;
 
     /**
-     * @var datetime
+     * @var \DateTime
      *
      * @gedmo:Timestampable(on="create")
      * @Column(name="created", type="date")
@@ -24,7 +24,7 @@ class Article
     private $created;
 
     /**
-     * @var datetime
+     * @var \DateTime
      *
      * @Column(name="updated", type="datetime")
      * @gedmo:Timestampable

--- a/tests/Gedmo/Mapping/Fixture/Yaml/BaseCategory.php
+++ b/tests/Gedmo/Mapping/Fixture/Yaml/BaseCategory.php
@@ -28,7 +28,7 @@ class BaseCategory
     private $rooted;
 
     /**
-     * @var datetime
+     * @var \DateTime
      *
      * @Column(name="created", type="datetime")
      */

--- a/tests/Gedmo/SoftDeleteable/Fixture/Document/User.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Document/User.php
@@ -23,8 +23,6 @@ class User
     /**
      * Sets deletedAt.
      *
-     * @param Datetime $deletedAt
-     *
      * @return $this
      */
     public function setDeletedAt(\DateTime $deletedAt)
@@ -37,7 +35,7 @@ class User
     /**
      * Returns deletedAt.
      *
-     * @return DateTime
+     * @return \DateTime
      */
     public function getDeletedAt()
     {

--- a/tests/Gedmo/SoftDeleteable/Fixture/Document/UserTimeAware.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Document/UserTimeAware.php
@@ -23,8 +23,6 @@ class UserTimeAware
     /**
      * Sets deletedAt.
      *
-     * @param Datetime $deletedAt
-     *
      * @return $this
      */
     public function setDeletedAt(\DateTime $deletedAt)

--- a/tests/Gedmo/Timestampable/Fixture/Article.php
+++ b/tests/Gedmo/Timestampable/Fixture/Article.php
@@ -35,7 +35,7 @@ class Article implements Timestampable
     private $author;
 
     /**
-     * @var datetime
+     * @var \DateTime
      *
      * @Gedmo\Timestampable(on="create")
      * @ORM\Column(name="created", type="date")
@@ -43,7 +43,7 @@ class Article implements Timestampable
     private $created;
 
     /**
-     * @var datetime
+     * @var \DateTime
      *
      * @ORM\Column(name="updated", type="datetime")
      * @Gedmo\Timestampable
@@ -51,7 +51,7 @@ class Article implements Timestampable
     private $updated;
 
     /**
-     * @var datetime
+     * @var \DateTime
      *
      * @ORM\Column(name="published", type="datetime", nullable=true)
      * @Gedmo\Timestampable(on="change", field="type.title", value="Published")
@@ -59,14 +59,14 @@ class Article implements Timestampable
     private $published;
 
     /**
-     * @var datetime
+     * @var \DateTime
      *
      * @ORM\Column(name="content_changed", type="datetime", nullable=true)
      * @Gedmo\Timestampable(on="change", field={"title", "body"})
      */
     private $contentChanged;
     /**
-     * @var datetime
+     * @var \DateTime
      *
      * @ORM\Column(name="author_changed", type="datetime", nullable=true)
      * @Gedmo\Timestampable(on="change", field={"author.name", "author.email"})

--- a/tests/Gedmo/Timestampable/Fixture/Comment.php
+++ b/tests/Gedmo/Timestampable/Fixture/Comment.php
@@ -30,7 +30,7 @@ class Comment implements Timestampable
     private $status;
 
     /**
-     * @var datetime
+     * @var \DateTime
      *
      * @ORM\Column(name="closed", type="datetime", nullable=true)
      * @Gedmo\Timestampable(on="change", field="status", value=1)
@@ -38,7 +38,7 @@ class Comment implements Timestampable
     private $closed;
 
     /**
-     * @var datetime
+     * @var \DateTime
      *
      * @ORM\Column(name="modified", type="time")
      * @Gedmo\Timestampable(on="update")

--- a/tests/Gedmo/Translatable/TranslatableEntityDefaultTranslationTest.php
+++ b/tests/Gedmo/Translatable/TranslatableEntityDefaultTranslationTest.php
@@ -3,10 +3,10 @@
 namespace Gedmo\Tests\Translatable;
 
 use Doctrine\Common\EventManager;
-use Doctrine\ORM\EntityRepository;
 use Gedmo\Tests\Tool\BaseTestCaseORM;
 use Gedmo\Tests\Translatable\Fixture\Article;
 use Gedmo\Tests\Translatable\Fixture\Comment;
+use Gedmo\Translatable\Entity\Repository\TranslationRepository;
 use Gedmo\Translatable\Entity\Translation;
 use Gedmo\Translatable\TranslatableListener;
 
@@ -31,7 +31,7 @@ final class TranslatableEntityDefaultTranslationTest extends BaseTestCaseORM
     private $translatableListener;
 
     /**
-     * @var EntityRepository
+     * @var TranslationRepository
      */
     private $repo;
 

--- a/tests/Gedmo/Tree/Fixture/Genealogy/Person.php
+++ b/tests/Gedmo/Tree/Fixture/Genealogy/Person.php
@@ -36,7 +36,7 @@ abstract class Person
     /**
      * @ORM\OneToMany(targetEntity="Person", mappedBy="parent")
      *
-     * @var Doctrine\Common\Collections\ArrayCollection
+     * @var \Doctrine\Common\Collections\ArrayCollection
      */
     protected $children;
 

--- a/tests/Gedmo/Tree/MaterializedPathODMMongoDBRepositoryTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathODMMongoDBRepositoryTest.php
@@ -24,7 +24,7 @@ final class MaterializedPathODMMongoDBRepositoryTest extends BaseTestCaseMongoOD
     private const CATEGORY = Category::class;
 
     /**
-     * @var Document\MongoDB\Repository\MaterializedPathRepository
+     * @var \Gedmo\Tree\Document\MongoDB\Repository\MaterializedPathRepository
      */
     protected $repo;
 

--- a/tests/object-manager.php
+++ b/tests/object-manager.php
@@ -1,0 +1,33 @@
+<?php
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\PsrCachedReader;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/*
+ * This is bootstrap for phpUnit unit tests,
+ * use README.md for more details
+ *
+ * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ * @author Christoph Krämer <cevou@gmx.de>
+ * @link http://www.gediminasm.org
+ * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+
+$reader = new AnnotationReader();
+$reader = new PsrCachedReader($reader, new ArrayAdapter());
+
+$config = new Configuration();
+$config->setProxyDir(TESTS_TEMP_DIR);
+$config->setProxyNamespace('Proxy');
+$config->setMetadataDriverImpl(new AnnotationDriver($reader));
+
+$conn = [
+    'driver' => 'pdo_sqlite',
+    'memory' => true,
+];
+
+return EntityManager::create($conn, $config);


### PR DESCRIPTION
This will allow phpstan to understand the `EntityManager::getRepository` calls (returning a configured repository), in level 2 it goes from 1111 errors to 859 (taking into account also the ones removed here with the `\DateTime` phpdoc fix).