### PR TITLE
Add support for attributes to Timestampable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ a release.
 ---
 
 ## [Unreleased]
+### Added
+- Support to use Timestampable annotations as attributes on PHP >= 8.0.
 
 ## [3.3.1] - 2021-11-18
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ a release.
 
 ## [Unreleased]
 ### Added
-- Support to use Timestampable annotations as attributes on PHP >= 8.0.
+- Timestampable: Support to use annotations as attributes on PHP >= 8.0.
 
 ## [3.3.1] - 2021-11-18
 ### Fixed

--- a/doc/timestampable.md
+++ b/doc/timestampable.md
@@ -59,9 +59,14 @@ on how to setup and use the extensions in most optimized way.
 ## Timestampable Entity example:
 
 ### Timestampable annotations:
-- **@Gedmo\Mapping\Annotation\Timestampable** this annotation tells that this column is timestampable
-by default it updates this column on update. If column is not date, datetime or time
+- **@Gedmo\Mapping\Annotation\Timestampable** this annotation tells that this column is timestampable.
+By default it updates this column on update. If column is not date, datetime or time
 type it will trigger an exception.
+
+### Timestampable attributes:
+- **@Gedmo\Mapping\Annotation\Timestampable** this attribute tells that this column is timestampable.
+  By default it updates this column on update. If column is not date, datetime or time
+  type it will trigger an exception.
 
 Available configuration options:
 
@@ -73,6 +78,8 @@ should be updated
 **Note:** that Timestampable interface is not necessary, except in cases where
 you need to identify entity as being Timestampable. The metadata is loaded only once then
 cache is activated
+
+### Annotations
 
 ``` php
 <?php
@@ -165,9 +172,92 @@ class Article
 }
 ```
 
+### Attributes
+
+```php
+#[ORM\Entity]
+class Article
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    private $id;
+
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
+    private $title;
+
+    #[ORM\Column(name: 'body', type: Types::STRING)]
+    private $body;
+
+    /**
+     * @var \DateTime
+     */
+    #[Gedmo\Timestampable(on: 'create')]
+    #[ORM\Column(name: 'created', type: Types::DATE_MUTABLE)]
+    private $created;
+
+    /**
+     * @var \DateTime
+     */
+    #[ORM\Column(name: 'updated', type: Types::DATETIME_MUTABLE)]
+    #[Gedmo\Timestampable]
+    private $updated;
+
+    /**
+     * @var \DateTime
+     */
+    #[ORM\Column(name: 'content_changed', type: Types::DATETIME_MUTABLE, nullable: true)]
+    #[Gedmo\Timestampable(on: 'change', field: ['title', 'body'])]
+    private $contentChanged;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    public function setBody($body)
+    {
+        $this->body = $body;
+    }
+
+    public function getBody()
+    {
+        return $this->body;
+    }
+
+    public function getCreated()
+    {
+        return $this->created;
+    }
+
+    public function getUpdated()
+    {
+        return $this->updated;
+    }
+
+    public function getContentChanged()
+    {
+        return $this->contentChanged;
+    }
+}
+```
+
 <a name="document-mapping"></a>
 
 ## Timestampable Document example:
+
+**Note:** this example is using annotations and attributes for mapping, you should use
+one of them, not both.
 
 ``` php
 <?php
@@ -200,6 +290,7 @@ class Article
      * @ODM\Date
      * @Gedmo\Timestampable(on="create")
      */
+     #[Gedmo\Timestampable(on: 'create')]
     private $created;
 
     /**
@@ -208,6 +299,7 @@ class Article
      * @ODM\Date
      * @Gedmo\Timestampable
      */
+     #[Gedmo\Timestampable]
     private $updated;
 
     /**
@@ -216,6 +308,7 @@ class Article
      * @ODM\Date
      * @Gedmo\Timestampable(on="change", field={"title", "body"})
      */
+     #[Gedmo\Timestampable(on: 'change', field: ['title', 'body'])]
     private $contentChanged;
 
     public function getId()

--- a/src/Mapping/Annotation/Timestampable.php
+++ b/src/Mapping/Annotation/Timestampable.php
@@ -2,18 +2,22 @@
 
 namespace Gedmo\Mapping\Annotation;
 
+use Attribute;
 use Doctrine\Common\Annotations\Annotation;
+use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 
 /**
  * Timestampable annotation for Timestampable behavioral extension
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("PROPERTY")
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
-final class Timestampable extends Annotation
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class Timestampable implements GedmoAnnotation
 {
     /** @var string */
     public $on = 'update';
@@ -21,4 +25,18 @@ final class Timestampable extends Annotation
     public $field;
     /** @var mixed */
     public $value;
+
+    public function __construct(array $data = [], string $on = 'update', $field = null, $value = null)
+    {
+        if ([] !== $data) {
+            trigger_error(sprintf(
+                'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
+        $this->on = $data['on'] ?? $on;
+        $this->field = $data['field'] ?? $field;
+        $this->value = $data['value'] ?? $value;
+    }
 }

--- a/src/Timestampable/Mapping/Driver/Attribute.php
+++ b/src/Timestampable/Mapping/Driver/Attribute.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Gedmo\Timestampable\Mapping\Driver;
+
+use Gedmo\Mapping\Annotation\Translatable;
+use Gedmo\Mapping\Driver\AttributeDriverInterface;
+
+/**
+ * This is an attribute mapping driver for Timestampable
+ * behavioral extension. Used for extraction of extended
+ * metadata from Annotations specifically for Timestampable
+ * extension.
+ *
+ * @author Kevin Mian Kraiker <kevin.mian@gmail.com>
+ * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
+ *
+ * @internal
+ */
+final class Attribute extends Annotation implements AttributeDriverInterface
+{
+}

--- a/src/Timestampable/Mapping/Driver/Attribute.php
+++ b/src/Timestampable/Mapping/Driver/Attribute.php
@@ -2,7 +2,6 @@
 
 namespace Gedmo\Timestampable\Mapping\Driver;
 
-use Gedmo\Mapping\Annotation\Translatable;
 use Gedmo\Mapping\Driver\AttributeDriverInterface;
 
 /**

--- a/src/Timestampable/Mapping/Driver/Attribute.php
+++ b/src/Timestampable/Mapping/Driver/Attribute.php
@@ -7,7 +7,7 @@ use Gedmo\Mapping\Driver\AttributeDriverInterface;
 /**
  * This is an attribute mapping driver for Timestampable
  * behavioral extension. Used for extraction of extended
- * metadata from Annotations specifically for Timestampable
+ * metadata from attributes specifically for Timestampable
  * extension.
  *
  * @author Kevin Mian Kraiker <kevin.mian@gmail.com>

--- a/src/Timestampable/Traits/TimestampableEntity.php
+++ b/src/Timestampable/Traits/TimestampableEntity.php
@@ -19,6 +19,7 @@ trait TimestampableEntity
      * @Gedmo\Timestampable(on="create")
      * @ORM\Column(type="datetime")
      */
+    #[Gedmo\Timestampable(on: 'create')]
     #[ORM\Column(type: Types::DATETIME_MUTABLE)]
     protected $createdAt;
 
@@ -27,6 +28,7 @@ trait TimestampableEntity
      * @Gedmo\Timestampable(on="update")
      * @ORM\Column(type="datetime")
      */
+    #[Gedmo\Timestampable(on: 'update')]
     #[ORM\Column(type: Types::DATETIME_MUTABLE)]
     protected $updatedAt;
 

--- a/tests/Gedmo/Timestampable/AttributeChangeTest.php
+++ b/tests/Gedmo/Timestampable/AttributeChangeTest.php
@@ -2,13 +2,9 @@
 
 namespace Gedmo\Tests\Timestampable;
 
-use Doctrine\Common\EventArgs;
 use Doctrine\Common\EventManager;
-use Gedmo\Mapping\Event\Adapter\ORM as BaseAdapterORM;
 use Gedmo\Tests\Timestampable\Fixture\Attribute\TitledArticle;
 use Gedmo\Tests\Tool\BaseTestCaseORM;
-use Gedmo\Timestampable\Mapping\Event\TimestampableAdapter;
-use Gedmo\Timestampable\TimestampableListener;
 
 /**
  * These are tests for Timestampable behavior

--- a/tests/Gedmo/Timestampable/AttributeChangeTest.php
+++ b/tests/Gedmo/Timestampable/AttributeChangeTest.php
@@ -56,7 +56,7 @@ final class AttributeChangeTest extends BaseTestCaseORM
         $this->em->persist($test);
         $this->em->flush();
         $this->em->clear();
-        //Changed
+        // Changed.
         static::assertEquals(
             $currentDate->format('Y-m-d H:i:s'),
             $test->getChtitle()->format('Y-m-d H:i:s')

--- a/tests/Gedmo/Timestampable/AttributeChangeTest.php
+++ b/tests/Gedmo/Timestampable/AttributeChangeTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Gedmo\Tests\Timestampable;
+
+use Doctrine\Common\EventArgs;
+use Doctrine\Common\EventManager;
+use Gedmo\Mapping\Event\Adapter\ORM as BaseAdapterORM;
+use Gedmo\Tests\Timestampable\Fixture\Attribute\TitledArticle;
+use Gedmo\Tests\Tool\BaseTestCaseORM;
+use Gedmo\Timestampable\Mapping\Event\TimestampableAdapter;
+use Gedmo\Timestampable\TimestampableListener;
+
+/**
+ * These are tests for Timestampable behavior
+ *
+ * @author Ivan Borzenkov <ivan.borzenkov@gmail.com>
+ *
+ * @see http://www.gediminasm.org
+ *
+ * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
+ *
+ * @requires PHP >= 8.0
+ */
+final class AttributeChangeTest extends BaseTestCaseORM
+{
+    public const FIXTURE = TitledArticle::class;
+
+    protected $listener;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->listener = new TimestampableListenerStub();
+        $this->listener->eventAdapter = new EventAdapterORMStub();
+
+        $evm = new EventManager();
+        $evm->addEventSubscriber($this->listener);
+
+        $this->getDefaultMockSqliteEntityManager($evm);
+    }
+
+    public function testChange(): void
+    {
+        $test = new TitledArticle();
+        $test->setTitle('Test');
+        $test->setText('Test');
+        $test->setState('Open');
+
+        $currentDate = new \DateTime('now');
+        $this->listener->eventAdapter->setDateValue($currentDate);
+
+        $this->em->persist($test);
+        $this->em->flush();
+        $this->em->clear();
+
+        $test = $this->em->getRepository(self::FIXTURE)->findOneBy(['title' => 'Test']);
+        $test->setTitle('New Title');
+        $test->setState('Closed');
+        $this->em->persist($test);
+        $this->em->flush();
+        $this->em->clear();
+        //Changed
+        static::assertEquals(
+            $currentDate->format('Y-m-d H:i:s'),
+            $test->getChtitle()->format('Y-m-d H:i:s')
+        );
+        static::assertEquals(
+            $currentDate->format('Y-m-d H:i:s'),
+            $test->getClosed()->format('Y-m-d H:i:s')
+        );
+
+        $anotherDate = \DateTime::createFromFormat('Y-m-d H:i:s', '2000-01-01 00:00:00');
+        $this->listener->eventAdapter->setDateValue($anotherDate);
+
+        $test = $this->em->getRepository(self::FIXTURE)->findOneBy(['title' => 'New Title']);
+        $test->setText('New Text');
+        $test->setState('Open');
+        $this->em->persist($test);
+        $this->em->flush();
+        $this->em->clear();
+        //Not Changed
+        static::assertEquals(
+            $currentDate->format('Y-m-d H:i:s'),
+            $test->getChtitle()->format('Y-m-d H:i:s')
+        );
+        static::assertEquals(
+            $currentDate->format('Y-m-d H:i:s'),
+            $test->getClosed()->format('Y-m-d H:i:s')
+        );
+
+        $test = $this->em->getRepository(self::FIXTURE)->findOneBy(['title' => 'New Title']);
+        $test->setState('Published');
+        $this->em->persist($test);
+        $this->em->flush();
+        $this->em->clear();
+        //Changed
+        static::assertEquals(
+            $anotherDate->format('Y-m-d H:i:s'),
+            $test->getClosed()->format('Y-m-d H:i:s')
+        );
+    }
+
+    protected function getUsedEntityFixtures(): array
+    {
+        return [
+            self::FIXTURE,
+        ];
+    }
+}

--- a/tests/Gedmo/Timestampable/AttributeChangeTest.php
+++ b/tests/Gedmo/Timestampable/AttributeChangeTest.php
@@ -90,7 +90,7 @@ final class AttributeChangeTest extends BaseTestCaseORM
         $this->em->persist($test);
         $this->em->flush();
         $this->em->clear();
-        //Changed
+        // Changed.
         static::assertEquals(
             $anotherDate->format('Y-m-d H:i:s'),
             $test->getClosed()->format('Y-m-d H:i:s')

--- a/tests/Gedmo/Timestampable/AttributeChangeTest.php
+++ b/tests/Gedmo/Timestampable/AttributeChangeTest.php
@@ -75,7 +75,7 @@ final class AttributeChangeTest extends BaseTestCaseORM
         $this->em->persist($test);
         $this->em->flush();
         $this->em->clear();
-        //Not Changed
+        // Not Changed.
         static::assertEquals(
             $currentDate->format('Y-m-d H:i:s'),
             $test->getChtitle()->format('Y-m-d H:i:s')

--- a/tests/Gedmo/Timestampable/ChangeTest.php
+++ b/tests/Gedmo/Timestampable/ChangeTest.php
@@ -35,7 +35,7 @@ final class ChangeTest extends BaseTestCaseORM
         $evm = new EventManager();
         $evm->addEventSubscriber($this->listener);
 
-        $this->getMockSqliteEntityManager($evm);
+        $this->getDefaultMockSqliteEntityManager($evm);
     }
 
     public function testChange()

--- a/tests/Gedmo/Timestampable/Fixture/Article.php
+++ b/tests/Gedmo/Timestampable/Fixture/Article.php
@@ -2,6 +2,7 @@
 
 namespace Gedmo\Tests\Timestampable\Fixture;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 use Gedmo\Timestampable\Timestampable;
@@ -9,73 +10,96 @@ use Gedmo\Timestampable\Timestampable;
 /**
  * @ORM\Entity
  */
+#[ORM\Entity]
 class Article implements Timestampable
 {
-    /** @ORM\Id @ORM\GeneratedValue @ORM\Column(type="integer") */
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     /**
      * @ORM\Column(name="title", type="string", length=128)
      */
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
     private $title;
 
     /**
      * @ORM\Column(name="body", type="string")
      */
+    #[ORM\Column(name: 'body', type: Types::STRING)]
     private $body;
 
     /**
      * @ORM\OneToMany(targetEntity="Gedmo\Tests\Timestampable\Fixture\Comment", mappedBy="article")
      */
+    #[ORM\OneToMany(targetEntity: Comment::class, mappedBy: 'article')]
     private $comments;
 
     /**
      * @ORM\Embedded(class="Gedmo\Tests\Timestampable\Fixture\Author")
      */
+    #[ORM\Embedded(class: Author::class)]
     private $author;
 
     /**
-     * @var datetime
+     * @var \DateTime
      *
      * @Gedmo\Timestampable(on="create")
      * @ORM\Column(name="created", type="date")
      */
+    #[Gedmo\Timestampable(on: 'create')]
+    #[ORM\Column(name: 'created', type: Types::DATE_MUTABLE)]
     private $created;
 
     /**
-     * @var datetime
+     * @var \DateTime
      *
      * @ORM\Column(name="updated", type="datetime")
      * @Gedmo\Timestampable
      */
+    #[ORM\Column(name: 'updated', type: Types::DATETIME_MUTABLE)]
+    #[Gedmo\Timestampable]
     private $updated;
 
     /**
-     * @var datetime
+     * @var \DateTime
      *
      * @ORM\Column(name="published", type="datetime", nullable=true)
      * @Gedmo\Timestampable(on="change", field="type.title", value="Published")
      */
+    #[ORM\Column(name: 'published', type: Types::DATETIME_MUTABLE, nullable: true)]
+    #[Gedmo\Timestampable(on: 'change', field: 'type.title', value: 'Published')]
     private $published;
 
     /**
-     * @var datetime
+     * @var \DateTime
      *
      * @ORM\Column(name="content_changed", type="datetime", nullable=true)
      * @Gedmo\Timestampable(on="change", field={"title", "body"})
      */
+    #[ORM\Column(name: 'content_changed', type: Types::DATETIME_MUTABLE, nullable: true)]
+    #[Gedmo\Timestampable(on: 'change', field: ['title', 'body'])]
     private $contentChanged;
     /**
-     * @var datetime
+     * @var \DateTime
      *
      * @ORM\Column(name="author_changed", type="datetime", nullable=true)
      * @Gedmo\Timestampable(on="change", field={"author.name", "author.email"})
      */
+    #[ORM\Column(name: 'author_changed', type: Types::DATETIME_MUTABLE, nullable: true)]
+    #[Gedmo\Timestampable(on: 'change', field: ['author.name', 'author.email'])]
     private $authorChanged;
 
     /**
      * @ORM\ManyToOne(targetEntity="Type", inversedBy="articles")
      */
+    #[ORM\ManyToOne(targetEntity: Type::class, inversedBy: 'articles')]
     private $type;
 
     public function setType($type)
@@ -132,7 +156,7 @@ class Article implements Timestampable
     /**
      * Get created
      *
-     * @return datetime $created
+     * @return \DateTime $created
      */
     public function getCreated()
     {
@@ -157,7 +181,7 @@ class Article implements Timestampable
     /**
      * Get updated
      *
-     * @return datetime $updated
+     * @return \DateTime $updated
      */
     public function getUpdated()
     {

--- a/tests/Gedmo/Timestampable/Fixture/Attribute/TitledArticle.php
+++ b/tests/Gedmo/Timestampable/Fixture/Attribute/TitledArticle.php
@@ -36,7 +36,7 @@ class TitledArticle implements Timestampable
     #[Gedmo\Timestampable(on: 'change', field: 'state', value: ['Published', 'Closed'])]
     private ?\DateTime $closed;
 
-    public function setChText(?\DateTime $chText): void
+    public function setChText(\DateTime $chText): void
     {
         $this->chText = $chText;
     }
@@ -46,7 +46,7 @@ class TitledArticle implements Timestampable
         return $this->chText;
     }
 
-    public function setChTitle(?\DateTime $chTitle): void
+    public function setChTitle(\DateTime $chTitle): void
     {
         $this->chTitle = $chTitle;
     }
@@ -56,7 +56,7 @@ class TitledArticle implements Timestampable
         return $this->chTitle;
     }
 
-    public function setClosed(?\DateTime $closed): void
+    public function setClosed(\DateTime $closed): void
     {
         $this->closed = $closed;
     }

--- a/tests/Gedmo/Timestampable/Fixture/Attribute/TitledArticle.php
+++ b/tests/Gedmo/Timestampable/Fixture/Attribute/TitledArticle.php
@@ -29,7 +29,7 @@ class TitledArticle implements Timestampable
      */
     #[ORM\Column(name: 'chtext', type: Types::DATETIME_MUTABLE, nullable: true)]
     #[Gedmo\Timestampable(on: 'change', field: 'text')]
-    private $chtext;
+    private $chText;
 
     /**
      * @var \DateTime

--- a/tests/Gedmo/Timestampable/Fixture/Attribute/TitledArticle.php
+++ b/tests/Gedmo/Timestampable/Fixture/Attribute/TitledArticle.php
@@ -48,7 +48,7 @@ class TitledArticle implements Timestampable
     /**
      * @param \DateTime $chtext
      */
-    public function setChtext($chtext)
+    public function setChtext($chtext): void
     {
         $this->chtext = $chtext;
     }

--- a/tests/Gedmo/Timestampable/Fixture/Attribute/TitledArticle.php
+++ b/tests/Gedmo/Timestampable/Fixture/Attribute/TitledArticle.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Gedmo\Tests\Timestampable\Fixture\Attribute;
+
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Gedmo\Timestampable\Timestampable;
+use Doctrine\DBAL\Types\Types;
+
+#[ORM\Entity]
+class TitledArticle implements Timestampable
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    private $id;
+
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
+    private $title;
+
+    #[ORM\Column(name: 'text', type: Types::STRING, length: 128)]
+    private $text;
+
+    #[ORM\Column(name: 'state', type: Types::STRING, length: 128)]
+    private $state;
+
+    /**
+     * @var \DateTime
+     */
+    #[ORM\Column(name: 'chtext', type: Types::DATETIME_MUTABLE, nullable: true)]
+    #[Gedmo\Timestampable(on: 'change', field: 'text')]
+    private $chtext;
+
+    /**
+     * @var \DateTime
+     */
+    #[ORM\Column(name: 'chtitle', type: Types::DATETIME_MUTABLE, nullable: true)]
+    #[Gedmo\Timestampable(on: 'change', field: 'title')]
+    private $chtitle;
+
+    /**
+     * @var \DateTime
+     */
+    #[ORM\Column(name: 'closed', type: TYPES::DATETIME_MUTABLE, nullable: true)]
+    #[Gedmo\Timestampable(on: 'change', field: 'state', value: ['Published', 'Closed'])]
+    private $closed;
+
+    /**
+     * @param \DateTime $chtext
+     */
+    public function setChtext($chtext)
+    {
+        $this->chtext = $chtext;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getChtext()
+    {
+        return $this->chtext;
+    }
+
+    /**
+     * @param \DateTime $chtitle
+     */
+    public function setChtitle($chtitle)
+    {
+        $this->chtitle = $chtitle;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getChtitle()
+    {
+        return $this->chtitle;
+    }
+
+    /**
+     * @param \DateTime $closed
+     */
+    public function setClosed($closed)
+    {
+        $this->closed = $closed;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getClosed()
+    {
+        return $this->closed;
+    }
+
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setText($text)
+    {
+        $this->text = $text;
+    }
+
+    public function getText()
+    {
+        return $this->text;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    public function setState($state)
+    {
+        $this->state = $state;
+    }
+
+    public function getState()
+    {
+        return $this->state;
+    }
+}

--- a/tests/Gedmo/Timestampable/Fixture/Attribute/TitledArticle.php
+++ b/tests/Gedmo/Timestampable/Fixture/Attribute/TitledArticle.php
@@ -46,35 +46,35 @@ class TitledArticle implements Timestampable
     private $closed;
 
     /**
-     * @param \DateTime $chtext
+     * @param \DateTime $chText
      */
-    public function setChtext($chtext): void
+    public function setChText($chText): void
     {
-        $this->chtext = $chtext;
+        $this->chText = $chText;
     }
 
     /**
      * @return \DateTime
      */
-    public function getChtext()
+    public function getChText()
     {
-        return $this->chtext;
+        return $this->chText;
     }
 
     /**
-     * @param \DateTime $chtitle
+     * @param \DateTime $chTitle
      */
-    public function setChtitle($chtitle)
+    public function setChTitle($chTitle)
     {
-        $this->chtitle = $chtitle;
+        $this->chTitle = $chTitle;
     }
 
     /**
      * @return \DateTime
      */
-    public function getChtitle()
+    public function getChTitle()
     {
-        return $this->chtitle;
+        return $this->chTitle;
     }
 
     /**

--- a/tests/Gedmo/Timestampable/Fixture/Attribute/TitledArticle.php
+++ b/tests/Gedmo/Timestampable/Fixture/Attribute/TitledArticle.php
@@ -2,10 +2,10 @@
 
 namespace Gedmo\Tests\Timestampable\Fixture\Attribute;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 use Gedmo\Timestampable\Timestampable;
-use Doctrine\DBAL\Types\Types;
 
 #[ORM\Entity]
 class TitledArticle implements Timestampable

--- a/tests/Gedmo/Timestampable/Fixture/Attribute/TitledArticle.php
+++ b/tests/Gedmo/Timestampable/Fixture/Attribute/TitledArticle.php
@@ -13,122 +13,95 @@ class TitledArticle implements Timestampable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id;
 
     #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
-    private $title;
+    private ?string $title;
 
     #[ORM\Column(name: 'text', type: Types::STRING, length: 128)]
-    private $text;
+    private ?string $text;
 
     #[ORM\Column(name: 'state', type: Types::STRING, length: 128)]
-    private $state;
+    private ?string $state;
 
-    /**
-     * @var \DateTime
-     */
     #[ORM\Column(name: 'chtext', type: Types::DATETIME_MUTABLE, nullable: true)]
     #[Gedmo\Timestampable(on: 'change', field: 'text')]
-    private $chText;
+    private ?\DateTime $chText;
 
-    /**
-     * @var \DateTime
-     */
     #[ORM\Column(name: 'chtitle', type: Types::DATETIME_MUTABLE, nullable: true)]
     #[Gedmo\Timestampable(on: 'change', field: 'title')]
-    private $chTitle;
+    private ?\DateTime $chTitle;
 
-    /**
-     * @var \DateTime
-     */
     #[ORM\Column(name: 'closed', type: TYPES::DATETIME_MUTABLE, nullable: true)]
     #[Gedmo\Timestampable(on: 'change', field: 'state', value: ['Published', 'Closed'])]
-    private $closed;
+    private ?\DateTime $closed;
 
-    /**
-     * @param \DateTime $chText
-     */
-    public function setChText($chText): void
+    public function setChText(?\DateTime $chText): void
     {
         $this->chText = $chText;
     }
 
-    /**
-     * @return \DateTime
-     */
-    public function getChText()
+    public function getChText(): ?\DateTime
     {
         return $this->chText;
     }
 
-    /**
-     * @param \DateTime $chTitle
-     */
-    public function setChTitle($chTitle)
+    public function setChTitle(?\DateTime $chTitle): void
     {
         $this->chTitle = $chTitle;
     }
 
-    /**
-     * @return \DateTime
-     */
-    public function getChTitle()
+    public function getChTitle(): ?\DateTime
     {
         return $this->chTitle;
     }
 
-    /**
-     * @param \DateTime $closed
-     */
-    public function setClosed($closed)
+    public function setClosed(?\DateTime $closed): void
     {
         $this->closed = $closed;
     }
 
-    /**
-     * @return \DateTime
-     */
-    public function getClosed()
+    public function getClosed(): ?\DateTime
     {
         return $this->closed;
     }
 
-    public function setId($id)
+    public function setId(int $id): void
     {
         $this->id = $id;
     }
 
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }
 
-    public function setText($text)
+    public function setText(string $text): void
     {
         $this->text = $text;
     }
 
-    public function getText()
+    public function getText(): ?string
     {
         return $this->text;
     }
 
-    public function setTitle($title)
+    public function setTitle(string $title): void
     {
         $this->title = $title;
     }
 
-    public function getTitle()
+    public function getTitle(): ?string
     {
         return $this->title;
     }
 
-    public function setState($state)
+    public function setState(string $state): void
     {
         $this->state = $state;
     }
 
-    public function getState()
+    public function getState(): ?string
     {
         return $this->state;
     }

--- a/tests/Gedmo/Timestampable/Fixture/Attribute/TitledArticle.php
+++ b/tests/Gedmo/Timestampable/Fixture/Attribute/TitledArticle.php
@@ -36,7 +36,7 @@ class TitledArticle implements Timestampable
      */
     #[ORM\Column(name: 'chtitle', type: Types::DATETIME_MUTABLE, nullable: true)]
     #[Gedmo\Timestampable(on: 'change', field: 'title')]
-    private $chtitle;
+    private $chTitle;
 
     /**
      * @var \DateTime

--- a/tests/Gedmo/Timestampable/Fixture/Author.php
+++ b/tests/Gedmo/Timestampable/Fixture/Author.php
@@ -2,21 +2,25 @@
 
 namespace Gedmo\Tests\Timestampable\Fixture;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Embeddable()
  */
+#[ORM\Embeddable]
 class Author
 {
     /**
      * @ORM\Column(name="author_name", type="string", length=128, nullable=true)
      */
+    #[ORM\Column(name: 'author_name', type: Types::STRING, length: 128, nullable: true)]
     private $name;
 
     /**
      * @ORM\Column(name="author_email", type="string", length=50, nullable=true)
      */
+    #[ORM\Column(name: 'author_email', type: Types::STRING, length: 50, nullable: true)]
     private $email;
 
     public function getName()

--- a/tests/Gedmo/Timestampable/Fixture/Comment.php
+++ b/tests/Gedmo/Timestampable/Fixture/Comment.php
@@ -2,6 +2,7 @@
 
 namespace Gedmo\Tests\Timestampable\Fixture;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 use Gedmo\Timestampable\Timestampable;
@@ -9,40 +10,55 @@ use Gedmo\Timestampable\Timestampable;
 /**
  * @ORM\Entity
  */
+#[ORM\Entity]
 class Comment implements Timestampable
 {
-    /** @ORM\Id @ORM\GeneratedValue @ORM\Column(type="integer") */
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     /**
      * @ORM\Column(name="message", type="text")
      */
+    #[ORM\Column(name: 'message', type: Types::TEXT)]
     private $message;
 
     /**
      * @ORM\ManyToOne(targetEntity="Gedmo\Tests\Timestampable\Fixture\Article", inversedBy="comments")
      */
+    #[ORM\ManyToOne(targetEntity: Article::class, inversedBy: 'comments')]
     private $article;
 
     /**
      * @ORM\Column(type="integer")
      */
+    #[ORM\Column(type: Types::INTEGER)]
     private $status;
 
     /**
-     * @var datetime
+     * @var \DateTime
      *
      * @ORM\Column(name="closed", type="datetime", nullable=true)
      * @Gedmo\Timestampable(on="change", field="status", value=1)
      */
+    #[ORM\Column(name: 'closed', type: Types::DATETIME_MUTABLE, nullable: true)]
+    #[Gedmo\Timestampable(on: 'change', field: 'status', value: 1)]
     private $closed;
 
     /**
-     * @var datetime
+     * @var \DateTime
      *
      * @ORM\Column(name="modified", type="time")
      * @Gedmo\Timestampable(on="update")
      */
+    #[ORM\Column(name: 'modified', type: Types::TIME_MUTABLE)]
+    #[Gedmo\Timestampable(on: 'update')]
     private $modified;
 
     public function setArticle($article)

--- a/tests/Gedmo/Timestampable/Fixture/MappedSupperClass.php
+++ b/tests/Gedmo/Timestampable/Fixture/MappedSupperClass.php
@@ -2,12 +2,14 @@
 
 namespace Gedmo\Tests\Timestampable\Fixture;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\MappedSuperclass
  */
+#[ORM\MappedSuperclass]
 class MappedSupperClass
 {
     /**
@@ -17,6 +19,9 @@ class MappedSupperClass
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="AUTO")
      */
+    #[ORM\Column(name: 'id', type: Types::INTEGER)]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
     protected $id;
 
     /**
@@ -24,6 +29,7 @@ class MappedSupperClass
      *
      * @Gedmo\Locale
      */
+    #[Gedmo\Locale]
     protected $locale;
 
     /**
@@ -32,6 +38,8 @@ class MappedSupperClass
      * @Gedmo\Translatable
      * @ORM\Column(name="name", type="string", length=191)
      */
+    #[Gedmo\Translatable]
+    #[ORM\Column(name: 'name', type: Types::STRING, length: 191)]
     protected $name;
 
     /**
@@ -40,6 +48,8 @@ class MappedSupperClass
      * @ORM\Column(name="created_at", type="datetime")
      * @Gedmo\Timestampable(on="create")
      */
+    #[ORM\Column(name: 'created_at', type: Types::DATETIME_MUTABLE)]
+    #[Gedmo\Timestampable(on: 'create')]
     protected $createdAt;
 
     /**

--- a/tests/Gedmo/Timestampable/Fixture/SupperClassExtension.php
+++ b/tests/Gedmo/Timestampable/Fixture/SupperClassExtension.php
@@ -8,12 +8,15 @@ use Gedmo\Mapping\Annotation as Gedmo;
 /**
  * @ORM\Entity
  */
+#[ORM\Entity]
 class SupperClassExtension extends MappedSupperClass
 {
     /**
      * @ORM\Column(length=128)
      * @Gedmo\Translatable
      */
+    #[ORM\Column(length: 128)]
+    #[Gedmo\Translatable]
     private $title;
 
     public function setTitle($title)

--- a/tests/Gedmo/Timestampable/Fixture/TitledArticle.php
+++ b/tests/Gedmo/Timestampable/Fixture/TitledArticle.php
@@ -2,6 +2,7 @@
 
 namespace Gedmo\Tests\Timestampable\Fixture;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 use Gedmo\Timestampable\Timestampable;
@@ -9,6 +10,7 @@ use Gedmo\Timestampable\Timestampable;
 /**
  * @ORM\Entity
  */
+#[ORM\Entity]
 class TitledArticle implements Timestampable
 {
     /**
@@ -16,21 +18,27 @@ class TitledArticle implements Timestampable
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
      */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     /**
      * @ORM\Column(name="title", type="string", length=128)
      */
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
     private $title;
 
     /**
      * @ORM\Column(name="text", type="string", length=128)
      */
+    #[ORM\Column(name: 'text', type: Types::STRING, length: 128)]
     private $text;
 
     /**
      * @ORM\Column(name="state", type="string", length=128)
      */
+    #[ORM\Column(name: 'state', type: Types::STRING, length: 128)]
     private $state;
 
     /**
@@ -39,6 +47,8 @@ class TitledArticle implements Timestampable
      * @ORM\Column(name="chtext", type="datetime", nullable=true)
      * @Gedmo\Timestampable(on="change", field="text")
      */
+    #[ORM\Column(name: 'chtext', type: Types::DATETIME_MUTABLE, nullable: true)]
+    #[Gedmo\Timestampable(on: 'change', field: 'text')]
     private $chtext;
 
     /**
@@ -47,6 +57,8 @@ class TitledArticle implements Timestampable
      * @ORM\Column(name="chtitle", type="datetime", nullable=true)
      * @Gedmo\Timestampable(on="change", field="title")
      */
+    #[ORM\Column(name: 'chtitle', type: Types::DATETIME_MUTABLE, nullable: true)]
+    #[Gedmo\Timestampable(on: 'change', field: 'title')]
     private $chtitle;
 
     /**
@@ -55,6 +67,8 @@ class TitledArticle implements Timestampable
      * @ORM\Column(name="closed", type="datetime", nullable=true)
      * @Gedmo\Timestampable(on="change", field="state", value={"Published", "Closed"})
      */
+    #[ORM\Column(name: 'closed', type: TYPES::DATETIME_MUTABLE, nullable: true)]
+    #[Gedmo\Timestampable(on: 'change', field: 'state', value: ['Published', 'Closed'])]
     private $closed;
 
     /**

--- a/tests/Gedmo/Timestampable/Fixture/TitledArticle.php
+++ b/tests/Gedmo/Timestampable/Fixture/TitledArticle.php
@@ -49,7 +49,7 @@ class TitledArticle implements Timestampable
      */
     #[ORM\Column(name: 'chtext', type: Types::DATETIME_MUTABLE, nullable: true)]
     #[Gedmo\Timestampable(on: 'change', field: 'text')]
-    private $chtext;
+    private $chText;
 
     /**
      * @var \DateTime
@@ -59,7 +59,7 @@ class TitledArticle implements Timestampable
      */
     #[ORM\Column(name: 'chtitle', type: Types::DATETIME_MUTABLE, nullable: true)]
     #[Gedmo\Timestampable(on: 'change', field: 'title')]
-    private $chtitle;
+    private $chTitle;
 
     /**
      * @var \DateTime
@@ -72,35 +72,35 @@ class TitledArticle implements Timestampable
     private $closed;
 
     /**
-     * @param \DateTime $chtext
+     * @param \DateTime $chText
      */
-    public function setChtext($chtext)
+    public function setChText($chText)
     {
-        $this->chtext = $chtext;
+        $this->chText = $chText;
     }
 
     /**
      * @return \DateTime
      */
-    public function getChtext()
+    public function getChText()
     {
-        return $this->chtext;
+        return $this->chText;
     }
 
     /**
-     * @param \DateTime $chtitle
+     * @param \DateTime $chTitle
      */
-    public function setChtitle($chtitle)
+    public function setChTitle($chTitle)
     {
-        $this->chtitle = $chtitle;
+        $this->chTitle = $chTitle;
     }
 
     /**
      * @return \DateTime
      */
-    public function getChtitle()
+    public function getChTitle()
     {
-        return $this->chtitle;
+        return $this->chTitle;
     }
 
     /**

--- a/tests/Gedmo/Timestampable/Fixture/Type.php
+++ b/tests/Gedmo/Timestampable/Fixture/Type.php
@@ -2,24 +2,35 @@
 
 namespace Gedmo\Tests\Timestampable\Fixture;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity
  */
+#[ORM\Entity]
 class Type
 {
-    /** @ORM\Id @ORM\GeneratedValue @ORM\Column(type="integer") */
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     /**
      * @ORM\Column(name="title", type="string", length=128)
      */
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
     private $title;
 
     /**
      * @ORM\OneToMany(targetEntity="Article", mappedBy="type")
      */
+    #[ORM\OneToMany(targetEntity: Article::class, mappedBy: 'type')]
     private $articles;
 
     public function getId()

--- a/tests/Gedmo/Timestampable/Fixture/UsingTrait.php
+++ b/tests/Gedmo/Timestampable/Fixture/UsingTrait.php
@@ -2,12 +2,14 @@
 
 namespace Gedmo\Tests\Timestampable\Fixture;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Timestampable\Traits\TimestampableEntity;
 
 /**
  * @ORM\Entity
  */
+#[ORM\Entity]
 class UsingTrait
 {
     /*
@@ -21,11 +23,15 @@ class UsingTrait
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
      */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     /**
      * @ORM\Column(length=128)
      */
+    #[ORM\Column(length: 128)]
     private $title;
 
     public function getId()

--- a/tests/Gedmo/Timestampable/Fixture/WithoutInterface.php
+++ b/tests/Gedmo/Timestampable/Fixture/WithoutInterface.php
@@ -8,26 +8,39 @@ use Gedmo\Mapping\Annotation as Gedmo;
 /**
  * @ORM\Entity
  */
+#[ORM\Entity]
 class WithoutInterface
 {
-    /** @ORM\Id @ORM\GeneratedValue @ORM\Column(type="integer") */
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
     private $id;
 
     /**
      * @ORM\Column(type="string", length=128)
      */
+    #[ORM\Column(type: 'string', length: 128)]
     private $title;
 
     /**
      * @Gedmo\Timestampable(on="create")
      * @ORM\Column(type="date")
      */
+    #[Gedmo\Timestampable(on: 'create')]
+    #[ORM\Column(type: 'date')]
     private $created;
 
     /**
      * @ORM\Column(type="datetime")
      * @Gedmo\Timestampable(on="update")
      */
+    #[ORM\Column(type: 'datetime')]
+    #[Gedmo\Timestampable(on: 'update')]
     private $updated;
 
     public function getId()

--- a/tests/Gedmo/Timestampable/Fixture/WithoutInterface.php
+++ b/tests/Gedmo/Timestampable/Fixture/WithoutInterface.php
@@ -2,6 +2,7 @@
 
 namespace Gedmo\Tests\Timestampable\Fixture;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
@@ -18,13 +19,13 @@ class WithoutInterface
      */
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     /**
      * @ORM\Column(type="string", length=128)
      */
-    #[ORM\Column(type: 'string', length: 128)]
+    #[ORM\Column(type: Types::STRING, length: 128)]
     private $title;
 
     /**
@@ -32,14 +33,14 @@ class WithoutInterface
      * @ORM\Column(type="date")
      */
     #[Gedmo\Timestampable(on: 'create')]
-    #[ORM\Column(type: 'date')]
+    #[ORM\Column(type: Types::DATE_MUTABLE)]
     private $created;
 
     /**
      * @ORM\Column(type="datetime")
      * @Gedmo\Timestampable(on="update")
      */
-    #[ORM\Column(type: 'datetime')]
+    #[ORM\Column(type: Types::DATETIME_MUTABLE)]
     #[Gedmo\Timestampable(on: 'update')]
     private $updated;
 

--- a/tests/Gedmo/Timestampable/NoInterfaceTest.php
+++ b/tests/Gedmo/Timestampable/NoInterfaceTest.php
@@ -30,7 +30,7 @@ final class NoInterfaceTest extends BaseTestCaseORM
         $this->getMockSqliteEntityManager($evm);
     }
 
-    public function testTimestampableNoInterface()
+    public function testTimestampableNoInterface(): void
     {
         $test = new WithoutInterface();
         $test->setTitle('Test');
@@ -51,7 +51,7 @@ final class NoInterfaceTest extends BaseTestCaseORM
         );
     }
 
-    protected function getUsedEntityFixtures()
+    protected function getUsedEntityFixtures(): array
     {
         return [
             self::FIXTURE,

--- a/tests/Gedmo/Timestampable/ProtectedPropertySupperclassTest.php
+++ b/tests/Gedmo/Timestampable/ProtectedPropertySupperclassTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Gedmo\Tests\Tree;
+namespace Gedmo\Tests\Timestampable;
 
 use Doctrine\Common\EventManager;
 use Gedmo\Tests\Timestampable\Fixture\SupperClassExtension;
@@ -33,7 +33,7 @@ final class ProtectedPropertySupperclassTest extends BaseTestCaseORM
         $evm->addEventSubscriber($translatableListener);
         $evm->addEventSubscriber(new TimestampableListener());
 
-        $this->getMockSqliteEntityManager($evm);
+        $this->getDefaultMockSqliteEntityManager($evm);
     }
 
     public function testProtectedProperty()

--- a/tests/Gedmo/Timestampable/TimestampableTest.php
+++ b/tests/Gedmo/Timestampable/TimestampableTest.php
@@ -33,7 +33,7 @@ final class TimestampableTest extends BaseTestCaseORM
         $evm = new EventManager();
         $evm->addEventSubscriber(new TimestampableListener());
 
-        $this->getMockSqliteEntityManager($evm);
+        $this->getDefaultMockSqliteEntityManager($evm);
     }
 
     /**

--- a/tests/Gedmo/Timestampable/TraitUsageTest.php
+++ b/tests/Gedmo/Timestampable/TraitUsageTest.php
@@ -27,7 +27,7 @@ final class TraitUsageTest extends BaseTestCaseORM
         $evm = new EventManager();
         $evm->addEventSubscriber(new TimestampableListener());
 
-        $this->getMockSqliteEntityManager($evm);
+        $this->getDefaultMockSqliteEntityManager($evm);
     }
 
     /**


### PR DESCRIPTION
Following [#2253](https://github.com/doctrine-extensions/DoctrineExtensions/pull/2253) as a baseline, I applied the changes needed to make Timestampable also work with Attributes, as I'm currently working on an attribute-based project and in need of this support.

All tests passed correctly, testing through both PHP 7.2 and PHP 8.0 Docker containers.