### PR TITLE
Closure: mirror Doctrine cache key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ a release.
 ### Fixed
 - Uploadable: `FileInfoInterface::getSize()` return type declaration (#2413).
 - Tree: Setting a new Tree Root when Tree Parent is `null`.
+- Tree: update cache key used by Closure to match Doctrine's one (#2416).
 
 ## [3.5.0] - 2022-01-10
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "doctrine/collections": "^1.0",
         "doctrine/common": "^2.13 || ^3.0",
         "doctrine/event-manager": "^1.0",
-        "doctrine/persistence": "^1.3.3 || ^2.0",
+        "doctrine/persistence": "^2.0",
         "psr/cache": "^1 || ^2 || ^3",
         "symfony/cache": "^4.4 || ^5.3 || ^6.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "doctrine/collections": "^1.0",
         "doctrine/common": "^2.13 || ^3.0",
         "doctrine/event-manager": "^1.0",
-        "doctrine/persistence": "^2.0",
+        "doctrine/persistence": "^2.2",
         "psr/cache": "^1 || ^2 || ^3",
         "symfony/cache": "^4.4 || ^5.3 || ^6.0"
     },

--- a/src/Tree/Strategy/ORM/Closure.php
+++ b/src/Tree/Strategy/ORM/Closure.php
@@ -201,10 +201,6 @@ class Closure implements Strategy
                 /* @see https://github.com/doctrine/persistence/pull/144 */
                 /* @see \Doctrine\Persistence\Mapping\AbstractClassMetadataFactory::getCacheKey */
                 $cacheDriver->save(
-                    $closureMetadata->getName().'$CLASSMETADATA',
-                    $closureMetadata
-                );
-                $cacheDriver->save(
                     str_replace('\\', '__', $closureMetadata->getName()).'__CLASSMETADATA__',
                     $closureMetadata
                 );

--- a/src/Tree/Strategy/ORM/Closure.php
+++ b/src/Tree/Strategy/ORM/Closure.php
@@ -198,7 +198,11 @@ class Closure implements Strategy
             $cacheDriver = $cmf->getCacheDriver();
 
             if ($cacheDriver instanceof Cache) {
-                $cacheDriver->save($closureMetadata->getName().'$CLASSMETADATA', $closureMetadata);
+                /* @see \Doctrine\Persistence\Mapping\AbstractClassMetadataFactory::getCacheKey */
+                $cacheDriver->save(
+                    str_replace('\\', '__', $closureMetadata->getName()).'__CLASSMETADATA__',
+                    $closureMetadata
+                );
             }
         }
     }

--- a/src/Tree/Strategy/ORM/Closure.php
+++ b/src/Tree/Strategy/ORM/Closure.php
@@ -198,7 +198,12 @@ class Closure implements Strategy
             $cacheDriver = $cmf->getCacheDriver();
 
             if ($cacheDriver instanceof Cache) {
+                /* @see https://github.com/doctrine/persistence/pull/144 */
                 /* @see \Doctrine\Persistence\Mapping\AbstractClassMetadataFactory::getCacheKey */
+                $cacheDriver->save(
+                    $closureMetadata->getName().'$CLASSMETADATA',
+                    $closureMetadata
+                );
                 $cacheDriver->save(
                     str_replace('\\', '__', $closureMetadata->getName()).'__CLASSMETADATA__',
                     $closureMetadata

--- a/src/Tree/Strategy/ORM/Closure.php
+++ b/src/Tree/Strategy/ORM/Closure.php
@@ -198,8 +198,8 @@ class Closure implements Strategy
             $cacheDriver = $cmf->getCacheDriver();
 
             if ($cacheDriver instanceof Cache) {
-                /* @see https://github.com/doctrine/persistence/pull/144 */
-                /* @see \Doctrine\Persistence\Mapping\AbstractClassMetadataFactory::getCacheKey */
+                // @see https://github.com/doctrine/persistence/pull/144
+                // @see \Doctrine\Persistence\Mapping\AbstractClassMetadataFactory::getCacheKey()
                 $cacheDriver->save(
                     str_replace('\\', '__', $closureMetadata->getName()).'__CLASSMETADATA__',
                     $closureMetadata

--- a/tests/Gedmo/Mapping/TreeMappingTest.php
+++ b/tests/Gedmo/Mapping/TreeMappingTest.php
@@ -79,7 +79,7 @@ final class TreeMappingTest extends ORMMappingTestCase
      * @group legacy
      *
      * @see https://github.com/doctrine/persistence/pull/144
-     * @see \Doctrine\Persistence\Mapping\AbstractClassMetadataFactory::getCacheKey
+     * @see \Doctrine\Persistence\Mapping\AbstractClassMetadataFactory::getCacheKey()
      */
     public function testApcCached(): void
     {

--- a/tests/Gedmo/Mapping/TreeMappingTest.php
+++ b/tests/Gedmo/Mapping/TreeMappingTest.php
@@ -78,12 +78,20 @@ final class TreeMappingTest extends ORMMappingTestCase
     /**
      * @group legacy
      *
+     * @see https://github.com/doctrine/persistence/pull/144
      * @see \Doctrine\Persistence\Mapping\AbstractClassMetadataFactory::getCacheKey
      */
     public function testApcCached(): void
     {
         $this->em->getClassMetadata(self::YAML_CLOSURE_CATEGORY);
         $this->em->getClassMetadata(CategoryClosureWithoutMapping::class);
+
+        $meta = $this->em->getMetadataFactory()->getCacheDriver()->fetch(
+            'Gedmo\\Tests\\Tree\\Fixture\\Closure\\CategoryClosureWithoutMapping$CLASSMETADATA'
+        );
+        static::assertNotFalse($meta);
+        static::assertTrue($meta->hasAssociation('ancestor'));
+        static::assertTrue($meta->hasAssociation('descendant'));
 
         $meta = $this->em->getMetadataFactory()->getCacheDriver()->fetch(
             'Gedmo__Tests__Tree__Fixture__Closure__CategoryClosureWithoutMapping__CLASSMETADATA__'

--- a/tests/Gedmo/Mapping/TreeMappingTest.php
+++ b/tests/Gedmo/Mapping/TreeMappingTest.php
@@ -77,6 +77,8 @@ final class TreeMappingTest extends ORMMappingTestCase
 
     /**
      * @group legacy
+     *
+     * @see \Doctrine\Persistence\Mapping\AbstractClassMetadataFactory::getCacheKey
      */
     public function testApcCached(): void
     {
@@ -84,8 +86,9 @@ final class TreeMappingTest extends ORMMappingTestCase
         $this->em->getClassMetadata(CategoryClosureWithoutMapping::class);
 
         $meta = $this->em->getMetadataFactory()->getCacheDriver()->fetch(
-            'Gedmo\\Tests\\Tree\\Fixture\\Closure\\CategoryClosureWithoutMapping$CLASSMETADATA'
+            'Gedmo__Tests__Tree__Fixture__Closure__CategoryClosureWithoutMapping__CLASSMETADATA__'
         );
+        static::assertNotFalse($meta);
         static::assertTrue($meta->hasAssociation('ancestor'));
         static::assertTrue($meta->hasAssociation('descendant'));
     }

--- a/tests/Gedmo/Mapping/TreeMappingTest.php
+++ b/tests/Gedmo/Mapping/TreeMappingTest.php
@@ -87,13 +87,6 @@ final class TreeMappingTest extends ORMMappingTestCase
         $this->em->getClassMetadata(CategoryClosureWithoutMapping::class);
 
         $meta = $this->em->getMetadataFactory()->getCacheDriver()->fetch(
-            'Gedmo\\Tests\\Tree\\Fixture\\Closure\\CategoryClosureWithoutMapping$CLASSMETADATA'
-        );
-        static::assertNotFalse($meta);
-        static::assertTrue($meta->hasAssociation('ancestor'));
-        static::assertTrue($meta->hasAssociation('descendant'));
-
-        $meta = $this->em->getMetadataFactory()->getCacheDriver()->fetch(
             'Gedmo__Tests__Tree__Fixture__Closure__CategoryClosureWithoutMapping__CLASSMETADATA__'
         );
         static::assertNotFalse($meta);


### PR DESCRIPTION
Hi, I had this bug for a while: yesterday I found the issue and the solution, but then I found https://github.com/doctrine-extensions/DoctrineExtensions/pull/2390 that basically wipes the bug when you forward upgrade the code as documented.

Still I think it's worth fixing it: when running `./cli orm:schema-tool:update`, the order in which classes are loaded into metadatas changes the outcome of the cache. In particluar, [this file iterator](https://github.com/doctrine/persistence/blob/f8af155c1e7963f3d2b4415097d55757bbaa53d8/lib/Doctrine/Persistence/Mapping/Driver/AnnotationDriver.php#L211-L218) could read the Closure class before or after the reference class.

If the Closure class is read first, than the reference class loads `ancestor` and `descendant` properties only afterward, which must be updated in the cache too, but the key is different so it gets stored in a cache key that will never be read/used.

Using explicit fields like pointed out in https://github.com/doctrine-extensions/DoctrineExtensions/pull/2390 fixes the issue, but still it's better to also fix this until `v4` is out.