### PR TITLE
Tree: Fix setting tree root when parent is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ a release.
 ## [Unreleased]
 ### Fixed
 - Uploadable: `FileInfoInterface::getSize()` return type declaration (#2413).
+- Tree: Setting a new Tree Root when Tree Parent is `null`.
 
 ## [3.5.0] - 2022-01-10
 ### Added

--- a/src/Tree/Strategy/ORM/Nested.php
+++ b/src/Tree/Strategy/ORM/Nested.php
@@ -387,7 +387,7 @@ class Nested implements Strategy
             }
             $newRoot = $parentRoot;
         } elseif (!isset($config['root']) ||
-            ($meta->isSingleValuedAssociation($config['root']) && ($newRoot = $meta->getFieldValue($node, $config['root'])))) {
+            ($meta->isSingleValuedAssociation($config['root']) && null !== $parent && ($newRoot = $meta->getFieldValue($node, $config['root'])))) {
             if (!isset($this->treeEdges[$meta->getName()])) {
                 $this->treeEdges[$meta->getName()] = $this->max($em, $config['useObjectClass'], $newRoot) + 1;
             }

--- a/tests/Gedmo/Tree/Fixture/Issue2408/Category.php
+++ b/tests/Gedmo/Tree/Fixture/Issue2408/Category.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Tree\Fixture\Issue2408;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
+
+/**
+ * @Gedmo\Tree(type="nested")
+ * @ORM\Table(name="categories")
+ * @ORM\Entity(repositoryClass="Gedmo\Tree\Entity\Repository\NestedTreeRepository")
+ */
+#[Gedmo\Tree(type: 'nested')]
+#[ORM\Table(name: 'categories')]
+#[ORM\Entity(repositoryClass: NestedTreeRepository::class)]
+class Category
+{
+    /**
+     * @var int|null
+     *
+     * @ORM\Column(name="id", type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    private $id;
+
+    /**
+     * @var string|null
+     *
+     * @ORM\Column(name="title", type="string", length=64)
+     */
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
+    private $title;
+
+    /**
+     * @var int|null
+     *
+     * @Gedmo\TreeLeft
+     * @ORM\Column(name="lft", type="integer")
+     */
+    #[ORM\Column(name: 'lft', type: Types::INTEGER)]
+    #[Gedmo\TreeLeft]
+    private $lft;
+
+    /**
+     * @var int|null
+     *
+     * @Gedmo\TreeRight
+     * @ORM\Column(name="rgt", type="integer")
+     */
+    #[ORM\Column(name: 'rgt', type: Types::INTEGER)]
+    #[Gedmo\TreeRight]
+    private $rgt;
+
+    /**
+     * @var int|null
+     *
+     * @Gedmo\TreeLevel
+     * @ORM\Column(name="lvl", type="integer")
+     */
+    #[ORM\Column(name: 'lvl', type: Types::INTEGER)]
+    #[Gedmo\TreeLevel]
+    private $lvl;
+
+    /**
+     * @var self|null
+     *
+     * @Gedmo\TreeRoot
+     * @ORM\ManyToOne(targetEntity="Category")
+     * @ORM\JoinColumn(name="tree_root", referencedColumnName="id", onDelete="CASCADE")
+     */
+    #[Gedmo\TreeRoot]
+    #[ORM\ManyToOne(targetEntity: self::class)]
+    #[ORM\JoinColumn(name: 'tree_root', referencedColumnName: 'id', onDelete: 'CASCADE')]
+    private $root;
+
+    /**
+     * @var self|null
+     *
+     * @Gedmo\TreeParent
+     * @ORM\ManyToOne(targetEntity="Category", inversedBy="children")
+     * @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
+     */
+    #[Gedmo\TreeParent]
+    #[ORM\ManyToOne(targetEntity: self::class, inversedBy: 'children')]
+    #[ORM\JoinColumn(name: 'parent_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
+    private $parent;
+
+    /**
+     * @var Collection<int, Category>
+     *
+     * @ORM\OneToMany(targetEntity="Category", mappedBy="parent")
+     * @ORM\OrderBy({"lft" = "ASC"})
+     */
+    #[ORM\OneToMany(targetEntity: self::class, mappedBy: 'parent')]
+    #[ORM\OrderBy(['lft' => 'ASC'])]
+    private $children;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setTitle(?string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function getRoot(): ?self
+    {
+        return $this->root;
+    }
+
+    public function setParent(self $parent = null): void
+    {
+        $this->parent = $parent;
+    }
+
+    public function getParent(): ?self
+    {
+        return $this->parent;
+    }
+}

--- a/tests/Gedmo/Tree/Issue/Issue2408Test.php
+++ b/tests/Gedmo/Tree/Issue/Issue2408Test.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Tree\Issue;
+
+use Doctrine\Common\EventManager;
+use Gedmo\Tests\Tool\BaseTestCaseORM;
+use Gedmo\Tests\Tree\Fixture\Issue2408\Category;
+use Gedmo\Tree\TreeListener;
+
+final class Issue2408Test extends BaseTestCaseORM
+{
+    /**
+     * @var TreeListener
+     */
+    private $listener;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->listener = new TreeListener();
+
+        $evm = new EventManager();
+        $evm->addEventSubscriber($this->listener);
+
+        $this->getDefaultMockSqliteEntityManager($evm);
+    }
+
+    public function testSettingParentNull(): void
+    {
+        $food = new Category();
+        $food->setTitle('Food');
+
+        $fruits = new Category();
+        $fruits->setTitle('Fruits');
+        $fruits->setParent($food);
+
+        $vegetables = new Category();
+        $vegetables->setTitle('Vegetables');
+        $vegetables->setParent($food);
+
+        $carrots = new Category();
+        $carrots->setTitle('Carrots');
+        $carrots->setParent($vegetables);
+
+        $this->em->persist($food);
+        $this->em->persist($fruits);
+        $this->em->persist($vegetables);
+        $this->em->persist($carrots);
+        $this->em->flush();
+
+        $this->em->refresh($carrots);
+
+        $carrots->setParent(null);
+        $this->em->flush();
+
+        $categoryRepository = $this->em->getRepository(Category::class);
+        $verify = $categoryRepository->verify();
+
+        static::assertTrue($verify);
+        static::assertSame($carrots, $carrots->getRoot());
+    }
+
+    protected function getUsedEntityFixtures(): array
+    {
+        return [Category::class];
+    }
+}


### PR DESCRIPTION
Supersedes https://github.com/doctrine-extensions/DoctrineExtensions/pull/2178

Fixes https://github.com/doctrine-extensions/DoctrineExtensions/issues/2408

I'm not using the Tree extension, @julienbornstein can you please verify if this is the correct behaviour? 