### PR TITLE
Adjust docs links

### DIFF
--- a/doc/annotations.md
+++ b/doc/annotations.md
@@ -63,7 +63,7 @@ New annotation reader does not depend on any namespaces, for that reason you can
 single reader instance for whole project. The example bellow shows how to setup the
 mapping and listeners:
 
-**Note:** using this repository you can test and check the [example demo configuration](https://github.com/Atlantic18/DoctrineExtensions/tree/main/example/em.php)
+**Note:** using this repository you can test and check the [example demo configuration](../example/em.php)
 
 ``` php
 <?php

--- a/doc/blameable.md
+++ b/doc/blameable.md
@@ -27,7 +27,7 @@ Features:
 
 **Symfony:**
 
-- **Blameable** is available as [Bundle](http://github.com/stof/StofDoctrineExtensionsBundle)
+- **Blameable** is available as [Bundle](https://github.com/stof/StofDoctrineExtensionsBundle)
 for **Symfony2**, together with all other extensions
 
 This article will cover the basic installation and functionality of **Blameable** behavior
@@ -46,8 +46,8 @@ Content:
 
 ## Setup and autoloading
 
-Read the [documentation](http://github.com/Atlantic18/DoctrineExtensions/tree/main/doc/annotations.md#em-setup)
-or check the [example code](http://github.com/Atlantic18/DoctrineExtensions/tree/main/example)
+Read the [documentation](./annotations.md#em-setup)
+or check the [example code](../example)
 on how to setup and use the extensions in most optimized way.
 
 <a name="entity-mapping"></a>

--- a/doc/ip_traceable.md
+++ b/doc/ip_traceable.md
@@ -22,7 +22,7 @@ Features:
 
 **Symfony:**
 
-- **IpTraceable** is not yet available as [Bundle](http://github.com/stof/StofDoctrineExtensionsBundle)
+- **IpTraceable** is not yet available as [Bundle](https://github.com/stof/StofDoctrineExtensionsBundle)
 for **Symfony2**, together with all other extensions
 
 This article will cover the basic installation and functionality of **IpTraceable** behavior
@@ -41,8 +41,8 @@ Content:
 
 ## Setup and autoloading
 
-Read the [documentation](http://github.com/Atlantic18/DoctrineExtensions/tree/main/doc/annotations.md#em-setup)
-or check the [example code](http://github.com/Atlantic18/DoctrineExtensions/tree/main/example)
+Read the [documentation](./annotations.md#em-setup)
+or check the [example code](../example)
 on how to setup and use the extensions in most optimized way.
 
 <a name="entity-mapping"></a>

--- a/doc/laminas.md
+++ b/doc/laminas.md
@@ -44,7 +44,7 @@ return array(
 );
 ```
 
-That's it! From now on you can use Gedmo annotations, just as it is described in [documentation](https://github.com/Atlantic18/DoctrineExtensions/tree/main/doc/annotations.md).
+That's it! From now on you can use Gedmo annotations, just as it is described in [documentation](./annotations.md).
 
 #### Note: You may need to provide additional settings for some of the available listeners.
 

--- a/doc/loggable.md
+++ b/doc/loggable.md
@@ -18,7 +18,7 @@ and any number of them
 
 **Portability:**
 
-- **Loggable** is now available as [Bundle](http://github.com/stof/StofDoctrineExtensionsBundle)
+- **Loggable** is now available as [Bundle](https://github.com/stof/StofDoctrineExtensionsBundle)
 ported to **Symfony2** by **Christophe Coevoet**, together with all other extensions
 
 This article will cover the basic installation and functionality of **Loggable**
@@ -37,8 +37,8 @@ Content:
 
 ## Setup and autoloading
 
-Read the [documentation](http://github.com/Atlantic18/DoctrineExtensions/tree/main/doc/annotations.md#em-setup)
-or check the [example code](http://github.com/Atlantic18/DoctrineExtensions/tree/main/example)
+Read the [documentation](./annotations.md#em-setup)
+or check the [example code](../example)
 on how to setup and use the extensions in most optimized way.
 
 ### Loggable annotations:

--- a/doc/mapping.md
+++ b/doc/mapping.md
@@ -11,7 +11,7 @@ Features:
 - Mapping drivers for annotation and yaml
 - Conventional extension points for metadata extraction and object manager abstraction
 
-- Public [Mapping repository](http://github.com/Atlantic18/DoctrineExtensions "Mapping extension on Github") is available on github
+- Public [Mapping repository](https://github.com/doctrine-extensions/DoctrineExtensions "Mapping extension on Github") is available on github
 - Last update date: **2012-01-02**
 
 This article will cover the basic installation and usage of **Mapping** extension
@@ -31,8 +31,8 @@ Content:
 
 ## Setup and autoloading
 
-Read the [documentation](http://github.com/Atlantic18/DoctrineExtensions/tree/main/doc/annotations.md#em-setup)
-or check the [example code](http://github.com/Atlantic18/DoctrineExtensions/tree/main/example)
+Read the [documentation](./annotations.md#em-setup)
+or check the [example code](../example)
 on how to setup and use the extensions in most optimized way.
 
 <a name="create-extension"></a>

--- a/doc/reference_integrity.md
+++ b/doc/reference_integrity.md
@@ -20,7 +20,7 @@ Features:
 
 **Symfony:**
 
-- **ReferenceIntegrity** is available as [Bundle](http://github.com/stof/StofDoctrineExtensionsBundle)
+- **ReferenceIntegrity** is available as [Bundle](https://github.com/stof/StofDoctrineExtensionsBundle)
 for **Symfony2**, together with all other extensions
 
 This article will cover the basic installation and functionality of **ReferenceIntegrity** behavior
@@ -36,8 +36,8 @@ Content:
 
 ## Setup and autoloading
 
-Read the [documentation](http://github.com/Atlantic18/DoctrineExtensions/tree/main/doc/annotations.md#em-setup)
-or check the [example code](http://github.com/Atlantic18/DoctrineExtensions/tree/main/example)
+Read the [documentation](./annotations.md#em-setup)
+or check the [example code](../example)
 on how to setup and use the extensions in most optimized way.
 
 <a name="document-mapping"></a>

--- a/doc/sluggable.md
+++ b/doc/sluggable.md
@@ -55,10 +55,10 @@ no more exceptions during concurrent flushes.
 
 **Note:**
 
-- There is a reported [issue](https://github.com/Atlantic18/DoctrineExtensions/issues/254) that sluggable transliterator
+- There is a reported [issue](https://github.com/doctrine-extensions/DoctrineExtensions/issues/254) that sluggable transliterator
 does not work on OSX 10.6 its ok starting again from 10.7 version. To overcome the problem
 you can use your [custom transliterator](#transliterator)
-- Public [Sluggable repository](http://github.com/Atlantic18/DoctrineExtensions "Sluggable extension on Github") is available on github
+- Public [Sluggable repository](https://github.com/doctrine-extensions/DoctrineExtensions "Sluggable extension on Github") is available on github
 - Last update date: **2012-02-26**
 - For usage together with **SoftDeleteable** in order to take into account softdeleted entities while generating unique
 slug, you must explicitly call **addManagedFilter** with a name of softdeleteable filter, so it can be disabled during
@@ -66,7 +66,7 @@ slug updates. The best place to do it, is when initializing sluggable listener. 
 
 **Portability:**
 
-- **Sluggable** is now available as [Bundle](http://github.com/stof/StofDoctrineExtensionsBundle)
+- **Sluggable** is now available as [Bundle](https://github.com/stof/StofDoctrineExtensionsBundle)
 ported to **Symfony2** by **Christophe Coevoet**, together with all other extensions
 
 This article will cover the basic installation and functionality of **Sluggable**
@@ -88,8 +88,8 @@ Content:
 
 ## Setup and autoloading
 
-Read the [documentation](http://github.com/Atlantic18/DoctrineExtensions/tree/main/doc/annotations.md#em-setup)
-or check the [example code](http://github.com/Atlantic18/DoctrineExtensions/tree/main/example)
+Read the [documentation](./annotations.md#em-setup)
+or check the [example code](../example)
 on how to setup and use the extensions in most optimized way.
 
 <a name="entity-mapping"></a>
@@ -640,7 +640,7 @@ Now the generated slug will be translated by Translatable behavior
 There are built-in slug handlers like described in configuration options of slug, but there
 can be also customized slug handlers depending on use cases. Usually the most logic use case
 is for related slug. For instance if user has a **ManyToOne relation to a **Company** we
-would like to have a url like **http://example.com/knplabs/gedi where **KnpLabs**
+would like to have a url like `http://example.com/knplabs/gedi` where **KnpLabs**
 is a company and user name is **Gedi**. In this case relation has a path separator **/**
 
 User entity example:
@@ -779,7 +779,7 @@ class Company
 ```
 
 For other mapping drivers see
-[xml](https://github.com/Atlantic18/DoctrineExtensions/tree/main/tests/Gedmo/Mapping/Driver/Xml/Mapping.Fixture.Xml.Sluggable.dcm.xml) or [yaml](https://github.com/Atlantic18/DoctrineExtensions/tree/main/tests/Gedmo/Mapping/Driver/Yaml/Mapping.Fixture.Yaml.Category.dcm.yml) examples from tests
+[xml](../tests/Gedmo/Mapping/Driver/Xml/Gedmo.Tests.Mapping.Fixture.Xml.Sluggable.dcm.xml) or [yaml](../tests/Gedmo/Mapping/Driver/Yaml/Gedmo.Tests.Mapping.Fixture.Yaml.Category.dcm.yml) examples from tests
 
 And the example usage:
 

--- a/doc/softdeleteable.md
+++ b/doc/softdeleteable.md
@@ -26,8 +26,8 @@ Content:
 
 ## Setup and autoloading
 
-Read the [documentation](http://github.com/Atlantic18/DoctrineExtensions/tree/main/doc/annotations.md#em-setup)
-or check the [example code](http://github.com/Atlantic18/DoctrineExtensions/tree/main/example)
+Read the [documentation](./annotations.md#em-setup)
+or check the [example code](../example)
 on how to setup and use the extensions in most optimized way.
 
 With SoftDeleteable there's one more step you need to do. You need to add the filter to your configuration:

--- a/doc/sortable.md
+++ b/doc/sortable.md
@@ -12,12 +12,12 @@ Features:
 
 **Note:**
 
-- Public [Sortable repository](http://github.com/Atlantic18/DoctrineExtensions "Sortable extension on Github") is available on github
+- Public [Sortable repository](https://github.com/doctrine-extensions/DoctrineExtensions "Sortable extension on Github") is available on github
 - Last update date: **2012-01-02**
 
 **Portability:**
 
-- **Sortable** is now available as [Bundle](http://github.com/stof/StofDoctrineExtensionsBundle)
+- **Sortable** is now available as [Bundle](https://github.com/stof/StofDoctrineExtensionsBundle)
 ported to **Symfony2** by **Christophe Coevoet**, together with all other extensions
 
 This article will cover the basic installation and functionality of **Sortable**
@@ -37,8 +37,8 @@ Content:
 
 ## Setup and autoloading
 
-Read the [documentation](http://github.com/Atlantic18/DoctrineExtensions/tree/main/doc/annotations.md#em-setup)
-or check the [example code](http://github.com/Atlantic18/DoctrineExtensions/tree/main/example)
+Read the [documentation](./annotations.md#em-setup)
+or check the [example code](../example)
 on how to setup and use the extensions in most optimized way.
 
 <a name="entity-mapping"></a>

--- a/doc/symfony2.md
+++ b/doc/symfony2.md
@@ -1,6 +1,6 @@
 # Install Gedmo Doctrine2 extensions in Symfony2
 
-Configure full featured [Doctrine2 extensions](http://github.com/Atlantic18/DoctrineExtensions) for your symfony2 project.
+Configure full featured [Doctrine2 extensions](https://github.com/doctrine-extensions/DoctrineExtensions) for your symfony2 project.
 This post will show you - how to create a simple configuration file to manage extensions with
 ability to use all features it provides.
 Interested? then bear with me! and don't be afraid, we're not diving into security component :)
@@ -23,7 +23,7 @@ Content:
 ## Symfony2 application
 
 First of all, we will need a symfony2 startup application, let's say [symfony-standard edition
-with composer](http://github.com/KnpLabs/symfony-with-composer). Follow the standard setup:
+with composer](https://github.com/KnpLabs/symfony-with-composer). Follow the standard setup:
 
 - `git clone git://github.com/KnpLabs/symfony-with-composer.git example`
 - `cd example && rm -rf .git && php bin/vendors install`
@@ -485,15 +485,15 @@ doctrine_mongodb:
 This also shows, how to make mappings based on single manager. All what differs is that **Document**
 instead of **Entity** is used. I haven't tested it with mongo though.
 
-**Note:** [extension repository](http://github.com/Atlantic18/DoctrineExtensions) contains all
-[documentation](http://github.com/Atlantic18/DoctrineExtensions/tree/main/doc) you may need
+**Note:** [extension repository](https://github.com/doctrine-extensions/DoctrineExtensions) contains all
+[documentation](../doc) you may need
 to understand how you can use it in your projects.
 
 <a name="alternative"></a>
 
 ## Alternative over configuration
 
-You can use [StofDoctrineExtensionsBundle](http://github.com/stof/StofDoctrineExtensionsBundle) which is a wrapper of these extensions
+You can use [StofDoctrineExtensionsBundle](https://github.com/stof/StofDoctrineExtensionsBundle) which is a wrapper of these extensions
 
 ## Troubleshooting
 

--- a/doc/symfony4.md
+++ b/doc/symfony4.md
@@ -1,6 +1,6 @@
 # Install Gedmo Doctrine2 extensions in Symfony 4
 
-Configure full featured [Doctrine2 extensions](http://github.com/Atlantic18/DoctrineExtensions) for your symfony 4 project.
+Configure full featured [Doctrine2 extensions](https://github.com/doctrine-extensions/DoctrineExtensions) for your symfony 4 project.
 This post will show you - how to create a simple configuration file to manage extensions with
 ability to use all features it provides.
 Interested? then bear with me! and don't be afraid, we're not diving into security component :)
@@ -456,15 +456,15 @@ doctrine_mongodb:
 This also shows, how to make mappings based on single manager. All what differs is that **Document**
 instead of **Entity** is used. I haven't tested it with mongo though.
 
-**Note:** [extension repository](http://github.com/Atlantic18/DoctrineExtensions) contains all
-[documentation](http://github.com/Atlantic18/DoctrineExtensions/tree/main/doc) you may need
+**Note:** [extension repository](https://github.com/doctrine-extensions/DoctrineExtensions) contains all
+[documentation](../doc) you may need
 to understand how you can use it in your projects.
 
 <a name="alternative"></a>
 
 ## Alternative over configuration
 
-You can use [StofDoctrineExtensionsBundle](http://github.com/stof/StofDoctrineExtensionsBundle) which is a wrapper of these extensions
+You can use [StofDoctrineExtensionsBundle](https://github.com/stof/StofDoctrineExtensionsBundle) which is a wrapper of these extensions
 
 ## Troubleshooting
 

--- a/doc/timestampable.md
+++ b/doc/timestampable.md
@@ -31,7 +31,7 @@ and any number of them
 
 **Portability:**
 
-- **Timestampable** is now available as [Bundle](http://github.com/stof/StofDoctrineExtensionsBundle)
+- **Timestampable** is now available as [Bundle](https://github.com/stof/StofDoctrineExtensionsBundle)
 ported to **Symfony2** by **Christophe Coevoet**, together with all other extensions
 
 This article will cover the basic installation and functionality of **Timestampable** behavior
@@ -50,8 +50,8 @@ Content:
 
 ## Setup and autoloading
 
-Read the [documentation](http://github.com/Atlantic18/DoctrineExtensions/tree/main/doc/annotations.md#em-setup)
-or check the [example code](http://github.com/Atlantic18/DoctrineExtensions/tree/main/example)
+Read the [documentation](./annotations.md#em-setup)
+or check the [example code](../example)
 on how to setup and use the extensions in most optimized way.
 
 <a name="entity-mapping"></a>

--- a/doc/transaction-safety.md
+++ b/doc/transaction-safety.md
@@ -23,7 +23,7 @@ begin the second one which in turn would lock the third one if there would be an
 
 **NOTE:** it is not enough to simply have a transaction.
 
-So how we can achieve this? The simplest solution is [pessimistic locking](http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/transactions-and-concurrency.html#pessimistic-locking) which is supported by ORM.
+So how we can achieve this? The simplest solution is [pessimistic locking](https://www.doctrine-project.org/projects/doctrine-orm/en/current/reference/transactions-and-concurrency.html#pessimistic-locking) which is supported by ORM.
 
 So how we can use it correctly to maintain our transactions safe from one another. Lets say we have two entity types in
 our application:

--- a/doc/translatable.md
+++ b/doc/translatable.md
@@ -22,7 +22,7 @@ constraint. This dramatically improves the management of translations
 **2012-01-04**
 
 - Refactored translatable to be able to persist, update many translations
-using repository, [issue #224](https://github.com/Atlantic18/DoctrineExtensions/issues/224)
+using repository, [issue #224](https://github.com/doctrine-extensions/DoctrineExtensions/issues/224)
 
 **2011-12-11**
 
@@ -54,14 +54,14 @@ and any number of them
 
 **Note list:**
 
-- Public [Translatable repository](http://github.com/Atlantic18/DoctrineExtensions "Translatable extension on Github") is available on github
+- Public [Translatable repository](https://github.com/doctrine-extensions/DoctrineExtensions "Translatable extension on Github") is available on github
 - Using other extensions on the same Entity fields may result in unexpected way
 - May impact your application performance since it does an additional query for translation if loaded without query hint
 - Last update date: **2012-02-15**
 
 **Portability:**
 
-- **Translatable** is now available as [Bundle](http://github.com/stof/StofDoctrineExtensionsBundle)
+- **Translatable** is now available as [Bundle](https://github.com/stof/StofDoctrineExtensionsBundle)
 ported to **Symfony2** by **Christophe Coevoet**, together with all other extensions
 
 This article will cover the basic installation and functionality of **Translatable** behavior
@@ -83,8 +83,8 @@ Content:
 
 ## Setup and autoloading
 
-Read the [documentation](http://github.com/Atlantic18/DoctrineExtensions/tree/main/doc/annotations.md#em-setup)
-or check the [example code](http://github.com/Atlantic18/DoctrineExtensions/tree/main/example)
+Read the [documentation](./annotations.md#em-setup)
+or check the [example code](../example)
 on how to setup and use the extensions in most optimized way.
 
 ### Translatable annotations:

--- a/doc/tree.md
+++ b/doc/tree.md
@@ -18,9 +18,9 @@ Features:
 
 Thanks for contributions to:
 
-- **[comfortablynumb](http://github.com/comfortablynumb) Gustavo Falco** for Closure and Materialized Path strategy
-- **[everzet](http://github.com/everzet) Kudryashov Konstantin** for TreeLevel implementation
-- **[stof](http://github.com/stof) Christophe Coevoet** for getTreeLeafs function
+- **[comfortablynumb](https://github.com/comfortablynumb) Gustavo Falco** for Closure and Materialized Path strategy
+- **[everzet](https://github.com/everzet) Kudryashov Konstantin** for TreeLevel implementation
+- **[stof](https://github.com/stof) Christophe Coevoet** for getTreeLeafs function
 
 Update **2018-02-26**
 
@@ -71,12 +71,12 @@ Update **2011-02-02**
 - After using a NestedTreeRepository functions: **verify, recover, removeFromTree** it is recommended to clear the EntityManager cache
 because nodes may have changed values in database but not in memory. Flushing dirty nodes can lead to unexpected behaviour.
 - Closure tree implementation is experimental and not fully functional, so far not documented either
-- Public [Tree repository](http://github.com/Atlantic18/DoctrineExtensions "Tree extension on Github") is available on github
+- Public [Tree repository](https://github.com/doctrine-extensions/DoctrineExtensions "Tree extension on Github") is available on github
 - Last update date: **2012-02-23**
 
 **Portability:**
 
-- **Tree** is now available as [Bundle](http://github.com/stof/StofDoctrineExtensionsBundle)
+- **Tree** is now available as [Bundle](https://github.com/stof/StofDoctrineExtensionsBundle)
 ported to **Symfony2** by **Christophe Coevoet**, together with all other extensions
 
 This article will cover the basic installation and functionality of **Tree** behavior
@@ -99,8 +99,8 @@ Content:
 
 ## Setup and autoloading
 
-Read the [documentation](http://github.com/Atlantic18/DoctrineExtensions/tree/main/doc/annotations.md#em-setup)
-or check the [example code](http://github.com/Atlantic18/DoctrineExtensions/tree/main/example)
+Read the [documentation](./annotations.md#em-setup)
+or check the [example code](../example)
 on how to setup and use the extensions in the most optimized way.
 
 <a name="entity-mapping"></a>

--- a/doc/upgrading/upgrade-v2.4-to-v3.0.md
+++ b/doc/upgrading/upgrade-v2.4-to-v3.0.md
@@ -9,13 +9,13 @@ Look for "_Applies To_" notes for when you may need to take action.
 ##### Known Issue: Doctrine MongoDB ODM 2.0 Mapping Drivers
 
 ODM 2.0 made significant changes to parts of their mappers. The YAML driver was removed completely, and the
-[XML driver added schema validation](https://github.com/Atlantic18/DoctrineExtensions/issues/2055) that does
+[XML driver added schema validation](https://github.com/doctrine-extensions/DoctrineExtensions/issues/2055) that does
 not allow mixing of native ODM and Extensions elements.
 
 **YAML and XML mapping users may not be able to use Doctrine Extensions 3.0**, which does not attempt to resolve
 these issues at the time.  If you use Annotations or PHP mapping drivers, you should be unaffected.
 
-See [Issue #2055](https://github.com/Atlantic18/DoctrineExtensions/issues/2055) on GitHub for more information.
+See [Issue #2055](https://github.com/doctrine-extensions/DoctrineExtensions/issues/2055) on GitHub for more information.
 Please leave a message if this affects your project.
 
 ## PHP 7.2 Required

--- a/doc/uploadable.md
+++ b/doc/uploadable.md
@@ -25,8 +25,8 @@ Content:
 
 ## Setup and autoloading
 
-Read the [documentation](http://github.com/Atlantic18/DoctrineExtensions/tree/main/doc/annotations.md#em-setup)
-or check the [example code](http://github.com/Atlantic18/DoctrineExtensions/tree/main/example)
+Read the [documentation](./annotations.md#em-setup)
+or check the [example code](../example)
 on how to setup and use the extensions in most optimized way.
 
 


### PR DESCRIPTION
Makes the docs links relative (which helps to browse docs on a branch going forward) and uses `https://` where applicable.