### PR TITLE
[#2351] Add `@return` docblock in methods implementing `EventSubscriber::getSubscribedEvents()`

### DIFF
--- a/src/Loggable/LoggableListener.php
+++ b/src/Loggable/LoggableListener.php
@@ -84,7 +84,7 @@ class LoggableListener extends MappedEventSubscriber
     }
 
     /**
-     * {@inheritdoc}
+     * @return string[]
      */
     public function getSubscribedEvents()
     {

--- a/src/ReferenceIntegrity/ReferenceIntegrityListener.php
+++ b/src/ReferenceIntegrity/ReferenceIntegrityListener.php
@@ -23,7 +23,7 @@ use Gedmo\ReferenceIntegrity\Mapping\Validator;
 class ReferenceIntegrityListener extends MappedEventSubscriber
 {
     /**
-     * {@inheritdoc}
+     * @return string[]
      */
     public function getSubscribedEvents()
     {

--- a/src/References/ReferencesListener.php
+++ b/src/References/ReferencesListener.php
@@ -113,6 +113,9 @@ class ReferencesListener extends MappedEventSubscriber
         $this->updateReferences($eventArgs);
     }
 
+    /**
+     * @return string[]
+     */
     public function getSubscribedEvents()
     {
         return [

--- a/src/Sluggable/SluggableListener.php
+++ b/src/Sluggable/SluggableListener.php
@@ -79,7 +79,7 @@ class SluggableListener extends MappedEventSubscriber
     /**
      * Specifies the list of events to listen
      *
-     * @return array
+     * @return string[]
      */
     public function getSubscribedEvents()
     {

--- a/src/SoftDeleteable/SoftDeleteableListener.php
+++ b/src/SoftDeleteable/SoftDeleteableListener.php
@@ -36,7 +36,7 @@ class SoftDeleteableListener extends MappedEventSubscriber
     public const POST_SOFT_DELETE = 'postSoftDelete';
 
     /**
-     * {@inheritdoc}
+     * @return string[]
      */
     public function getSubscribedEvents()
     {

--- a/src/Sortable/SortableListener.php
+++ b/src/Sortable/SortableListener.php
@@ -35,7 +35,7 @@ class SortableListener extends MappedEventSubscriber
     /**
      * Specifies the list of events to listen
      *
-     * @return array
+     * @return string[]
      */
     public function getSubscribedEvents()
     {

--- a/src/Translatable/TranslatableListener.php
+++ b/src/Translatable/TranslatableListener.php
@@ -120,7 +120,7 @@ class TranslatableListener extends MappedEventSubscriber
     /**
      * Specifies the list of events to listen
      *
-     * @return array
+     * @return string[]
      */
     public function getSubscribedEvents()
     {

--- a/src/Tree/TreeListener.php
+++ b/src/Tree/TreeListener.php
@@ -46,7 +46,7 @@ class TreeListener extends MappedEventSubscriber
     /**
      * Specifies the list of events to listen
      *
-     * @return array
+     * @return string[]
      */
     public function getSubscribedEvents()
     {

--- a/src/Uploadable/UploadableListener.php
+++ b/src/Uploadable/UploadableListener.php
@@ -56,7 +56,7 @@ class UploadableListener extends MappedEventSubscriber
     /**
      * Mime type guesser
      *
-     * @var \Gedmo\Uploadable\MimeType\MimeTypeGuesserInterface
+     * @var MimeTypeGuesserInterface
      */
     private $mimeTypeGuesser;
 
@@ -90,7 +90,7 @@ class UploadableListener extends MappedEventSubscriber
     }
 
     /**
-     * {@inheritdoc}
+     * @return string[]
      */
     public function getSubscribedEvents()
     {


### PR DESCRIPTION
Thank you for reporting this issue @jokaorgua.
Could you please confirm if these changes are enough to avoid the deprecation message?

Closes #2351.