### PR TITLE
Fix ReferenceIntegrity using annotations

### DIFF
--- a/src/Mapping/Annotation/ReferenceIntegrity.php
+++ b/src/Mapping/Annotation/ReferenceIntegrity.php
@@ -17,6 +17,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * ReferenceIntegrity annotation for ReferenceIntegrity behavioral extension
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("PROPERTY")
  *
  * @author Evert Harmeling <evert.harmeling@freshheads.com>
@@ -27,9 +28,14 @@ final class ReferenceIntegrity implements GedmoAnnotation
     /** @var string|null */
     public $value;
 
-    public function __construct(array $data = [], ?string $value = null)
+    /**
+     * @param string|array|null $data
+     */
+    public function __construct($data = [], ?string $value = null)
     {
-        if ([] !== $data) {
+        if (is_string($data)) {
+            $data = ['value' => $data];
+        } elseif ([] !== $data) {
             @trigger_error(sprintf(
                 'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
                 __METHOD__

--- a/tests/Gedmo/ReferenceIntegrity/ReferenceIntegrityDocumentTest.php
+++ b/tests/Gedmo/ReferenceIntegrity/ReferenceIntegrityDocumentTest.php
@@ -25,20 +25,20 @@ use Gedmo\Tests\Tool\BaseTestCaseMongoODM;
  */
 final class ReferenceIntegrityDocumentTest extends BaseTestCaseMongoODM
 {
-    public const TYPE_ONE_NULLIFY_CLASS = \Gedmo\Tests\ReferenceIntegrity\Fixture\Document\OneNullify\Type::class;
-    public const ARTICLE_ONE_NULLIFY_CLASS = \Gedmo\Tests\ReferenceIntegrity\Fixture\Document\OneNullify\Article::class;
+    public const TYPE_ONE_NULLIFY_CLASS = Fixture\Document\OneNullify\Type::class;
+    public const ARTICLE_ONE_NULLIFY_CLASS = Fixture\Document\OneNullify\Article::class;
 
-    public const TYPE_MANY_NULLIFY_CLASS = \Gedmo\Tests\ReferenceIntegrity\Fixture\Document\ManyNullify\Type::class;
-    public const ARTICLE_MANY_NULLIFY_CLASS = \Gedmo\Tests\ReferenceIntegrity\Fixture\Document\ManyNullify\Article::class;
+    public const TYPE_MANY_NULLIFY_CLASS = Fixture\Document\ManyNullify\Type::class;
+    public const ARTICLE_MANY_NULLIFY_CLASS = Fixture\Document\ManyNullify\Article::class;
 
-    public const TYPE_ONE_PULL_CLASS = \Gedmo\Tests\ReferenceIntegrity\Fixture\Document\OnePull\Type::class;
-    public const ARTICLE_ONE_PULL_CLASS = \Gedmo\Tests\ReferenceIntegrity\Fixture\Document\OnePull\Article::class;
+    public const TYPE_ONE_PULL_CLASS = Fixture\Document\OnePull\Type::class;
+    public const ARTICLE_ONE_PULL_CLASS = Fixture\Document\OnePull\Article::class;
 
-    public const TYPE_MANY_PULL_CLASS = \Gedmo\Tests\ReferenceIntegrity\Fixture\Document\ManyPull\Type::class;
-    public const ARTICLE_MANY_PULL_CLASS = \Gedmo\Tests\ReferenceIntegrity\Fixture\Document\ManyPull\Article::class;
+    public const TYPE_MANY_PULL_CLASS = Fixture\Document\ManyPull\Type::class;
+    public const ARTICLE_MANY_PULL_CLASS = Fixture\Document\ManyPull\Article::class;
 
-    public const TYPE_ONE_RESTRICT_CLASS = \Gedmo\Tests\ReferenceIntegrity\Fixture\Document\OneRestrict\Type::class;
-    public const ARTICLE_ONE_RESTRICT_CLASS = \Gedmo\Tests\ReferenceIntegrity\Fixture\Document\OneRestrict\Article::class;
+    public const TYPE_ONE_RESTRICT_CLASS = Fixture\Document\OneRestrict\Type::class;
+    public const ARTICLE_ONE_RESTRICT_CLASS = Fixture\Document\OneRestrict\Article::class;
 
     public const TYPE_MANY_RESTRICT_CLASS = Type::class;
     public const ARTICLE_MANY_RESTRICT_CLASS = Article::class;


### PR DESCRIPTION
This fixes when using `ReferenceIntegrity` as annotation passing the value directly (extracted from https://github.com/doctrine-extensions/DoctrineExtensions/pull/2364).