### PR TITLE
Replace kernel.root_dir by kernel.project_dir

### DIFF
--- a/doc/symfony4.md
+++ b/doc/symfony4.md
@@ -58,7 +58,7 @@ doctrine:
                 alias: Gedmo
                 prefix: Gedmo\Translatable\Entity
                 # make sure vendor library location is correct
-                dir: "%kernel.root_dir%/../vendor/gedmo/doctrine-extensions/src/Translatable/Entity"
+                dir: "%kernel.project_dir%/vendor/gedmo/doctrine-extensions/src/Translatable/Entity"
 ```
 
 After that, running **php bin/console doctrine:mapping:info** you should see the output:
@@ -83,7 +83,7 @@ mappings:
         alias: Gedmo
         prefix: Gedmo\Translatable\Entity
         # make sure vendor library location is correct
-        dir: "%kernel.root_dir%/../vendor/gedmo/doctrine-extensions/src/Translatable/Entity/MappedSuperclass"
+        dir: "%kernel.project_dir%/vendor/gedmo/doctrine-extensions/src/Translatable/Entity/MappedSuperclass"
 ```
 
 The configuration above, adds a **/MappedSuperclass** into directory depth, after running
@@ -110,17 +110,17 @@ orm:
             alias: Gedmo
             prefix: Gedmo\Translatable\Entity
             # make sure vendor library location is correct
-            dir: "%kernel.root_dir%/../vendor/gedmo/doctrine-extensions/src/Translatable/Entity"
+            dir: "%kernel.project_dir%/vendor/gedmo/doctrine-extensions/src/Translatable/Entity"
         loggable:
             type: annotation # or attribute
             alias: Gedmo
             prefix: Gedmo\Loggable\Entity
-            dir: "%kernel.root_dir%/../vendor/gedmo/doctrine-extensions/src/Loggable/Entity"
+            dir: "%kernel.project_dir%/vendor/gedmo/doctrine-extensions/src/Loggable/Entity"
         tree:
             type: annotation # or attribute
             alias: Gedmo
             prefix: Gedmo\Tree\Entity
-            dir: "%kernel.root_dir%/../vendor/gedmo/doctrine-extensions/src/Tree/Entity"
+            dir: "%kernel.project_dir%/vendor/gedmo/doctrine-extensions/src/Tree/Entity"
 ```
 <a name="ext-filtering"></a>
 ## Filters
@@ -450,7 +450,7 @@ doctrine_mongodb:
                     alias: GedmoDocument
                     prefix: Gedmo\Translatable\Document
                     # make sure vendor library location is correct
-                    dir: "%kernel.root_dir%/../vendor/gedmo/doctrine-extensions/src/Translatable/Document"
+                    dir: "%kernel.project_dir%/vendor/gedmo/doctrine-extensions/src/Translatable/Document"
 ```
 
 This also shows, how to make mappings based on single manager. All what differs is that **Document**


### PR DESCRIPTION
[`kernel.root_dir` was deprecated in Symfony 4.2](https://symfony.com/blog/new-in-symfony-4-2-important-deprecations#deprecated-the-kernel-name-and-the-root-dir)