### PR TITLE
Add index for translation search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ a release.
 - ReferenceIntegrity: Support to use annotations as attributes on PHP >= 8.0.
 - SoftDeleteable: Support for custom column types (like Carbon).
 - Timestampable: Support for custom column types (like Carbon).
+- Translatable: Added an index to `Translation` entity to speed up searches using 
+  `Gedmo\Translatable\Entity\Repository\TranslationRepository::findTranslations()` method. 
 
 ### Fixed
 - Blameable, IpTraceable, Timestampable: Type handling for the tracked field values configured in the origin field.

--- a/src/Translatable/Entity/Translation.php
+++ b/src/Translatable/Entity/Translation.php
@@ -21,9 +21,14 @@ use Gedmo\Translatable\Entity\Repository\TranslationRepository;
  * @Table(
  *         name="ext_translations",
  *         options={"row_format":"DYNAMIC"},
- *         indexes={@Index(name="translations_lookup_idx", columns={
- *             "locale", "object_class", "foreign_key"
- *         })},
+ *         indexes={
+ *             @Index(name="translations_lookup_idx", columns={
+ *                 "locale", "object_class", "foreign_key"
+ *             }),
+ *             @Index(name="general_translations_lookup_idx", columns={
+ *                 "object_class", "foreign_key"
+ *             })
+ *         },
  *         uniqueConstraints={@UniqueConstraint(name="lookup_unique_idx", columns={
  *             "locale", "object_class", "field", "foreign_key"
  *         })}
@@ -33,6 +38,7 @@ use Gedmo\Translatable\Entity\Repository\TranslationRepository;
 #[Entity(repositoryClass: TranslationRepository::class)]
 #[Table(name: 'ext_translations', options: ['row_format' => 'DYNAMIC'])]
 #[Index(name: 'translations_lookup_idx', columns: ['locale', 'object_class', 'foreign_key'])]
+#[Index(name: 'general_translations_lookup_idx', columns: ['object_class', 'foreign_key'])]
 #[UniqueConstraint(name: 'lookup_unique_idx', columns: ['locale', 'object_class', 'field', 'foreign_key'])]
 class Translation extends MappedSuperclass\AbstractTranslation
 {


### PR DESCRIPTION
supersedes https://github.com/doctrine-extensions/DoctrineExtensions/pull/2144

The idea is that in 

https://github.com/doctrine-extensions/DoctrineExtensions/blob/adcedc11c6dd9d419e01f84dd95fc3c599137722/src/Translatable/Entity/Repository/TranslationRepository.php#L141-L144

only `foreignKey` and `objectClass` are used in the `WHERE` part and there was no index for that searches.