### PR TITLE
Fix Deprecation notice `add "array" as a native return type` on the getSubscribedEvents()

### DIFF
--- a/src/AbstractTrackingListener.php
+++ b/src/AbstractTrackingListener.php
@@ -32,9 +32,9 @@ abstract class AbstractTrackingListener extends MappedEventSubscriber
     /**
      * Specifies the list of events to listen on.
      *
-     * @return string[]
+     * @return array
      */
-    public function getSubscribedEvents()
+    public function getSubscribedEvents():array
     {
         return [
             'prePersist',

--- a/src/Loggable/LoggableListener.php
+++ b/src/Loggable/LoggableListener.php
@@ -89,7 +89,7 @@ class LoggableListener extends MappedEventSubscriber
     /**
      * @return string[]
      */
-    public function getSubscribedEvents()
+    public function getSubscribedEvents():array
     {
         return [
             'onFlush',

--- a/src/ReferenceIntegrity/ReferenceIntegrityListener.php
+++ b/src/ReferenceIntegrity/ReferenceIntegrityListener.php
@@ -24,9 +24,9 @@ use Gedmo\ReferenceIntegrity\Mapping\Validator;
 class ReferenceIntegrityListener extends MappedEventSubscriber
 {
     /**
-     * @return string[]
+     * @return array
      */
-    public function getSubscribedEvents()
+    public function getSubscribedEvents():array
     {
         return [
             'loadClassMetadata',

--- a/src/References/ReferencesListener.php
+++ b/src/References/ReferencesListener.php
@@ -135,9 +135,9 @@ class ReferencesListener extends MappedEventSubscriber
     }
 
     /**
-     * @return string[]
+     * @return array
      */
-    public function getSubscribedEvents()
+    public function getSubscribedEvents():array
     {
         return [
             'postLoad',

--- a/src/Sluggable/SluggableListener.php
+++ b/src/Sluggable/SluggableListener.php
@@ -79,9 +79,9 @@ class SluggableListener extends MappedEventSubscriber
     /**
      * Specifies the list of events to listen
      *
-     * @return string[]
+     * @return array
      */
-    public function getSubscribedEvents()
+    public function getSubscribedEvents():array
     {
         return [
             'onFlush',

--- a/src/SoftDeleteable/SoftDeleteableListener.php
+++ b/src/SoftDeleteable/SoftDeleteableListener.php
@@ -37,9 +37,9 @@ class SoftDeleteableListener extends MappedEventSubscriber
     public const POST_SOFT_DELETE = 'postSoftDelete';
 
     /**
-     * @return string[]
+     * @return array
      */
-    public function getSubscribedEvents()
+    public function getSubscribedEvents():array
     {
         return [
             'loadClassMetadata',

--- a/src/Sortable/SortableListener.php
+++ b/src/Sortable/SortableListener.php
@@ -43,9 +43,9 @@ class SortableListener extends MappedEventSubscriber
     /**
      * Specifies the list of events to listen
      *
-     * @return string[]
+     * @return array
      */
-    public function getSubscribedEvents()
+    public function getSubscribedEvents():array
     {
         return [
             'onFlush',

--- a/src/Translatable/TranslatableListener.php
+++ b/src/Translatable/TranslatableListener.php
@@ -122,9 +122,9 @@ class TranslatableListener extends MappedEventSubscriber
     /**
      * Specifies the list of events to listen
      *
-     * @return string[]
+     * @return array
      */
-    public function getSubscribedEvents()
+    public function getSubscribedEvents():array
     {
         return [
             'postLoad',

--- a/src/Tree/TreeListener.php
+++ b/src/Tree/TreeListener.php
@@ -47,9 +47,9 @@ class TreeListener extends MappedEventSubscriber
     /**
      * Specifies the list of events to listen
      *
-     * @return string[]
+     * @return array
      */
-    public function getSubscribedEvents()
+    public function getSubscribedEvents():array
     {
         return [
             'prePersist',

--- a/src/Uploadable/UploadableListener.php
+++ b/src/Uploadable/UploadableListener.php
@@ -92,9 +92,9 @@ class UploadableListener extends MappedEventSubscriber
     }
 
     /**
-     * @return string[]
+     * @return array
      */
-    public function getSubscribedEvents()
+    public function getSubscribedEvents():array
     {
         return [
             'loadClassMetadata',


### PR DESCRIPTION
On Symfony 5.4, I have dozens of Deprecation notice.  e.g. : 

`
php.INFO: User Deprecated: Method "Doctrine\Common\EventSubscriber::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Gedmo\Loggable\LoggableListener" now to avoid errors or add an explicit @return annotation to suppress this message. {"exception":"[object] (ErrorException(code: 0): User Deprecated: Method \"Doctrine\\Common\\EventSubscriber::getSubscribedEvents()\" might add \"array\" as a native return type declaration in the future. Do the same in implementation \"Gedmo\\Loggable\\LoggableListener\" now to avoid errors or add an explicit @return annotation to suppress this message. at /app/vendor/symfony/error-handler/DebugClassLoader.php:325)"} []`

This pull request fix these deprecations adding a `: array` to every `getSubscribedEvents()` method declared in the Listeners classes.

