### PR TITLE
[Uploadable] Fix `FileInfoInterface::getSize()` return type declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ a release.
 ---
 
 ## [Unreleased]
+### Fixed
+- Uploadable: `FileInfoInterface::getSize()` return type declaration (#2413).
 
 ## [3.5.0] - 2022-01-10
 ### Added

--- a/src/Uploadable/FileInfo/FileInfoInterface.php
+++ b/src/Uploadable/FileInfo/FileInfoInterface.php
@@ -28,7 +28,7 @@ interface FileInfoInterface
     public function getName();
 
     /**
-     * @return string|null
+     * @return int|null
      */
     public function getSize();
 

--- a/src/Uploadable/UploadableListener.php
+++ b/src/Uploadable/UploadableListener.php
@@ -10,6 +10,7 @@
 namespace Gedmo\Uploadable;
 
 use Doctrine\Common\EventArgs;
+use Doctrine\DBAL\Types\Type;
 use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\NotifyPropertyChanged;
@@ -325,7 +326,12 @@ class UploadableListener extends MappedEventSubscriber
         }
 
         if ($config['fileSizeField']) {
-            $this->updateField($object, $uow, $ea, $meta, $config['fileSizeField'], $info['fileSize']);
+            $typeOfSizeField = Type::getType($meta->getTypeOfField($config['fileSizeField']));
+            $value = $typeOfSizeField->convertToPHPValue(
+                $info['fileSize'],
+                $om->getConnection()->getDatabasePlatform()
+            );
+            $this->updateField($object, $uow, $ea, $meta, $config['fileSizeField'], $value);
         }
 
         $ea->recomputeSingleObjectChangeSet($uow, $meta, $object);

--- a/tests/Gedmo/Uploadable/Fixture/Entity/FileWithMaxSize.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/FileWithMaxSize.php
@@ -17,10 +17,10 @@ use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
- * @Gedmo\Uploadable(allowOverwrite=true, pathMethod="getPath", callback="callbackMethod", maxSize="1")
+ * @Gedmo\Uploadable(allowOverwrite=true, pathMethod="getPath", callback="callbackMethod", maxSize="2")
  */
 #[ORM\Entity]
-#[Gedmo\Uploadable(allowOverwrite: true, pathMethod: 'getPath', callback: 'callbackMethod', maxSize: '1')]
+#[Gedmo\Uploadable(allowOverwrite: true, pathMethod: 'getPath', callback: 'callbackMethod', maxSize: '2')]
 class FileWithMaxSize
 {
     /**

--- a/tests/Gedmo/Uploadable/Fixture/Entity/ImageWithTypedProperties.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/ImageWithTypedProperties.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Uploadable\Fixture\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * @ORM\Entity
+ * @Gedmo\Uploadable(pathMethod="getPath")
+ */
+#[ORM\Entity]
+#[Gedmo\Uploadable(pathMethod: 'getPath')]
+class ImageWithTypedProperties
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="IDENTITY")
+     * @ORM\Column(type="integer")
+     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    #[ORM\Column(type: Types::INTEGER)]
+    private ?int $id = null;
+
+    /**
+     * @ORM\Column(name="title", type="string")
+     */
+    #[ORM\Column(name: 'title', type: Types::STRING)]
+    private ?string $title = null;
+
+    /**
+     * @ORM\Column(name="path", type="string", nullable=true)
+     * @Gedmo\UploadableFilePath
+     */
+    #[ORM\Column(name: 'path', type: Types::STRING, nullable: true)]
+    #[Gedmo\UploadableFilePath]
+    private ?string $filePath = null;
+
+    /**
+     * @ORM\Column(name="size", type="decimal", nullable=true)
+     * @Gedmo\UploadableFileSize
+     */
+    #[ORM\Column(name: 'size', type: Types::DECIMAL, nullable: true)]
+    #[Gedmo\UploadableFileSize]
+    private ?string $size = null;
+
+    /**
+     * @ORM\Column(name="mime_type", type="string", nullable=true)
+     * @Gedmo\UploadableFileMimeType
+     */
+    #[ORM\Column(name: 'mime_type', type: Types::STRING, nullable: true)]
+    #[Gedmo\UploadableFileMimeType]
+    private ?string $mime = null;
+
+    private bool $useBasePath = false;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setTitle(?string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setFilePath(?string $filePath): void
+    {
+        $this->filePath = $filePath;
+    }
+
+    public function getFilePath(): ?string
+    {
+        return $this->filePath;
+    }
+
+    public function getPath(?string $basePath = null): string
+    {
+        if ($this->useBasePath) {
+            return $basePath.'/abc/def';
+        }
+
+        return TESTS_TEMP_DIR.'/uploadable';
+    }
+
+    public function setMime(?string $mime): void
+    {
+        $this->mime = $mime;
+    }
+
+    public function getMime(): ?string
+    {
+        return $this->mime;
+    }
+
+    public function setSize(?string $size): void
+    {
+        $this->size = $size;
+    }
+
+    public function getSize(): ?string
+    {
+        return $this->size;
+    }
+
+    public function setUseBasePath(bool $useBasePath): void
+    {
+        $this->useBasePath = $useBasePath;
+    }
+}

--- a/tests/Gedmo/Uploadable/UploadableEntitySizeTypeTest.php
+++ b/tests/Gedmo/Uploadable/UploadableEntitySizeTypeTest.php
@@ -18,7 +18,7 @@ use Gedmo\Tests\Uploadable\Stub\MimeTypeGuesserStub;
 use Gedmo\Tests\Uploadable\Stub\UploadableListenerStub;
 
 /**
- * These are tests for Uploadable behavior with different size types
+ * This test is for Uploadable behavior with typed properties
  *
  * @requires PHP >= 7.4
  */
@@ -34,27 +34,7 @@ final class UploadableEntitySizeTypeTest extends BaseTestCaseORM
     /**
      * @var string
      */
-    private $testFile;
-
-    /**
-     * @var string
-     */
     private $destinationTestDir;
-
-    /**
-     * @var string
-     */
-    private $testFilename;
-
-    /**
-     * @var string
-     */
-    private $testFileSize;
-
-    /**
-     * @var string
-     */
-    private $testFileMimeType;
 
     protected function setUp(): void
     {
@@ -67,11 +47,8 @@ final class UploadableEntitySizeTypeTest extends BaseTestCaseORM
         $evm->addEventSubscriber($this->listener);
         $config = $this->getDefaultConfiguration();
         $this->em = $this->getDefaultMockSqliteEntityManager($evm, $config);
-        $this->testFile = TESTS_PATH.'/data/test_for_typed_properties.txt';
+
         $this->destinationTestDir = TESTS_TEMP_DIR.'/uploadable';
-        $this->testFilename = substr($this->testFile, strrpos($this->testFile, '/') + 1);
-        $this->testFileSize = '4';
-        $this->testFileMimeType = 'text/plain';
 
         $this->clearFilesAndDirectories();
 
@@ -87,7 +64,18 @@ final class UploadableEntitySizeTypeTest extends BaseTestCaseORM
 
     public function testUploadableEntity(): void
     {
-        $fileInfo = $this->generateUploadedFile();
+        $testFile = TESTS_PATH.'/data/test_for_typed_properties.txt';
+        $testFilename = substr($testFile, strrpos($testFile, '/') + 1);
+        $testFileSize = '4';
+        $testFileMimeType = 'text/plain';
+
+        $fileInfo = [
+            'tmp_name' => $testFile,
+            'name' => $testFilename,
+            'size' => $testFileSize,
+            'type' => $testFileMimeType,
+            'error' => 0,
+        ];
 
         $image = new ImageWithTypedProperties();
         $image->setTitle('456');
@@ -100,10 +88,10 @@ final class UploadableEntitySizeTypeTest extends BaseTestCaseORM
 
         $file = $image->getFilePath();
 
-        $this->assertPathEquals($image->getPath().'/'.$fileInfo['name'], $image->getFilePath());
+        $this->assertPathEquals($image->getPath().'/'.$testFilename, $image->getFilePath());
         static::assertTrue(is_file($file));
-        static::assertSame($fileInfo['size'], $image->getSize());
-        static::assertSame($fileInfo['type'], $image->getMime());
+        static::assertSame($testFileSize, $image->getSize());
+        static::assertSame($testFileMimeType, $image->getMime());
 
         $this->em->remove($image);
         $this->em->flush();
@@ -121,21 +109,6 @@ final class UploadableEntitySizeTypeTest extends BaseTestCaseORM
     protected function assertPathEquals(string $expected, string $path, string $message = ''): void
     {
         static::assertSame($expected, $path, $message);
-    }
-
-    // Util
-
-    private function generateUploadedFile($filePath = false, $filename = false, array $info = []): array
-    {
-        $defaultInfo = [
-            'tmp_name' => !$filePath ? $this->testFile : $filePath,
-            'name' => !$filename ? $this->testFilename : $filename,
-            'size' => $this->testFileSize,
-            'type' => $this->testFileMimeType,
-            'error' => 0,
-        ];
-
-        return array_merge($defaultInfo, $info);
     }
 
     private function clearFilesAndDirectories(): void

--- a/tests/Gedmo/Uploadable/UploadableEntitySizeTypeTest.php
+++ b/tests/Gedmo/Uploadable/UploadableEntitySizeTypeTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Uploadable;
+
+use Doctrine\Common\EventManager;
+use Gedmo\Tests\Tool\BaseTestCaseORM;
+use Gedmo\Tests\Uploadable\Fixture\Entity\ImageWithTypedProperties;
+use Gedmo\Tests\Uploadable\Stub\MimeTypeGuesserStub;
+use Gedmo\Tests\Uploadable\Stub\UploadableListenerStub;
+
+/**
+ * These are tests for Uploadable behavior with different size types
+ *
+ * @requires PHP >= 7.4
+ */
+final class UploadableEntitySizeTypeTest extends BaseTestCaseORM
+{
+    public const IMAGE_WITH_TYPED_PROPERTIES_CLASS = ImageWithTypedProperties::class;
+
+    /**
+     * @var UploadableListenerStub
+     */
+    private $listener;
+
+    /**
+     * @var string
+     */
+    private $testFile;
+
+    /**
+     * @var string
+     */
+    private $destinationTestDir;
+
+    /**
+     * @var string
+     */
+    private $testFilename;
+
+    /**
+     * @var string
+     */
+    private $testFileSize;
+
+    /**
+     * @var string
+     */
+    private $testFileMimeType;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $evm = new EventManager();
+        $this->listener = new UploadableListenerStub();
+        $this->listener->setMimeTypeGuesser(new MimeTypeGuesserStub('text/plain'));
+
+        $evm->addEventSubscriber($this->listener);
+        $config = $this->getDefaultConfiguration();
+        $this->em = $this->getDefaultMockSqliteEntityManager($evm, $config);
+        $this->testFile = TESTS_PATH.'/data/test_for_typed_properties.txt';
+        $this->destinationTestDir = TESTS_TEMP_DIR.'/uploadable';
+        $this->testFilename = substr($this->testFile, strrpos($this->testFile, '/') + 1);
+        $this->testFileSize = '4';
+        $this->testFileMimeType = 'text/plain';
+
+        $this->clearFilesAndDirectories();
+
+        if (!is_dir($this->destinationTestDir)) {
+            mkdir($this->destinationTestDir);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        $this->clearFilesAndDirectories();
+    }
+
+    public function testUploadableEntity(): void
+    {
+        $fileInfo = $this->generateUploadedFile();
+
+        $image = new ImageWithTypedProperties();
+        $image->setTitle('456');
+        $this->listener->addEntityFileInfo($image, $fileInfo);
+
+        $this->em->persist($image);
+        $this->em->flush();
+
+        $this->em->refresh($image);
+
+        $file = $image->getFilePath();
+
+        $this->assertPathEquals($image->getPath().'/'.$fileInfo['name'], $image->getFilePath());
+        static::assertTrue(is_file($file));
+        static::assertSame($fileInfo['size'], $image->getSize());
+        static::assertSame($fileInfo['type'], $image->getMime());
+
+        $this->em->remove($image);
+        $this->em->flush();
+
+        static::assertFalse(is_file($file));
+    }
+
+    protected function getUsedEntityFixtures(): array
+    {
+        return [
+            self::IMAGE_WITH_TYPED_PROPERTIES_CLASS,
+        ];
+    }
+
+    protected function assertPathEquals(string $expected, string $path, string $message = ''): void
+    {
+        static::assertSame($expected, $path, $message);
+    }
+
+    // Util
+
+    private function generateUploadedFile($filePath = false, $filename = false, array $info = []): array
+    {
+        $defaultInfo = [
+            'tmp_name' => !$filePath ? $this->testFile : $filePath,
+            'name' => !$filename ? $this->testFilename : $filename,
+            'size' => $this->testFileSize,
+            'type' => $this->testFileMimeType,
+            'error' => 0,
+        ];
+
+        return array_merge($defaultInfo, $info);
+    }
+
+    private function clearFilesAndDirectories(): void
+    {
+        if (is_dir($this->destinationTestDir)) {
+            $iter = new \DirectoryIterator($this->destinationTestDir);
+
+            foreach ($iter as $fileInfo) {
+                if (!$fileInfo->isDot()) {
+                    @unlink($fileInfo->getPathname());
+                }
+            }
+        }
+    }
+}

--- a/tests/Gedmo/Uploadable/UploadableEntitySizeTypeTest.php
+++ b/tests/Gedmo/Uploadable/UploadableEntitySizeTypeTest.php
@@ -66,7 +66,7 @@ final class UploadableEntitySizeTypeTest extends BaseTestCaseORM
     {
         $testFile = TESTS_PATH.'/data/test_for_typed_properties.txt';
         $testFilename = substr($testFile, strrpos($testFile, '/') + 1);
-        $testFileSize = '4';
+        $testFileSize = 4;
         $testFileMimeType = 'text/plain';
 
         $fileInfo = [
@@ -90,7 +90,7 @@ final class UploadableEntitySizeTypeTest extends BaseTestCaseORM
 
         $this->assertPathEquals($image->getPath().'/'.$testFilename, $image->getFilePath());
         static::assertTrue(is_file($file));
-        static::assertSame($testFileSize, $image->getSize());
+        static::assertSame((string) $testFileSize, $image->getSize());
         static::assertSame($testFileMimeType, $image->getMime());
 
         $this->em->remove($image);

--- a/tests/Gedmo/Uploadable/UploadableEntityTest.php
+++ b/tests/Gedmo/Uploadable/UploadableEntityTest.php
@@ -119,7 +119,7 @@ final class UploadableEntityTest extends BaseTestCaseORM
     /** @var false|string */
     private $testFilenameWithSpaces;
 
-    /** @var string */
+    /** @var int */
     private $testFileSize;
 
     /** @var string */
@@ -152,7 +152,7 @@ final class UploadableEntityTest extends BaseTestCaseORM
         $this->testFilename3 = substr($this->testFile3, strrpos($this->testFile3, '/') + 1);
         $this->testFilenameWithoutExt = substr($this->testFileWithoutExt, strrpos($this->testFileWithoutExt, '/') + 1);
         $this->testFilenameWithSpaces = substr($this->testFileWithSpaces, strrpos($this->testFileWithSpaces, '/') + 1);
-        $this->testFileSize = '4';
+        $this->testFileSize = 4;
         $this->testFileMimeType = 'text/plain';
 
         $this->clearFilesAndDirectories();
@@ -197,7 +197,7 @@ final class UploadableEntityTest extends BaseTestCaseORM
 
         $this->assertPathEquals($image2->getPath().'/'.$fileInfo['name'], $image2->getFilePath());
         static::assertTrue(is_file($firstFile));
-        static::assertSame($fileInfo['size'], $image2->getSize());
+        static::assertSame((string) $fileInfo['size'], $image2->getSize());
         static::assertSame($fileInfo['type'], $image2->getMime());
 
         // UPDATE of an Uploadable Entity
@@ -251,7 +251,7 @@ final class UploadableEntityTest extends BaseTestCaseORM
 
         $this->assertPathEquals($image2->getPath($this->destinationTestDir).'/'.$fileInfo['name'], $image2->getFilePath());
         static::assertTrue(is_file($firstFile));
-        static::assertSame($fileInfo['size'], $image2->getSize());
+        static::assertSame((string) $fileInfo['size'], $image2->getSize());
         static::assertSame($fileInfo['type'], $image2->getMime());
 
         // UPDATE of an Uploadable Entity
@@ -596,7 +596,7 @@ final class UploadableEntityTest extends BaseTestCaseORM
         $this->listener->setDefaultPath($this->destinationTestDir);
 
         $file = new FileWithMaxSize();
-        $size = '0.0001';
+        $size = 1;
         $fileInfo = $this->generateUploadedFile(false, false, ['size' => $size]);
 
         $this->listener->addEntityFileInfo($file, $fileInfo);
@@ -606,7 +606,7 @@ final class UploadableEntityTest extends BaseTestCaseORM
 
         $this->em->refresh($file);
 
-        static::assertSame($size, $file->getFileSize());
+        static::assertSame((string) $size, $file->getFileSize());
     }
 
     public function testIfMimeTypeGuesserCantResolveTypeThrowException(): void

--- a/tests/data/test_for_typed_properties.txt
+++ b/tests/data/test_for_typed_properties.txt
@@ -1,0 +1,1 @@
+test for typed properties


### PR DESCRIPTION
Fixes #2413

I've added a conversion that is not really needed, but IMO looks better. It is not needed because apparently you can set an `int` to a `string` property (using strict types) through reflection: https://3v4l.org/jLBuI
