### PR TITLE
Expand type info on tree annotations, deprecate unused `@Tree::$identifierMethod`

### DIFF
--- a/src/Mapping/Annotation/Tree.php
+++ b/src/Mapping/Annotation/Tree.php
@@ -21,15 +21,25 @@ use Doctrine\Common\Annotations\Annotation;
  */
 final class Tree extends Annotation
 {
-    /** @var string */
+    /**
+     * @var string
+     * @phpstan-var 'closure'|'materializedPath'|'nested'
+     */
     public $type = 'nested';
 
     /** @var bool */
     public $activateLocking = false;
 
-    /** @var int */
+    /**
+     * @var int
+     * @phpstan-var positive-int
+     */
     public $lockingTimeout = 3;
 
-    /** @var string */
+    /**
+     * @var string
+     *
+     * @deprecated to be removed in 4.0, unused, configure the property on the TreeRoot annotation instead
+     */
     public $identifierMethod;
 }

--- a/src/Mapping/Annotation/TreeClosure.php
+++ b/src/Mapping/Annotation/TreeClosure.php
@@ -10,6 +10,7 @@
 namespace Gedmo\Mapping\Annotation;
 
 use Doctrine\Common\Annotations\Annotation;
+use Gedmo\Tree\Entity\MappedSuperclass\AbstractClosure;
 
 /**
  * TreeClosure annotation for Tree behavioral extension
@@ -21,6 +22,9 @@ use Doctrine\Common\Annotations\Annotation;
  */
 final class TreeClosure extends Annotation
 {
-    /** @var string @Required */
+    /**
+     * @var string
+     * @phpstan-var class-string<AbstractClosure>
+     */
     public $class;
 }

--- a/src/Mapping/Annotation/TreePath.php
+++ b/src/Mapping/Annotation/TreePath.php
@@ -23,11 +23,15 @@ use Doctrine\Common\Annotations\Annotation;
  */
 final class TreePath extends Annotation
 {
+    /** @var string */
     public $separator = ',';
 
+    /** @var bool|null */
     public $appendId;
 
+    /** @var bool */
     public $startsWithSeparator = false;
 
+    /** @var bool */
     public $endsWithSeparator = true;
 }


### PR DESCRIPTION
Adds `@phpstan-var` annotations when specific values are expected to improve static analysis

Deprecates the unused `@Tree::$identifierMethod` property, this is actually read from the `@TreeRoot` annotation