### PR TITLE
Fix type handling for the tracked field values configured in the timestampable field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,10 @@ a release.
 ## [Unreleased]
 ### Added
 - SoftDeleteable: Support to use annotations as attributes on PHP >= 8.0.
-
-### Added
 - Blameable: Support to use annotations as attributes on PHP >= 8.0.
 
 ### Fixed
+- Blameable, IpTraceable, Timestampable: Type handling for the tracked field values configured in the origin field.
 - Loggable: Using only PHP 8 attributes.
 
 ## [3.4.0] - 2021-12-05

--- a/src/AbstractTrackingListener.php
+++ b/src/AbstractTrackingListener.php
@@ -10,10 +10,14 @@
 namespace Gedmo;
 
 use Doctrine\Common\EventArgs;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Types\Type as TypeODM;
 use Doctrine\ORM\UnitOfWork;
 use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\NotifyPropertyChanged;
+use Doctrine\Persistence\ObjectManager;
 use Gedmo\Exception\UnexpectedValueException;
 use Gedmo\Mapping\Event\AdapterInterface;
 use Gedmo\Mapping\MappedEventSubscriber;
@@ -137,7 +141,9 @@ abstract class AbstractTrackingListener extends MappedEventSubscriber
                                 $value = $changes[1];
                             }
 
-                            if (null === $options['value'] || ($singleField && in_array($value, (array) $options['value'], true))) {
+                            $configuredValues = $this->getPhpValues($options['value'], $meta->getTypeOfField($tracked), $om);
+
+                            if (null === $configuredValues || ($singleField && in_array($value, $configuredValues, true))) {
                                 $needChanges = true;
                                 $this->updateField($object, $ea, $meta, $options['field']);
                             }
@@ -220,5 +226,39 @@ abstract class AbstractTrackingListener extends MappedEventSubscriber
             $uow = $eventAdapter->getObjectManager()->getUnitOfWork();
             $uow->propertyChanged($object, $field, $oldValue, $newValue);
         }
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return mixed[]|null
+     */
+    private function getPhpValues($values, ?string $type, ObjectManager $om): ?array
+    {
+        if (null === $values) {
+            return null;
+        }
+
+        if (!is_array($values)) {
+            $values = [$values];
+        }
+
+        if (null !== $type) {
+            foreach ($values as $i => $value) {
+                if ($om instanceof DocumentManager) {
+                    if (TypeODM::hasType($type)) {
+                        $values[$i] = TypeODM::getType($type)
+                            ->convertToPHPValue($value);
+                    } else {
+                        $values[$i] = $value;
+                    }
+                } elseif (Type::hasType($type)) {
+                    $values[$i] = Type::getType($type)
+                        ->convertToPHPValue($value, $om->getConnection()->getDatabasePlatform());
+                }
+            }
+        }
+
+        return $values;
     }
 }

--- a/tests/Gedmo/Timestampable/Fixture/Article.php
+++ b/tests/Gedmo/Timestampable/Fixture/Article.php
@@ -111,6 +111,24 @@ class Article implements Timestampable
     #[ORM\ManyToOne(targetEntity: Type::class, inversedBy: 'articles')]
     private $type;
 
+    /**
+     * @ORM\Column(name="level", type="integer")
+     */
+    #[ORM\Column(name: 'level', type: Types::INTEGER)]
+    private $level = 0;
+
+    /**
+     * We use the value "10" as string here in order to check the behavior of `AbstractTrackingListener`
+     *
+     * @var \DateTimeInterface
+     *
+     * @ORM\Column(name="reached_relevant_level", type="datetime", nullable=true)
+     * @Gedmo\Timestampable(on="change", field="level", value="10")
+     */
+    #[ORM\Column(name: 'reached_relevant_level', type: Types::DATE_MUTABLE, nullable: true)]
+    #[Gedmo\Timestampable(on: 'change', field: 'level', value: '10')]
+    private $reachedRelevantLevel;
+
     public function setType($type)
     {
         $this->type = $type;
@@ -215,5 +233,20 @@ class Article implements Timestampable
     public function getAuthorChanged()
     {
         return $this->authorChanged;
+    }
+
+    public function setLevel(int $level): void
+    {
+        $this->level = $level;
+    }
+
+    public function getLevel(): int
+    {
+        return $this->level;
+    }
+
+    public function getReachedRelevantLevel(): ?\DateTimeInterface
+    {
+        return $this->reachedRelevantLevel;
     }
 }


### PR DESCRIPTION
Fixes #2367.

**TODO**:
- [x] Cover the case where the configured value is an array.

Even if these changes could work, I'll be trying to get this solved from the mapping instead, as I think that will be the proper fix.