### PR TITLE
[Bleameable, Loggable] Update user identifier determination logic

### DIFF
--- a/src/Blameable/BlameableListener.php
+++ b/src/Blameable/BlameableListener.php
@@ -44,8 +44,11 @@ class BlameableListener extends AbstractTrackingListener
             return $this->user;
         }
 
-        // ok so its not an association, then it is a string
+        // ok so it's not an association, then it is a string, or an object
         if (is_object($this->user)) {
+            if (method_exists($this->user, 'getUserIdentifier')) {
+                return (string) $this->user->getUserIdentifier();
+            }
             if (method_exists($this->user, 'getUsername')) {
                 return (string) $this->user->getUsername();
             }
@@ -53,7 +56,7 @@ class BlameableListener extends AbstractTrackingListener
                 return $this->user->__toString();
             }
 
-            throw new InvalidArgumentException('Field expects string, user must be a string, or object should have method getUsername or __toString');
+            throw new InvalidArgumentException('Field expects string, user must be a string, or object should have method getUserIdentifier, getUsername or __toString');
         }
 
         return $this->user;

--- a/src/Loggable/LoggableListener.php
+++ b/src/Loggable/LoggableListener.php
@@ -81,8 +81,10 @@ class LoggableListener extends MappedEventSubscriber
             $this->username = (string) $username->getUserIdentifier();
         } elseif (is_object($username) && method_exists($username, 'getUsername')) {
             $this->username = (string) $username->getUsername();
+        } elseif (is_object($username) && method_exists($username, '__toString')) {
+            $this->username = $username->__toString();
         } else {
-            throw new \Gedmo\Exception\InvalidArgumentException('Username must be a string, or object should have method: getUsername');
+            throw new \Gedmo\Exception\InvalidArgumentException('Username must be a string, or object should have method getUserIdentifier, getUsername or __toString');
         }
     }
 


### PR DESCRIPTION

Closes #2424
with the addition of `getUserIdentifier()` support to `BlameableListener`


additionally to that, I imagined it didn't make a lot of sense for this logic to be different between the two
(hope I'm not mistaken.. - or could it be an idea to move it somewhere, re-usable?)

so, in `LoggableListener` I've also ported the support for stringable objects (addition of `__toString` support) already available in  BlameableListener

