### PR TITLE
Deprecate `AbstractWrapper::clear()` and `WrapperInterface::populate()` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ a release.
 - Using YAML mapping is deprecated, you SHOULD migrate to attributes, annotations or XML.
 - `Gedmo\Mapping\Event\AdapterInterface::__call()` method.
 - `Gedmo\Tool\Wrapper\AbstractWrapper::clear()` method.
+- `Gedmo\Tool\Wrapper\WrapperInterface::populate()` method.
 
 ### Changed
 - In order to use a custom cache for storing configuration of an extension, the user has to call `setCacheItemPool()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ a release.
 - `Gedmo\Tool\Logging\DBAL\QueryAnalizer` class without replacement.
 - Using YAML mapping is deprecated, you SHOULD migrate to attributes, annotations or XML.
 - `Gedmo\Mapping\Event\AdapterInterface::__call()` method.
+- `Gedmo\Tool\Wrapper\AbstractWrapper::clear()` method.
 
 ### Changed
 - In order to use a custom cache for storing configuration of an extension, the user has to call `setCacheItemPool()`

--- a/src/Sluggable/SluggableListener.php
+++ b/src/Sluggable/SluggableListener.php
@@ -17,7 +17,6 @@ use Gedmo\Sluggable\Handler\SlugHandlerInterface;
 use Gedmo\Sluggable\Handler\SlugHandlerWithUniqueCallbackInterface;
 use Gedmo\Sluggable\Mapping\Event\SluggableAdapter;
 use Gedmo\Sluggable\Util\Urlizer;
-use Gedmo\Tool\Wrapper\AbstractWrapper;
 
 /**
  * The SluggableListener handles the generation of slugs
@@ -241,8 +240,6 @@ class SluggableListener extends MappedEventSubscriber
         }
 
         $this->manageFiltersAfterGeneration($om);
-
-        AbstractWrapper::clear();
     }
 
     protected function getNamespace()

--- a/src/Tool/Wrapper/AbstractWrapper.php
+++ b/src/Tool/Wrapper/AbstractWrapper.php
@@ -89,6 +89,11 @@ abstract class AbstractWrapper implements WrapperInterface
 
     public function populate(array $data)
     {
+        @trigger_error(sprintf(
+            'Using "%s()" method is deprecated since gedmo/doctrine-extensions 3.x and will be removed in version 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         foreach ($data as $field => $value) {
             $this->setPropertyValue($field, $value);
         }

--- a/src/Tool/Wrapper/AbstractWrapper.php
+++ b/src/Tool/Wrapper/AbstractWrapper.php
@@ -46,13 +46,6 @@ abstract class AbstractWrapper implements WrapperInterface
     protected $om;
 
     /**
-     * List of wrapped object references
-     *
-     * @var array
-     */
-    private static $wrappedObjectReferences;
-
-    /**
      * Wrap object factory method
      *
      * @param object $object
@@ -78,7 +71,10 @@ abstract class AbstractWrapper implements WrapperInterface
      */
     public static function clear()
     {
-        self::$wrappedObjectReferences = [];
+        @trigger_error(sprintf(
+            'Using "%s()" method is deprecated since gedmo/doctrine-extensions 3.x and will be removed in version 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
     }
 
     public function getObject()

--- a/src/Tool/WrapperInterface.php
+++ b/src/Tool/WrapperInterface.php
@@ -45,6 +45,8 @@ interface WrapperInterface
     public function setPropertyValue($property, $value);
 
     /**
+     * @deprecated since gedmo/doctrine-extensions 3.x and to be removed in version 4.0.
+     *
      * Populates the wrapped object with the given property values.
      *
      * @return $this

--- a/tests/Gedmo/Wrapper/EntityWrapperTest.php
+++ b/tests/Gedmo/Wrapper/EntityWrapperTest.php
@@ -88,7 +88,7 @@ final class EntityWrapperTest extends BaseTestCaseORM
         $test = new Article();
         $wrapped = new EntityWrapper($test, $this->em);
 
-        $wrapped->populate(['title' => 'test']);
+        $test->setTitle('test');
         static::assertSame('test', $wrapped->getPropertyValue('title'));
 
         static::assertFalse($wrapped->hasValidIdentifier());

--- a/tests/Gedmo/Wrapper/MongoDocumentWrapperTest.php
+++ b/tests/Gedmo/Wrapper/MongoDocumentWrapperTest.php
@@ -86,7 +86,7 @@ final class MongoDocumentWrapperTest extends BaseTestCaseMongoODM
         $test = new Article();
         $wrapped = new MongoDocumentWrapper($test, $this->dm);
 
-        $wrapped->populate(['title' => 'test']);
+        $test->setTitle('test');
         static::assertSame('test', $wrapped->getPropertyValue('title'));
 
         static::assertFalse($wrapped->hasValidIdentifier());


### PR DESCRIPTION
`AbstractWrapper::clear()` method was reseting `$wrappedObjectReferences` which was an unused private variable and `WrapperInterface::populate()` method is was only used in tests.

In another PR I think we can deprecate the whole `AbstractWrapper` and use a `FactoryWrapper` with the `wrap` method.