### PR TITLE
Fix link to CHANGELOG.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ pull request title.
   
 ## Changelog
 
-All updates must include an entry in the [Changelog](/changelog.md).
+All updates must include an entry in the [Changelog](/CHANGELOG.md).
 Put your entry in the `[Unreleased]` section at the top, under the
 corresponding Extension and Category.
 


### PR DESCRIPTION
Hi,

I was checking CONTRIBUTING.md and noticed that the link to CHANGELOG.md was broken. This PR fixes it.

Thanks!