### PR TITLE
Add support for attribute mapping for `doctrine/mongodb-odm`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ a release.
 
 ## [Unreleased]
 ### Added
+- PHP 8 Attributes support for Doctrine MongoDB to document & traits
 - Support for doctrine/dbal >=3.2
 - Timestampable: Support to use annotations as attributes on PHP >= 8.0.
 

--- a/src/Blameable/Traits/BlameableDocument.php
+++ b/src/Blameable/Traits/BlameableDocument.php
@@ -10,6 +10,7 @@
 namespace Gedmo\Blameable\Traits;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Types\Type;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
@@ -24,6 +25,7 @@ trait BlameableDocument
      * @Gedmo\Blameable(on="create")
      * @ODM\Field(type="string")
      */
+    #[ODM\Field(type: Type::STRING)]
     protected $createdBy;
 
     /**
@@ -31,6 +33,7 @@ trait BlameableDocument
      * @Gedmo\Blameable(on="update")
      * @ODM\Field(type="string")
      */
+    #[ODM\Field(type: Type::STRING)]
     protected $updatedBy;
 
     /**

--- a/src/IpTraceable/Traits/IpTraceableDocument.php
+++ b/src/IpTraceable/Traits/IpTraceableDocument.php
@@ -10,6 +10,7 @@
 namespace Gedmo\IpTraceable\Traits;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Types\Type;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
@@ -24,6 +25,7 @@ trait IpTraceableDocument
      * @Gedmo\IpTraceable(on="create")
      * @ODM\Field(type="string")
      */
+    #[ODM\Field(type: Type::STRING)]
     protected $createdFromIp;
 
     /**
@@ -31,6 +33,7 @@ trait IpTraceableDocument
      * @Gedmo\IpTraceable(on="update")
      * @ODM\Field(type="string")
      */
+    #[ODM\Field(type: Type::STRING)]
     protected $updatedFromIp;
 
     /**

--- a/src/Loggable/Document/LogEntry.php
+++ b/src/Loggable/Document/LogEntry.php
@@ -10,6 +10,7 @@
 namespace Gedmo\Loggable\Document;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoODM;
+use Gedmo\Loggable\Document\Repository\LogEntryRepository;
 
 /**
  * Gedmo\Loggable\Document\LogEntry
@@ -24,6 +25,11 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoODM;
  *     }
  * )
  */
+#[MongoODM\Document(repositoryClass: LogEntryRepository::class)]
+#[MongoODM\Index(keys: ['objectId' => 'asc', 'objectClass' => 'asc', 'version' => 'asc'])]
+#[MongoODM\Index(keys: ['loggedAt' => 'asc'])]
+#[MongoODM\Index(keys: ['objectClass' => 'asc'])]
+#[MongoODM\Index(keys: ['username' => 'asc'])]
 class LogEntry extends MappedSuperclass\AbstractLogEntry
 {
     /*

--- a/src/Loggable/Document/MappedSuperclass/AbstractLogEntry.php
+++ b/src/Loggable/Document/MappedSuperclass/AbstractLogEntry.php
@@ -10,12 +10,14 @@
 namespace Gedmo\Loggable\Document\MappedSuperclass;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoODM;
+use Doctrine\ODM\MongoDB\Types\Type;
 
 /**
  * Gedmo\Loggable\Document\MappedSuperclass\AbstractLogEntry
  *
  * @MongoODM\MappedSuperclass
  */
+#[MongoODM\MappedSuperclass]
 abstract class AbstractLogEntry
 {
     /**
@@ -23,6 +25,7 @@ abstract class AbstractLogEntry
      *
      * @MongoODM\Id
      */
+    #[MongoODM\Id]
     protected $id;
 
     /**
@@ -30,6 +33,7 @@ abstract class AbstractLogEntry
      *
      * @MongoODM\Field(type="string")
      */
+    #[MongoODM\Field(type: Type::STRING)]
     protected $action;
 
     /**
@@ -37,6 +41,7 @@ abstract class AbstractLogEntry
      *
      * @MongoODM\Field(type="date")
      */
+    #[MongoODM\Field(type: Type::DATE)]
     protected $loggedAt;
 
     /**
@@ -44,6 +49,7 @@ abstract class AbstractLogEntry
      *
      * @MongoODM\Field(type="string", nullable=true)
      */
+    #[MongoODM\Field(type: Type::STRING, nullable: true)]
     protected $objectId;
 
     /**
@@ -51,6 +57,7 @@ abstract class AbstractLogEntry
      *
      * @MongoODM\Field(type="string")
      */
+    #[MongoODM\Field(type: Type::STRING)]
     protected $objectClass;
 
     /**
@@ -58,6 +65,7 @@ abstract class AbstractLogEntry
      *
      * @MongoODM\Field(type="int")
      */
+    #[MongoODM\Field(type: Type::INT)]
     protected $version;
 
     /**
@@ -65,6 +73,7 @@ abstract class AbstractLogEntry
      *
      * @MongoODM\Field(type="hash", nullable=true)
      */
+    #[MongoODM\Field(type: Type::HASH, nullable: true)]
     protected $data;
 
     /**
@@ -72,6 +81,7 @@ abstract class AbstractLogEntry
      *
      * @MongoODM\Field(type="string", nullable=true)
      */
+    #[MongoODM\Field(type: Type::STRING, nullable: true)]
     protected $username;
 
     /**

--- a/src/SoftDeleteable/Traits/SoftDeleteableDocument.php
+++ b/src/SoftDeleteable/Traits/SoftDeleteableDocument.php
@@ -11,6 +11,7 @@ namespace Gedmo\SoftDeleteable\Traits;
 
 use DateTime;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Types\Type;
 
 /**
  * A soft deletable trait you can apply to your MongoDB entities.
@@ -25,6 +26,7 @@ trait SoftDeleteableDocument
      *
      * @var DateTime|null
      */
+    #[ODM\Field(type: Type::DATE)]
     protected $deletedAt;
 
     /**

--- a/src/Timestampable/Traits/TimestampableDocument.php
+++ b/src/Timestampable/Traits/TimestampableDocument.php
@@ -10,6 +10,7 @@
 namespace Gedmo\Timestampable\Traits;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Types\Type;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
@@ -24,6 +25,8 @@ trait TimestampableDocument
      * @Gedmo\Timestampable(on="create")
      * @ODM\Field(type="date")
      */
+    #[Gedmo\Timestampable(on: 'create')]
+    #[ODM\Field(type: Type::DATE)]
     protected $createdAt;
 
     /**
@@ -31,6 +34,8 @@ trait TimestampableDocument
      * @Gedmo\Timestampable(on="update")
      * @ODM\Field(type="date")
      */
+    #[Gedmo\Timestampable(on: 'update')]
+    #[ODM\Field(type: Type::DATE)]
     protected $updatedAt;
 
     /**

--- a/src/Translatable/Document/MappedSuperclass/AbstractPersonalTranslation.php
+++ b/src/Translatable/Document/MappedSuperclass/AbstractPersonalTranslation.php
@@ -10,12 +10,14 @@
 namespace Gedmo\Translatable\Document\MappedSuperclass;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoODM;
+use Doctrine\ODM\MongoDB\Types\Type;
 
 /**
  * Gedmo\Translatable\Document\AbstractPersonalTranslation
  *
  * @MongoODM\MappedSuperclass
  */
+#[MongoODM\MappedSuperclass]
 abstract class AbstractPersonalTranslation
 {
     /**
@@ -23,6 +25,7 @@ abstract class AbstractPersonalTranslation
      *
      * @MongoODM\Id
      */
+    #[MongoODM\Id]
     protected $id;
 
     /**
@@ -30,6 +33,7 @@ abstract class AbstractPersonalTranslation
      *
      * @MongoODM\Field(type="string")
      */
+    #[MongoODM\Field(type: Type::STRING)]
     protected $locale;
 
     /**
@@ -45,6 +49,7 @@ abstract class AbstractPersonalTranslation
      *
      * @MongoODM\Field(type="string")
      */
+    #[MongoODM\Field(type: Type::STRING)]
     protected $field;
 
     /**
@@ -52,6 +57,7 @@ abstract class AbstractPersonalTranslation
      *
      * @MongoODM\Field(type="string")
      */
+    #[MongoODM\Field(type: Type::STRING)]
     protected $content;
 
     /**

--- a/src/Translatable/Document/MappedSuperclass/AbstractTranslation.php
+++ b/src/Translatable/Document/MappedSuperclass/AbstractTranslation.php
@@ -10,12 +10,14 @@
 namespace Gedmo\Translatable\Document\MappedSuperclass;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoODM;
+use Doctrine\ODM\MongoDB\Types\Type;
 
 /**
  * Gedmo\Translatable\Document\MappedSuperclass\AbstractTranslation
  *
  * @MongoODM\MappedSuperclass
  */
+#[MongoODM\MappedSuperclass]
 abstract class AbstractTranslation
 {
     /**
@@ -23,6 +25,7 @@ abstract class AbstractTranslation
      *
      * @MongoODM\Id
      */
+    #[MongoODM\Id]
     protected $id;
 
     /**
@@ -30,6 +33,7 @@ abstract class AbstractTranslation
      *
      * @MongoODM\Field(type="string")
      */
+    #[MongoODM\Field(type: Type::STRING)]
     protected $locale;
 
     /**
@@ -37,6 +41,7 @@ abstract class AbstractTranslation
      *
      * @MongoODM\Field(type="string")
      */
+    #[MongoODM\Field(type: Type::STRING)]
     protected $objectClass;
 
     /**
@@ -44,6 +49,7 @@ abstract class AbstractTranslation
      *
      * @MongoODM\Field(type="string")
      */
+    #[MongoODM\Field(type: Type::STRING)]
     protected $field;
 
     /**
@@ -51,6 +57,7 @@ abstract class AbstractTranslation
      *
      * @MongoODM\Field(type="string", name="foreign_key")
      */
+    #[MongoODM\Field(name: 'foreign_key', type: Type::STRING)]
     protected $foreignKey;
 
     /**
@@ -58,6 +65,7 @@ abstract class AbstractTranslation
      *
      * @MongoODM\Field(type="string")
      */
+    #[MongoODM\Field(type: Type::STRING)]
     protected $content;
 
     /**

--- a/src/Translatable/Document/Translation.php
+++ b/src/Translatable/Document/Translation.php
@@ -9,26 +9,28 @@
 
 namespace Gedmo\Translatable\Document;
 
-use Doctrine\ODM\MongoDB\Mapping\Annotations\Document;
-use Doctrine\ODM\MongoDB\Mapping\Annotations\Index;
-use Doctrine\ODM\MongoDB\Mapping\Annotations\UniqueIndex;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Gedmo\Translatable\Document\Repository\TranslationRepository;
 
 /**
  * Gedmo\Translatable\Document\Translation
  *
- * @Document(repositoryClass="Gedmo\Translatable\Document\Repository\TranslationRepository")
- * @UniqueIndex(name="lookup_unique_idx", keys={
+ * @ODM\Document(repositoryClass="Gedmo\Translatable\Document\Repository\TranslationRepository")
+ * @ODM\UniqueIndex(name="lookup_unique_idx", keys={
  *         "locale" = "asc",
  *         "object_class" = "asc",
  *         "foreign_key" = "asc",
  *         "field" = "asc"
  * })
- * @Index(name="translations_lookup_idx", keys={
+ * @ODM\Index(name="translations_lookup_idx", keys={
  *      "locale" = "asc",
  *      "object_class" = "asc",
  *      "foreign_key" = "asc"
  * })
  */
+#[ODM\Document(repositoryClass: TranslationRepository::class)]
+#[ODM\UniqueIndex(name: 'lookup_unique_idx', keys: ['locale' => 'asc', 'object_class' => 'asc', 'foreign_key' => 'asc', 'field' => 'asc'])]
+#[ODM\Index(name: 'translations_lookup_idx', keys: ['locale' => 'asc', 'object_class' => 'asc', 'foreign_key' => 'asc'])]
 class Translation extends MappedSuperclass\AbstractTranslation
 {
     /*

--- a/src/Translator/Document/Translation.php
+++ b/src/Translator/Document/Translation.php
@@ -10,8 +10,7 @@
 namespace Gedmo\Translator\Document;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Mapping\Annotations\Id;
-use Doctrine\ODM\MongoDB\Mapping\Annotations\MappedSuperclass;
+use Doctrine\ODM\MongoDB\Types\Type;
 use Gedmo\Translator\Translation as BaseTranslation;
 
 /**
@@ -19,13 +18,15 @@ use Gedmo\Translator\Translation as BaseTranslation;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  *
- * @MappedSuperclass
+ * @ODM\MappedSuperclass
  */
+#[ODM\MappedSuperclass]
 abstract class Translation extends BaseTranslation
 {
     /**
-     * @Id
+     * @ODM\Id
      */
+    #[ODM\Id]
     protected $id;
 
     /**
@@ -33,6 +34,7 @@ abstract class Translation extends BaseTranslation
      *
      * @ODM\Field(type="string")
      */
+    #[ODM\Field(type: Type::STRING)]
     protected $locale;
 
     /**
@@ -40,6 +42,7 @@ abstract class Translation extends BaseTranslation
      *
      * @ODM\Field(type="string")
      */
+    #[ODM\Field(type: Type::STRING)]
     protected $property;
 
     /**
@@ -47,6 +50,7 @@ abstract class Translation extends BaseTranslation
      *
      * @ODM\Field(type="string")
      */
+    #[ODM\Field(type: Type::STRING)]
     protected $value;
 
     /**

--- a/tests/Gedmo/Timestampable/Fixture/Document/Article.php
+++ b/tests/Gedmo/Timestampable/Fixture/Document/Article.php
@@ -12,24 +12,29 @@ declare(strict_types=1);
 namespace Gedmo\Tests\Timestampable\Fixture\Document;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Types\Type as MongoDBType;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ODM\Document(collection="articles")
  */
+#[ODM\Document(collection: 'articles')]
 class Article
 {
     /** @ODM\Id */
+    #[ODM\Id]
     private $id;
 
     /**
      * @ODM\Field(type="string")
      */
+    #[ODM\Field(type: MongoDBType::STRING)]
     private $title;
 
     /**
      * @ODM\ReferenceOne(targetDocument="Gedmo\Tests\Timestampable\Fixture\Document\Type")
      */
+    #[ODM\ReferenceOne(targetDocument: Type::class)]
     private $type;
 
     /**
@@ -38,6 +43,8 @@ class Article
      * @ODM\Field(type="timestamp")
      * @Gedmo\Timestampable(on="create")
      */
+    #[Gedmo\Timestampable(on: 'create')]
+    #[ODM\Field(type: MongoDBType::TIMESTAMP)]
     private $created;
 
     /**
@@ -46,6 +53,8 @@ class Article
      * @ODM\Field(type="date")
      * @Gedmo\Timestampable
      */
+    #[Gedmo\Timestampable]
+    #[ODM\Field(type: MongoDBType::DATE)]
     private $updated;
 
     /**
@@ -54,6 +63,8 @@ class Article
      * @ODM\Field(type="date")
      * @Gedmo\Timestampable(on="change", field="type.title", value="Published")
      */
+    #[Gedmo\Timestampable(on: 'change', field: 'type.title', value: 'Published')]
+    #[ODM\Field(type: MongoDBType::DATE)]
     private $published;
 
     /**
@@ -62,6 +73,8 @@ class Article
      * @ODM\Field(type="date")
      * @Gedmo\Timestampable(on="change", field="isReady", value=true)
      */
+    #[Gedmo\Timestampable(on: 'change', field: 'isReady', value: true)]
+    #[ODM\Field(type: MongoDBType::DATE)]
     private $ready;
 
     /**
@@ -69,6 +82,7 @@ class Article
      *
      * @ODM\Field(type="boolean")
      */
+    #[ODM\Field(type: MongoDBType::BOOL)]
     private $isReady = false;
 
     public function getId()

--- a/tests/Gedmo/Timestampable/Fixture/Document/Book.php
+++ b/tests/Gedmo/Timestampable/Fixture/Document/Book.php
@@ -14,10 +14,12 @@ namespace Gedmo\Tests\Timestampable\Fixture\Document;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Types\Type as MongoDBType;
 
 /**
  * @ODM\Document(collection="books")
  */
+#[ODM\Document(collection: 'books')]
 class Book
 {
     /**
@@ -25,6 +27,7 @@ class Book
      *
      * @var string
      */
+    #[ODM\Id]
     protected $id;
 
     /**
@@ -32,6 +35,7 @@ class Book
      *
      * @var string
      */
+    #[ODM\Field(type: MongoDBType::STRING)]
     protected $title;
 
     /**
@@ -39,6 +43,7 @@ class Book
      *
      * @var Collection<int, Tag>
      */
+    #[ODM\EmbedMany(targetDocument: Tag::class)]
     protected $tags;
 
     public function __construct()

--- a/tests/Gedmo/Timestampable/Fixture/Document/Tag.php
+++ b/tests/Gedmo/Timestampable/Fixture/Document/Tag.php
@@ -12,11 +12,13 @@ declare(strict_types=1);
 namespace Gedmo\Tests\Timestampable\Fixture\Document;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Types\Type as MongoDBType;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ODM\EmbeddedDocument()
  */
+#[ODM\EmbeddedDocument]
 class Tag
 {
     /**
@@ -24,6 +26,7 @@ class Tag
      *
      * @var string
      */
+    #[ODM\Field(type: MongoDBType::STRING)]
     protected $name;
 
     /**
@@ -32,6 +35,8 @@ class Tag
      *
      * @var \DateTime
      */
+    #[Gedmo\Timestampable(on: 'create')]
+    #[ODM\Field(type: MongoDBType::DATE)]
     protected $created;
 
     /**
@@ -40,6 +45,8 @@ class Tag
      *
      * @var \DateTime
      */
+    #[Gedmo\Timestampable]
+    #[ODM\Field(type: MongoDBType::DATE)]
     protected $updated;
 
     /**

--- a/tests/Gedmo/Timestampable/Fixture/Document/Type.php
+++ b/tests/Gedmo/Timestampable/Fixture/Document/Type.php
@@ -12,23 +12,28 @@ declare(strict_types=1);
 namespace Gedmo\Tests\Timestampable\Fixture\Document;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Types\Type as MongoDBType;
 
 /**
  * @ODM\Document(collection="types")
  */
+#[ODM\Document(collection: 'types')]
 class Type
 {
     /** @ODM\Id */
+    #[ODM\Id]
     private $id;
 
     /**
      * @ODM\Field(type="string")
      */
+    #[ODM\Field(type: MongoDBType::STRING)]
     private $title;
 
     /**
      * @ODM\Field(type="string")
      */
+    #[ODM\Field(type: MongoDBType::STRING)]
     private $identifier;
 
     public function getId()

--- a/tests/Gedmo/Timestampable/TimestampableDocumentTest.php
+++ b/tests/Gedmo/Timestampable/TimestampableDocumentTest.php
@@ -33,7 +33,7 @@ final class TimestampableDocumentTest extends BaseTestCaseMongoODM
         $evm = new EventManager();
         $evm->addEventSubscriber(new TimestampableListener());
 
-        $this->getMockDocumentManager($evm);
+        $this->getDefaultDocumentManager($evm);
         $this->populate();
     }
 

--- a/tests/Gedmo/Timestampable/TimestampableEmbeddedDocumentTest.php
+++ b/tests/Gedmo/Timestampable/TimestampableEmbeddedDocumentTest.php
@@ -32,7 +32,7 @@ final class TimestampableEmbeddedDocumentTest extends BaseTestCaseMongoODM
         $evm = new EventManager();
         $evm->addEventSubscriber(new TimestampableListener());
 
-        $this->getMockDocumentManager($evm);
+        $this->getDefaultDocumentManager($evm);
     }
 
     public function testPersistEmbeddedDocumentWithParent()

--- a/tests/Gedmo/Tool/BaseTestCaseMongoODM.php
+++ b/tests/Gedmo/Tool/BaseTestCaseMongoODM.php
@@ -15,6 +15,7 @@ use Doctrine\Common\EventManager;
 use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
+use Doctrine\ODM\MongoDB\Mapping\Driver\AttributeDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Gedmo\Loggable\LoggableListener;
 use Gedmo\Sluggable\SluggableListener;
@@ -79,6 +80,11 @@ abstract class BaseTestCaseMongoODM extends \PHPUnit\Framework\TestCase
         return $this->dm = DocumentManager::create($client, $config, $evm);
     }
 
+    protected function getDefaultDocumentManager(EventManager $evm = null): DocumentManager
+    {
+        return $this->getMockDocumentManager($evm, $this->getDefaultConfiguration());
+    }
+
     /**
      * DocumentManager mock object with
      * annotation mapping driver
@@ -123,6 +129,31 @@ abstract class BaseTestCaseMongoODM extends \PHPUnit\Framework\TestCase
         $config->setMetadataDriverImpl($this->getMetadataDriverImplementation());
 
         return $config;
+    }
+
+    private function getDefaultConfiguration(): Configuration
+    {
+        $config = new Configuration();
+        $config->addFilter('softdeleteable', SoftDeleteableFilter::class);
+        $config->setProxyDir(TESTS_TEMP_DIR);
+        $config->setHydratorDir(TESTS_TEMP_DIR);
+        $config->setProxyNamespace('Proxy');
+        $config->setHydratorNamespace('Hydrator');
+        $config->setDefaultDB('gedmo_extensions_test');
+        $config->setAutoGenerateProxyClasses(Configuration::AUTOGENERATE_EVAL);
+        $config->setAutoGenerateHydratorClasses(Configuration::AUTOGENERATE_EVAL);
+        $config->setMetadataDriverImpl($this->getMetadataDefaultDriverImplementation());
+
+        return $config;
+    }
+
+    private function getMetadataDefaultDriverImplementation(): MappingDriver
+    {
+        if (PHP_VERSION_ID >= 80000 && class_exists(AttributeDriver::class)) {
+            return new AttributeDriver([]);
+        }
+
+        return new AnnotationDriver($_ENV['annotation_reader']);
     }
 
     /**

--- a/tests/Gedmo/Translatable/Fixture/Document/Article.php
+++ b/tests/Gedmo/Translatable/Fixture/Document/Article.php
@@ -12,26 +12,33 @@ declare(strict_types=1);
 namespace Gedmo\Tests\Translatable\Fixture\Document;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoODM;
+use Doctrine\ODM\MongoDB\Types\Type;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @MongoODM\Document(collection="articles")
  */
+#[MongoODM\Document(collection: 'articles')]
 class Article
 {
     /** @MongoODM\Id */
+    #[MongoODM\Id]
     private $id;
 
     /**
      * @Gedmo\Translatable
      * @MongoODM\Field(type="string")
      */
+    #[Gedmo\Translatable]
+    #[MongoODM\Field(type: Type::STRING)]
     private $title;
 
     /**
      * @Gedmo\Translatable
      * @MongoODM\Field(type="string")
      */
+    #[Gedmo\Translatable]
+    #[MongoODM\Field(type: Type::STRING)]
     private $code;
 
     /**
@@ -39,6 +46,8 @@ class Article
      * @Gedmo\Translatable
      * @MongoODM\Field(type="string")
      */
+    #[Gedmo\Translatable]
+    #[MongoODM\Field(type: Type::STRING)]
     private $slug;
 
     public function getId()

--- a/tests/Gedmo/Translatable/Fixture/Document/Personal/Article.php
+++ b/tests/Gedmo/Translatable/Fixture/Document/Personal/Article.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Gedmo\Tests\Translatable\Fixture\Document\Personal;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoODM;
+use Doctrine\ODM\MongoDB\Types\Type;
 use Gedmo\Mapping\Annotation as Gedmo;
 use Gedmo\Tests\Translatable\Fixture\Personal\PersonalArticleTranslation;
 
@@ -19,20 +20,26 @@ use Gedmo\Tests\Translatable\Fixture\Personal\PersonalArticleTranslation;
  * @Gedmo\TranslationEntity(class="Gedmo\Tests\Translatable\Fixture\Document\Personal\ArticleTranslation")
  * @MongoODM\Document(collection="articles")
  */
+#[Gedmo\TranslationEntity(class: ArticleTranslation::class)]
+#[MongoODM\Document(collection: 'articles')]
 class Article
 {
     /** @MongoODM\Id */
+    #[MongoODM\Id]
     private $id;
 
     /**
      * @Gedmo\Translatable
      * @MongoODM\Field(type="string")
      */
+    #[Gedmo\Translatable]
+    #[MongoODM\Field(type: Type::STRING)]
     private $title;
 
     /**
      * @MongoODM\ReferenceMany(targetDocument="Gedmo\Tests\Translatable\Fixture\Document\Personal\ArticleTranslation", mappedBy="object")
      */
+    #[MongoODM\ReferenceMany(targetDocument: ArticleTranslation::class, mappedBy: 'object')]
     private $translations;
 
     /**

--- a/tests/Gedmo/Translatable/Fixture/Document/Personal/ArticleTranslation.php
+++ b/tests/Gedmo/Translatable/Fixture/Document/Personal/ArticleTranslation.php
@@ -17,10 +17,12 @@ use Gedmo\Translatable\Document\MappedSuperclass\AbstractPersonalTranslation;
 /**
  * @MongoODM\Document(collection="article_translations")
  */
+#[MongoODM\Document(collection: 'article_translations')]
 class ArticleTranslation extends AbstractPersonalTranslation
 {
     /**
      * @MongoODM\ReferenceOne(targetDocument="Gedmo\Tests\Translatable\Fixture\Document\Personal\Article", inversedBy="translations")
      */
+    #[MongoODM\ReferenceOne(targetDocument: Article::class, inversedBy: 'translations')]
     protected $object;
 }

--- a/tests/Gedmo/Translatable/Fixture/Document/SimpleArticle.php
+++ b/tests/Gedmo/Translatable/Fixture/Document/SimpleArticle.php
@@ -12,26 +12,33 @@ declare(strict_types=1);
 namespace Gedmo\Tests\Translatable\Fixture\Document;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoODM;
+use Doctrine\ODM\MongoDB\Types\Type;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @MongoODM\Document(collection="articles")
  */
+#[MongoODM\Document(collection: 'articles')]
 class SimpleArticle
 {
     /** @MongoODM\Id */
+    #[MongoODM\Id]
     private $id;
 
     /**
      * @Gedmo\Translatable
      * @MongoODM\Field(type="string")
      */
+    #[Gedmo\Translatable]
+    #[MongoODM\Field(type: Type::STRING)]
     private $title;
 
     /**
      * @Gedmo\Translatable
      * @MongoODM\Field(type="string")
      */
+    #[Gedmo\Translatable]
+    #[MongoODM\Field(type: Type::STRING)]
     private $content;
 
     public function getId()

--- a/tests/Gedmo/Translatable/Fixture/Issue165/SimpleArticle.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue165/SimpleArticle.php
@@ -12,31 +12,39 @@ declare(strict_types=1);
 namespace Gedmo\Tests\Translatable\Fixture\Issue165;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoODM;
+use Doctrine\ODM\MongoDB\Types\Type;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @MongoODM\Document(collection="articles")
  */
+#[MongoODM\Document(collection: 'articles')]
 class SimpleArticle
 {
     /** @MongoODM\Id */
+    #[MongoODM\Id]
     private $id;
 
     /**
      * @Gedmo\Translatable
      * @MongoODM\Field(type="string")
      */
+    #[Gedmo\Translatable]
+    #[MongoODM\Field(type: Type::STRING)]
     private $title;
 
     /**
      * @Gedmo\Translatable
      * @MongoODM\Field(type="string")
      */
+    #[Gedmo\Translatable]
+    #[MongoODM\Field(type: Type::STRING)]
     private $content;
 
     /**
      * @MongoODM\Field(type="string")
      */
+    #[MongoODM\Field(type: Type::STRING)]
     private $untranslated;
 
     public function getId()

--- a/tests/Gedmo/Translatable/Issue/Issue165Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue165Test.php
@@ -39,7 +39,7 @@ final class Issue165Test extends BaseTestCaseMongoODM
         $this->translatableListener->setTranslatableLocale('en');
         $evm->addEventSubscriber($this->translatableListener);
 
-        $this->getMockDocumentManager($evm);
+        $this->getDefaultDocumentManager($evm);
     }
 
     /**

--- a/tests/Gedmo/Translatable/PersonalTranslationDocumentTest.php
+++ b/tests/Gedmo/Translatable/PersonalTranslationDocumentTest.php
@@ -40,7 +40,7 @@ final class PersonalTranslationDocumentTest extends BaseTestCaseMongoODM
         $this->translatableListener->setTranslatableLocale('en');
         $evm->addEventSubscriber($this->translatableListener);
 
-        $this->getMockDocumentManager($evm);
+        $this->getDefaultDocumentManager($evm);
     }
 
     /**

--- a/tests/Gedmo/Translatable/TranslatableDocumentCollectionTest.php
+++ b/tests/Gedmo/Translatable/TranslatableDocumentCollectionTest.php
@@ -41,7 +41,7 @@ final class TranslatableDocumentCollectionTest extends BaseTestCaseMongoODM
         $this->translatableListener->setTranslatableLocale('en_us');
         $evm->addEventSubscriber($this->translatableListener);
 
-        $this->getMockDocumentManager($evm);
+        $this->getDefaultDocumentManager($evm);
         $this->populate();
     }
 

--- a/tests/Gedmo/Translatable/TranslatableDocumentTest.php
+++ b/tests/Gedmo/Translatable/TranslatableDocumentTest.php
@@ -15,6 +15,7 @@ use Doctrine\Common\EventManager;
 use Gedmo\Sluggable\SluggableListener;
 use Gedmo\Tests\Tool\BaseTestCaseMongoODM;
 use Gedmo\Tests\Translatable\Fixture\Document\Article;
+use Gedmo\Translatable\Document\Repository\TranslationRepository;
 use Gedmo\Translatable\Document\Translation;
 use Gedmo\Translatable\TranslatableListener;
 
@@ -41,7 +42,7 @@ final class TranslatableDocumentTest extends BaseTestCaseMongoODM
         $evm->addEventSubscriber(new SluggableListener());
         $evm->addEventSubscriber($this->translatableListener);
 
-        $this->getMockDocumentManager($evm);
+        $this->getDefaultDocumentManager($evm);
         $this->populate();
     }
 
@@ -49,13 +50,13 @@ final class TranslatableDocumentTest extends BaseTestCaseMongoODM
     {
         // test inserted translations
         $repo = $this->dm->getRepository(self::ARTICLE);
-        /*$article = $repo->findOneBy(['title' => 'Title EN']);
+        $article = $repo->findOneBy(['title' => 'Title EN']);
 
         $transRepo = $this->dm->getRepository(self::TRANSLATION);
-        $this->assertTrue($transRepo instanceof Document\Repository\TranslationRepository);
+        static::assertInstanceOf(TranslationRepository::class, $transRepo);
 
         $translations = $transRepo->findTranslations($article);
-        $this->assertCount(0, $translations);
+        static::assertCount(0, $translations);
 
         // test second translations
         $this->translatableListener->setTranslatableLocale('de_de');
@@ -68,20 +69,20 @@ final class TranslatableDocumentTest extends BaseTestCaseMongoODM
 
         $article = $repo->find($this->articleId);
         $translations = $transRepo->findTranslations($article);
-        $this->assertCount(1, $translations);
+        static::assertCount(1, $translations);
 
-        $this->assertArrayHasKey('de_de', $translations);
-        $this->assertArrayHasKey('title', $translations['de_de']);
-        $this->assertEquals('Title DE', $translations['de_de']['title']);
+        static::assertArrayHasKey('de_de', $translations);
+        static::assertArrayHasKey('title', $translations['de_de']);
+        static::assertSame('Title DE', $translations['de_de']['title']);
 
-        $this->assertArrayHasKey('code', $translations['de_de']);
-        $this->assertEquals('Code DE', $translations['de_de']['code']);
+        static::assertArrayHasKey('code', $translations['de_de']);
+        static::assertSame('Code DE', $translations['de_de']['code']);
 
-        $this->assertArrayHasKey('slug', $translations['de_de']);
-        $this->assertEquals('title-de-code-de', $translations['de_de']['slug']);
+        static::assertArrayHasKey('slug', $translations['de_de']);
+        static::assertSame('title-de-code-de', $translations['de_de']['slug']);
 
         // test value update
-        $this->dm->clear();*/
+        $this->dm->clear();
         $this->translatableListener->setTranslatableLocale('en_us');
         $article = $repo->find($this->articleId);
 
@@ -90,15 +91,15 @@ final class TranslatableDocumentTest extends BaseTestCaseMongoODM
         static::assertSame('title-en-code-en', $article->getSlug());
 
         // test translation update
-        /*$article->setTitle('Title EN Updated');
+        $article->setTitle('Title EN Updated');
         $article->setCode('Code EN Updated');
         $this->dm->persist($article);
         $this->dm->flush();
         $this->dm->clear();
 
         $article = $repo->find($this->articleId);
-        $this->assertEquals('Title EN Updated', $article->getTitle());
-        $this->assertEquals('Code EN Updated', $article->getCode());
+        static::assertSame('Title EN Updated', $article->getTitle());
+        static::assertSame('Code EN Updated', $article->getCode());
 
         // test removal of translations
         $this->dm->remove($article);
@@ -106,10 +107,10 @@ final class TranslatableDocumentTest extends BaseTestCaseMongoODM
         $this->dm->clear();
 
         $article = $repo->find($this->articleId);
-        $this->assertNull($article);
+        static::assertNull($article);
 
         $translations = $transRepo->findTranslationsByObjectId($this->articleId);
-        $this->assertCount(0, $translations);*/
+        static::assertCount(0, $translations);
     }
 
     private function populate(): void


### PR DESCRIPTION
`doctrine/mongodb-odm` will support attributes on the next minor version, this PR adds compatibility for users using attribute mapping with mongodb.

~I'll leave it as draft until that version is released.~