### PR TITLE
Sortable - clean relocation delta

### DIFF
--- a/src/Sortable/SortableListener.php
+++ b/src/Sortable/SortableListener.php
@@ -523,11 +523,12 @@ class SortableListener extends MappedEventSubscriber
         $em = $ea->getObjectManager();
         foreach ($this->relocations as $hash => $relocation) {
             $config = $this->getConfiguration($em, $relocation['name']);
-            foreach ($relocation['deltas'] as $delta) {
+            foreach ($relocation['deltas'] as $deltaKey => $delta) {
                 if ($delta['start'] > $this->maxPositions[$hash] || 0 == $delta['delta']) {
                     continue;
                 }
                 $ea->updatePositions($relocation, $delta, $config);
+                unset($this->relocations[$hash]['deltas'][$deltaKey]);
             }
         }
 


### PR DESCRIPTION
Avoid doing relocations multiple times
Bug found in a personal project when setting manually a position.