### PR TITLE
[Tree] [NestedSet] [ClosureTree] childrenQueryBuilder() to allow specifying sort order separately for each field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ a release.
 
 ## [Unreleased]
 
+### Tree
+#### Added
+-  [NestedSet] childrenQueryBuilder() to allow specifying sort order separately for each field
+
 ## [3.6.0] - 2022-03-19
 ### Added
 - Translatable: Add defaultTranslationValue option to allow null or string value (#2167). TranslatableListener can hydrate object properties with null value, but it may cause a Type error for non-nullable getter upon a missing translation.

--- a/src/Tree/Entity/Repository/AbstractTreeRepository.php
+++ b/src/Tree/Entity/Repository/AbstractTreeRepository.php
@@ -208,11 +208,11 @@ abstract class AbstractTreeRepository extends EntityRepository implements Reposi
     /**
      * Get list of children followed by given $node. This returns a QueryBuilder object
      *
-     * @param object|null $node        if null, all tree nodes will be taken
-     * @param bool        $direct      true to take only direct children
-     * @param string      $sortByField field name to sort by
-     * @param string      $direction   sort direction : "ASC" or "DESC"
-     * @param bool        $includeNode Include the root node in results?
+     * @param object|null          $node        If null, all tree nodes will be taken
+     * @param bool                 $direct      True to take only direct children
+     * @param string|string[]|null $sortByField Field name or array of fields names to sort by
+     * @param string|string[]      $direction   Sort order ('ASC'|'DESC'). If $sortByField is an array, this may also be an array with matching number of elements
+     * @param bool                 $includeNode Include the root node in results?
      *
      * @return QueryBuilder QueryBuilder object
      */
@@ -221,11 +221,11 @@ abstract class AbstractTreeRepository extends EntityRepository implements Reposi
     /**
      * Get list of children followed by given $node. This returns a Query
      *
-     * @param object|null $node        if null, all tree nodes will be taken
-     * @param bool        $direct      true to take only direct children
-     * @param string      $sortByField field name to sort by
-     * @param string      $direction   sort direction : "ASC" or "DESC"
-     * @param bool        $includeNode Include the root node in results?
+     * @param object|null          $node        If null, all tree nodes will be taken
+     * @param bool                 $direct      True to take only direct children
+     * @param string|string[]|null $sortByField Field name or array of fields names to sort by
+     * @param string|string[]      $direction   Sort order ('ASC'|'DESC'). If $sortByField is an array, this may also be an array with matching number of elements
+     * @param bool                 $includeNode Include the root node in results?
      *
      * @return Query Query object
      */

--- a/src/Tree/Entity/Repository/ClosureTreeRepository.php
+++ b/src/Tree/Entity/Repository/ClosureTreeRepository.php
@@ -101,11 +101,11 @@ class ClosureTreeRepository extends AbstractTreeRepository
     }
 
     /**
-     * @param object|null $node        if null, all tree nodes will be taken
-     * @param bool        $direct      true to take only direct children
-     * @param string      $sortByField field name to sort by
-     * @param string      $direction   sort direction : "ASC" or "DESC"
-     * @param bool        $includeNode Include the root node in results?
+     * @param object|null          $node        If null, all tree nodes will be taken
+     * @param bool                 $direct      True to take only direct children
+     * @param string|string[]|null $sortByField Field name or array of fields names to sort by
+     * @param string|string[]      $direction   Sort order ('ASC'|'DESC'). If $sortByField is an array, this may also be an array with matching number of elements
+     * @param bool                 $includeNode Include the root node in results?
      *
      * @return QueryBuilder QueryBuilder object
      */
@@ -150,7 +150,11 @@ class ClosureTreeRepository extends AbstractTreeRepository
         }
 
         if ($sortByField) {
-            if ($meta->hasField($sortByField) && in_array(strtolower($direction), ['asc', 'desc'], true)) {
+            if (is_array($sortByField)) {
+                foreach ($sortByField as $key => $field) {
+                    $qb->addOrderBy('node.'.$field, is_array($direction) ? $direction[$key] : $direction);
+                }
+            } elseif ($meta->hasField($sortByField) && in_array(strtolower($direction), ['asc', 'desc'], true)) {
                 $qb->orderBy('node.'.$sortByField, $direction);
             } else {
                 throw new InvalidArgumentException("Invalid sort options specified: field - {$sortByField}, direction - {$direction}");
@@ -165,11 +169,11 @@ class ClosureTreeRepository extends AbstractTreeRepository
     }
 
     /**
-     * @param object|null $node        if null, all tree nodes will be taken
-     * @param bool        $direct      true to take only direct children
-     * @param string      $sortByField field name to sort by
-     * @param string      $direction   sort direction : "ASC" or "DESC"
-     * @param bool        $includeNode Include the root node in results?
+     * @param object|null          $node        If null, all tree nodes will be taken
+     * @param bool                 $direct      True to take only direct children
+     * @param string|string[]|null $sortByField Field name or array of fields names to sort by
+     * @param string|string[]      $direction   Sort order ('ASC'|'DESC'). If $sortByField is an array, this may also be an array with matching number of elements
+     * @param bool                 $includeNode Include the root node in results?
      *
      * @return Query Query object
      */
@@ -179,11 +183,11 @@ class ClosureTreeRepository extends AbstractTreeRepository
     }
 
     /**
-     * @param object|null          $node        The object to fetch children for; if null, all nodes will be retrieved
-     * @param bool                 $direct      Flag indicating whether only direct children should be retrieved
-     * @param string|string[]|null $sortByField Field name(s) to sort by
-     * @param string               $direction   Sort direction : "ASC" or "DESC"
-     * @param bool                 $includeNode Flag indicating whether the given node should be included in the results
+     * @param object|null          $node        If null, all tree nodes will be taken
+     * @param bool                 $direct      True to take only direct children
+     * @param string|string[]|null $sortByField Field name or array of fields names to sort by
+     * @param string|string[]      $direction   Sort order ('ASC'|'DESC'). If $sortByField is an array, this may also be an array with matching number of elements
+     * @param bool                 $includeNode Include the root node in results?
      *
      * @return array|null List of children or null on failure
      */

--- a/src/Tree/Entity/Repository/ClosureTreeRepository.php
+++ b/src/Tree/Entity/Repository/ClosureTreeRepository.php
@@ -152,12 +152,19 @@ class ClosureTreeRepository extends AbstractTreeRepository
         if ($sortByField) {
             if (is_array($sortByField)) {
                 foreach ($sortByField as $key => $field) {
-                    $qb->addOrderBy('node.'.$field, is_array($direction) ? $direction[$key] : $direction);
+                    $fieldDirection = strtolower(is_array($direction) ? ($direction[$key] ?? 'asc') : $direction);
+                    if ($meta->hasField($field) && in_array($fieldDirection, ['asc', 'desc'], true)) {
+                        $qb->addOrderBy('node.'.$field, $fieldDirection);
+                    } else {
+                        throw new InvalidArgumentException(sprintf('Invalid sort options specified: field - %s, direction - %s', $field, $fieldDirection));
+                    }
                 }
-            } elseif ($meta->hasField($sortByField) && in_array(strtolower($direction), ['asc', 'desc'], true)) {
-                $qb->orderBy('node.'.$sortByField, $direction);
             } else {
-                throw new InvalidArgumentException("Invalid sort options specified: field - {$sortByField}, direction - {$direction}");
+                if ($meta->hasField($sortByField) && in_array(strtolower($direction), ['asc', 'desc'], true)) {
+                    $qb->orderBy('node.'.$sortByField, $direction);
+                } else {
+                    throw new InvalidArgumentException(sprintf('Invalid sort options specified: field - %s, direction - %s', $sortByField, $direction));
+                }
             }
         }
 

--- a/src/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/src/Tree/Entity/Repository/NestedTreeRepository.php
@@ -247,12 +247,9 @@ class NestedTreeRepository extends AbstractTreeRepository
         if (!$sortByField) {
             $qb->orderBy('node.'.$config['left'], 'ASC');
         } elseif (is_array($sortByField)) {
-            $fields = '';
-            foreach ($sortByField as $field) {
-                $fields .= 'node.'.$field.',';
+            foreach ($sortByField as $key => $field) {
+                $qb->addOrderBy('node.'.$field, is_array($direction) ? $direction[$key] : $direction);
             }
-            $fields = rtrim($fields, ',');
-            $qb->orderBy($fields, $direction);
         } else {
             if ($meta->hasField($sortByField) && in_array(strtolower($direction), ['asc', 'desc'], true)) {
                 $qb->orderBy('node.'.$sortByField, $direction);

--- a/src/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/src/Tree/Entity/Repository/NestedTreeRepository.php
@@ -193,10 +193,10 @@ class NestedTreeRepository extends AbstractTreeRepository
     }
 
     /**
-     * @param object|null          $node        if null, all tree nodes will be taken
-     * @param bool                 $direct      true to take only direct children
-     * @param string|string[]|null $sortByField field name to sort by
-     * @param string               $direction   sort direction : "ASC" or "DESC"
+     * @param object|null          $node        If null, all tree nodes will be taken
+     * @param bool                 $direct      True to take only direct children
+     * @param string|string[]|null $sortByField Field name or array of fields names to sort by
+     * @param string|string[]      $direction   Sort order ('ASC'|'DESC'). If $sortByField is an array, this may also be an array with matching number of elements
      * @param bool                 $includeNode Include the root node in results?
      *
      * @return QueryBuilder QueryBuilder object
@@ -262,11 +262,11 @@ class NestedTreeRepository extends AbstractTreeRepository
     }
 
     /**
-     * @param object|null $node        if null, all tree nodes will be taken
-     * @param bool        $direct      true to take only direct children
-     * @param string      $sortByField field name to sort by
-     * @param string      $direction   sort direction : "ASC" or "DESC"
-     * @param bool        $includeNode Include the root node in results?
+     * @param object|null          $node        if null, all tree nodes will be taken
+     * @param bool                 $direct      true to take only direct children
+     * @param string|string[]|null $sortByField Field name or array of fields names to sort by
+     * @param string|string[]      $direction   Sort order ('ASC'|'DESC'). If $sortByField is an array, this may also be an array with matching number of elements
+     * @param bool                 $includeNode Include the root node in results?
      *
      * @return Query Query object
      */
@@ -278,8 +278,8 @@ class NestedTreeRepository extends AbstractTreeRepository
     /**
      * @param object|null          $node        The object to fetch children for; if null, all nodes will be retrieved
      * @param bool                 $direct      Flag indicating whether only direct children should be retrieved
-     * @param string|string[]|null $sortByField Field name(s) to sort by
-     * @param string               $direction   Sort direction : "ASC" or "DESC"
+     * @param string|string[]|null $sortByField Field name or array of fields names to sort by
+     * @param string|string[]      $direction   Sort order ('ASC'|'DESC'). If $sortByField is an array, this may also be an array with matching number of elements
      * @param bool                 $includeNode Flag indicating whether the given node should be included in the results
      *
      * @return array|null List of children or null on failure
@@ -292,11 +292,11 @@ class NestedTreeRepository extends AbstractTreeRepository
     }
 
     /**
-     * @param object|null $node        if null, all tree nodes will be taken
-     * @param bool        $direct      true to take only direct children
-     * @param string      $sortByField field name to sort by
-     * @param string      $direction   sort direction : "ASC" or "DESC"
-     * @param bool        $includeNode Include the root node in results?
+     * @param object|null          $node        if null, all tree nodes will be taken
+     * @param bool                 $direct      true to take only direct children
+     * @param string|string[]|null $sortByField Field name or array of fields names to sort by
+     * @param string|string[]      $direction   Sort order ('ASC'|'DESC'). If $sortByField is an array, this may also be an array with matching number of elements
+     * @param bool                 $includeNode Include the root node in results?
      *
      * @return QueryBuilder Query object
      */

--- a/src/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/src/Tree/Entity/Repository/NestedTreeRepository.php
@@ -193,11 +193,11 @@ class NestedTreeRepository extends AbstractTreeRepository
     }
 
     /**
-     * @param object|null $node        if null, all tree nodes will be taken
-     * @param bool        $direct      true to take only direct children
-     * @param string      $sortByField field name to sort by
-     * @param string      $direction   sort direction : "ASC" or "DESC"
-     * @param bool        $includeNode Include the root node in results?
+     * @param object|null          $node        if null, all tree nodes will be taken
+     * @param bool                 $direct      true to take only direct children
+     * @param string|string[]|null $sortByField field name to sort by
+     * @param string               $direction   sort direction : "ASC" or "DESC"
+     * @param bool                 $includeNode Include the root node in results?
      *
      * @return QueryBuilder QueryBuilder object
      */

--- a/src/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/src/Tree/Entity/Repository/NestedTreeRepository.php
@@ -248,13 +248,18 @@ class NestedTreeRepository extends AbstractTreeRepository
             $qb->orderBy('node.'.$config['left'], 'ASC');
         } elseif (is_array($sortByField)) {
             foreach ($sortByField as $key => $field) {
-                $qb->addOrderBy('node.'.$field, is_array($direction) ? $direction[$key] : $direction);
+                $fieldDirection = strtolower(is_array($direction) ? ($direction[$key] ?? 'asc') : $direction);
+                if ($meta->hasField($field) && in_array($fieldDirection, ['asc', 'desc'], true)) {
+                    $qb->addOrderBy('node.'.$field, $fieldDirection);
+                } else {
+                    throw new InvalidArgumentException(sprintf('Invalid sort options specified: field - %s, direction - %s', $field, $fieldDirection));
+                }
             }
         } else {
             if ($meta->hasField($sortByField) && in_array(strtolower($direction), ['asc', 'desc'], true)) {
                 $qb->orderBy('node.'.$sortByField, $direction);
             } else {
-                throw new InvalidArgumentException("Invalid sort options specified: field - {$sortByField}, direction - {$direction}");
+                throw new InvalidArgumentException(sprintf('Invalid sort options specified: field - %s, direction - %s', $sortByField, $direction));
             }
         }
 

--- a/src/Tree/RepositoryInterface.php
+++ b/src/Tree/RepositoryInterface.php
@@ -44,11 +44,11 @@ interface RepositoryInterface extends RepositoryUtilsInterface
     /**
      * Get the list of children for the given node.
      *
-     * @param object|null          $node        The object to fetch children for; if null, all nodes will be retrieved
-     * @param bool                 $direct      Flag indicating whether only direct children should be retrieved
-     * @param string|string[]|null $sortByField Field name(s) to sort by
-     * @param string               $direction   Sort direction : "ASC" or "DESC"
-     * @param bool                 $includeNode Flag indicating whether the given node should be included in the results
+     * @param object|null          $node        If null, all tree nodes will be taken
+     * @param bool                 $direct      True to take only direct children
+     * @param string|string[]|null $sortByField Field name or array of fields names to sort by
+     * @param string|string[]      $direction   Sort order ('ASC'|'DESC'). If $sortByField is an array, this may also be an array with matching number of elements
+     * @param bool                 $includeNode Include the root node in results?
      *
      * @return array|null List of children or null on failure
      */

--- a/tests/Gedmo/Tree/ClosureTreeRepositoryTest.php
+++ b/tests/Gedmo/Tree/ClosureTreeRepositoryTest.php
@@ -157,6 +157,14 @@ final class ClosureTreeRepositoryTest extends BaseTestCaseORM
         static::assertSame('Berries', $children[3]->getTitle());
         static::assertSame('Strawberries', $children[4]->getTitle());
 
+        $children = $repo->children($fruits, false, ['level', 'title'], ['ASC'], true);
+        static::assertCount(5, $children);
+        static::assertSame('Fruits', $children[0]->getTitle());
+        static::assertSame('Berries', $children[1]->getTitle());
+        static::assertSame('Lemons', $children[2]->getTitle());
+        static::assertSame('Oranges', $children[3]->getTitle());
+        static::assertSame('Strawberries', $children[4]->getTitle());
+
         // direct root nodes
         $children = $repo->children(null, true, 'title');
         static::assertCount(2, $children);

--- a/tests/Gedmo/Tree/ClosureTreeRepositoryTest.php
+++ b/tests/Gedmo/Tree/ClosureTreeRepositoryTest.php
@@ -140,6 +140,23 @@ final class ClosureTreeRepositoryTest extends BaseTestCaseORM
         static::assertSame('Oranges', $children[3]->getTitle());
         static::assertSame('Strawberries', $children[4]->getTitle());
 
+        // test children sorting by array of fields
+        $children = $repo->children($fruits, false, ['title'], 'ASC', true);
+        static::assertCount(5, $children);
+        static::assertSame('Berries', $children[0]->getTitle());
+        static::assertSame('Fruits', $children[1]->getTitle());
+        static::assertSame('Lemons', $children[2]->getTitle());
+        static::assertSame('Oranges', $children[3]->getTitle());
+        static::assertSame('Strawberries', $children[4]->getTitle());
+
+        $children = $repo->children($fruits, false, ['level', 'title'], ['ASC', 'DESC'], true);
+        static::assertCount(5, $children);
+        static::assertSame('Fruits', $children[0]->getTitle());
+        static::assertSame('Oranges', $children[1]->getTitle());
+        static::assertSame('Lemons', $children[2]->getTitle());
+        static::assertSame('Berries', $children[3]->getTitle());
+        static::assertSame('Strawberries', $children[4]->getTitle());
+
         // direct root nodes
         $children = $repo->children(null, true, 'title');
         static::assertCount(2, $children);

--- a/tests/Gedmo/Tree/RepositoryTest.php
+++ b/tests/Gedmo/Tree/RepositoryTest.php
@@ -94,6 +94,24 @@ final class RepositoryTest extends BaseTestCaseORM
 
         static::assertCount(6, $children);
 
+        // test children sorting
+
+        $children = $this->em->getRepository(self::CATEGORY)
+             ->children($food, true, ['title'], 'ASC');
+
+        $this->assertCount(2, $children);
+        $this->assertEquals('Fruits', $children[0]->getTitle());
+        $this->assertEquals('Vegitables', $children[1]->getTitle());
+
+        $children = $this->em->getRepository(self::CATEGORY)
+             ->children($food, false, ['level', 'title'], ['ASC', 'DESC']);
+
+        $this->assertCount(4, $children);
+        $this->assertEquals('Vegitables', $children[0]->getTitle());
+        $this->assertEquals('Fruits', $children[1]->getTitle());
+        $this->assertEquals('Potatoes', $children[2]->getTitle());
+        $this->assertEquals('Carrots', $children[3]->getTitle());
+
         // path
 
         $path = $this->em->getRepository(self::CATEGORY)

--- a/tests/Gedmo/Tree/RepositoryTest.php
+++ b/tests/Gedmo/Tree/RepositoryTest.php
@@ -112,6 +112,15 @@ final class RepositoryTest extends BaseTestCaseORM
         static::assertSame('Potatoes', $children[2]->getTitle());
         static::assertSame('Carrots', $children[3]->getTitle());
 
+        $children = $this->em->getRepository(self::CATEGORY)
+             ->children($food, false, ['level', 'title'], ['ASC']);
+
+        static::assertCount(4, $children);
+        static::assertSame('Fruits', $children[0]->getTitle());
+        static::assertSame('Vegitables', $children[1]->getTitle());
+        static::assertSame('Carrots', $children[2]->getTitle());
+        static::assertSame('Potatoes', $children[3]->getTitle());
+
         // path
 
         $path = $this->em->getRepository(self::CATEGORY)

--- a/tests/Gedmo/Tree/RepositoryTest.php
+++ b/tests/Gedmo/Tree/RepositoryTest.php
@@ -99,18 +99,18 @@ final class RepositoryTest extends BaseTestCaseORM
         $children = $this->em->getRepository(self::CATEGORY)
              ->children($food, true, ['title'], 'ASC');
 
-        $this->assertCount(2, $children);
-        $this->assertEquals('Fruits', $children[0]->getTitle());
-        $this->assertEquals('Vegitables', $children[1]->getTitle());
+        static::assertCount(2, $children);
+        static::assertSame('Fruits', $children[0]->getTitle());
+        static::assertSame('Vegitables', $children[1]->getTitle());
 
         $children = $this->em->getRepository(self::CATEGORY)
              ->children($food, false, ['level', 'title'], ['ASC', 'DESC']);
 
-        $this->assertCount(4, $children);
-        $this->assertEquals('Vegitables', $children[0]->getTitle());
-        $this->assertEquals('Fruits', $children[1]->getTitle());
-        $this->assertEquals('Potatoes', $children[2]->getTitle());
-        $this->assertEquals('Carrots', $children[3]->getTitle());
+        static::assertCount(4, $children);
+        static::assertSame('Vegitables', $children[0]->getTitle());
+        static::assertSame('Fruits', $children[1]->getTitle());
+        static::assertSame('Potatoes', $children[2]->getTitle());
+        static::assertSame('Carrots', $children[3]->getTitle());
 
         // path
 


### PR DESCRIPTION
When sorting by more than one field, before you could only specify the sort order of the primary field. Now you can specify the order for each field you're sorting on