### PR TITLE
allow php8 attributes for Tree extension

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - support-attributes
   pull_request:
 
 jobs:

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - support-attributes
   pull_request:
 
 jobs:

--- a/src/Mapping/Annotation/Slug.php
+++ b/src/Mapping/Annotation/Slug.php
@@ -9,7 +9,9 @@
 
 namespace Gedmo\Mapping\Annotation;
 
+use Attribute;
 use Doctrine\Common\Annotations\Annotation;
+use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 
 /**
  * Slug annotation for Sluggable behavioral extension
@@ -19,7 +21,8 @@ use Doctrine\Common\Annotations\Annotation;
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
-final class Slug extends Annotation
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class Slug implements GedmoAnnotation
 {
     /** @var array<string> @Required */
     public $fields = [];
@@ -41,4 +44,38 @@ final class Slug extends Annotation
     public $handlers = [];
     /** @var string */
     public $dateFormat = 'Y-m-d-H:i';
+
+    /**
+     * @phpstan-param class-string|null $type
+     */
+    public function __construct(array $data = [],
+                                array $fields = [],
+                                bool $updatable = true,
+                                string $style = 'default', // or "camel"
+                                bool $unique = true,
+                                string $unique_base = '',
+                                string $separator = '-',
+                                string $prefix = '',
+                                string $suffix = '',
+                                iterable $handlers = [],
+                                string $dateFormat = 'Y-m-d-H:i'
+    ) {
+        if ([] !== $data) {
+            @trigger_error(sprintf(
+                'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
+        $this->fields = $data['fields'] ?? $fields;
+        $this->updatable = $data['updatable'] ?? $updatable;
+        $this->style = $data['style'] ?? $style;
+        $this->unique = $data['unique'] ?? $unique;
+        $this->unique_base = $data['unique_base'] ?? $unique_base;
+        $this->separator = $data['separator'] ?? $separator;
+        $this->prefix = $data['prefix'] ?? $prefix;
+        $this->suffix = $data['suffix'] ?? $suffix;
+        $this->handlers = $data['handlers'] ?? $handlers;
+        $this->dateFormat = $data['dateFormat'] ?? $dateFormat;
+    }
 }

--- a/src/Mapping/Annotation/Slug.php
+++ b/src/Mapping/Annotation/Slug.php
@@ -32,7 +32,7 @@ final class Slug implements GedmoAnnotation
     public $style = 'default'; // or "camel"
     /** @var bool */
     public $unique = true;
-    /** @var string */
+    /** @var string|null */
     public $unique_base;
     /** @var string */
     public $separator = '-';
@@ -53,7 +53,7 @@ final class Slug implements GedmoAnnotation
                                 bool $updatable = true,
                                 string $style = 'default', // or "camel"
                                 bool $unique = true,
-                                string $unique_base = '',
+                                ?string $unique_base = null,
                                 string $separator = '-',
                                 string $prefix = '',
                                 string $suffix = '',

--- a/src/Mapping/Annotation/Tree.php
+++ b/src/Mapping/Annotation/Tree.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
  * This file is part of the Doctrine Behavioral Extensions package.
  * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
@@ -9,9 +8,9 @@
 
 namespace Gedmo\Mapping\Annotation;
 
+use Attribute;
 use Doctrine\Common\Annotations\Annotation;
 use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
-use Attribute;
 
 /**
  * Tree annotation for Tree behavioral extension
@@ -64,6 +63,4 @@ final class Tree implements GedmoAnnotation
         $this->lockingTimeout = $data['lockingTimeout'] ?? $lockingTimeout;
         $this->identifierMethod = $data['identifierMethod'] ?? $identifierMethod;
     }
-
 }
-

--- a/src/Mapping/Annotation/Tree.php
+++ b/src/Mapping/Annotation/Tree.php
@@ -44,12 +44,13 @@ final class Tree implements GedmoAnnotation
      *
      * @deprecated to be removed in 4.0, unused, configure the property on the TreeRoot annotation instead
      */
+
     public $identifierMethod;
 
     /**
      * @phpstan-param class-string|null $type
      */
-    public function __construct(array $data = [], ?string $type = null)
+    public function __construct(array $data = [], ?string $type = null, bool $activateLocking = false, int $lockingTimeout = 3, string $identifierMethod)
     {
         if ([] !== $data) {
             @trigger_error(sprintf(
@@ -59,6 +60,9 @@ final class Tree implements GedmoAnnotation
         }
 
         $this->type = $data['type'] ?? $type;
+        $this->activateLocking = $data['activateLocking'] ?? $activateLocking;
+        $this->lockingTimeout = $data['lockingTimeout'] ?? $lockingTimeout;
+        $this->identifierMethod = $data['identifierMethod'] ?? $identifierMethod;
     }
 
 }

--- a/src/Mapping/Annotation/Tree.php
+++ b/src/Mapping/Annotation/Tree.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the Doctrine Behavioral Extensions package.
  * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
@@ -43,13 +44,12 @@ final class Tree implements GedmoAnnotation
      *
      * @deprecated to be removed in 4.0, unused, configure the property on the TreeRoot annotation instead
      */
-
     public $identifierMethod;
 
     /**
      * @phpstan-param class-string|null $type
      */
-    public function __construct(array $data = [], ?string $type = null, bool $activateLocking = false, int $lockingTimeout = 3, ?string $identifierMethod=null)
+    public function __construct(array $data = [], ?string $type = null, bool $activateLocking = false, int $lockingTimeout = 3, ?string $identifierMethod = null)
     {
         if ([] !== $data) {
             @trigger_error(sprintf(

--- a/src/Mapping/Annotation/Tree.php
+++ b/src/Mapping/Annotation/Tree.php
@@ -10,6 +10,8 @@
 namespace Gedmo\Mapping\Annotation;
 
 use Doctrine\Common\Annotations\Annotation;
+use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
+use Attribute;
 
 /**
  * Tree annotation for Tree behavioral extension
@@ -19,7 +21,8 @@ use Doctrine\Common\Annotations\Annotation;
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
-final class Tree extends Annotation
+#[Attribute(Attribute::TARGET_CLASS)]
+final class Tree implements GedmoAnnotation
 {
     /**
      * @var string
@@ -42,4 +45,21 @@ final class Tree extends Annotation
      * @deprecated to be removed in 4.0, unused, configure the property on the TreeRoot annotation instead
      */
     public $identifierMethod;
+
+    /**
+     * @phpstan-param class-string|null $type
+     */
+    public function __construct(array $data = [], ?string $type = null)
+    {
+        if ([] !== $data) {
+            @trigger_error(sprintf(
+                'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
+        $this->type = $data['type'] ?? $type;
+    }
+
 }
+

--- a/src/Mapping/Annotation/Tree.php
+++ b/src/Mapping/Annotation/Tree.php
@@ -49,7 +49,7 @@ final class Tree implements GedmoAnnotation
     /**
      * @phpstan-param class-string|null $type
      */
-    public function __construct(array $data = [], ?string $type = null, bool $activateLocking = false, int $lockingTimeout = 3, string $identifierMethod)
+    public function __construct(array $data = [], ?string $type = null, bool $activateLocking = false, int $lockingTimeout = 3, ?string $identifierMethod=null)
     {
         if ([] !== $data) {
             @trigger_error(sprintf(

--- a/src/Mapping/Annotation/TreeLeft.php
+++ b/src/Mapping/Annotation/TreeLeft.php
@@ -10,6 +10,8 @@
 namespace Gedmo\Mapping\Annotation;
 
 use Doctrine\Common\Annotations\Annotation;
+use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
+use Attribute;
 
 /**
  * TreeLeft annotation for Tree behavioral extension
@@ -19,6 +21,7 @@ use Doctrine\Common\Annotations\Annotation;
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
-final class TreeLeft extends Annotation
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class TreeLeft implements GedmoAnnotation
 {
 }

--- a/src/Mapping/Annotation/TreeLeft.php
+++ b/src/Mapping/Annotation/TreeLeft.php
@@ -9,9 +9,9 @@
 
 namespace Gedmo\Mapping\Annotation;
 
+use Attribute;
 use Doctrine\Common\Annotations\Annotation;
 use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
-use Attribute;
 
 /**
  * TreeLeft annotation for Tree behavioral extension

--- a/src/Mapping/Annotation/TreeLevel.php
+++ b/src/Mapping/Annotation/TreeLevel.php
@@ -9,8 +9,8 @@
 
 namespace Gedmo\Mapping\Annotation;
 
-use Doctrine\Common\Annotations\Annotation;
 use Attribute;
+use Doctrine\Common\Annotations\Annotation;
 use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 
 /**

--- a/src/Mapping/Annotation/TreeLevel.php
+++ b/src/Mapping/Annotation/TreeLevel.php
@@ -10,6 +10,9 @@
 namespace Gedmo\Mapping\Annotation;
 
 use Doctrine\Common\Annotations\Annotation;
+use Attribute;
+use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
+
 
 /**
  * TreeLevel annotation for Tree behavioral extension
@@ -19,6 +22,7 @@ use Doctrine\Common\Annotations\Annotation;
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
-final class TreeLevel extends Annotation
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class TreeLevel implements GedmoAnnotation
 {
 }

--- a/src/Mapping/Annotation/TreeLevel.php
+++ b/src/Mapping/Annotation/TreeLevel.php
@@ -13,7 +13,6 @@ use Doctrine\Common\Annotations\Annotation;
 use Attribute;
 use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 
-
 /**
  * TreeLevel annotation for Tree behavioral extension
  *

--- a/src/Mapping/Annotation/TreeParent.php
+++ b/src/Mapping/Annotation/TreeParent.php
@@ -10,6 +10,8 @@
 namespace Gedmo\Mapping\Annotation;
 
 use Doctrine\Common\Annotations\Annotation;
+use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
+use Attribute;
 
 /**
  * TreeParent annotation for Tree behavioral extension
@@ -19,6 +21,7 @@ use Doctrine\Common\Annotations\Annotation;
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
-final class TreeParent extends Annotation
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class TreeParent implements GedmoAnnotation
 {
 }

--- a/src/Mapping/Annotation/TreeParent.php
+++ b/src/Mapping/Annotation/TreeParent.php
@@ -9,9 +9,9 @@
 
 namespace Gedmo\Mapping\Annotation;
 
+use Attribute;
 use Doctrine\Common\Annotations\Annotation;
 use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
-use Attribute;
 
 /**
  * TreeParent annotation for Tree behavioral extension

--- a/src/Mapping/Annotation/TreeRight.php
+++ b/src/Mapping/Annotation/TreeRight.php
@@ -10,6 +10,8 @@
 namespace Gedmo\Mapping\Annotation;
 
 use Doctrine\Common\Annotations\Annotation;
+use Attribute;
+use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 
 /**
  * TreeRight annotation for Tree behavioral extension
@@ -19,6 +21,7 @@ use Doctrine\Common\Annotations\Annotation;
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
-final class TreeRight extends Annotation
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class TreeRight implements GedmoAnnotation
 {
 }

--- a/src/Mapping/Annotation/TreeRight.php
+++ b/src/Mapping/Annotation/TreeRight.php
@@ -9,8 +9,8 @@
 
 namespace Gedmo\Mapping\Annotation;
 
-use Doctrine\Common\Annotations\Annotation;
 use Attribute;
+use Doctrine\Common\Annotations\Annotation;
 use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 
 /**

--- a/src/Mapping/Annotation/TreeRoot.php
+++ b/src/Mapping/Annotation/TreeRoot.php
@@ -10,6 +10,8 @@
 namespace Gedmo\Mapping\Annotation;
 
 use Doctrine\Common\Annotations\Annotation;
+use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
+use Attribute;
 
 /**
  * TreeRoot annotation for Tree behavioral extension
@@ -19,7 +21,8 @@ use Doctrine\Common\Annotations\Annotation;
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
-final class TreeRoot extends Annotation
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class TreeRoot implements GedmoAnnotation
 {
     /** @var string */
     public $identifierMethod;

--- a/src/Mapping/Annotation/TreeRoot.php
+++ b/src/Mapping/Annotation/TreeRoot.php
@@ -9,9 +9,9 @@
 
 namespace Gedmo\Mapping\Annotation;
 
+use Attribute;
 use Doctrine\Common\Annotations\Annotation;
 use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
-use Attribute;
 
 /**
  * TreeRoot annotation for Tree behavioral extension

--- a/src/Tree/Mapping/Driver/Attribute.php
+++ b/src/Tree/Mapping/Driver/Attribute.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tree\Mapping\Driver;
+
+use Gedmo\Mapping\Driver\AttributeDriverInterface;
+
+/**
+ * This is an attribute mapping driver for Tree
+ * behavioral extension. Used for extraction of extended
+ * metadata from attributes specifically for Tree
+ * extension.
+ *
+ * @author Kevin Mian Kraiker <kevin.mian@gmail.com>
+ * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
+ *
+ * @internal
+ */
+final class Attribute extends Annotation implements AttributeDriverInterface
+{
+}


### PR DESCRIPTION
This PR follows the pattern in Loggable to allow for PHP 8 attributes, #2363

However, it doesn't quite work yet, when trying to use a class that implements this I get

    Tree object class: App\Entity\Location must have tree metadata at this point

I imagine that in src/Tree/Mapping/Driver/Annotation.php, it is not loading the attributes, but I can't figure out where that's happening.  Can someone point me in the right direction?  