### PR TITLE
Allow to set a cache to store configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,9 +38,14 @@ a release.
 - References: Avoid deprecations using LazyCollection with PHP 8.1
 - Tree: Association mapping problems using Closure tree strategy (by manually defining mapping on the closure entity).
 - Wrong PHPDoc type declarations.
+- Avoid calling deprecated `AbstractClassMetadataFactory::getCacheDriver()` method.
 
 ### Deprecated
 - Tree: When using Closure tree strategy, it is deprecated not defining the mapping associations of the closure entity.
+
+### Changed
+- In order to use a custom cache for storing configuration of an extension, the user has to call `setCacheItemPool()`
+  on the extension listener passing an instance of `Psr\Cache\CacheItemPoolInterface`.
 
 ## [3.4.0] - 2021-12-05
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,9 @@
         "doctrine/collections": "^1.0",
         "doctrine/common": "^2.13 || ^3.0",
         "doctrine/event-manager": "^1.0",
-        "doctrine/persistence": "^1.3.3 || ^2.0"
+        "doctrine/persistence": "^1.3.3 || ^2.0",
+        "psr/cache": "^1 || ^2 || ^3",
+        "symfony/cache": "^4.4 || ^5.3 || ^6.0"
     },
     "require-dev": {
         "doctrine/cache": "^1.11 || ^2.0",
@@ -58,7 +60,6 @@
         "phpstan/phpstan-doctrine": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",
         "phpunit/phpunit": "^8.5 || ^9.5",
-        "symfony/cache": "^4.4 || ^5.3 || ^6.0",
         "symfony/console": "^4.4 || ^5.3 || ^6.0",
         "symfony/yaml": "^4.4 || ^5.3 || ^6.0"
     },

--- a/example/em.php
+++ b/example/em.php
@@ -79,27 +79,32 @@ $eventManager = new Doctrine\Common\EventManager();
 // Sluggable extension
 $sluggableListener = new Gedmo\Sluggable\SluggableListener();
 $sluggableListener->setAnnotationReader($annotationReader);
+$sluggableListener->setCacheItemPool($cache);
 $eventManager->addEventSubscriber($sluggableListener);
 
 // Tree extension
 $treeListener = new Gedmo\Tree\TreeListener();
 $treeListener->setAnnotationReader($annotationReader);
+$treeListener->setCacheItemPool($cache);
 $eventManager->addEventSubscriber($treeListener);
 
 // Loggable extension, not used in example
 //$loggableListener = new Gedmo\Loggable\LoggableListener;
 //$loggableListener->setAnnotationReader($annotationReader);
+//$loggableListener->setCacheItemPool($cache);
 //$loggableListener->setUsername('admin');
 //$eventManager->addEventSubscriber($loggableListener);
 
 // Timestampable extension
 $timestampableListener = new Gedmo\Timestampable\TimestampableListener();
 $timestampableListener->setAnnotationReader($annotationReader);
+$timestampableListener->setCacheItemPool($cache);
 $eventManager->addEventSubscriber($timestampableListener);
 
 // Blameable extension
 $blameableListener = new \Gedmo\Blameable\BlameableListener();
 $blameableListener->setAnnotationReader($annotationReader);
+$blameableListener->setCacheItemPool($cache);
 $blameableListener->setUserValue('MyUsername'); // determine from your environment
 $eventManager->addEventSubscriber($blameableListener);
 
@@ -111,11 +116,13 @@ $translatableListener = new Gedmo\Translatable\TranslatableListener();
 $translatableListener->setTranslatableLocale('en');
 $translatableListener->setDefaultLocale('en');
 $translatableListener->setAnnotationReader($annotationReader);
+$translatableListener->setCacheItemPool($cache);
 $eventManager->addEventSubscriber($translatableListener);
 
 // Sortable extension, not used in example
 //$sortableListener = new Gedmo\Sortable\SortableListener;
 //$sortableListener->setAnnotationReader($annotationReader);
+//$sortableListener->setCacheItemPool($cache);
 //$eventManager->addEventSubscriber($sortableListener);
 
 // Now we will build our ORM configuration.

--- a/src/Mapping/ExtensionMetadataFactory.php
+++ b/src/Mapping/ExtensionMetadataFactory.php
@@ -10,7 +10,6 @@
 namespace Gedmo\Mapping;
 
 use Doctrine\Bundle\DoctrineBundle\Mapping\MappingDriver as DoctrineBundleMappingDriver;
-use Doctrine\Common\Cache\Cache;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\Driver\DefaultFileLocator;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
@@ -22,6 +21,7 @@ use Gedmo\Mapping\Driver\AttributeAnnotationReader;
 use Gedmo\Mapping\Driver\AttributeDriverInterface;
 use Gedmo\Mapping\Driver\AttributeReader;
 use Gedmo\Mapping\Driver\File as FileDriver;
+use Psr\Cache\CacheItemPoolInterface;
 
 /**
  * The extension metadata factory is responsible for extension driver
@@ -60,18 +60,18 @@ class ExtensionMetadataFactory
     protected $annotationReader;
 
     /**
-     * Initializes extension driver
-     *
-     * @param string $extensionNamespace
-     * @param object $annotationReader
+     * @var CacheItemPoolInterface|null
      */
-    public function __construct(ObjectManager $objectManager, $extensionNamespace, $annotationReader)
+    private $cacheItemPool;
+
+    public function __construct(ObjectManager $objectManager, string $extensionNamespace, object $annotationReader, ?CacheItemPoolInterface $cacheItemPool = null)
     {
         $this->objectManager = $objectManager;
         $this->annotationReader = $annotationReader;
         $this->extensionNamespace = $extensionNamespace;
         $omDriver = $objectManager->getConfiguration()->getMetadataDriverImpl();
         $this->driver = $this->getDriver($omDriver);
+        $this->cacheItemPool = $cacheItemPool;
     }
 
     /**
@@ -111,14 +111,7 @@ class ExtensionMetadataFactory
             $config['useObjectClass'] = $useObjectName;
         }
 
-        $cacheDriver = $cmf->getCacheDriver();
-
-        if ($cacheDriver instanceof Cache) {
-            // Cache the result, even if it's empty, to prevent re-parsing non-existent annotations.
-            $cacheId = self::getCacheId($meta->getName(), $this->extensionNamespace);
-
-            $cacheDriver->save($cacheId, $config);
-        }
+        $this->storeConfiguration($meta->getName(), $config);
 
         return $config;
     }
@@ -133,7 +126,7 @@ class ExtensionMetadataFactory
      */
     public static function getCacheId($className, $extensionNamespace)
     {
-        return $className.'\\$'.strtoupper(str_replace('\\', '_', $extensionNamespace)).'_CLASSMETADATA';
+        return str_replace('\\', '_', $className).'_$'.strtoupper(str_replace('\\', '_', $extensionNamespace)).'_CLASSMETADATA';
     }
 
     /**
@@ -201,5 +194,19 @@ class ExtensionMetadataFactory
         }
 
         return $driver;
+    }
+
+    private function storeConfiguration(string $className, array $config): void
+    {
+        if (null === $this->cacheItemPool) {
+            return;
+        }
+
+        // Cache the result, even if it's empty, to prevent re-parsing non-existent annotations.
+        $cacheId = self::getCacheId($className, $this->extensionNamespace);
+
+        $item = $this->cacheItemPool->getItem($cacheId);
+
+        $this->cacheItemPool->save($item->set($config));
     }
 }

--- a/tests/Gedmo/Mapping/LoggableORMMappingTest.php
+++ b/tests/Gedmo/Mapping/LoggableORMMappingTest.php
@@ -11,31 +11,33 @@ declare(strict_types=1);
 
 namespace Gedmo\Tests\Mapping;
 
+use Doctrine\Common\EventManager;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Gedmo\Loggable\Entity\LogEntry;
 use Gedmo\Loggable\LoggableListener;
 use Gedmo\Mapping\ExtensionMetadataFactory;
 use Gedmo\Tests\Mapping\Fixture\Yaml\Category;
-use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 /**
  * These are mapping tests for tree extension
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
-final class LoggableMappingTest extends \PHPUnit\Framework\TestCase
+final class LoggableORMMappingTest extends ORMMappingTestCase
 {
     public const YAML_CATEGORY = Category::class;
+
+    /**
+     * @var \Doctrine\ORM\EntityManager
+     */
     private $em;
 
     protected function setUp(): void
     {
-        $config = new \Doctrine\ORM\Configuration();
-        $config->setMetadataCache(new ArrayAdapter());
-        $config->setQueryCache(new ArrayAdapter());
-        $config->setProxyDir(TESTS_TEMP_DIR);
-        $config->setProxyNamespace('Gedmo\Mapping\Proxy');
+        parent::setUp();
+
+        $config = $this->getBasicConfiguration();
         $chainDriverImpl = new MappingDriverChain();
         $chainDriverImpl->addDriver(
             new YamlDriver([__DIR__.'/Driver/Yaml']),
@@ -48,10 +50,10 @@ final class LoggableMappingTest extends \PHPUnit\Framework\TestCase
             'memory' => true,
         ];
 
-        //$config->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger());
-
-        $evm = new \Doctrine\Common\EventManager();
-        $evm->addEventSubscriber(new LoggableListener());
+        $evm = new EventManager();
+        $loggableListener = new LoggableListener();
+        $loggableListener->setCacheItemPool($this->cache);
+        $evm->addEventSubscriber($loggableListener);
         $this->em = \Doctrine\ORM\EntityManager::create($conn, $config, $evm);
     }
 
@@ -59,7 +61,7 @@ final class LoggableMappingTest extends \PHPUnit\Framework\TestCase
     {
         $meta = $this->em->getClassMetadata(self::YAML_CATEGORY);
         $cacheId = ExtensionMetadataFactory::getCacheId(self::YAML_CATEGORY, 'Gedmo\Loggable');
-        $config = $this->em->getMetadataFactory()->getCacheDriver()->fetch($cacheId);
+        $config = $this->cache->getItem($cacheId)->get();
 
         static::assertArrayHasKey('loggable', $config);
         static::assertTrue($config['loggable']);

--- a/tests/Gedmo/Mapping/ORMMappingTestCase.php
+++ b/tests/Gedmo/Mapping/ORMMappingTestCase.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Mapping;
+
+use Doctrine\ORM\Configuration;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+abstract class ORMMappingTestCase extends TestCase
+{
+    /**
+     * @var CacheItemPoolInterface
+     */
+    protected $cache;
+
+    protected function setUp(): void
+    {
+        $this->cache = new ArrayAdapter();
+    }
+
+    final protected function getBasicConfiguration(): Configuration
+    {
+        $config = new Configuration();
+        $config->setMetadataCache(new ArrayAdapter());
+        $config->setQueryCache(new ArrayAdapter());
+        $config->setProxyDir(TESTS_TEMP_DIR);
+        $config->setProxyNamespace('Gedmo\Mapping\Proxy');
+
+        return $config;
+    }
+}

--- a/tests/Gedmo/Mapping/SluggableMappingTest.php
+++ b/tests/Gedmo/Mapping/SluggableMappingTest.php
@@ -11,6 +11,9 @@ declare(strict_types=1);
 
 namespace Gedmo\Tests\Mapping;
 
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
+use Doctrine\Common\EventManager;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Gedmo\Mapping\ExtensionMetadataFactory;
@@ -19,33 +22,34 @@ use Gedmo\Sluggable\Handler\TreeSlugHandler;
 use Gedmo\Sluggable\SluggableListener;
 use Gedmo\Tests\Mapping\Fixture\Sluggable;
 use Gedmo\Tests\Mapping\Fixture\Yaml\Category;
-use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 /**
  * These are mapping tests for sluggable extension
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
-final class SluggableMappingTest extends \PHPUnit\Framework\TestCase
+final class SluggableMappingTest extends ORMMappingTestCase
 {
     public const TEST_YAML_ENTITY_CLASS = Category::class;
     public const SLUGGABLE = Sluggable::class;
+
+    /**
+     * @var \Doctrine\ORM\EntityManager
+     */
     private $em;
 
     protected function setUp(): void
     {
-        $config = new \Doctrine\ORM\Configuration();
-        $config->setMetadataCache(new ArrayAdapter());
-        $config->setQueryCache(new ArrayAdapter());
-        $config->setProxyDir(TESTS_TEMP_DIR);
-        $config->setProxyNamespace('Gedmo\Mapping\Proxy');
+        parent::setUp();
+
+        $config = $this->getBasicConfiguration();
         $chainDriverImpl = new MappingDriverChain();
         $chainDriverImpl->addDriver(
             new YamlDriver([__DIR__.'/Driver/Yaml']),
             'Gedmo\Tests\Mapping\Fixture\Yaml'
         );
-        $reader = new \Doctrine\Common\Annotations\AnnotationReader();
-        \Doctrine\Common\Annotations\AnnotationRegistry::registerAutoloadNamespace(
+        $reader = new AnnotationReader();
+        AnnotationRegistry::registerAutoloadNamespace(
             'Gedmo\\Mapping\\Annotation',
             dirname(VENDOR_PATH).'/src'
         );
@@ -60,8 +64,10 @@ final class SluggableMappingTest extends \PHPUnit\Framework\TestCase
             'memory' => true,
         ];
 
-        $evm = new \Doctrine\Common\EventManager();
-        $evm->addEventSubscriber(new SluggableListener());
+        $evm = new EventManager();
+        $listener = new SluggableListener();
+        $listener->setCacheItemPool($this->cache);
+        $evm->addEventSubscriber($listener);
         $this->em = \Doctrine\ORM\EntityManager::create($conn, $config, $evm);
     }
 
@@ -72,7 +78,7 @@ final class SluggableMappingTest extends \PHPUnit\Framework\TestCase
             self::TEST_YAML_ENTITY_CLASS,
             'Gedmo\Sluggable'
         );
-        $config = $this->em->getMetadataFactory()->getCacheDriver()->fetch($cacheId);
+        $config = $this->cache->getItem($cacheId)->get();
 
         static::assertArrayHasKey('slugs', $config);
         static::assertArrayHasKey('slug', $config['slugs']);
@@ -120,7 +126,7 @@ final class SluggableMappingTest extends \PHPUnit\Framework\TestCase
             self::SLUGGABLE,
             'Gedmo\Sluggable'
         );
-        $config = $this->em->getMetadataFactory()->getCacheDriver()->fetch($cacheId);
+        $config = $this->cache->getItem($cacheId)->get();
 
         static::assertArrayHasKey('handlers', $config['slugs']['slug']);
         $handlers = $config['slugs']['slug']['handlers'];

--- a/tests/Gedmo/Mapping/TreeMappingTest.php
+++ b/tests/Gedmo/Mapping/TreeMappingTest.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Gedmo\Tests\Mapping;
 
+use Doctrine\Common\EventManager;
+use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Gedmo\Mapping\ExtensionMetadataFactory;
@@ -19,21 +21,20 @@ use Gedmo\Tests\Mapping\Fixture\Yaml\ClosureCategory;
 use Gedmo\Tests\Mapping\Fixture\Yaml\MaterializedPathCategory;
 use Gedmo\Tests\Tree\Fixture\Closure\CategoryClosureWithoutMapping;
 use Gedmo\Tree\TreeListener;
-use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 /**
  * These are mapping tests for tree extension
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
-final class TreeMappingTest extends \PHPUnit\Framework\TestCase
+final class TreeMappingTest extends ORMMappingTestCase
 {
     public const TEST_YAML_ENTITY_CLASS = Category::class;
     public const YAML_CLOSURE_CATEGORY = ClosureCategory::class;
     public const YAML_MATERIALIZED_PATH_CATEGORY = MaterializedPathCategory::class;
 
     /**
-     * @var \Doctrine\ORM\EntityManager
+     * @var EntityManager
      */
     private $em;
 
@@ -44,11 +45,9 @@ final class TreeMappingTest extends \PHPUnit\Framework\TestCase
 
     protected function setUp(): void
     {
-        $config = new \Doctrine\ORM\Configuration();
-        $config->setMetadataCache(new ArrayAdapter());
-        $config->setQueryCache(new ArrayAdapter());
-        $config->setProxyDir(TESTS_TEMP_DIR);
-        $config->setProxyNamespace('Gedmo\Mapping\Proxy');
+        parent::setUp();
+
+        $config = $this->getBasicConfiguration();
         $chainDriverImpl = new MappingDriverChain();
         $chainDriverImpl->addDriver(
             new YamlDriver([__DIR__.'/Driver/Yaml']),
@@ -70,9 +69,10 @@ final class TreeMappingTest extends \PHPUnit\Framework\TestCase
         ];
 
         $this->listener = new TreeListener();
-        $evm = new \Doctrine\Common\EventManager();
-        $evm->addEventSubscriber(new TreeListener());
-        $this->em = \Doctrine\ORM\EntityManager::create($conn, $config, $evm);
+        $this->listener->setCacheItemPool($this->cache);
+        $evm = new EventManager();
+        $evm->addEventSubscriber($this->listener);
+        $this->em = EntityManager::create($conn, $config, $evm);
     }
 
     public function testApcCached(): void
@@ -94,7 +94,7 @@ final class TreeMappingTest extends \PHPUnit\Framework\TestCase
             self::TEST_YAML_ENTITY_CLASS,
             'Gedmo\Tree'
         );
-        $config = $this->em->getMetadataFactory()->getCacheDriver()->fetch($cacheId);
+        $config = $this->cache->getItem($cacheId)->get();
         static::assertArrayHasKey('left', $config);
         static::assertSame('left', $config['left']);
         static::assertArrayHasKey('right', $config);
@@ -113,7 +113,7 @@ final class TreeMappingTest extends \PHPUnit\Framework\TestCase
     {
         $meta = $this->em->getClassMetadata(self::YAML_CLOSURE_CATEGORY);
         $cacheId = ExtensionMetadataFactory::getCacheId(self::YAML_CLOSURE_CATEGORY, 'Gedmo\Tree');
-        $config = $this->em->getMetadataFactory()->getCacheDriver()->fetch($cacheId);
+        $config = $this->cache->getItem($cacheId)->get();
 
         static::assertArrayHasKey('parent', $config);
         static::assertSame('parent', $config['parent']);

--- a/tests/Gedmo/Sluggable/CustomTransliteratorTest.php
+++ b/tests/Gedmo/Sluggable/CustomTransliteratorTest.php
@@ -75,6 +75,8 @@ class MySluggableListener extends SluggableListener
 {
     public function __construct()
     {
+        parent::__construct();
+
         $this->setTransliterator([Transliterator::class, 'transliterate']);
     }
 }

--- a/tests/Gedmo/Sluggable/Fixture/Issue939/SluggableListener.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue939/SluggableListener.php
@@ -27,6 +27,8 @@ final class SluggableListener extends BaseSluggableListener
 
     public function __construct()
     {
+        parent::__construct();
+
         $this->originalTransliterator = $this->getTransliterator();
         $this->originalUrlizer = $this->getUrlizer();
 


### PR DESCRIPTION
Fixes https://github.com/doctrine-extensions/DoctrineExtensions/issues/2365, https://github.com/doctrine-extensions/DoctrineExtensions/issues/2227

Instead of relying on the metadata cache from the orm/odm, this PR adds a `MappedEventSubscriber::setCacheItemPool()` method to configure the cache service, in case it is not provided it uses an `ArrayAdapter` (this will invalidate existing caches).

For the bundle, a service can be created (allowing users to configure their own) and call `setCacheItemPool` in every definition as `setAnnotationReader` (https://github.com/stof/StofDoctrineExtensionsBundle/blob/a2bffca41974d1c968557b343e269a60a8d5ffa4/src/Resources/config/blameable.xml#L13-L15)

- [x] There is still one call to `AbstractClassMetadataFactory::getCacheDriver()` ~that we have to figure out what to do~ (https://github.com/doctrine-extensions/DoctrineExtensions/pull/2390). 

