### PR TITLE
Use strict comparison where possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,17 @@ a release.
 
 ## [Unreleased]
 ### Added
-- PHP 8 Attributes support for Doctrine MongoDB to document & traits
-- Support for doctrine/dbal >=3.2
+- PHP 8 Attributes support for Doctrine MongoDB to document & traits.
+- Support for doctrine/dbal >=3.2.
 - Timestampable: Support to use annotations as attributes on PHP >= 8.0.
 
 ### Changes
-- Dropped support for doctrine/dbal < 2.13.1
+- Translatable: Dropped support for other values than "true", "false", "1" and "0" in the `fallback` attribute of the XML mapping.
+- Tree: Dropped support for other values than "true", "false", "1" and "0" in the `activate-locking` attribute of the `tree`
+  element in the XML mapping.
+  Tree: Dropped support for other values than "true", "false", "1" and "0" in the `append_id`, `starts_with_separator` and
+  `ends_with_separator` attributes of the `tree-path` element in the XML mapping.
+- Dropped support for doctrine/dbal < 2.13.1.
 - The third argument of `Gedmo\SoftDeleteable\Query\TreeWalker\Exec\MultiTableDeleteExecutor::__construct()` requires a `Doctrine\ORM\Mapping\ClassMetadata` instance.
 
 ## [3.3.1] - 2021-11-18

--- a/src/Blameable/Mapping/Driver/Annotation.php
+++ b/src/Blameable/Mapping/Driver/Annotation.php
@@ -72,7 +72,7 @@ class Annotation extends AbstractAnnotationDriver
                 if (!in_array($blameable->on, ['update', 'create', 'change'], true)) {
                     throw new InvalidMappingException("Field - [{$field}] trigger 'on' is not one of [update, create, change] in class - {$meta->getName()}");
                 }
-                if ('change' == $blameable->on) {
+                if ('change' === $blameable->on) {
                     if (!isset($blameable->field)) {
                         throw new InvalidMappingException("Missing parameters on property - {$field}, field must be set on [change] trigger in class - {$meta->getName()}");
                     }

--- a/src/Blameable/Mapping/Driver/Xml.php
+++ b/src/Blameable/Mapping/Driver/Xml.php
@@ -64,7 +64,7 @@ class Xml extends BaseXml
                         throw new InvalidMappingException("Field - [{$field}] trigger 'on' is not one of [update, create, change] in class - {$meta->getName()}");
                     }
 
-                    if ('change' == $this->_getAttribute($data, 'on')) {
+                    if ('change' === $this->_getAttribute($data, 'on')) {
                         if (!$this->_isAttributeSet($data, 'field')) {
                             throw new InvalidMappingException("Missing parameters on property - {$field}, field must be set on [change] trigger in class - {$meta->getName()}");
                         }
@@ -97,7 +97,7 @@ class Xml extends BaseXml
                         throw new InvalidMappingException("Field - [{$field}] trigger 'on' is not one of [update, create, change] in class - {$meta->getName()}");
                     }
 
-                    if ('change' == $this->_getAttribute($data, 'on')) {
+                    if ('change' === $this->_getAttribute($data, 'on')) {
                         if (!$this->_isAttributeSet($data, 'field')) {
                             throw new InvalidMappingException("Missing parameters on property - {$field}, field must be set on [change] trigger in class - {$meta->getName()}");
                         }

--- a/src/Blameable/Mapping/Driver/Yaml.php
+++ b/src/Blameable/Mapping/Driver/Yaml.php
@@ -59,7 +59,7 @@ class Yaml extends File implements Driver
                         throw new InvalidMappingException("Field - [{$field}] trigger 'on' is not one of [update, create, change] in class - {$meta->getName()}");
                     }
 
-                    if ('change' == $mappingProperty['on']) {
+                    if ('change' === $mappingProperty['on']) {
                         if (!isset($mappingProperty['field'])) {
                             throw new InvalidMappingException("Missing parameters on property - {$field}, field must be set on [change] trigger in class - {$meta->getName()}");
                         }
@@ -90,7 +90,7 @@ class Yaml extends File implements Driver
                         throw new InvalidMappingException("Field - [{$field}] trigger 'on' is not one of [update, create, change] in class - {$meta->getName()}");
                     }
 
-                    if ('change' == $mappingProperty['on']) {
+                    if ('change' === $mappingProperty['on']) {
                         if (!isset($mappingProperty['field'])) {
                             throw new InvalidMappingException("Missing parameters on property - {$field}, field must be set on [change] trigger in class - {$meta->getName()}");
                         }

--- a/src/IpTraceable/Mapping/Driver/Annotation.php
+++ b/src/IpTraceable/Mapping/Driver/Annotation.php
@@ -63,7 +63,7 @@ class Annotation extends AbstractAnnotationDriver
                 if (!in_array($ipTraceable->on, ['update', 'create', 'change'], true)) {
                     throw new InvalidMappingException("Field - [{$field}] trigger 'on' is not one of [update, create, change] in class - {$meta->getName()}");
                 }
-                if ('change' == $ipTraceable->on) {
+                if ('change' === $ipTraceable->on) {
                     if (!isset($ipTraceable->field)) {
                         throw new InvalidMappingException("Missing parameters on property - {$field}, field must be set on [change] trigger in class - {$meta->getName()}");
                     }

--- a/src/IpTraceable/Mapping/Driver/Xml.php
+++ b/src/IpTraceable/Mapping/Driver/Xml.php
@@ -64,7 +64,7 @@ class Xml extends BaseXml
                         throw new InvalidMappingException("Field - [{$field}] trigger 'on' is not one of [update, create, change] in class - {$meta->getName()}");
                     }
 
-                    if ('change' == $this->_getAttribute($data, 'on')) {
+                    if ('change' === $this->_getAttribute($data, 'on')) {
                         if (!$this->_isAttributeSet($data, 'field')) {
                             throw new InvalidMappingException("Missing parameters on property - {$field}, field must be set on [change] trigger in class - {$meta->getName()}");
                         }
@@ -101,7 +101,7 @@ class Xml extends BaseXml
                         throw new InvalidMappingException("Field - [{$field}] trigger 'on' is not one of [update, create, change] in class - {$meta->getName()}");
                     }
 
-                    if ('change' == $this->_getAttribute($data, 'on')) {
+                    if ('change' === $this->_getAttribute($data, 'on')) {
                         if (!$this->_isAttributeSet($data, 'field')) {
                             throw new InvalidMappingException("Missing parameters on property - {$field}, field must be set on [change] trigger in class - {$meta->getName()}");
                         }

--- a/src/IpTraceable/Mapping/Driver/Yaml.php
+++ b/src/IpTraceable/Mapping/Driver/Yaml.php
@@ -57,7 +57,7 @@ class Yaml extends File implements Driver
                         throw new InvalidMappingException("Field - [{$field}] trigger 'on' is not one of [update, create, change] in class - {$meta->getName()}");
                     }
 
-                    if ('change' == $mappingProperty['on']) {
+                    if ('change' === $mappingProperty['on']) {
                         if (!isset($mappingProperty['field'])) {
                             throw new InvalidMappingException("Missing parameters on property - {$field}, field must be set on [change] trigger in class - {$meta->getName()}");
                         }
@@ -88,7 +88,7 @@ class Yaml extends File implements Driver
                         throw new InvalidMappingException("Field - [{$field}] trigger 'on' is not one of [update, create, change] in class - {$meta->getName()}");
                     }
 
-                    if ('change' == $mappingProperty['on']) {
+                    if ('change' === $mappingProperty['on']) {
                         if (!isset($mappingProperty['field'])) {
                             throw new InvalidMappingException("Missing parameters on property - {$field}, field must be set on [change] trigger in class - {$meta->getName()}");
                         }

--- a/src/Loggable/Mapping/Driver/Xml.php
+++ b/src/Loggable/Mapping/Driver/Xml.php
@@ -38,7 +38,7 @@ class Xml extends BaseXml
 
         $xml = $xml->children(self::GEDMO_NAMESPACE_URI);
 
-        if ('entity' == $xmlDoctrine->getName() || 'document' == $xmlDoctrine->getName() || 'mapped-superclass' == $xmlDoctrine->getName()) {
+        if ('entity' === $xmlDoctrine->getName() || 'document' === $xmlDoctrine->getName() || 'mapped-superclass' === $xmlDoctrine->getName()) {
             if (isset($xml->loggable)) {
                 /**
                  * @var \SimpleXMLElement;

--- a/src/Mapping/Driver/Xml.php
+++ b/src/Mapping/Driver/Xml.php
@@ -75,7 +75,7 @@ abstract class Xml extends File
      *
      * @param string $attributeName
      *
-     * @return string
+     * @return bool
      */
     protected function _isAttributeSet(SimpleXmlElement $node, $attributeName)
     {

--- a/src/Mapping/ExtensionMetadataFactory.php
+++ b/src/Mapping/ExtensionMetadataFactory.php
@@ -154,7 +154,7 @@ class ExtensionMetadataFactory
         $driver = null;
         $className = get_class($omDriver);
         $driverName = substr($className, strrpos($className, '\\') + 1);
-        if ($omDriver instanceof MappingDriverChain || 'DriverChain' == $driverName) {
+        if ($omDriver instanceof MappingDriverChain || 'DriverChain' === $driverName) {
             $driver = new Driver\Chain();
             foreach ($omDriver->getDrivers() as $namespace => $nestedOmDriver) {
                 $driver->addDriver($this->getDriver($nestedOmDriver), $namespace);

--- a/src/Timestampable/Mapping/Driver/Annotation.php
+++ b/src/Timestampable/Mapping/Driver/Annotation.php
@@ -72,7 +72,7 @@ class Annotation extends AbstractAnnotationDriver
                 if (!in_array($timestampable->on, ['update', 'create', 'change'], true)) {
                     throw new InvalidMappingException("Field - [{$field}] trigger 'on' is not one of [update, create, change] in class - {$meta->getName()}");
                 }
-                if ('change' == $timestampable->on) {
+                if ('change' === $timestampable->on) {
                     if (!isset($timestampable->field)) {
                         throw new InvalidMappingException("Missing parameters on property - {$field}, field must be set on [change] trigger in class - {$meta->getName()}");
                     }

--- a/src/Timestampable/Mapping/Driver/Xml.php
+++ b/src/Timestampable/Mapping/Driver/Xml.php
@@ -73,7 +73,7 @@ class Xml extends BaseXml
                         throw new InvalidMappingException("Field - [{$field}] trigger 'on' is not one of [update, create, change] in class - {$meta->getName()}");
                     }
 
-                    if ('change' == $this->_getAttribute($data, 'on')) {
+                    if ('change' === $this->_getAttribute($data, 'on')) {
                         if (!$this->_isAttributeSet($data, 'field')) {
                             throw new InvalidMappingException("Missing parameters on property - {$field}, field must be set on [change] trigger in class - {$meta->getName()}");
                         }

--- a/src/Timestampable/Mapping/Driver/Yaml.php
+++ b/src/Timestampable/Mapping/Driver/Yaml.php
@@ -67,7 +67,7 @@ class Yaml extends File implements Driver
                         throw new InvalidMappingException("Field - [{$field}] trigger 'on' is not one of [update, create, change] in class - {$meta->getName()}");
                     }
 
-                    if ('change' == $mappingProperty['on']) {
+                    if ('change' === $mappingProperty['on']) {
                         if (!isset($mappingProperty['field'])) {
                             throw new InvalidMappingException("Missing parameters on property - {$field}, field must be set on [change] trigger in class - {$meta->getName()}");
                         }

--- a/src/Translatable/Mapping/Driver/Xml.php
+++ b/src/Translatable/Mapping/Driver/Xml.php
@@ -36,7 +36,7 @@ class Xml extends BaseXml
 
         $xml = $xml->children(self::GEDMO_NAMESPACE_URI);
 
-        if (('entity' == $xmlDoctrine->getName() || 'mapped-superclass' == $xmlDoctrine->getName())) {
+        if (('entity' === $xmlDoctrine->getName() || 'mapped-superclass' === $xmlDoctrine->getName())) {
             if ($xml->count() && isset($xml->translation)) {
                 /**
                  * @var \SimpleXmlElement
@@ -107,7 +107,7 @@ class Xml extends BaseXml
             /** @var \SimpleXmlElement $data */
             $data = $mapping->translatable;
             if ($this->_isAttributeSet($data, 'fallback')) {
-                $config['fallback'][$fieldName] = 'true' == $this->_getAttribute($data, 'fallback') ? true : false;
+                $config['fallback'][$fieldName] = $this->_getBooleanAttribute($data, 'fallback');
             }
         }
     }

--- a/src/Tree/Entity/Repository/ClosureTreeRepository.php
+++ b/src/Tree/Entity/Repository/ClosureTreeRepository.php
@@ -391,7 +391,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
             isset($options['childSort']['field'], $options['childSort']['dir'])) {
             $q->addOrderBy(
                 'node.'.$options['childSort']['field'],
-                'asc' == strtolower($options['childSort']['dir']) ? 'asc' : 'desc'
+                'asc' === strtolower($options['childSort']['dir']) ? 'asc' : 'desc'
             );
         }
 

--- a/src/Tree/Mapping/Driver/Xml.php
+++ b/src/Tree/Mapping/Driver/Xml.php
@@ -55,7 +55,7 @@ class Xml extends BaseXml
                 throw new InvalidMappingException("Tree type: $strategy is not available.");
             }
             $config['strategy'] = $strategy;
-            $config['activate_locking'] = 'true' === $this->_getAttribute($xml->tree, 'activate-locking') ? true : false;
+            $config['activate_locking'] = $this->_isAttributeSet($xml->tree, 'activate-locking') && $this->_getBooleanAttribute($xml->tree, 'activate-locking');
 
             if ($lockingTimeout = $this->_getAttribute($xml->tree, 'locking-timeout')) {
                 $config['locking_timeout'] = (int) $lockingTimeout;
@@ -111,29 +111,9 @@ class Xml extends BaseXml
                         throw new InvalidMappingException("Tree Path field - [{$field}] Separator {$separator} is invalid. It must be only one character long.");
                     }
 
-                    $appendId = $this->_getAttribute($mapping->{'tree-path'}, 'append_id');
-
-                    if (!$appendId) {
-                        $appendId = true;
-                    } else {
-                        $appendId = 'false' == strtolower($appendId) ? false : true;
-                    }
-
-                    $startsWithSeparator = $this->_getAttribute($mapping->{'tree-path'}, 'starts_with_separator');
-
-                    if (!$startsWithSeparator) {
-                        $startsWithSeparator = false;
-                    } else {
-                        $startsWithSeparator = 'false' == strtolower($startsWithSeparator) ? false : true;
-                    }
-
-                    $endsWithSeparator = $this->_getAttribute($mapping->{'tree-path'}, 'ends_with_separator');
-
-                    if (!$endsWithSeparator) {
-                        $endsWithSeparator = true;
-                    } else {
-                        $endsWithSeparator = 'false' == strtolower($endsWithSeparator) ? false : true;
-                    }
+                    $appendId = !$this->_isAttributeSet($mapping->{'tree-path'}, 'append_id') || $this->_getBooleanAttribute($mapping->{'tree-path'}, 'append_id');
+                    $startsWithSeparator = $this->_isAttributeSet($mapping->{'tree-path'}, 'starts_with_separator') && $this->_getBooleanAttribute($mapping->{'tree-path'}, 'starts_with_separator');
+                    $endsWithSeparator = !$this->_isAttributeSet($mapping->{'tree-path'}, 'ends_with_separator') || $this->_getBooleanAttribute($mapping->{'tree-path'}, 'ends_with_separator');
 
                     $config['path'] = $field;
                     $config['path_separator'] = $separator;
@@ -163,7 +143,7 @@ class Xml extends BaseXml
             throw new InvalidMappingException('You need to map a date field as the tree lock time field to activate locking support.');
         }
 
-        if ('mapped-superclass' == $xmlDoctrine->getName()) {
+        if ('mapped-superclass' === $xmlDoctrine->getName()) {
             if (isset($xmlDoctrine->{'many-to-one'})) {
                 foreach ($xmlDoctrine->{'many-to-one'} as $manyToOneMapping) {
                     /**
@@ -211,7 +191,7 @@ class Xml extends BaseXml
                     }
                 }
             }
-        } elseif ('entity' == $xmlDoctrine->getName()) {
+        } elseif ('entity' === $xmlDoctrine->getName()) {
             if (isset($xmlDoctrine->{'many-to-one'})) {
                 foreach ($xmlDoctrine->{'many-to-one'} as $manyToOneMapping) {
                     /**
@@ -237,7 +217,7 @@ class Xml extends BaseXml
                     }
                 }
             }
-        } elseif ('document' == $xmlDoctrine->getName()) {
+        } elseif ('document' === $xmlDoctrine->getName()) {
             if (isset($xmlDoctrine->{'reference-one'})) {
                 foreach ($xmlDoctrine->{'reference-one'} as $referenceOneMapping) {
                     /**

--- a/src/Uploadable/Mapping/Driver/Xml.php
+++ b/src/Uploadable/Mapping/Driver/Xml.php
@@ -36,7 +36,7 @@ class Xml extends BaseXml
         $xmlDoctrine = $xml;
         $xml = $xml->children(self::GEDMO_NAMESPACE_URI);
 
-        if ('entity' == $xmlDoctrine->getName() || 'mapped-superclass' == $xmlDoctrine->getName()) {
+        if ('entity' === $xmlDoctrine->getName() || 'mapped-superclass' === $xmlDoctrine->getName()) {
             if (isset($xml->uploadable)) {
                 $xmlUploadable = $xml->uploadable;
                 $config['uploadable'] = true;

--- a/tests/Gedmo/Translatable/PersonalTranslationTest.php
+++ b/tests/Gedmo/Translatable/PersonalTranslationTest.php
@@ -98,7 +98,7 @@ final class PersonalTranslationTest extends BaseTestCaseORM
      */
     public function shouldCascadeDeletionsByForeignKeyConstraints()
     {
-        if ('sqlite' == $this->em->getConnection()->getDatabasePlatform()->getName()) {
+        if ('sqlite' === $this->em->getConnection()->getDatabasePlatform()->getName()) {
             static::markTestSkipped('Foreign key constraints does not map in sqlite.');
         }
         $this->populate();


### PR DESCRIPTION
- Use strict comparison instead of loose checks where possible.
- Translatable: Dropped support for other values than "true", "false", "1" and "0" in the `fallback` attribute of the XML mapping.
- Tree: Dropped support for other values than "true", "false", "1" and "0" in the `activate-locking` attribute of the `tree`
  element in the XML mapping.
  Tree: Dropped support for other values than "true", "false", "1" and "0" in the `append_id`, `starts_with_separator` and
  `ends_with_separator` attributes of the `tree-path` element in the XML mapping.

Even when some of these changes may seem like a BC break, I think we can introduce them in a minor release as they were already covered by the XSD schema and the documentation.