### PR TITLE
Deprecate `QueryAnalyzer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ a release.
 
 ### Deprecated
 - Tree: When using Closure tree strategy, it is deprecated not defining the mapping associations of the closure entity.
+- `Gedmo\Tool\Logging\DBAL\QueryAnalizer` class without replacement.
 
 ### Changed
 - In order to use a custom cache for storing configuration of an extension, the user has to call `setCacheItemPool()`

--- a/tests/Gedmo/Sortable/SortableGroupTest.php
+++ b/tests/Gedmo/Sortable/SortableGroupTest.php
@@ -189,7 +189,6 @@ final class SortableGroupTest extends BaseTestCaseORM
     {
         $this->populate();
 
-        $this->startQueryLog();
         $repo = $this->em->getRepository(self::ITEM);
         $repoCategory = $this->em->getRepository(self::CATEGORY);
 
@@ -218,7 +217,6 @@ final class SortableGroupTest extends BaseTestCaseORM
         $item->setPosition(4);
         $this->em->persist($item);
         $this->em->flush();
-        $this->stopQueryLog(false, true);
 
         unset($vehicles, $accessories);
 

--- a/tests/Gedmo/Sortable/SortableTest.php
+++ b/tests/Gedmo/Sortable/SortableTest.php
@@ -57,11 +57,6 @@ final class SortableTest extends BaseTestCaseORM
         $this->populate();
     }
 
-    protected function tearDown(): void
-    {
-        //$this->stopQueryLog();
-    }
-
     public function testShouldSetSortPositionToInsertedNode(): void
     {
         $node = $this->em->find(self::NODE, $this->nodeId);

--- a/tests/Gedmo/Tool/QueryAnalyzer.php
+++ b/tests/Gedmo/Tool/QueryAnalyzer.php
@@ -7,39 +7,25 @@
  * file that was distributed with this source code.
  */
 
-namespace Gedmo\Tool\Logging\DBAL;
+namespace Gedmo\Tests\Tool;
 
 use Doctrine\DBAL\Logging\SQLLogger;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
 
 /**
- * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ * TODO: Remove it when dropping support of doctrine/dbal 2
  *
- * @deprecated since gedmo/doctrine-extensions 3.x.
+ * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
-class QueryAnalyzer implements SQLLogger
+final class QueryAnalyzer implements SQLLogger
 {
     /**
      * Used database platform
      *
      * @var AbstractPlatform
      */
-    protected $platform;
-
-    /**
-     * Start time of currently executed query
-     *
-     * @var float
-     */
-    private $queryStartTime;
-
-    /**
-     * Total execution time of all queries
-     *
-     * @var float
-     */
-    private $totalExecutionTime = 0;
+    private $platform;
 
     /**
      * List of queries executed
@@ -48,139 +34,38 @@ class QueryAnalyzer implements SQLLogger
      */
     private $queries = [];
 
-    /**
-     * Query execution times indexed
-     * in same order as queries
-     *
-     * @var float[]
-     */
-    private $queryExecutionTimes = [];
-
-    /**
-     * Initialize log listener with database
-     * platform, which is needed for parameter
-     * conversion
-     */
     public function __construct(AbstractPlatform $platform)
     {
         $this->platform = $platform;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function startQuery($sql, array $params = null, array $types = null)
     {
-        $this->queryStartTime = microtime(true);
         $this->queries[] = $this->generateSql($sql, $params, $types);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function stopQuery()
+    public function stopQuery(): void
     {
-        $ms = round(microtime(true) - $this->queryStartTime, 4) * 1000;
-        $this->queryExecutionTimes[] = $ms;
-        $this->totalExecutionTime += $ms;
     }
 
-    /**
-     * Clean all collected data
-     *
-     * @return QueryAnalyzer
-     */
-    public function cleanUp()
+    public function cleanUp(): self
     {
         $this->queries = [];
-        $this->queryExecutionTimes = [];
-        $this->totalExecutionTime = 0;
 
         return $this;
     }
 
     /**
-     * Dump the statistics of executed queries
-     *
-     * @param bool $dumpOnlySql
-     *
-     * @return string
-     */
-    public function getOutput($dumpOnlySql = false)
-    {
-        $output = '';
-        if (!$dumpOnlySql) {
-            $output .= 'Platform: '.$this->platform->getName().PHP_EOL;
-            $output .= 'Executed queries: '.count($this->queries).', total time: '.$this->totalExecutionTime.' ms'.PHP_EOL;
-        }
-        foreach ($this->queries as $index => $sql) {
-            if (!$dumpOnlySql) {
-                $output .= 'Query('.($index + 1).') - '.$this->queryExecutionTimes[$index].' ms'.PHP_EOL;
-            }
-            $output .= $sql.';'.PHP_EOL;
-        }
-        $output .= PHP_EOL;
-
-        return $output;
-    }
-
-    /**
-     * Index of the slowest query executed
-     *
-     * @return int
-     */
-    public function getSlowestQueryIndex()
-    {
-        $index = 0;
-        $slowest = 0;
-        foreach ($this->queryExecutionTimes as $i => $time) {
-            if ($time > $slowest) {
-                $slowest = $time;
-                $index = $i;
-            }
-        }
-
-        return $index;
-    }
-
-    /**
-     * Get total execution time of queries
-     *
-     * @return float
-     */
-    public function getTotalExecutionTime()
-    {
-        return $this->totalExecutionTime;
-    }
-
-    /**
-     * Get all queries
-     *
      * @return string[]
      */
-    public function getExecutedQueries()
+    public function getExecutedQueries(): array
     {
         return $this->queries;
     }
 
-    /**
-     * Get number of executed queries
-     *
-     * @return int
-     */
-    public function getNumExecutedQueries()
+    public function getNumExecutedQueries(): int
     {
         return count($this->queries);
-    }
-
-    /**
-     * Get all query execution times
-     *
-     * @return float[]
-     */
-    public function getExecutionTimes()
-    {
-        return $this->queryExecutionTimes;
     }
 
     /**

--- a/tests/Gedmo/Translatable/TranslationQueryWalkerTest.php
+++ b/tests/Gedmo/Translatable/TranslationQueryWalkerTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Gedmo\Tests\Translatable;
 
 use Doctrine\Common\EventManager;
+use Doctrine\DBAL\Logging\Middleware;
 use Doctrine\ORM\Query;
 use Gedmo\Tests\Tool\BaseTestCaseORM;
 use Gedmo\Tests\Translatable\Fixture\Article;
@@ -148,17 +149,40 @@ final class TranslationQueryWalkerTest extends BaseTestCaseORM
         $this->translatableListener->setTranslatableLocale('ru_ru');
         $this->translatableListener->setTranslationFallback(false);
 
+        // TODO: Remove the "if" check and "else" body when dropping support of doctrine/dbal 2.
+        if (class_exists(Middleware::class)) {
+            $this->queryLogger
+                ->expects(static::exactly(2))
+                ->method('debug')
+                ->withConsecutive(
+                    ['Executing query: {sql}'],
+                    ['Executing query: {sql}']
+                );
+        } else {
+            $this->startQueryLog();
+        }
+
         // simple object hydration
-        $this->startQueryLog();
         $result = $q->getResult(Query::HYDRATE_SIMPLEOBJECT);
-        static::assertSame(1, $this->queryAnalyzer->getNumExecutedQueries());
+
+        // TODO: Remove the "if" block when dropping support of doctrine/dbal 2.
+        if (!class_exists(Middleware::class)) {
+            static::assertSame(1, $this->queryAnalyzer->getNumExecutedQueries());
+            $this->queryAnalyzer->cleanUp();
+        }
+
         static::assertNull($result[0]->getTitle());
         static::assertNull($result[0]->getContent());
 
         $this->translatableListener->setTranslationFallback(true);
-        $this->queryAnalyzer->cleanUp();
+
         $result = $q->getResult(Query::HYDRATE_SIMPLEOBJECT);
-        static::assertSame(1, $this->queryAnalyzer->getNumExecutedQueries());
+
+        // TODO: Remove the "if" block when dropping support of doctrine/dbal 2.
+        if (!class_exists(Middleware::class)) {
+            static::assertSame(1, $this->queryAnalyzer->getNumExecutedQueries());
+        }
+
         //Default translation is en_us, so we expect the results in that locale
         static::assertSame('Food', $result[0]->getTitle());
         static::assertSame('about food', $result[0]->getContent());
@@ -174,17 +198,40 @@ final class TranslationQueryWalkerTest extends BaseTestCaseORM
         $this->translatableListener->setTranslatableLocale('ru_ru');
         $this->translatableListener->setTranslationFallback(false);
 
+        // TODO: Remove the "if" check and "else" body when dropping support of doctrine/dbal 2.
+        if (class_exists(Middleware::class)) {
+            $this->queryLogger
+                ->expects(static::exactly(2))
+                ->method('debug')
+                ->withConsecutive(
+                    ['Executing query: {sql}'],
+                    ['Executing query: {sql}']
+                );
+        } else {
+            $this->startQueryLog();
+        }
+
         // array hydration
-        $this->startQueryLog();
         $result = $q->getArrayResult();
-        static::assertSame(1, $this->queryAnalyzer->getNumExecutedQueries());
+
+        // TODO: Remove the "if" block when dropping support of doctrine/dbal 2.
+        if (!class_exists(Middleware::class)) {
+            static::assertSame(1, $this->queryAnalyzer->getNumExecutedQueries());
+            $this->queryAnalyzer->cleanUp();
+        }
+
         static::assertNull($result[0]['title']);
         static::assertNull($result[0]['content']);
 
         $this->translatableListener->setTranslationFallback(true);
-        $this->queryAnalyzer->cleanUp();
+
         $result = $q->getArrayResult();
-        static::assertSame(1, $this->queryAnalyzer->getNumExecutedQueries());
+
+        // TODO: Remove the "if" block when dropping support of doctrine/dbal 2.
+        if (!class_exists(Middleware::class)) {
+            static::assertSame(1, $this->queryAnalyzer->getNumExecutedQueries());
+        }
+
         //Default translation is en_us, so we expect the results in that locale
         static::assertSame('Food', $result[0]['title']);
         static::assertSame('about food', $result[0]['content']);
@@ -204,18 +251,40 @@ final class TranslationQueryWalkerTest extends BaseTestCaseORM
         $this->translatableListener->setTranslatableLocale('ru_ru');
         $this->translatableListener->setTranslationFallback(false);
 
+        // TODO: Remove the "if" check and "else" body when dropping support of doctrine/dbal 2.
+        if (class_exists(Middleware::class)) {
+            $this->queryLogger
+                ->expects(static::exactly(2))
+                ->method('debug')
+                ->withConsecutive(
+                    ['Executing query: {sql}'],
+                    ['Executing query: {sql}']
+                );
+        } else {
+            $this->startQueryLog();
+        }
+
         // simple object hydration
-        $this->startQueryLog();
         $result = $q->getResult(Query::HYDRATE_SIMPLEOBJECT);
-        static::assertSame(1, $this->queryAnalyzer->getNumExecutedQueries());
+
+        // TODO: Remove the "if" block when dropping support of doctrine/dbal 2.
+        if (!class_exists(Middleware::class)) {
+            static::assertSame(1, $this->queryAnalyzer->getNumExecutedQueries());
+            $this->queryAnalyzer->cleanUp();
+        }
+
         static::assertNull($result[0]->getTitle());
         static::assertSame('John Doe', $result[0]->getAuthor()); // optional fallback is true,  force fallback
         static::assertNull($result[0]->getViews());
 
         $this->translatableListener->setTranslationFallback(true);
-        $this->queryAnalyzer->cleanUp();
         $result = $q->getResult(Query::HYDRATE_SIMPLEOBJECT);
-        static::assertSame(1, $this->queryAnalyzer->getNumExecutedQueries());
+
+        // TODO: Remove the "if" block when dropping support of doctrine/dbal 2.
+        if (!class_exists(Middleware::class)) {
+            static::assertSame(1, $this->queryAnalyzer->getNumExecutedQueries());
+        }
+
         //Default translation is en_us, so we expect the results in that locale
         static::assertSame('Food', $result[0]->getTitle());
         static::assertSame('John Doe', $result[0]->getAuthor());
@@ -295,17 +364,41 @@ final class TranslationQueryWalkerTest extends BaseTestCaseORM
         $this->translatableListener->setTranslatableLocale('ru_ru');
         $this->translatableListener->setTranslationFallback(false);
 
+        // TODO: Remove the "if" check and "else" body when dropping support of doctrine/dbal 2.
+        if (class_exists(Middleware::class)) {
+            $this->queryLogger
+                ->expects(static::exactly(4))
+                ->method('debug')
+                ->withConsecutive(
+                    ['Executing query: {sql}'],
+                    ['Executing query: {sql}'],
+                    ['Executing query: {sql}'],
+                    ['Executing query: {sql}']
+                );
+        } else {
+            $this->startQueryLog();
+        }
+
         // object hydration
-        $this->startQueryLog();
         $result = $q->getResult();
-        static::assertSame(1, $this->queryAnalyzer->getNumExecutedQueries());
+
+        // TODO: Remove the "if" block when dropping support of doctrine/dbal 2.
+        if (!class_exists(Middleware::class)) {
+            static::assertSame(1, $this->queryAnalyzer->getNumExecutedQueries());
+            $this->queryAnalyzer->cleanUp();
+        }
+
         static::assertNull($result[0]->getTitle());
         static::assertNull($result[0]->getContent());
 
         $this->translatableListener->setTranslationFallback(true);
-        $this->queryAnalyzer->cleanUp();
         $result = $q->getResult();
-        static::assertSame(1, $this->queryAnalyzer->getNumExecutedQueries());
+
+        // TODO: Remove the "if" block when dropping support of doctrine/dbal 2.
+        if (!class_exists(Middleware::class)) {
+            static::assertSame(1, $this->queryAnalyzer->getNumExecutedQueries());
+        }
+
         //Default translation is en_us, so we expect the results in that locale
         static::assertSame('Food', $result[0]->getTitle());
         static::assertSame('about food', $result[0]->getContent());


### PR DESCRIPTION
`QueryAnalyzer` is only used for testing purposes and it implements the deprecated (in `doctrine/dbal` 3) `Doctrine\DBAL\Logging\SQLLogger`.

This PR deprecates the one in `src` and creates a basic `QueryAnalyzer` for testing purposes under the `tests` namespace that won't be necessary when dropping support of `doctrine/dbal` 2.

I've tried to implement `LoggerInterface` in the new `QueryAnalyzer` to try to use it with the new `Middleware` way of logging, but the messages are different in version 2 and 3, so I think it's not worth it and I used `if-else` structures for supporting both.

In `SortableGroupTest` the queries were logged, but they weren't used.

Fixes https://github.com/doctrine-extensions/DoctrineExtensions/pull/2233 by deprecating the class.