### PR TITLE
Use Doctrine MetadataCache if a cache is not set

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
         "php": "^7.2 || ^8.0",
         "behat/transliterator": "~1.2",
         "doctrine/annotations": "^1.13",
+        "doctrine/cache": "^1.11 || ^2.0",
         "doctrine/collections": "^1.0",
         "doctrine/common": "^2.13 || ^3.0",
         "doctrine/event-manager": "^1.0",
@@ -49,8 +50,8 @@
         "symfony/cache": "^4.4 || ^5.3 || ^6.0"
     },
     "require-dev": {
-        "doctrine/cache": "^1.11 || ^2.0",
         "doctrine/dbal": "^2.13.1 || ^3.2",
+        "doctrine/deprecations": "^0.5.3",
         "doctrine/doctrine-bundle": "^2.3",
         "doctrine/mongodb-odm": "^2.2",
         "doctrine/orm": "^2.10.2",

--- a/tests/Gedmo/Mapping/MappingEventSubscriberTest.php
+++ b/tests/Gedmo/Mapping/MappingEventSubscriberTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Mapping;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\EventManager;
+use Doctrine\Deprecations\Deprecation;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+use Doctrine\Persistence\Reflection\TypedNoDefaultReflectionPropertyBase;
+use Gedmo\Sluggable\SluggableListener;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+
+final class MappingEventSubscriberTest extends ORMMappingTestCase
+{
+    use VerifyDeprecations;
+    use ExpectDeprecationTrait;
+
+    /**
+     * @var EntityManager
+     */
+    private $em;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $config = $this->getBasicConfiguration();
+
+        $config->setMetadataDriverImpl(new AnnotationDriver(new AnnotationReader()));
+
+        $conn = [
+            'driver' => 'pdo_sqlite',
+            'memory' => true,
+        ];
+
+        $this->em = EntityManager::create($conn, $config, new EventManager());
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testGetConfigurationCachedFromDoctrine(): void
+    {
+        // doctrine/persistence changed from trigger_error to doctrine/deprecations in 2.2.1. In 2.2.2 this trait was
+        // added, this is used to know if the doctrine/persistence version is using trigger_error or
+        // doctrine/deprecations. This "if" check can be removed once we drop support for doctrine/persistence < 2.2.1
+        if (trait_exists(TypedNoDefaultReflectionPropertyBase::class)) {
+            Deprecation::enableWithTriggerError();
+
+            $this->expectDeprecationWithIdentifier('https://github.com/doctrine/persistence/issues/184');
+        } else {
+            $this->expectDeprecation('Doctrine\Persistence\Mapping\AbstractClassMetadataFactory::getCacheDriver is deprecated. Use getCache() instead.');
+        }
+
+        $subscriber = new SluggableListener();
+        $subscriber->getExtensionMetadataFactory($this->em);
+    }
+
+    protected function getUsedEntityFixtures(): array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
I'm a bit concern about performance after https://github.com/doctrine-extensions/DoctrineExtensions/pull/2373 because before that, the cache was shared among the listeners and now it should be set externally.

I've created https://github.com/stof/StofDoctrineExtensionsBundle/pull/436 to try to solve it for the bundle.

In the meantime, instead of creating a new `ArrayAdapter` as fallback, I think we can go back to doctrine metadata cache so everything should work as before.

~I'll try later today to add a test and~ after this I'm fine releasing `3.5.0`.