### PR TITLE
Fix using Loggable extension with only attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ a release.
 
 ## [Unreleased]
 
+### Fixed
+- Loggable: Using only PHP 8 attributes.
+
 ## [3.4.0] - 2021-12-05
 ### Added
 - PHP 8 Attributes support for Doctrine MongoDB to document & traits.

--- a/src/Loggable/Mapping/Driver/Attribute.php
+++ b/src/Loggable/Mapping/Driver/Attribute.php
@@ -9,12 +9,16 @@
 
 namespace Gedmo\Loggable\Mapping\Driver;
 
+use Gedmo\Mapping\Driver\AttributeDriverInterface;
+
 /**
  * This is an attribute mapping driver for Loggable
  * behavioral extension. Used for extraction of extended
  * metadata from attributes specifically for Loggable
  * extension.
+ *
+ * @internal
  */
-final class Attribute extends Annotation
+final class Attribute extends Annotation implements AttributeDriverInterface
 {
 }


### PR DESCRIPTION
I missed implementing `AttributeDriverInterface`. 

I've also marked `Attribute` as internal as the other existing `Attribute` classes. I know it has been released, but IMO it has been there just a couple of days and I don't think someone would have used directly the `Attribute` class from the `Loggable` extension.