### PR TITLE
Remove unused cache

### DIFF
--- a/src/Tree/Strategy/ORM/Closure.php
+++ b/src/Tree/Strategy/ORM/Closure.php
@@ -9,7 +9,6 @@
 
 namespace Gedmo\Tree\Strategy\ORM;
 
-use Doctrine\Common\Cache\Cache;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
@@ -155,12 +154,6 @@ class Closure implements Strategy
         $closureMetadata->table['indexes'][$indexName] = [
             'columns' => ['depth'],
         ];
-
-        $cacheDriver = $cmf->getCacheDriver();
-
-        if ($cacheDriver instanceof Cache) {
-            $cacheDriver->save($closureMetadata->getName().'$CLASSMETADATA', $closureMetadata);
-        }
     }
 
     /**

--- a/tests/Gedmo/Mapping/TreeMappingTest.php
+++ b/tests/Gedmo/Mapping/TreeMappingTest.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Gedmo\Tests\Tree;
+namespace Gedmo\Tests\Mapping;
 
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
@@ -73,18 +73,6 @@ final class TreeMappingTest extends \PHPUnit\Framework\TestCase
         $evm = new \Doctrine\Common\EventManager();
         $evm->addEventSubscriber(new TreeListener());
         $this->em = \Doctrine\ORM\EntityManager::create($conn, $config, $evm);
-    }
-
-    public function testApcCached()
-    {
-        $this->em->getClassMetadata(self::YAML_CLOSURE_CATEGORY);
-        $this->em->getClassMetadata(CategoryClosure::class);
-
-        $meta = $this->em->getMetadataFactory()->getCacheDriver()->fetch(
-            'Gedmo\\Tests\\Tree\\Fixture\\Closure\\CategoryClosure$CLASSMETADATA'
-        );
-        static::assertTrue($meta->hasAssociation('ancestor'));
-        static::assertTrue($meta->hasAssociation('descendant'));
     }
 
     public function testYamlNestedMapping()


### PR DESCRIPTION
I was taking a look at not using cache from metadata factory and bump into this.

It was added https://github.com/doctrine-extensions/DoctrineExtensions/commit/56e4f69f5a7dcd0bace35332cbce4b95e9207ba3 because of https://github.com/doctrine-extensions/DoctrineExtensions/issues/58. I guess that was added because at that time the key for storing metadata was created like that based on:

https://github.com/doctrine/orm/blob/b67d400e940b7bd0c99e37b2f6112f8dc1ac7710/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php#L165-L174

The way the key is generated has been changed lately [when supporting PRS-6](https://github.com/doctrine/persistence/pull/144) because the cache key can't contain `\`, so not sure if this is needed anymore.

I'll try to see if I can find out if this is really needed, but since I don't use the extension any comment is appreciated.