### PR TITLE
[Sortable] Fix duplicated position when position for more than one object is changed manually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,12 @@ a release.
 ---
 
 ## [Unreleased]
-###
-- Sortable: Fix duplicated positions when manually updating position on more than one object
 
 ### Fixed
 - Tree: Allow sorting children by a ManyToOne relation (#2492)
 - Tree: Fix passing `null` to `abs()` function
 - Timestampable: Use an attribute in Timestampable attribute docs
+- Sortable: Fix duplicated positions when manually updating position on more than one object
 
 ### Deprecated
 - Tree: Passing `null` as argument 8 to `Nested::shiftRangeRL()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ a release.
 ---
 
 ## [Unreleased]
+###
+- Sortable: Fix duplicated positions when manually updating position on more than one object
 
 ### Fixed
 - Tree: Allow sorting children by a ManyToOne relation (#2492)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -452,7 +452,7 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\<object\\>\\:\\:getReflectionProperty\\(\\)\\.$#"
-			count: 3
+			count: 4
 			path: src/Sortable/SortableListener.php
 
 		-

--- a/src/Sortable/Mapping/Event/Adapter/ORM.php
+++ b/src/Sortable/Mapping/Event/Adapter/ORM.php
@@ -36,7 +36,7 @@ final class ORM extends BaseAdapterORM implements SortableAdapter
         $em = $this->getObjectManager();
 
         $qb = $em->createQueryBuilder();
-        $qb->select('MAX(n.'.$config['position'].')')
+        $qb->select('COUNT(n.'.$config['position'].')')
            ->from($config['useObjectClass'], 'n');
         $this->addGroupWhere($qb, $meta, $groups);
         $query = $qb->getQuery();
@@ -44,7 +44,7 @@ final class ORM extends BaseAdapterORM implements SortableAdapter
         $query->disableResultCache();
         $res = $query->getResult();
 
-        return $res[0][1];
+        return $res[0][1] > 0 ? $res[0][1] - 1 : null;
     }
 
     /**

--- a/src/Sortable/Mapping/Event/Adapter/ORM.php
+++ b/src/Sortable/Mapping/Event/Adapter/ORM.php
@@ -36,7 +36,7 @@ final class ORM extends BaseAdapterORM implements SortableAdapter
         $em = $this->getObjectManager();
 
         $qb = $em->createQueryBuilder();
-        $qb->select('COUNT(n.'.$config['position'].')')
+        $qb->select('MAX(n.'.$config['position'].')')
            ->from($config['useObjectClass'], 'n');
         $this->addGroupWhere($qb, $meta, $groups);
         $query = $qb->getQuery();
@@ -44,7 +44,7 @@ final class ORM extends BaseAdapterORM implements SortableAdapter
         $query->disableResultCache();
         $res = $query->getResult();
 
-        return $res[0][1] > 0 ? $res[0][1] - 1 : null;
+        return $res[0][1];
     }
 
     /**

--- a/src/Sortable/SortableListener.php
+++ b/src/Sortable/SortableListener.php
@@ -122,12 +122,18 @@ class SortableListener extends MappedEventSubscriber
             }
         }
 
+        $updateValues = [];
         // process all objects being updated
         foreach ($ea->getScheduledObjectUpdates($uow) as $object) {
             $meta = $om->getClassMetadata(get_class($object));
             if ($config = $this->getConfiguration($om, $meta->getName())) {
-                $this->processUpdate($ea, $config, $meta, $object);
+                $position = $meta->getReflectionProperty($config['position'])->getValue($object);
+                $updateValues[$position] = [$ea, $config, $meta, $object];
             }
+        }
+        krsort($updateValues);
+        foreach ($updateValues as $updateValue) {
+            $this->processUpdate($updateValue[0], $updateValue[1], $updateValue[2], $updateValue[3]);
         }
 
         // process all objects being inserted
@@ -483,18 +489,6 @@ class SortableListener extends MappedEventSubscriber
         } elseif ($newPosition > $oldPosition) {
             $relocation = [$hash, $config['useObjectClass'], $groups, $oldPosition + 1, $newPosition + 1, -1];
         }
-
-        // Apply existing relocations
-        $applyDelta = 0;
-        if (isset($this->relocations[$hash])) {
-            foreach ($this->relocations[$hash]['deltas'] as $delta) {
-                if ($delta['start'] <= $newPosition
-                        && ($delta['stop'] > $newPosition || $delta['stop'] < 0)) {
-                    $applyDelta += $delta['delta'];
-                }
-            }
-        }
-        $newPosition += $applyDelta;
 
         if ($relocation) {
             // Add relocation

--- a/src/Sortable/SortableListener.php
+++ b/src/Sortable/SortableListener.php
@@ -132,8 +132,8 @@ class SortableListener extends MappedEventSubscriber
             }
         }
         krsort($updateValues);
-        foreach ($updateValues as $updateValue) {
-            $this->processUpdate($updateValue[0], $updateValue[1], $updateValue[2], $updateValue[3]);
+        foreach ($updateValues as [$ea, $config, $meta, $object]) {
+            $this->processUpdate($ea, $config, $meta, $object);
         }
 
         // process all objects being inserted

--- a/src/Sortable/SortableListener.php
+++ b/src/Sortable/SortableListener.php
@@ -63,6 +63,9 @@ class SortableListener extends MappedEventSubscriber
     /** @var array<string, int> */
     private $maxPositions = [];
 
+    /** @var array<string, int> */
+    private $changeDueToMaxPosition = [];
+
     /**
      * Specifies the list of events to listen
      *
@@ -132,8 +135,8 @@ class SortableListener extends MappedEventSubscriber
             }
         }
         krsort($updateValues);
-        foreach ($updateValues as $updateValue) {
-            $this->processUpdate($updateValue[0], $updateValue[1], $updateValue[2], $updateValue[3]);
+        foreach ($updateValues as [$ea, $config, $meta, $object]) {
+            $this->processUpdate($ea, $config, $meta, $object);
         }
 
         // process all objects being inserted
@@ -459,10 +462,11 @@ class SortableListener extends MappedEventSubscriber
             if ($groupHasChanged) {
                 $newPosition = $this->maxPositions[$hash] + 1;
             } else {
+                $this->changeDueToMaxPosition[$hash] = $newPosition - $this->maxPositions[$hash];
                 $newPosition = $this->maxPositions[$hash];
             }
         } else {
-            $newPosition = min([$this->maxPositions[$hash], $newPosition]);
+            $newPosition = min([$this->maxPositions[$hash] - ($this->changeDueToMaxPosition[$hash] ?? 0), $newPosition]);
         }
 
         // Compute relocations

--- a/src/Sortable/SortableListener.php
+++ b/src/Sortable/SortableListener.php
@@ -63,9 +63,6 @@ class SortableListener extends MappedEventSubscriber
     /** @var array<string, int> */
     private $maxPositions = [];
 
-    /** @var array<string, int> */
-    private $changeDueToMaxPosition = [];
-
     /**
      * Specifies the list of events to listen
      *
@@ -135,8 +132,8 @@ class SortableListener extends MappedEventSubscriber
             }
         }
         krsort($updateValues);
-        foreach ($updateValues as [$ea, $config, $meta, $object]) {
-            $this->processUpdate($ea, $config, $meta, $object);
+        foreach ($updateValues as $updateValue) {
+            $this->processUpdate($updateValue[0], $updateValue[1], $updateValue[2], $updateValue[3]);
         }
 
         // process all objects being inserted
@@ -462,11 +459,10 @@ class SortableListener extends MappedEventSubscriber
             if ($groupHasChanged) {
                 $newPosition = $this->maxPositions[$hash] + 1;
             } else {
-                $this->changeDueToMaxPosition[$hash] = $newPosition - $this->maxPositions[$hash];
                 $newPosition = $this->maxPositions[$hash];
             }
         } else {
-            $newPosition = min([$this->maxPositions[$hash] - ($this->changeDueToMaxPosition[$hash] ?? 0), $newPosition]);
+            $newPosition = min([$this->maxPositions[$hash], $newPosition]);
         }
 
         // Compute relocations

--- a/tests/Gedmo/Sortable/SortableTest.php
+++ b/tests/Gedmo/Sortable/SortableTest.php
@@ -159,7 +159,7 @@ final class SortableTest extends BaseTestCaseORM
         }
     }
 
-    public function testShouldShiftPositionsProperlyWhenMoreThenOneWasUpdated(): void
+    public function testShouldShiftPositionsProperlyWhenMoreThanOneWasUpdated(): void
     {
         $node2 = new Node();
         $node2->setName('Node2');

--- a/tests/Gedmo/Sortable/SortableTest.php
+++ b/tests/Gedmo/Sortable/SortableTest.php
@@ -159,7 +159,7 @@ final class SortableTest extends BaseTestCaseORM
         }
     }
 
-    public function testShouldShiftPositionsProperlyWhenMoreThanOneWasUpdated(): void
+    public function testShouldShiftPositionsProperlyWhenMoreThenOneWasUpdated(): void
     {
         $node2 = new Node();
         $node2->setName('Node2');
@@ -198,51 +198,6 @@ final class SortableTest extends BaseTestCaseORM
         static::assertSame('Node5', $nodes[2]->getName());
         static::assertSame('Node2', $nodes[3]->getName());
         static::assertSame('Node3', $nodes[4]->getName());
-
-        for ($i = 0; $i < count($nodes); ++$i) {
-            static::assertSame($i, $nodes[$i]->getPosition());
-        }
-    }
-
-    public function testShouldShiftPositionsProperlyWhenAllWereUpdated(): void
-    {
-        $node2 = new Node();
-        $node2->setName('Node2');
-        $node2->setPath('/');
-        $this->em->persist($node2);
-
-        $node3 = new Node();
-        $node3->setName('Node3');
-        $node3->setPath('/');
-        $this->em->persist($node3);
-
-        $node4 = new Node();
-        $node4->setName('Node4');
-        $node4->setPath('/');
-        $this->em->persist($node4);
-
-        $this->em->flush();
-        $repo = $this->em->getRepository(self::NODE);
-
-        /** @var Node $node1 */
-        $node1 = $repo->find($this->nodeId);
-
-        static::assertSame(0, $node1->getPosition());
-        static::assertSame(1, $node2->getPosition());
-        static::assertSame(2, $node3->getPosition());
-        static::assertSame(3, $node4->getPosition());
-        $node1->setPosition(3);
-        $node4->setPosition(4);
-        $node2->setPosition(1);
-        $node3->setPosition(2);
-        $this->em->flush();
-
-        $nodes = $repo->getBySortableGroups(['path' => '/']);
-
-        static::assertSame('Node2', $nodes[0]->getName());
-        static::assertSame('Node3', $nodes[1]->getName());
-        static::assertSame('Node1', $nodes[2]->getName());
-        static::assertSame('Node4', $nodes[3]->getName());
 
         for ($i = 0; $i < count($nodes); ++$i) {
             static::assertSame($i, $nodes[$i]->getPosition());

--- a/tests/Gedmo/Sortable/SortableTest.php
+++ b/tests/Gedmo/Sortable/SortableTest.php
@@ -158,6 +158,7 @@ final class SortableTest extends BaseTestCaseORM
             static::assertSame($i, $nodes[$i]->getPosition());
         }
     }
+
     public function testShouldShiftPositionsProperlyWhenMoreThenOneWasUpdated(): void
     {
         $node2 = new Node();

--- a/tests/Gedmo/Sortable/SortableTest.php
+++ b/tests/Gedmo/Sortable/SortableTest.php
@@ -158,6 +158,50 @@ final class SortableTest extends BaseTestCaseORM
             static::assertSame($i, $nodes[$i]->getPosition());
         }
     }
+    public function testShouldShiftPositionsProperlyWhenMoreThenOneWasUpdated(): void
+    {
+        $node2 = new Node();
+        $node2->setName('Node2');
+        $node2->setPath('/');
+        $this->em->persist($node2);
+
+        $node3 = new Node();
+        $node3->setName('Node3');
+        $node3->setPath('/');
+        $this->em->persist($node3);
+
+        $node = new Node();
+        $node->setName('Node4');
+        $node->setPath('/');
+        $this->em->persist($node);
+
+        $node = new Node();
+        $node->setName('Node5');
+        $node->setPath('/');
+        $this->em->persist($node);
+
+        $this->em->flush();
+
+        static::assertSame(1, $node2->getPosition());
+        $node2->setPosition(3);
+        $node3->setPosition(4);
+        $this->em->persist($node2);
+        $this->em->persist($node3);
+        $this->em->flush();
+
+        $repo = $this->em->getRepository(self::NODE);
+        $nodes = $repo->getBySortableGroups(['path' => '/']);
+
+        static::assertSame('Node1', $nodes[0]->getName());
+        static::assertSame('Node4', $nodes[1]->getName());
+        static::assertSame('Node5', $nodes[2]->getName());
+        static::assertSame('Node2', $nodes[3]->getName());
+        static::assertSame('Node3', $nodes[4]->getName());
+
+        for ($i = 0; $i < count($nodes); ++$i) {
+            static::assertSame($i, $nodes[$i]->getPosition());
+        }
+    }
 
     public function testShouldShiftPositionBackward(): void
     {

--- a/tests/Gedmo/Sortable/SortableTest.php
+++ b/tests/Gedmo/Sortable/SortableTest.php
@@ -159,7 +159,7 @@ final class SortableTest extends BaseTestCaseORM
         }
     }
 
-    public function testShouldShiftPositionsProperlyWhenMoreThenOneWasUpdated(): void
+    public function testShouldShiftPositionsProperlyWhenMoreThanOneWasUpdated(): void
     {
         $node2 = new Node();
         $node2->setName('Node2');
@@ -198,6 +198,51 @@ final class SortableTest extends BaseTestCaseORM
         static::assertSame('Node5', $nodes[2]->getName());
         static::assertSame('Node2', $nodes[3]->getName());
         static::assertSame('Node3', $nodes[4]->getName());
+
+        for ($i = 0; $i < count($nodes); ++$i) {
+            static::assertSame($i, $nodes[$i]->getPosition());
+        }
+    }
+
+    public function testShouldShiftPositionsProperlyWhenAllWereUpdated(): void
+    {
+        $node2 = new Node();
+        $node2->setName('Node2');
+        $node2->setPath('/');
+        $this->em->persist($node2);
+
+        $node3 = new Node();
+        $node3->setName('Node3');
+        $node3->setPath('/');
+        $this->em->persist($node3);
+
+        $node4 = new Node();
+        $node4->setName('Node4');
+        $node4->setPath('/');
+        $this->em->persist($node4);
+
+        $this->em->flush();
+        $repo = $this->em->getRepository(self::NODE);
+
+        /** @var Node $node1 */
+        $node1 = $repo->find($this->nodeId);
+
+        static::assertSame(0, $node1->getPosition());
+        static::assertSame(1, $node2->getPosition());
+        static::assertSame(2, $node3->getPosition());
+        static::assertSame(3, $node4->getPosition());
+        $node1->setPosition(3);
+        $node4->setPosition(4);
+        $node2->setPosition(1);
+        $node3->setPosition(2);
+        $this->em->flush();
+
+        $nodes = $repo->getBySortableGroups(['path' => '/']);
+
+        static::assertSame('Node2', $nodes[0]->getName());
+        static::assertSame('Node3', $nodes[1]->getName());
+        static::assertSame('Node1', $nodes[2]->getName());
+        static::assertSame('Node4', $nodes[3]->getName());
 
         for ($i = 0; $i < count($nodes); ++$i) {
             static::assertSame($i, $nodes[$i]->getPosition());


### PR DESCRIPTION
I discovered issue where if you edit 2 objects positions, relocation code changes second object position to be the same as existing record in db. I removed that relocation  change and sorted in DESC order objects for update to make position updates correct