### PR TITLE
Fixed accessing to a non-existing key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ a release.
 - Wrong PHPDoc type declarations.
 - Avoid calling deprecated `AbstractClassMetadataFactory::getCacheDriver()` method.
 - Avoid deprecations using `doctrine/mongodb-odm` >= 2.2
+- Translatable: `Gedmo\Translatable\Document\Repository\TranslationRepository::findObjectByTranslatedField()`
+  method accessing a non-existing key.
 
 ### Deprecated
 - Tree: When using Closure tree strategy, it is deprecated not defining the mapping associations of the closure entity.

--- a/src/Translatable/Document/Repository/TranslationRepository.php
+++ b/src/Translatable/Document/Repository/TranslationRepository.php
@@ -167,27 +167,32 @@ class TranslationRepository extends DocumentRepository
      */
     public function findObjectByTranslatedField($field, $value, $class)
     {
-        $document = null;
         $meta = $this->dm->getClassMetadata($class);
-        if ($meta->hasField($field)) {
-            $qb = $this->createQueryBuilder();
-            $q = $qb->field('field')->equals($field)
-                ->field('objectClass')->equals($meta->rootDocumentName)
-                ->field('content')->equals($value)
-                ->getQuery();
 
-            $q->setHydrate(false);
-            $result = $q->execute();
-            if ($result instanceof Iterator) {
-                $result = $result->toArray();
-            }
-            $id = $result[0]['foreign_key'] ?? null;
-            if ($id) {
-                $document = $this->dm->find($class, $id);
-            }
+        if (!$meta->hasField($field)) {
+            return null;
         }
 
-        return $document;
+        $qb = $this->createQueryBuilder();
+        $q = $qb->field('field')->equals($field)
+            ->field('objectClass')->equals($meta->rootDocumentName)
+            ->field('content')->equals($value)
+            ->getQuery();
+
+        $q->setHydrate(false);
+        $result = $q->execute();
+
+        if ($result instanceof Iterator) {
+            $result = $result->toArray();
+        }
+
+        $id = $result[0]['foreign_key'] ?? null;
+
+        if (null === $id) {
+            return null;
+        }
+
+        return $this->dm->find($class, $id);
     }
 
     /**

--- a/src/Translatable/Document/Repository/TranslationRepository.php
+++ b/src/Translatable/Document/Repository/TranslationRepository.php
@@ -181,7 +181,7 @@ class TranslationRepository extends DocumentRepository
             if ($result instanceof Iterator) {
                 $result = $result->toArray();
             }
-            $id = count($result) ? $result[0]['foreignKey'] : null;
+            $id = $result[0]['foreign_key'] ?? null;
             if ($id) {
                 $document = $this->dm->find($class, $id);
             }

--- a/tests/Gedmo/Translatable/TranslatableDocumentTest.php
+++ b/tests/Gedmo/Translatable/TranslatableDocumentTest.php
@@ -113,6 +113,33 @@ final class TranslatableDocumentTest extends BaseTestCaseMongoODM
         static::assertCount(0, $translations);
     }
 
+    public function testFindObjectByTranslatedField(): void
+    {
+        $repo = $this->dm->getRepository(self::ARTICLE);
+        $article = $repo->findOneBy(['title' => 'Title EN']);
+        static::assertInstanceOf(self::ARTICLE, $article);
+
+        $this->translatableListener->setTranslatableLocale('de_de');
+        $article->setTitle('Title DE');
+        $article->setCode('Code DE');
+
+        $this->dm->persist($article);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $transRepo = $this->dm->getRepository(self::TRANSLATION);
+        static::assertInstanceOf(TranslationRepository::class, $transRepo);
+
+        $articleFound = $transRepo->findObjectByTranslatedField(
+            'title',
+            'Title DE',
+            self::ARTICLE
+        );
+        static::assertInstanceOf(self::ARTICLE, $articleFound);
+
+        static::assertSame($article->getId(), $articleFound->getId());
+    }
+
     private function populate(): void
     {
         $art0 = new Article();


### PR DESCRIPTION
Fixes https://github.com/doctrine-extensions/DoctrineExtensions/issues/2039

Accessing here

https://github.com/doctrine-extensions/DoctrineExtensions/blob/ca2849656df9f5097a7a92fba2162fdba34c504a/src/Translatable/Document/Repository/TranslationRepository.php#L184

when the key is `foreign_key`:

https://github.com/doctrine-extensions/DoctrineExtensions/blob/ca2849656df9f5097a7a92fba2162fdba34c504a/src/Translatable/Document/MappedSuperclass/AbstractTranslation.php#L55-L61

