### PR TITLE
Sortable - clean relocations

### DIFF
--- a/src/Sortable/SortableListener.php
+++ b/src/Sortable/SortableListener.php
@@ -528,6 +528,7 @@ class SortableListener extends MappedEventSubscriber
                     continue;
                 }
                 $ea->updatePositions($relocation, $delta, $config);
+                unset($this->relocations[$hash]['deltas'][$deltaKey]);
             }
         }
 


### PR DESCRIPTION
Avoid doing relocations multiple times
Bug found in a personal project when setting manually a position.