### PR TITLE
Dropped support for PHP 7.2 and 7.3

### DIFF
--- a/.docker/php/Dockerfile
+++ b/.docker/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2-cli
+FROM php:7.4-cli
 
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,8 +23,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.2"
-          - "7.3"
           - "7.4"
           - "8.0"
         deps:
@@ -33,7 +31,7 @@ jobs:
           - ""
         include:
           - deps: "lowest"
-            php-version: "7.2"
+            php-version: "7.4"
           - deps: "highest"
             php-version: "8.0"
             dbal-version: "^2.13.1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ a release.
 
 ## [Unreleased]
 
+### Changed
+- Dropped support for PHP 7.2 and 7.2, which are End of Life (EOL)
+
 ## [3.4.0] - 2021-12-05
 ### Added
 - PHP 8 Attributes support for Doctrine MongoDB to document & traits.

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "wiki": "https://github.com/Atlantic18/DoctrineExtensions/tree/main/doc"
     },
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "behat/transliterator": "~1.2",
         "doctrine/annotations": "^1.13",
         "doctrine/collections": "^1.0",


### PR DESCRIPTION
In a few hours, PHP 7.3 becomes End of Life. That's why I think it's safe to drop support for it.