### PR TITLE
[Sluggable] Add datetime_immutable as valid type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ a release.
 ---
 
 ## [Unreleased]
+#### Added
+- Sluggable: Add support for DateTimeImmutable fields
 
 #### Added
 - Tree: [NestedSet] `childrenQueryBuilder()` to allow specifying sort order separately for each field

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,6 @@ a release.
 ## [Unreleased]
 #### Added
 - Sluggable: Add support for DateTimeImmutable fields
-
-#### Added
 - Tree: [NestedSet] `childrenQueryBuilder()` to allow specifying sort order separately for each field
 - Tree: [NestedSet] Added option to reorder only direct children in `reorder()` method
 

--- a/src/Sluggable/Mapping/Driver/Annotation.php
+++ b/src/Sluggable/Mapping/Driver/Annotation.php
@@ -52,8 +52,12 @@ class Annotation extends AbstractAnnotationDriver
         'text',
         'integer',
         'int',
+        'date',
+        'date_immutable',
         'datetime',
+        'datetime_immutable',
         'datetimetz',
+        'datetimetz_immutable',
         'citext',
     ];
 

--- a/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDate.php
+++ b/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDate.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Sluggable\Fixture\DateTimeTypes;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Gedmo\Sluggable\Sluggable;
+
+/**
+ * @ORM\Entity
+ */
+#[ORM\Entity]
+class ArticleDate implements Sluggable
+{
+    /**
+     * @var int|null
+     *
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    private $id;
+
+    /**
+     * @var string|null
+     *
+     * @ORM\Column(name="title", type="string", length=64)
+     */
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
+    private $title;
+
+    /**
+     * @var \DateTime|null
+     *
+     * @ORM\Column(name="created_at", type="date")
+     */
+    #[ORM\Column(name: 'created_at', type: Types::DATE_MUTABLE)]
+    private $createdAt;
+
+    /**
+     * @var string|null
+     *
+     * @Gedmo\Slug(separator="-", updatable=true, fields={"title", "createdAt"}, dateFormat="Y-m-d")
+     * @ORM\Column(name="slug", type="string", length=64, unique=true)
+     */
+    #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title', 'createdAt'], dateFormat: 'Y-m-d')]
+    #[ORM\Column(name: 'slug', type: Types::STRING, length: 64, unique: true)]
+    private $slug;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setTitle(?string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setCreatedAt(?\DateTime $createdAt): void
+    {
+        $this->createdAt = $createdAt;
+    }
+
+    public function getCreatedAt(): ?\DateTime
+    {
+        return $this->createdAt;
+    }
+
+    public function setSlug(?string $slug): void
+    {
+        $this->slug = $slug;
+    }
+
+    public function getSlug(): ?string
+    {
+        return $this->slug;
+    }
+}

--- a/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateImmutable.php
+++ b/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateImmutable.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Sluggable\Fixture\DateTimeTypes;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Gedmo\Sluggable\Sluggable;
+
+/**
+ * @ORM\Entity
+ */
+#[ORM\Entity]
+class ArticleDateImmutable implements Sluggable
+{
+    /**
+     * @var int|null
+     *
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    private $id;
+
+    /**
+     * @var string|null
+     *
+     * @ORM\Column(name="title", type="string", length=64)
+     */
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
+    private $title;
+
+    /**
+     * @var \DateTimeImmutable|null
+     *
+     * @ORM\Column(name="created_at", type="date_immutable")
+     */
+    #[ORM\Column(name: 'created_at', type: Types::DATE_IMMUTABLE)]
+    private $createdAt;
+
+    /**
+     * @var string|null
+     *
+     * @Gedmo\Slug(separator="-", updatable=true, fields={"title", "createdAt"}, dateFormat="Y-m-d")
+     * @ORM\Column(name="slug", type="string", length=64, unique=true)
+     */
+    #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title', 'createdAt'], dateFormat: 'Y-m-d')]
+    #[ORM\Column(name: 'slug', type: Types::STRING, length: 64, unique: true)]
+    private $slug;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setTitle(?string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setCreatedAt(?\DateTimeImmutable $createdAt): void
+    {
+        $this->createdAt = $createdAt;
+    }
+
+    public function getCreatedAt(): ?\DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function setSlug(?string $slug): void
+    {
+        $this->slug = $slug;
+    }
+
+    public function getSlug(): ?string
+    {
+        return $this->slug;
+    }
+}

--- a/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateTime.php
+++ b/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateTime.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Sluggable\Fixture\DateTimeTypes;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Gedmo\Sluggable\Sluggable;
+
+/**
+ * @ORM\Entity
+ */
+#[ORM\Entity]
+class ArticleDateTime implements Sluggable
+{
+    /**
+     * @var int|null
+     *
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    private $id;
+
+    /**
+     * @var string|null
+     *
+     * @ORM\Column(name="title", type="string", length=64)
+     */
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
+    private $title;
+
+    /**
+     * @var \DateTime|null
+     *
+     * @ORM\Column(name="created_at", type="datetime")
+     */
+    #[ORM\Column(name: 'created_at', type: Types::DATETIME_MUTABLE)]
+    private $createdAt;
+
+    /**
+     * @var string|null
+     *
+     * @Gedmo\Slug(separator="-", updatable=true, fields={"title", "createdAt"}, dateFormat="Y-m-d")
+     * @ORM\Column(name="slug", type="string", length=64, unique=true)
+     */
+    #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title', 'createdAt'], dateFormat: 'Y-m-d')]
+    #[ORM\Column(name: 'slug', type: Types::STRING, length: 64, unique: true)]
+    private $slug;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setTitle(?string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setCreatedAt(?\DateTime $createdAt): void
+    {
+        $this->createdAt = $createdAt;
+    }
+
+    public function getCreatedAt(): ?\DateTime
+    {
+        return $this->createdAt;
+    }
+
+    public function setSlug(?string $slug): void
+    {
+        $this->slug = $slug;
+    }
+
+    public function getSlug(): ?string
+    {
+        return $this->slug;
+    }
+}

--- a/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateTimeImmutable.php
+++ b/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateTimeImmutable.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Sluggable\Fixture\DateTimeTypes;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Gedmo\Sluggable\Sluggable;
+
+/**
+ * @ORM\Entity
+ */
+#[ORM\Entity]
+class ArticleDateTimeImmutable implements Sluggable
+{
+    /**
+     * @var int|null
+     *
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    private $id;
+
+    /**
+     * @var string|null
+     *
+     * @ORM\Column(name="title", type="string", length=64)
+     */
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
+    private $title;
+
+    /**
+     * @var \DateTimeImmutable|null
+     *
+     * @ORM\Column(name="created_at", type="datetime_immutable")
+     */
+    #[ORM\Column(name: 'created_at', type: Types::DATETIME_IMMUTABLE)]
+    private $createdAt;
+
+    /**
+     * @var string|null
+     *
+     * @Gedmo\Slug(separator="-", updatable=true, fields={"title", "createdAt"}, dateFormat="Y-m-d")
+     * @ORM\Column(name="slug", type="string", length=64, unique=true)
+     */
+    #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title', 'createdAt'], dateFormat: 'Y-m-d')]
+    #[ORM\Column(name: 'slug', type: Types::STRING, length: 64, unique: true)]
+    private $slug;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setTitle(?string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setCreatedAt(?\DateTimeImmutable $createdAt): void
+    {
+        $this->createdAt = $createdAt;
+    }
+
+    public function getCreatedAt(): ?\DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function setSlug(?string $slug): void
+    {
+        $this->slug = $slug;
+    }
+
+    public function getSlug(): ?string
+    {
+        return $this->slug;
+    }
+}

--- a/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateTimeTz.php
+++ b/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateTimeTz.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Sluggable\Fixture\DateTimeTypes;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Gedmo\Sluggable\Sluggable;
+
+/**
+ * @ORM\Entity
+ */
+#[ORM\Entity]
+class ArticleDateTimeTz implements Sluggable
+{
+    /**
+     * @var int|null
+     *
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    private $id;
+
+    /**
+     * @var string|null
+     *
+     * @ORM\Column(name="title", type="string", length=64)
+     */
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
+    private $title;
+
+    /**
+     * @var \DateTime|null
+     *
+     * @ORM\Column(name="created_at", type="datetimetz")
+     */
+    #[ORM\Column(name: 'created_at', type: Types::DATETIMETZ_MUTABLE)]
+    private $createdAt;
+
+    /**
+     * @var string|null
+     *
+     * @Gedmo\Slug(separator="-", updatable=true, fields={"title", "createdAt"}, dateFormat="Y-m-d")
+     * @ORM\Column(name="slug", type="string", length=64, unique=true)
+     */
+    #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title', 'createdAt'], dateFormat: 'Y-m-d')]
+    #[ORM\Column(name: 'slug', type: Types::STRING, length: 64, unique: true)]
+    private $slug;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setTitle(?string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setCreatedAt(?\DateTime $createdAt): void
+    {
+        $this->createdAt = $createdAt;
+    }
+
+    public function getCreatedAt(): ?\DateTime
+    {
+        return $this->createdAt;
+    }
+
+    public function setSlug(?string $slug): void
+    {
+        $this->slug = $slug;
+    }
+
+    public function getSlug(): ?string
+    {
+        return $this->slug;
+    }
+}

--- a/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateTimeTzImmutable.php
+++ b/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateTimeTzImmutable.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Sluggable\Fixture\DateTimeTypes;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Gedmo\Sluggable\Sluggable;
+
+/**
+ * @ORM\Entity
+ */
+#[ORM\Entity]
+class ArticleDateTimeTzImmutable implements Sluggable
+{
+    /**
+     * @var int|null
+     *
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    private $id;
+
+    /**
+     * @var string|null
+     *
+     * @ORM\Column(name="title", type="string", length=64)
+     */
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
+    private $title;
+
+    /**
+     * @var \DateTimeImmutable|null
+     *
+     * @ORM\Column(name="created_at", type="datetimetz_immutable")
+     */
+    #[ORM\Column(name: 'created_at', type: Types::DATETIMETZ_IMMUTABLE)]
+    private $createdAt;
+
+    /**
+     * @var string|null
+     *
+     * @Gedmo\Slug(separator="-", updatable=true, fields={"title", "createdAt"}, dateFormat="Y-m-d")
+     * @ORM\Column(name="slug", type="string", length=64, unique=true)
+     */
+    #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title', 'createdAt'], dateFormat: 'Y-m-d')]
+    #[ORM\Column(name: 'slug', type: Types::STRING, length: 64, unique: true)]
+    private $slug;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setTitle(?string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setCreatedAt(?\DateTimeImmutable $createdAt): void
+    {
+        $this->createdAt = $createdAt;
+    }
+
+    public function getCreatedAt(): ?\DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function setSlug(?string $slug): void
+    {
+        $this->slug = $slug;
+    }
+
+    public function getSlug(): ?string
+    {
+        return $this->slug;
+    }
+}

--- a/tests/Gedmo/Sluggable/SluggableDateTimeTypesTest.php
+++ b/tests/Gedmo/Sluggable/SluggableDateTimeTypesTest.php
@@ -1,0 +1,286 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Sluggable;
+
+use Doctrine\Common\EventManager;
+use Gedmo\Sluggable\Sluggable;
+use Gedmo\Sluggable\SluggableListener;
+use Gedmo\Tests\Sluggable\Fixture\DateTimeTypes\ArticleDate;
+use Gedmo\Tests\Sluggable\Fixture\DateTimeTypes\ArticleDateImmutable;
+use Gedmo\Tests\Sluggable\Fixture\DateTimeTypes\ArticleDateTime;
+use Gedmo\Tests\Sluggable\Fixture\DateTimeTypes\ArticleDateTimeImmutable;
+use Gedmo\Tests\Sluggable\Fixture\DateTimeTypes\ArticleDateTimeTz;
+use Gedmo\Tests\Sluggable\Fixture\DateTimeTypes\ArticleDateTimeTzImmutable;
+use Gedmo\Tests\Tool\BaseTestCaseORM;
+
+/**
+ * These are tests for sluggable behavior
+ *
+ * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ */
+final class SluggableDateTimeTypesTest extends BaseTestCaseORM
+{
+    public const ARTICLE_DATE = ArticleDate::class;
+    public const ARTICLE_DATE_IMMUTABLE = ArticleDateImmutable::class;
+    public const ARTICLE_DATETIME = ArticleDateTime::class;
+    public const ARTICLE_DATETIME_IMMUTABLE = ArticleDateTimeImmutable::class;
+    public const ARTICLE_DATETIME_TZ = ArticleDateTimeTz::class;
+    public const ARTICLE_DATETIME_TZ_IMMUTABLE = ArticleDateTimeTzImmutable::class;
+
+    /**
+     * @var int|null
+     */
+    private $articleId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $evm = new EventManager();
+        $evm->addEventSubscriber(new SluggableListener());
+
+        $this->getDefaultMockSqliteEntityManager($evm);
+        $this->populate();
+    }
+
+    public function testShouldInsertNewSlug(): void
+    {
+        $article = $this->em->find(self::ARTICLE_DATETIME_IMMUTABLE, $this->articleId);
+
+        static::assertInstanceOf(Sluggable::class, $article);
+        static::assertSame('the-title-2022-04-01', $article->getSlug());
+    }
+
+    public function testShouldBuildUniqueSlug(): void
+    {
+        for ($i = 0; $i < 12; ++$i) {
+            $article = new ArticleDateTimeImmutable();
+            $article->setTitle('the title');
+            $article->setCreatedAt(new \DateTimeImmutable('2022-04-01'));
+
+            $this->em->persist($article);
+            $this->em->flush();
+            $this->em->clear();
+            static::assertSame($article->getSlug(), 'the-title-2022-04-01-'.($i + 1));
+        }
+    }
+
+    public function testShouldBuildSlugWithAllDateTimeTypes(): void
+    {
+        $articleDate = new ArticleDate();
+        $articleDate->setTitle('the title');
+        $articleDate->setCreatedAt(new \DateTime('2022-04-01'));
+
+        $this->em->persist($articleDate);
+        $this->em->flush();
+        $this->em->clear();
+        static::assertSame('the-title-2022-04-01', $articleDate->getSlug(), 'with date');
+
+        $articleDateImmutable = new ArticleDateImmutable();
+        $articleDateImmutable->setTitle('the title');
+        $articleDateImmutable->setCreatedAt(new \DateTimeImmutable('2022-04-01'));
+
+        $this->em->persist($articleDateImmutable);
+        $this->em->flush();
+        $this->em->clear();
+        static::assertSame('the-title-2022-04-01', $articleDateImmutable->getSlug(), 'with date_immutable');
+
+        $articleDateTime = new ArticleDateTime();
+        $articleDateTime->setTitle('the title');
+        $articleDateTime->setCreatedAt(new \DateTime('2022-04-01'));
+
+        $this->em->persist($articleDateTime);
+        $this->em->flush();
+        $this->em->clear();
+        static::assertSame('the-title-2022-04-01', $articleDateTime->getSlug(), 'with datetime');
+
+        $articleDateTimeImmutable = new ArticleDateTimeImmutable();
+        $articleDateTimeImmutable->setTitle('the title');
+        $articleDateTimeImmutable->setCreatedAt(new \DateTimeImmutable('2022-04-01'));
+
+        $this->em->persist($articleDateTimeImmutable);
+        $this->em->flush();
+        $this->em->clear();
+        static::assertSame('the-title-2022-04-01-1', $articleDateTimeImmutable->getSlug(), 'with datetime_immutable');
+
+        $articleDateTimeTz = new ArticleDateTimeTz();
+        $articleDateTimeTz->setTitle('the title');
+        $articleDateTimeTz->setCreatedAt(new \DateTime('2022-04-01'));
+
+        $this->em->persist($articleDateTimeTz);
+        $this->em->flush();
+        $this->em->clear();
+        static::assertSame('the-title-2022-04-01', $articleDateTimeTz->getSlug(), 'with datetimetz');
+
+        $articleDateTimeTzImmutable = new ArticleDateTimeTzImmutable();
+        $articleDateTimeTzImmutable->setTitle('the title');
+        $articleDateTimeTzImmutable->setCreatedAt(new \DateTimeImmutable('2022-04-01'));
+
+        $this->em->persist($articleDateTimeTzImmutable);
+        $this->em->flush();
+        $this->em->clear();
+        static::assertSame('the-title-2022-04-01', $articleDateTimeTzImmutable->getSlug(), 'with datetimetz_immutable');
+    }
+
+    public function testShouldHandleUniqueSlugLimitedLength(): void
+    {
+        $long = 'the title the title the title the title the title the title the title';
+        $article = new ArticleDateTimeImmutable();
+        $article->setTitle($long);
+        $article->setCreatedAt(new \DateTimeImmutable('2022-04-01'));
+
+        $this->em->persist($article);
+        $this->em->flush();
+        $this->em->clear();
+        for ($i = 1; $i <= 12; ++$i) {
+            $uniqueSuffix = (string) $i;
+
+            $article = new ArticleDateTimeImmutable();
+            $article->setTitle($long);
+            $article->setCreatedAt(new \DateTimeImmutable('2022-04-01'));
+
+            $this->em->persist($article);
+            $this->em->flush();
+            $this->em->clear();
+
+            $shorten = $article->getSlug();
+            static::assertSame(64, strlen($shorten));
+            $expected = 'the-title-the-title-the-title-the-title-the-title-the-title-the-';
+            $expected = substr($expected, 0, 64 - (strlen($uniqueSuffix) + 1)).'-'.$uniqueSuffix;
+            static::assertSame($shorten, $expected);
+        }
+    }
+
+    public function testDoubleDelimiterShouldBeRemoved(): void
+    {
+        $long = 'Sample long title which should be correctly slugged blablabla';
+        $article = new ArticleDateTimeImmutable();
+        $article->setTitle($long);
+        $article->setCreatedAt(new \DateTimeImmutable('2022-04-01'));
+        $article2 = new ArticleDateTimeImmutable();
+        $article2->setTitle($long);
+        $article2->setCreatedAt(new \DateTimeImmutable('2022-04-01'));
+
+        $this->em->persist($article);
+        $this->em->persist($article2);
+        $this->em->flush();
+        $this->em->clear();
+        static::assertSame('sample-long-title-which-should-be-correctly-slugged-blablabla-20', $article->getSlug());
+        // OLD IMPLEMENTATION PRODUCE SLUG sample-long-title-which-should-be-correctly-slugged-blablabla--1
+        static::assertSame('sample-long-title-which-should-be-correctly-slugged-blablabla-1', $article2->getSlug());
+    }
+
+    public function testShouldUpdateSlug(): void
+    {
+        $article = $this->em->find(self::ARTICLE_DATETIME_IMMUTABLE, $this->articleId);
+        $article->setTitle('the title updated');
+        $this->em->persist($article);
+        $this->em->flush();
+
+        static::assertSame('the-title-updated-2022-04-01', $article->getSlug());
+    }
+
+    public function testShouldBeAbleToForceRegenerationOfSlug(): void
+    {
+        $article = $this->em->find(self::ARTICLE_DATETIME_IMMUTABLE, $this->articleId);
+        $article->setSlug(null);
+        $this->em->persist($article);
+        $this->em->flush();
+
+        static::assertSame('the-title-2022-04-01', $article->getSlug());
+    }
+
+    public function testShouldBeAbleToForceTheSlug(): void
+    {
+        $article = $this->em->find(self::ARTICLE_DATETIME_IMMUTABLE, $this->articleId);
+        $article->setSlug('my-forced-slug');
+        $this->em->persist($article);
+
+        $new = new ArticleDateTimeImmutable();
+        $new->setTitle('hey');
+        $new->setCreatedAt(new \DateTimeImmutable('2022-04-01'));
+        $new->setSlug('forced');
+        $this->em->persist($new);
+
+        $this->em->flush();
+        static::assertSame('my-forced-slug', $article->getSlug());
+        static::assertSame('forced', $new->getSlug());
+    }
+
+    public function testShouldSolveGithubIssue45(): void
+    {
+        // persist new records with same slug
+        $article = new ArticleDateTimeImmutable();
+        $article->setTitle('test');
+        $article->setCreatedAt(new \DateTimeImmutable('2022-04-01'));
+        $this->em->persist($article);
+
+        $article2 = new ArticleDateTimeImmutable();
+        $article2->setTitle('test');
+        $article2->setCreatedAt(new \DateTimeImmutable('2022-04-01'));
+        $this->em->persist($article2);
+
+        $this->em->flush();
+        static::assertSame('test-2022-04-01', $article->getSlug());
+        static::assertSame('test-2022-04-01-1', $article2->getSlug());
+    }
+
+    public function testShouldAllowForcingEmptySlugAndRegenerateIfNullIssue807(): void
+    {
+        $article = $this->em->find(self::ARTICLE_DATETIME_IMMUTABLE, $this->articleId);
+        $article->setSlug('');
+
+        $this->em->persist($article);
+        $this->em->flush();
+
+        static::assertSame('', $article->getSlug());
+        $article->setSlug(null);
+
+        $this->em->persist($article);
+        $this->em->flush();
+
+        static::assertSame('the-title-2022-04-01', $article->getSlug());
+
+        $same = new ArticleDateTimeImmutable();
+        $same->setTitle('any');
+        $same->setCreatedAt(new \DateTimeImmutable('2022-04-01'));
+        $same->setSlug('the-title-2022-04-01');
+        $this->em->persist($same);
+        $this->em->flush();
+
+        static::assertSame('the-title-2022-04-01-1', $same->getSlug());
+    }
+
+    protected function getUsedEntityFixtures(): array
+    {
+        return [
+            self::ARTICLE_DATE,
+            self::ARTICLE_DATE_IMMUTABLE,
+            self::ARTICLE_DATETIME,
+            self::ARTICLE_DATETIME_IMMUTABLE,
+            self::ARTICLE_DATETIME_TZ,
+            self::ARTICLE_DATETIME_TZ_IMMUTABLE,
+        ];
+    }
+
+    private function populate(): void
+    {
+        $article = new ArticleDateTimeImmutable();
+        $article->setTitle('the title');
+        $article->setCreatedAt(new \DateTimeImmutable('2022-04-01'));
+
+        $this->em->persist($article);
+        $this->em->flush();
+        $this->em->clear();
+        $this->articleId = $article->getId();
+    }
+}

--- a/tests/Gedmo/Sluggable/SluggableDateTimeTypesTest.php
+++ b/tests/Gedmo/Sluggable/SluggableDateTimeTypesTest.php
@@ -36,11 +36,6 @@ final class SluggableDateTimeTypesTest extends BaseTestCaseORM
     public const ARTICLE_DATETIME_TZ = ArticleDateTimeTz::class;
     public const ARTICLE_DATETIME_TZ_IMMUTABLE = ArticleDateTimeTzImmutable::class;
 
-    /**
-     * @var int|null
-     */
-    private $articleId;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -49,29 +44,6 @@ final class SluggableDateTimeTypesTest extends BaseTestCaseORM
         $evm->addEventSubscriber(new SluggableListener());
 
         $this->getDefaultMockSqliteEntityManager($evm);
-        $this->populate();
-    }
-
-    public function testShouldInsertNewSlug(): void
-    {
-        $article = $this->em->find(self::ARTICLE_DATETIME_IMMUTABLE, $this->articleId);
-
-        static::assertInstanceOf(Sluggable::class, $article);
-        static::assertSame('the-title-2022-04-01', $article->getSlug());
-    }
-
-    public function testShouldBuildUniqueSlug(): void
-    {
-        for ($i = 0; $i < 12; ++$i) {
-            $article = new ArticleDateTimeImmutable();
-            $article->setTitle('the title');
-            $article->setCreatedAt(new \DateTimeImmutable('2022-04-01'));
-
-            $this->em->persist($article);
-            $this->em->flush();
-            $this->em->clear();
-            static::assertSame($article->getSlug(), 'the-title-2022-04-01-'.($i + 1));
-        }
     }
 
     public function testShouldBuildSlugWithAllDateTimeTypes(): void
@@ -110,7 +82,7 @@ final class SluggableDateTimeTypesTest extends BaseTestCaseORM
         $this->em->persist($articleDateTimeImmutable);
         $this->em->flush();
         $this->em->clear();
-        static::assertSame('the-title-2022-04-01-1', $articleDateTimeImmutable->getSlug(), 'with datetime_immutable');
+        static::assertSame('the-title-2022-04-01', $articleDateTimeImmutable->getSlug(), 'with datetime_immutable');
 
         $articleDateTimeTz = new ArticleDateTimeTz();
         $articleDateTimeTz->setTitle('the title');
@@ -131,135 +103,6 @@ final class SluggableDateTimeTypesTest extends BaseTestCaseORM
         static::assertSame('the-title-2022-04-01', $articleDateTimeTzImmutable->getSlug(), 'with datetimetz_immutable');
     }
 
-    public function testShouldHandleUniqueSlugLimitedLength(): void
-    {
-        $long = 'the title the title the title the title the title the title the title';
-        $article = new ArticleDateTimeImmutable();
-        $article->setTitle($long);
-        $article->setCreatedAt(new \DateTimeImmutable('2022-04-01'));
-
-        $this->em->persist($article);
-        $this->em->flush();
-        $this->em->clear();
-        for ($i = 1; $i <= 12; ++$i) {
-            $uniqueSuffix = (string) $i;
-
-            $article = new ArticleDateTimeImmutable();
-            $article->setTitle($long);
-            $article->setCreatedAt(new \DateTimeImmutable('2022-04-01'));
-
-            $this->em->persist($article);
-            $this->em->flush();
-            $this->em->clear();
-
-            $shorten = $article->getSlug();
-            static::assertSame(64, strlen($shorten));
-            $expected = 'the-title-the-title-the-title-the-title-the-title-the-title-the-';
-            $expected = substr($expected, 0, 64 - (strlen($uniqueSuffix) + 1)).'-'.$uniqueSuffix;
-            static::assertSame($shorten, $expected);
-        }
-    }
-
-    public function testDoubleDelimiterShouldBeRemoved(): void
-    {
-        $long = 'Sample long title which should be correctly slugged blablabla';
-        $article = new ArticleDateTimeImmutable();
-        $article->setTitle($long);
-        $article->setCreatedAt(new \DateTimeImmutable('2022-04-01'));
-        $article2 = new ArticleDateTimeImmutable();
-        $article2->setTitle($long);
-        $article2->setCreatedAt(new \DateTimeImmutable('2022-04-01'));
-
-        $this->em->persist($article);
-        $this->em->persist($article2);
-        $this->em->flush();
-        $this->em->clear();
-        static::assertSame('sample-long-title-which-should-be-correctly-slugged-blablabla-20', $article->getSlug());
-        // OLD IMPLEMENTATION PRODUCE SLUG sample-long-title-which-should-be-correctly-slugged-blablabla--1
-        static::assertSame('sample-long-title-which-should-be-correctly-slugged-blablabla-1', $article2->getSlug());
-    }
-
-    public function testShouldUpdateSlug(): void
-    {
-        $article = $this->em->find(self::ARTICLE_DATETIME_IMMUTABLE, $this->articleId);
-        $article->setTitle('the title updated');
-        $this->em->persist($article);
-        $this->em->flush();
-
-        static::assertSame('the-title-updated-2022-04-01', $article->getSlug());
-    }
-
-    public function testShouldBeAbleToForceRegenerationOfSlug(): void
-    {
-        $article = $this->em->find(self::ARTICLE_DATETIME_IMMUTABLE, $this->articleId);
-        $article->setSlug(null);
-        $this->em->persist($article);
-        $this->em->flush();
-
-        static::assertSame('the-title-2022-04-01', $article->getSlug());
-    }
-
-    public function testShouldBeAbleToForceTheSlug(): void
-    {
-        $article = $this->em->find(self::ARTICLE_DATETIME_IMMUTABLE, $this->articleId);
-        $article->setSlug('my-forced-slug');
-        $this->em->persist($article);
-
-        $new = new ArticleDateTimeImmutable();
-        $new->setTitle('hey');
-        $new->setCreatedAt(new \DateTimeImmutable('2022-04-01'));
-        $new->setSlug('forced');
-        $this->em->persist($new);
-
-        $this->em->flush();
-        static::assertSame('my-forced-slug', $article->getSlug());
-        static::assertSame('forced', $new->getSlug());
-    }
-
-    public function testShouldSolveGithubIssue45(): void
-    {
-        // persist new records with same slug
-        $article = new ArticleDateTimeImmutable();
-        $article->setTitle('test');
-        $article->setCreatedAt(new \DateTimeImmutable('2022-04-01'));
-        $this->em->persist($article);
-
-        $article2 = new ArticleDateTimeImmutable();
-        $article2->setTitle('test');
-        $article2->setCreatedAt(new \DateTimeImmutable('2022-04-01'));
-        $this->em->persist($article2);
-
-        $this->em->flush();
-        static::assertSame('test-2022-04-01', $article->getSlug());
-        static::assertSame('test-2022-04-01-1', $article2->getSlug());
-    }
-
-    public function testShouldAllowForcingEmptySlugAndRegenerateIfNullIssue807(): void
-    {
-        $article = $this->em->find(self::ARTICLE_DATETIME_IMMUTABLE, $this->articleId);
-        $article->setSlug('');
-
-        $this->em->persist($article);
-        $this->em->flush();
-
-        static::assertSame('', $article->getSlug());
-        $article->setSlug(null);
-
-        $this->em->persist($article);
-        $this->em->flush();
-
-        static::assertSame('the-title-2022-04-01', $article->getSlug());
-
-        $same = new ArticleDateTimeImmutable();
-        $same->setTitle('any');
-        $same->setCreatedAt(new \DateTimeImmutable('2022-04-01'));
-        $same->setSlug('the-title-2022-04-01');
-        $this->em->persist($same);
-        $this->em->flush();
-
-        static::assertSame('the-title-2022-04-01-1', $same->getSlug());
-    }
-
     protected function getUsedEntityFixtures(): array
     {
         return [
@@ -270,17 +113,5 @@ final class SluggableDateTimeTypesTest extends BaseTestCaseORM
             self::ARTICLE_DATETIME_TZ,
             self::ARTICLE_DATETIME_TZ_IMMUTABLE,
         ];
-    }
-
-    private function populate(): void
-    {
-        $article = new ArticleDateTimeImmutable();
-        $article->setTitle('the title');
-        $article->setCreatedAt(new \DateTimeImmutable('2022-04-01'));
-
-        $this->em->persist($article);
-        $this->em->flush();
-        $this->em->clear();
-        $this->articleId = $article->getId();
     }
 }


### PR DESCRIPTION
Slug fields already allow datetime and datetimez, all Doctrine date type variations that instanciate \DateTime and \DateTimeImmutable objects should work either.

## [Unreleased]
### Sluggable
#### Added
- Add support for DateTimeImmutable fields