### PR TITLE
Make users add mapping to tree closure entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ a release.
 - Blameable, IpTraceable, Timestampable: Type handling for the tracked field values configured in the origin field.
 - Loggable: Using only PHP 8 attributes.
 - References: Avoid deprecations using LazyCollection with PHP 8.1
+- Tree: Association mapping problems using Closure tree strategy (by manually defining mapping on the closure entity).
+
+### Deprecated
+- Tree: When using Closure tree strategy, it is deprecated not defining the mapping associations of the closure entity.
 
 ## [3.4.0] - 2021-12-05
 ### Added

--- a/doc/tree.md
+++ b/doc/tree.md
@@ -1249,7 +1249,7 @@ You must pass a value in seconds to this parameter.
 ## Closure Table
 
 To be able to use this strategy, you'll need an additional entity which represents the closures. We already provide you an abstract
-entity, so you only need to extend it.
+entity, so you need to extend from it and add mapping information for ancestor and descendant.
 
 ### Closure Entity
 
@@ -1263,9 +1263,29 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity
+ * @ORM\UniqueConstraint(name="closure_unique_idx", columns={"ancestor", "descendant"})
+ * @ORM\Index(name="closure_depth_idx", columns={"depth"})
  */
+#[ORM\Entity]
+#[ORM\UniqueConstraint(name: 'closure_unique_idx', columns: ['ancestor', 'descendant'])]
+#[ORM\Index(name: 'closure_depth_idx', columns: ['depth'])]
 class CategoryClosure extends AbstractClosure
 {
+    /**
+     * @ORM\ManyToOne(targetEntity="YourNamespace\Entity\Category")
+     * @ORM\JoinColumn(name="ancestor", referencedColumnName="id", nullable=false, onDelete="CASCADE")
+     */
+    #[ORM\ManyToOne(targetEntity: Category::class)]
+    #[ORM\JoinColumn(name: 'ancestor', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    protected $ancestor;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="YourNamespace\Entity\Category")
+     * @ORM\JoinColumn(name="descendant", referencedColumnName="id", nullable=false, onDelete="CASCADE")
+     */
+    #[ORM\ManyToOne(targetEntity: Category::class)]
+    #[ORM\JoinColumn(name: 'descendant', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    protected $descendant;
 }
 ```
 

--- a/tests/Gedmo/Mapping/Driver/Yaml/Gedmo.Tests.Mapping.Fixture.Yaml.ClosureCategory.dcm.yml
+++ b/tests/Gedmo/Mapping/Driver/Yaml/Gedmo.Tests.Mapping.Fixture.Yaml.ClosureCategory.dcm.yml
@@ -10,7 +10,7 @@ Gedmo\Tests\Mapping\Fixture\Yaml\ClosureCategory:
   gedmo:
     tree:
       type: closure
-      closure: Gedmo\Tests\Tree\Fixture\Closure\CategoryClosure
+      closure: Gedmo\Tests\Tree\Fixture\Closure\CategoryClosureWithoutMapping
   fields:
     title:
       type: string

--- a/tests/Gedmo/Mapping/Fixture/ClosureTreeClosure.php
+++ b/tests/Gedmo/Mapping/Fixture/ClosureTreeClosure.php
@@ -12,11 +12,36 @@ declare(strict_types=1);
 namespace Gedmo\Tests\Mapping\Fixture;
 
 use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Tests\Mapping\Fixture\Xml\ClosureTree;
 use Gedmo\Tree\Entity\MappedSuperclass\AbstractClosure;
 
 /**
  * @ORM\Entity
+ * @ORM\Table(
+ *         indexes={@ORM\Index(name="closure_tree_depth_idx", columns={"depth"})},
+ *         uniqueConstraints={@ORM\UniqueConstraint(name="closure_tree_unique_idx", columns={
+ *             "ancestor", "descendant"
+ *         })}
+ * )
  */
+#[ORM\Entity]
+#[ORM\UniqueConstraint(name: 'closure_tree_unique_idx', columns: ['ancestor', 'descendant'])]
+#[ORM\Index(name: 'closure_tree_depth_idx', columns: ['depth'])]
 class ClosureTreeClosure extends AbstractClosure
 {
+    /**
+     * @ORM\ManyToOne(targetEntity="Gedmo\Tests\Mapping\Fixture\Xml\ClosureTree")
+     * @ORM\JoinColumn(name="ancestor", referencedColumnName="id", nullable=false, onDelete="CASCADE")
+     */
+    #[ORM\ManyToOne(targetEntity: ClosureTree::class)]
+    #[ORM\JoinColumn(name: 'ancestor', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    protected $ancestor;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="Gedmo\Tests\Mapping\Fixture\Xml\ClosureTree")
+     * @ORM\JoinColumn(name="descendant", referencedColumnName="id", nullable=false, onDelete="CASCADE")
+     */
+    #[ORM\ManyToOne(targetEntity: ClosureTree::class)]
+    #[ORM\JoinColumn(name: 'descendant', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    protected $descendant;
 }

--- a/tests/Gedmo/Mapping/TreeMappingTest.php
+++ b/tests/Gedmo/Mapping/TreeMappingTest.php
@@ -17,7 +17,7 @@ use Gedmo\Mapping\ExtensionMetadataFactory;
 use Gedmo\Tests\Mapping\Fixture\Yaml\Category;
 use Gedmo\Tests\Mapping\Fixture\Yaml\ClosureCategory;
 use Gedmo\Tests\Mapping\Fixture\Yaml\MaterializedPathCategory;
-use Gedmo\Tests\Tree\Fixture\Closure\CategoryClosure;
+use Gedmo\Tests\Tree\Fixture\Closure\CategoryClosureWithoutMapping;
 use Gedmo\Tree\TreeListener;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
@@ -78,10 +78,10 @@ final class TreeMappingTest extends \PHPUnit\Framework\TestCase
     public function testApcCached(): void
     {
         $this->em->getClassMetadata(self::YAML_CLOSURE_CATEGORY);
-        $this->em->getClassMetadata(CategoryClosure::class);
+        $this->em->getClassMetadata(CategoryClosureWithoutMapping::class);
 
         $meta = $this->em->getMetadataFactory()->getCacheDriver()->fetch(
-            'Gedmo\\Tests\\Tree\\Fixture\\Closure\\CategoryClosure$CLASSMETADATA'
+            'Gedmo\\Tests\\Tree\\Fixture\\Closure\\CategoryClosureWithoutMapping$CLASSMETADATA'
         );
         static::assertTrue($meta->hasAssociation('ancestor'));
         static::assertTrue($meta->hasAssociation('descendant'));
@@ -120,7 +120,7 @@ final class TreeMappingTest extends \PHPUnit\Framework\TestCase
         static::assertArrayHasKey('strategy', $config);
         static::assertSame('closure', $config['strategy']);
         static::assertArrayHasKey('closure', $config);
-        static::assertSame(CategoryClosure::class, $config['closure']);
+        static::assertSame(CategoryClosureWithoutMapping::class, $config['closure']);
     }
 
     public function testYamlMaterializedPathMapping(): void

--- a/tests/Gedmo/Tree/Fixture/Closure/CategoryClosure.php
+++ b/tests/Gedmo/Tree/Fixture/Closure/CategoryClosure.php
@@ -16,8 +16,31 @@ use Gedmo\Tree\Entity\MappedSuperclass\AbstractClosure;
 
 /**
  * @ORM\Entity
+ * @ORM\Table(
+ *         indexes={@ORM\Index(name="closure_category_depth_idx", columns={"depth"})},
+ *         uniqueConstraints={@ORM\UniqueConstraint(name="closure_category_unique_idx", columns={
+ *             "ancestor", "descendant"
+ *         })}
+ * )
  */
 #[ORM\Entity]
+#[ORM\UniqueConstraint(name: 'closure_category_unique_idx', columns: ['ancestor', 'descendant'])]
+#[ORM\Index(name: 'closure_category_depth_idx', columns: ['depth'])]
 class CategoryClosure extends AbstractClosure
 {
+    /**
+     * @ORM\ManyToOne(targetEntity="Gedmo\Tests\Tree\Fixture\Closure\Category")
+     * @ORM\JoinColumn(name="ancestor", referencedColumnName="id", nullable=false, onDelete="CASCADE")
+     */
+    #[ORM\ManyToOne(targetEntity: Category::class)]
+    #[ORM\JoinColumn(name: 'ancestor', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    protected $ancestor;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="Gedmo\Tests\Tree\Fixture\Closure\Category")
+     * @ORM\JoinColumn(name="descendant", referencedColumnName="id", nullable=false, onDelete="CASCADE")
+     */
+    #[ORM\ManyToOne(targetEntity: Category::class)]
+    #[ORM\JoinColumn(name: 'descendant', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    protected $descendant;
 }

--- a/tests/Gedmo/Tree/Fixture/Closure/CategoryClosureWithoutMapping.php
+++ b/tests/Gedmo/Tree/Fixture/Closure/CategoryClosureWithoutMapping.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Tree\Fixture\Closure;
+
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Tree\Entity\MappedSuperclass\AbstractClosure;
+
+/**
+ * @ORM\Entity
+ */
+#[ORM\Entity]
+class CategoryClosureWithoutMapping extends AbstractClosure
+{
+}

--- a/tests/Gedmo/Tree/Fixture/Closure/CategoryWithoutLevelClosure.php
+++ b/tests/Gedmo/Tree/Fixture/Closure/CategoryWithoutLevelClosure.php
@@ -16,8 +16,31 @@ use Gedmo\Tree\Entity\MappedSuperclass\AbstractClosure;
 
 /**
  * @ORM\Entity
+ * @ORM\Table(
+ *         indexes={@ORM\Index(name="closure_category_without_level_depth_idx", columns={"depth"})},
+ *         uniqueConstraints={@ORM\UniqueConstraint(name="closure_category_without_level_unique_idx", columns={
+ *             "ancestor", "descendant"
+ *         })}
+ * )
  */
 #[ORM\Entity]
+#[ORM\UniqueConstraint(name: 'closure_category_without_level_unique_idx', columns: ['ancestor', 'descendant'])]
+#[ORM\Index(name: 'closure_category_without_level_depth_idx', columns: ['depth'])]
 class CategoryWithoutLevelClosure extends AbstractClosure
 {
+    /**
+     * @ORM\ManyToOne(targetEntity="Gedmo\Tests\Tree\Fixture\Closure\CategoryWithoutLevel")
+     * @ORM\JoinColumn(name="ancestor", referencedColumnName="id", nullable=false, onDelete="CASCADE")
+     */
+    #[ORM\ManyToOne(targetEntity: CategoryWithoutLevel::class)]
+    #[ORM\JoinColumn(name: 'ancestor', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    protected $ancestor;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="Gedmo\Tests\Tree\Fixture\Closure\CategoryWithoutLevel")
+     * @ORM\JoinColumn(name="descendant", referencedColumnName="id", nullable=false, onDelete="CASCADE")
+     */
+    #[ORM\ManyToOne(targetEntity: CategoryWithoutLevel::class)]
+    #[ORM\JoinColumn(name: 'descendant', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    protected $descendant;
 }

--- a/tests/Gedmo/Tree/Fixture/Closure/PersonClosure.php
+++ b/tests/Gedmo/Tree/Fixture/Closure/PersonClosure.php
@@ -16,8 +16,31 @@ use Gedmo\Tree\Entity\MappedSuperclass\AbstractClosure;
 
 /**
  * @ORM\Entity
+ * @ORM\Table(
+ *         indexes={@ORM\Index(name="closure_person_depth_idx", columns={"depth"})},
+ *         uniqueConstraints={@ORM\UniqueConstraint(name="closure_person_unique_idx", columns={
+ *             "ancestor", "descendant"
+ *         })}
+ * )
  */
 #[ORM\Entity]
+#[ORM\UniqueConstraint(name: 'closure_person_unique_idx', columns: ['ancestor', 'descendant'])]
+#[ORM\Index(name: 'closure_person_depth_idx', columns: ['depth'])]
 class PersonClosure extends AbstractClosure
 {
+    /**
+     * @ORM\ManyToOne(targetEntity="Gedmo\Tests\Tree\Fixture\Closure\Person")
+     * @ORM\JoinColumn(name="ancestor", referencedColumnName="id", nullable=false, onDelete="CASCADE")
+     */
+    #[ORM\ManyToOne(targetEntity: Person::class)]
+    #[ORM\JoinColumn(name: 'ancestor', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    protected $ancestor;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="Gedmo\Tests\Tree\Fixture\Closure\Person")
+     * @ORM\JoinColumn(name="descendant", referencedColumnName="id", nullable=false, onDelete="CASCADE")
+     */
+    #[ORM\ManyToOne(targetEntity: Person::class)]
+    #[ORM\JoinColumn(name: 'descendant', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    protected $descendant;
 }


### PR DESCRIPTION
In https://github.com/doctrine-extensions/DoctrineExtensions/issues/58 one of the solution was to make the user to map the associations manually.

Fixes https://github.com/doctrine-extensions/DoctrineExtensions/issues/2236 and probably https://github.com/doctrine-extensions/DoctrineExtensions/issues/2240

This PR supersedes https://github.com/doctrine-extensions/DoctrineExtensions/pull/2370