### PR TITLE
[Tree] [NestedSet] New additions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ a release.
 ## [Unreleased]
 
 ### Added
+- Tree: [NestedSet] Added "base" property for tree level annotation
+- Tree: [NestedSet] Added `$options` as parameter 2 in `getPathQueryBuilder()` to specify whether you want the starting node included or not
+- Tree: [NestedSet] Added `getPathAsString()` method to entity repository
+- Tree: [NestedSet] Added "treeRootNode" option in `verify()` in case you want to verify a single tree in a forest
+- Tree: [NestedSet] Added `recoverFast()` method for where speed is more important than safety and entity manager state
+- Tree: [NestedSet] Added options to `recover()` for sibling order, tree root in a forest, verification skip and auto-flushing
+- Tree: [NestedSet] Verify and recover wrong levels in nested set
+
+### Added
 - Tree: Add `Nested::ALLOWED_NODE_POSITIONS` constant in order to expose the available node positions
 - Support for `doctrine/collections` 2.0
 - Support for `doctrine/event-manager` 2.0
@@ -107,8 +116,8 @@ a release.
 - ReferenceIntegrity: Support to use annotations as attributes on PHP >= 8.0.
 - SoftDeleteable: Support for custom column types (like Carbon).
 - Timestampable: Support for custom column types (like Carbon).
-- Translatable: Added an index to `Translation` entity to speed up searches using 
-  `Gedmo\Translatable\Entity\Repository\TranslationRepository::findTranslations()` method. 
+- Translatable: Added an index to `Translation` entity to speed up searches using
+  `Gedmo\Translatable\Entity\Repository\TranslationRepository::findTranslations()` method.
 - `Gedmo\Mapping\Event\AdapterInterface::getObject()` method.
 
 ### Fixed
@@ -178,7 +187,7 @@ a release.
 
 ## [3.2.0] - 2021-10-05
 ### Added
-- PHP 8 Attributes for Doctrine ORM to entities & traits (#2251) 
+- PHP 8 Attributes for Doctrine ORM to entities & traits (#2251)
 
 ### Fixed
 - Removed legacy checks targeting older versions of PHP (#2201)

--- a/src/Mapping/Annotation/TreeLevel.php
+++ b/src/Mapping/Annotation/TreeLevel.php
@@ -17,6 +17,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * TreeLevel annotation for Tree behavioral extension
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("PROPERTY")
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
@@ -24,4 +25,24 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class TreeLevel implements GedmoAnnotation
 {
+    /**
+     * The level which root nodes will have
+     *
+     * @var int
+     */
+    public $base = 0;
+
+    public function __construct(
+        array $data = [],
+        int $base = 0
+    ) {
+        if ([] !== $data) {
+            @trigger_error(sprintf(
+                'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
+        $this->base = $data['base'] ?? $base;
+    }
 }

--- a/src/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/src/Tree/Entity/Repository/NestedTreeRepository.php
@@ -9,10 +9,12 @@
 
 namespace Gedmo\Tree\Entity\Repository;
 
+use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\Proxy\Proxy;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
 use Gedmo\Exception\InvalidArgumentException;
+use Gedmo\Exception\RuntimeException;
 use Gedmo\Exception\UnexpectedValueException;
 use Gedmo\Tool\Wrapper\EntityWrapper;
 use Gedmo\Tree\Strategy;
@@ -61,7 +63,7 @@ class NestedTreeRepository extends AbstractTreeRepository
     {
         if ('persistAs' === substr($method, 0, 9)) {
             if (!isset($args[0])) {
-                throw new \Gedmo\Exception\InvalidArgumentException('Node to persist must be available as first argument');
+                throw new InvalidArgumentException('Node to persist must be available as first argument.');
             }
             $node = $args[0];
             $wrapped = new EntityWrapper($node, $this->_em);
@@ -70,7 +72,7 @@ class NestedTreeRepository extends AbstractTreeRepository
             $position = substr($method, 9);
             if ('Of' === substr($method, -2)) {
                 if (!isset($args[1])) {
-                    throw new \Gedmo\Exception\InvalidArgumentException('If "Of" is specified you must provide parent or sibling as the second argument');
+                    throw new InvalidArgumentException('If "Of" is specified you must provide parent or sibling as the second argument.');
                 }
                 $parentOrSibling = $args[1];
                 if (strstr($method, 'Sibling')) {
@@ -134,13 +136,27 @@ class NestedTreeRepository extends AbstractTreeRepository
      * Get the Tree path query builder by given $node
      *
      * @param object $node
+     * @phpstan-param array{includeNode?: bool} $options
      *
-     * @throws InvalidArgumentException if input is not valid
+     * options:
+     * - includeNode: (bool) Whether to include the node itself. Defaults to true.
      *
      * @return QueryBuilder
+     *
+     * @throws InvalidArgumentException if input is not valid
      */
-    public function getPathQueryBuilder($node)
+    public function getPathQueryBuilder($node/* , array $options = [] */) // @phpstan-ignore-line
     {
+        $options = func_get_args()[1] ?? [];
+        if (!\is_array($options)) {
+            throw new \TypeError('Argument 2 MUST be an array.');
+        }
+
+        $defaultOptions = [
+            'includeNode' => true,
+        ];
+        $options += $defaultOptions;
+
         $meta = $this->getClassMetadata();
         if (!is_a($node, $meta->getName())) {
             throw new InvalidArgumentException('Node is not related to this repository');
@@ -155,10 +171,15 @@ class NestedTreeRepository extends AbstractTreeRepository
         $qb = $this->getQueryBuilder();
         $qb->select('node')
             ->from($config['useObjectClass'], 'node')
-            ->where($qb->expr()->lte('node.'.$config['left'], $left))
-            ->andWhere($qb->expr()->gte('node.'.$config['right'], $right))
             ->orderBy('node.'.$config['left'], 'ASC')
         ;
+        if ($options['includeNode']) {
+            $qb->where($qb->expr()->lte('node.'.$config['left'], $left))
+               ->andWhere($qb->expr()->gte('node.'.$config['right'], $right));
+        } else {
+            $qb->where($qb->expr()->lt('node.'.$config['left'], $left))
+               ->andWhere($qb->expr()->gt('node.'.$config['right'], $right));
+        }
         if (isset($config['root'])) {
             $rootId = $wrapped->getPropertyValue($config['root']);
             $qb->andWhere($qb->expr()->eq('node.'.$config['root'], ':rid'));
@@ -172,24 +193,82 @@ class NestedTreeRepository extends AbstractTreeRepository
      * Get the Tree path query by given $node
      *
      * @param object $node
+     * @phpstan-param array{includeNode?: bool} $options
      *
-     * @return \Doctrine\ORM\Query
+     * options:
+     * - includeNode: (bool) Whether to include the node itself. Defaults to true.
+     *
+     * @return Query
      */
-    public function getPathQuery($node)
+    public function getPathQuery($node/* , array $options = [] */) // @phpstan-ignore-line
     {
-        return $this->getPathQueryBuilder($node)->getQuery();
+        $options = func_get_args()[1] ?? [];
+        if (!\is_array($options)) {
+            throw new \TypeError('Argument 2 MUST be an array.');
+        }
+
+        return $this->getPathQueryBuilder($node, $options)->getQuery();
     }
 
     /**
      * Get the Tree path of Nodes by given $node
      *
      * @param object $node
+     * @phpstan-param array{includeNode?: bool} $options
+     *
+     * options:
+     * - includeNode: (bool) Whether to include the node itself. Defaults to true.
      *
      * @return array list of Nodes in path
      */
-    public function getPath($node)
+    public function getPath($node/* , array $options = [] */) // @phpstan-ignore-line
     {
-        return $this->getPathQuery($node)->getResult();
+        $options = func_get_args()[1] ?? [];
+        if (!\is_array($options)) {
+            throw new \TypeError('Argument 2 MUST be an array.');
+        }
+
+        return $this->getPathQuery($node, $options)->getResult();
+    }
+
+    /**
+     * Get the Tree path of Nodes by given $node as a string
+     *
+     * @phpstan-param array{
+     *     includeNode?: bool,
+     *     separator?: string,
+     *     stringMethod?: string
+     * } $options
+     *
+     * options:
+     * - includeNode:  (bool)   Whether to include the node itself. Defaults to true.
+     * - separator:    (string) The string separating the nodes of the tree. Defaults to ' > '.
+     * - stringMethod: (string) Entity method returning its displayable name. Defaults to '__toString'.
+     *
+     * @throws InvalidArgumentException
+     */
+    public function getPathAsString(object $node, array $options = []): string
+    {
+        $defaultOptions = [
+            'includeNode' => true,
+            'separator' => ' > ',
+            'stringMethod' => '__toString',
+        ];
+        $options += $defaultOptions;
+
+        if (!is_string($options['stringMethod'])) {
+            throw new InvalidArgumentException(sprintf('"stringMethod" option passed in argument 2 to %s must be a valid string.', __METHOD__));
+        }
+        if (!method_exists($node, $options['stringMethod'])) {
+            throw new InvalidArgumentException(sprintf('%s must implement method "%s".', get_class($node), $options['stringMethod']));
+        }
+
+        $path = [];
+        foreach ($this->getPath($node, $options) as $pathNode) {
+            $path[] = $pathNode->{$options['stringMethod']}();
+        }
+
+        return implode($options['separator'], $path);
     }
 
     /**
@@ -381,7 +460,7 @@ class NestedTreeRepository extends AbstractTreeRepository
      * @param string $sortByField field name to sort by
      * @param string $direction   sort direction : "ASC" or "DESC"
      *
-     * @return \Doctrine\ORM\Query
+     * @return Query
      */
     public function getLeafsQuery($root = null, $sortByField = null, $direction = 'ASC')
     {
@@ -408,9 +487,9 @@ class NestedTreeRepository extends AbstractTreeRepository
      * @param object $node
      * @param bool   $includeSelf include the node itself
      *
-     * @throws \Gedmo\Exception\InvalidArgumentException if input is invalid
-     *
      * @return QueryBuilder
+     *
+     * @throws InvalidArgumentException if input is invalid
      */
     public function getNextSiblingsQueryBuilder($node, $includeSelf = false)
     {
@@ -462,7 +541,7 @@ class NestedTreeRepository extends AbstractTreeRepository
      * @param object $node
      * @param bool   $includeSelf include the node itself
      *
-     * @return \Doctrine\ORM\Query
+     * @return Query
      */
     public function getNextSiblingsQuery($node, $includeSelf = false)
     {
@@ -488,9 +567,9 @@ class NestedTreeRepository extends AbstractTreeRepository
      * @param object $node
      * @param bool   $includeSelf include the node itself
      *
-     * @throws \Gedmo\Exception\InvalidArgumentException if input is invalid
-     *
      * @return QueryBuilder
+     *
+     * @throws InvalidArgumentException if input is invalid
      */
     public function getPrevSiblingsQueryBuilder($node, $includeSelf = false)
     {
@@ -539,9 +618,9 @@ class NestedTreeRepository extends AbstractTreeRepository
      * @param object $node
      * @param bool   $includeSelf include the node itself
      *
-     * @throws \Gedmo\Exception\InvalidArgumentException if input is invalid
+     * @return Query
      *
-     * @return \Doctrine\ORM\Query
+     * @throws InvalidArgumentException if input is invalid
      */
     public function getPrevSiblingsQuery($node, $includeSelf = false)
     {
@@ -752,7 +831,7 @@ class NestedTreeRepository extends AbstractTreeRepository
                 $this->_em->close();
                 $this->_em->getConnection()->rollback();
 
-                throw new \Gedmo\Exception\RuntimeException('Transaction failed', $e->getCode(), $e);
+                throw new RuntimeException('Transaction failed', $e->getCode(), $e);
             }
         } else {
             throw new InvalidArgumentException('Node is not related to this repository');
@@ -814,10 +893,25 @@ class NestedTreeRepository extends AbstractTreeRepository
      * If any error is detected it will return an array
      * with a list of errors found on tree
      *
+     * @phpstan-param array{treeRootNode?: object} $options
+     *
+     * options:
+     * - treeRootNode: (object) Optional tree root node to verify, if not the whole forest (only available for forests, not for single trees).
+     *
      * @return array|bool true on success,error list on failure
      */
-    public function verify()
+    public function verify(/* array $options = [] */) // @phpstan-ignore-line
     {
+        $options = func_get_args()[0] ?? [];
+        if (!\is_array($options)) {
+            throw new \TypeError('Argument 1 MUST be an array.');
+        }
+
+        $defaultOptions = [
+            'treeRootNode' => null,
+        ];
+        $options += $defaultOptions;
+
         if (!$this->childCount()) {
             return true; // tree is empty
         }
@@ -828,6 +922,10 @@ class NestedTreeRepository extends AbstractTreeRepository
         if (isset($config['root'])) {
             $trees = $this->getRootNodes();
             foreach ($trees as $tree) {
+                // if a root node is specified, verify only it
+                if (null !== $options['treeRootNode'] && $options['treeRootNode'] !== $tree) {
+                    continue;
+                }
                 $this->verifyTree($errors, $tree);
             }
         } else {
@@ -838,48 +936,167 @@ class NestedTreeRepository extends AbstractTreeRepository
     }
 
     /**
-     * NOTE: flush your entity manager after
+     * Tries to recover the tree, avoiding entity object hydration and using DQL
+     *
+     * NOTE: DQL UPDATE statements are ported directly into a Database UPDATE statement and therefore bypass any locking
+     * scheme, events and do not increment the version column. Entities that are already loaded into the persistence
+     * context will NOT be synced with the updated database state.
+     * It is recommended to call EntityManager#clear() and retrieve new instances of any affected entity.
+     *
+     * @phpstan-param array{sortByField?: string, sortDirection?: string} $options
+     *
+     * options:
+     * - sortByField:   (string) Optionally sort siblings by specified field while recovering. Defaults to null.
+     * - sortDirection: (string) The order to sort siblings in, when sortByField is specified ('ASC', 'DESC'). Defaults to 'ASC'.
+     *
+     * @throws ORMException
+     */
+    public function recoverFast(array $options = []): void
+    {
+        $defaultOptions = [
+            'sortByField' => null,
+            'sortDirection' => 'ASC',
+        ];
+        $options += $defaultOptions;
+
+        $meta = $this->getClassMetadata();
+        $config = $this->listener->getConfiguration($this->getEntityManager(), $meta->name);
+        $em = $this->getEntityManager();
+
+        $updateQb = $em->createQueryBuilder()
+                       ->update($meta->getName(), 'node')
+                       ->set('node.'.$config['left'], ':left')
+                       ->set('node.'.$config['right'], ':right')
+                       ->where('node.id = :id');
+        if (isset($config['level'])) {
+            $updateQb->set('node.'.$config['level'], ':level');
+        }
+
+        $doRecover = function (array $root, int &$count, int $level) use ($meta, $em, $options, $updateQb, &$doRecover): void {
+            $rootEntity = $em->getReference($meta->getName(), $root['node_id']);
+            $left = $count++;
+            $childrenQuery = $this->getChildrenQuery($rootEntity, true, $options['sortByField'], $options['sortDirection']);
+            foreach ($childrenQuery->getScalarResult() as $child) {
+                $doRecover($child, $count, $level + 1);
+            }
+            $right = $count++;
+
+            $updateQb
+                ->setParameter('left', $left)
+                ->setParameter('right', $right)
+                ->setParameter('id', $root['node_id'])
+                ->setParameter('level', $level)
+                ->getQuery()->execute();
+        };
+
+        // if it's a forest
+        if (isset($config['root'])) {
+            $rootNodesQuery = $this->getRootNodesQuery($options['sortByField'], $options['sortDirection']);
+            $roots = $rootNodesQuery->getScalarResult();
+            foreach ($roots as $root) {
+                // reset on every root node
+                $count = 1;
+                $level = $config['level_base'] ?? 0;
+                $doRecover($root, $count, $level);
+                $em->clear();
+            }
+        } else {
+            $count = 1;
+            $level = $config['level_base'] ?? 0;
+            $childrenQuery = $this->getChildrenQuery(null, true, $options['sortByField'], $options['sortDirection']);
+            foreach ($childrenQuery->getScalarResult() as $root) {
+                $doRecover($root, $count, $level);
+                $em->clear();
+            }
+        }
+    }
+
+    /**
+     * NOTE: flush your entity manager after, unless the 'flush' option has been set to true
      *
      * Tries to recover the tree
      *
+     * @phpstan-param array{
+     *     flush?: bool,
+     *     treeRootNode?: ?object,
+     *     skipVerify?: bool,
+     *     sortByField?: string,
+     *     sortDirection?: string
+     * } $options
+     *
+     * options:
+     * - flush:         (bool)   Flush entity manager after each root node is recovered. Defaults to false.
+     * - treeRootNode:  (object) Optional tree root node to recover, if not the whole forest (only available for forests, not for single trees). Defaults to null.
+     * - skipVerify:    (bool)   Whether to skip verification and recover anyway. Defaults to false.
+     * - sortByField:   (string) Optionally sort siblings by specified field while recovering. Defaults to null.
+     * - sortDirection: (string) The order to sort siblings in, when sortByField is specified ('ASC', 'DESC'). Defaults to 'ASC'.
+     *
      * @return void
      */
-    public function recover()
+    public function recover(/* array $options = [] */) // @phpstan-ignore-line
     {
-        if (true === $this->verify()) {
+        $options = func_get_args()[0] ?? [];
+        if (!\is_array($options)) {
+            throw new \TypeError('Argument 1 MUST be an array.');
+        }
+
+        $defaultOptions = [
+            'flush' => false,
+            'treeRootNode' => null,
+            'skipVerify' => false,
+            'sortByField' => null,
+            'sortDirection' => 'ASC',
+        ];
+        $options += $defaultOptions;
+
+        if (!$options['skipVerify'] && (true === $this->verify())) {
             return;
         }
+
         $meta = $this->getClassMetadata();
         $config = $this->listener->getConfiguration($this->_em, $meta->getName());
-        $self = $this;
         $em = $this->_em;
 
-        $doRecover = static function ($root, &$count, &$lvl) use ($meta, $config, $self, $em, &$doRecover) {
-            $lft = $count++;
-            foreach ($self->getChildren($root, true) as $child) {
+        $doRecover = function ($root, &$count, &$lvl) use ($meta, $config, $em, $options, &$doRecover) {
+            $left = $count++;
+            foreach ($this->getChildren($root, true, $options['sortByField'], $options['sortDirection']) as $child) {
                 $depth = ($lvl + 1);
                 $doRecover($child, $count, $depth);
             }
-            $rgt = $count++;
-            $meta->getReflectionProperty($config['left'])->setValue($root, $lft);
-            $meta->getReflectionProperty($config['right'])->setValue($root, $rgt);
+            $right = $count++;
+            $meta->getReflectionProperty($config['left'])->setValue($root, $left);
+            $meta->getReflectionProperty($config['right'])->setValue($root, $right);
             if (isset($config['level'])) {
                 $meta->getReflectionProperty($config['level'])->setValue($root, $lvl);
             }
             $em->persist($root);
         };
 
+        // if it's a forest
         if (isset($config['root'])) {
-            foreach ($this->getRootNodes() as $root) {
+            foreach ($this->getRootNodes($options['sortByField'], $options['sortDirection']) as $root) {
+                // if a root node is specified, recover only it
+                if (null !== $options['treeRootNode'] && $options['treeRootNode'] !== $root) {
+                    continue;
+                }
+
                 $count = 1; // reset on every root node
-                $lvl = 0;
+                $lvl = $config['level_base'] ?? 0;
                 $doRecover($root, $count, $lvl);
+
+                if ($options['flush']) {
+                    $em->flush();
+                }
             }
         } else {
             $count = 1;
-            $lvl = 0;
-            foreach ($this->getChildren(null, true) as $root) {
+            $lvl = $config['level_base'] ?? 0;
+            foreach ($this->getChildren(null, true, $options['sortByField'], $options['sortDirection']) as $root) {
                 $doRecover($root, $count, $lvl);
+
+                if ($options['flush']) {
+                    $em->flush();
+                }
             }
         }
     }
@@ -986,6 +1203,7 @@ class NestedTreeRepository extends AbstractTreeRepository
             return; // loading broken relation can cause infinite loop
         }
 
+        // check for nodes that have a right value lower than the left
         $qb = $this->getQueryBuilder();
         $qb->select('node')
             ->from($config['useObjectClass'], 'node')
@@ -1036,7 +1254,25 @@ class NestedTreeRepository extends AbstractTreeRepository
                 } elseif ($right > $parentRight) {
                     $errors[] = "node [{$id}] right is greater than parent`s [{$parentId}] right value";
                 }
+                // check that level of node is exactly after its parent's level
+                if (isset($config['level'])) {
+                    $parentLevel = $meta->getReflectionProperty($config['level'])->getValue($parent);
+                    $level = $meta->getReflectionProperty($config['level'])->getValue($node);
+                    if ($level !== $parentLevel + 1) {
+                        $errors[] = "node [{$id}] should be on the level right after its parent`s [{$parentId}] level";
+                    }
+                }
             } else {
+                // check that level of the root node is the base level defined
+                if (isset($config['level'])) {
+                    $baseLevel = $config['level_base'] ?? 0;
+                    $level = $meta->getReflectionProperty($config['level'])->getValue($node);
+                    if ($level !== $baseLevel) {
+                        $errors[] = "node [{$id}] should be on level {$baseLevel}, not {$level}";
+                    }
+                }
+
+                // get number of parents of node, based on left and right values
                 $qb = $this->getQueryBuilder();
                 $qb->select($qb->expr()->count('node.'.$identifier))
                     ->from($config['useObjectClass'], 'node')

--- a/src/Tree/Mapping/Driver/Annotation.php
+++ b/src/Tree/Mapping/Driver/Annotation.php
@@ -182,7 +182,8 @@ class Annotation extends AbstractAnnotationDriver
                 $config['root'] = $field;
             }
             // level
-            if ($this->reader->getPropertyAnnotation($property, self::LEVEL)) {
+            $levelAnnotation = $this->reader->getPropertyAnnotation($property, self::LEVEL);
+            if (null !== $levelAnnotation) {
                 $field = $property->getName();
                 if (!$meta->hasField($field)) {
                     throw new InvalidMappingException("Unable to find 'level' - [{$field}] as mapped property in entity - {$meta->getName()}");
@@ -191,9 +192,11 @@ class Annotation extends AbstractAnnotationDriver
                     throw new InvalidMappingException("Tree level field - [{$field}] type is not valid and must be 'integer' in class - {$meta->getName()}");
                 }
                 $config['level'] = $field;
+                $config['level_base'] = (int) $levelAnnotation->base;
             }
             // path
-            if ($pathAnnotation = $this->reader->getPropertyAnnotation($property, self::PATH)) {
+            $pathAnnotation = $this->reader->getPropertyAnnotation($property, self::PATH);
+            if (null !== $pathAnnotation) {
                 $field = $property->getName();
                 if (!$meta->hasField($field)) {
                     throw new InvalidMappingException("Unable to find 'path' - [{$field}] as mapped property in entity - {$meta->getName()}");
@@ -211,7 +214,7 @@ class Annotation extends AbstractAnnotationDriver
                 $config['path_ends_with_separator'] = $pathAnnotation->endsWithSeparator;
             }
             // path source
-            if ($this->reader->getPropertyAnnotation($property, self::PATH_SOURCE)) {
+            if (null !== $this->reader->getPropertyAnnotation($property, self::PATH_SOURCE)) {
                 $field = $property->getName();
                 if (!$meta->hasField($field)) {
                     throw new InvalidMappingException("Unable to find 'path_source' - [{$field}] as mapped property in entity - {$meta->getName()}");
@@ -223,7 +226,7 @@ class Annotation extends AbstractAnnotationDriver
             }
 
             // path hash
-            if ($this->reader->getPropertyAnnotation($property, self::PATH_HASH)) {
+            if (null !== $this->reader->getPropertyAnnotation($property, self::PATH_HASH)) {
                 $field = $property->getName();
                 if (!$meta->hasField($field)) {
                     throw new InvalidMappingException("Unable to find 'path_hash' - [{$field}] as mapped property in entity - {$meta->getName()}");
@@ -235,7 +238,7 @@ class Annotation extends AbstractAnnotationDriver
             }
             // lock time
 
-            if ($this->reader->getPropertyAnnotation($property, self::LOCK_TIME)) {
+            if (null !== $this->reader->getPropertyAnnotation($property, self::LOCK_TIME)) {
                 $field = $property->getName();
                 if (!$meta->hasField($field)) {
                     throw new InvalidMappingException("Unable to find 'lock_time' - [{$field}] as mapped property in entity - {$meta->getName()}");

--- a/src/Tree/Strategy/ORM/Nested.php
+++ b/src/Tree/Strategy/ORM/Nested.php
@@ -298,7 +298,7 @@ class Nested implements Strategy
         if (isset($this->nodePositions[$oid])) {
             $position = $this->nodePositions[$oid];
         }
-        $level = 0;
+        $level = $config['level_base'] ?? 0;
         $treeSize = $right - $left + 1;
         $newRoot = null;
         if ($parent) {    // || (!$parent && isset($config['rootIdentifierMethod']))

--- a/src/Tree/TreeListener.php
+++ b/src/Tree/TreeListener.php
@@ -42,6 +42,7 @@ use Gedmo\Tree\Mapping\Event\TreeAdapter;
  *   rootIdentifierMethod?: string,
  *   strategy?: string,
  *   useObjectClass?: class-string,
+ *   level_base?: int,
  * }
  *
  * @phpstan-method TreeConfiguration getConfiguration(ObjectManager $objectManager, $class)

--- a/tests/Gedmo/Tree/Fixture/RootCategory.php
+++ b/tests/Gedmo/Tree/Fixture/RootCategory.php
@@ -99,11 +99,11 @@ class RootCategory
     /**
      * @var int|null
      *
-     * @Gedmo\TreeLevel
+     * @Gedmo\TreeLevel(base=1)
      * @ORM\Column(name="lvl", type="integer")
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER)]
-    #[Gedmo\TreeLevel]
+    #[Gedmo\TreeLevel(base: 1)]
     private $level;
 
     public function getId(): ?int

--- a/tests/Gedmo/Tree/NestedTreePositionTest.php
+++ b/tests/Gedmo/Tree/NestedTreePositionTest.php
@@ -81,7 +81,7 @@ final class NestedTreePositionTest extends BaseTestCaseORM
         $oranges = $repo->findOneBy(['title' => 'Oranges']);
         $meat = $repo->findOneBy(['title' => 'Meat']);
 
-        static::assertSame(2, $oranges->getLevel());
+        static::assertSame(3, $oranges->getLevel());
         static::assertSame(7, $oranges->getLeft());
         static::assertSame(8, $oranges->getRight());
 
@@ -105,7 +105,7 @@ final class NestedTreePositionTest extends BaseTestCaseORM
 
         static::assertSame(9, $meat_array[0]['c_lft']);
         static::assertSame(10, $meat_array[0]['c_rgt']);
-        static::assertSame(2, $meat_array[0]['c_level']);
+        static::assertSame(3, $meat_array[0]['c_level']);
     }
 
     public function testTreeChildPositionMove3(): void
@@ -116,7 +116,7 @@ final class NestedTreePositionTest extends BaseTestCaseORM
         $oranges = $repo->findOneBy(['title' => 'Oranges']);
         $milk = $repo->findOneBy(['title' => 'Milk']);
 
-        static::assertSame(2, $oranges->getLevel());
+        static::assertSame(3, $oranges->getLevel());
         static::assertSame(7, $oranges->getLeft());
         static::assertSame(8, $oranges->getRight());
 
@@ -136,7 +136,7 @@ final class NestedTreePositionTest extends BaseTestCaseORM
         $milk_array = $this->em->createQuery($dql)->getScalarResult();
         static::assertSame(9, $milk_array[0]['c_lft']);
         static::assertSame(10, $milk_array[0]['c_rgt']);
-        static::assertSame(2, $milk_array[0]['c_level']);
+        static::assertSame(3, $milk_array[0]['c_level']);
     }
 
     public function testPositionedUpdates(): void
@@ -177,12 +177,12 @@ final class NestedTreePositionTest extends BaseTestCaseORM
         $oranges = $repo->findOneBy(['title' => 'Oranges']);
         $fruits = $repo->findOneBy(['title' => 'Fruits']);
 
-        static::assertSame(2, $oranges->getLevel());
+        static::assertSame(3, $oranges->getLevel());
 
         $repo->persistAsNextSiblingOf($oranges, $fruits);
         $this->em->flush();
 
-        static::assertSame(1, $oranges->getLevel());
+        static::assertSame(2, $oranges->getLevel());
         static::assertCount(1, $repo->children($fruits, true));
 
         $vegies = $repo->findOneBy(['title' => 'Vegitables']);
@@ -230,7 +230,7 @@ final class NestedTreePositionTest extends BaseTestCaseORM
 
         $this->em->flush();
         $dql = 'SELECT COUNT(c) FROM '.self::ROOT_CATEGORY.' c';
-        $dql .= ' WHERE c.lft = 1 AND c.rgt = 2 AND c.parent IS NULL AND c.level = 0';
+        $dql .= ' WHERE c.lft = 1 AND c.rgt = 2 AND c.parent IS NULL AND c.level = 1';
         $count = $this->em->createQuery($dql)->getSingleScalarResult();
         static::assertSame(6, (int) $count);
 

--- a/tests/Gedmo/Tree/NestedTreeRootAssociationTest.php
+++ b/tests/Gedmo/Tree/NestedTreeRootAssociationTest.php
@@ -61,6 +61,41 @@ final class NestedTreeRootAssociationTest extends BaseTestCaseORM
         static::assertSame($sports->getId(), $sports->getRoot()->getId());
     }
 
+    public function testRemoveParentForNode(): void
+    {
+        $repo = $this->em->getRepository(self::CATEGORY);
+
+        /** @var RootAssociationCategory $food */
+        $food = $repo->findOneBy(['title' => 'Food']);
+        static::assertSame($food->getId(), $food->getRoot()->getId());
+        static::assertSame(0, $food->getLevel());
+        static::assertSame(1, $food->getLeft());
+        static::assertSame(10, $food->getRight());
+
+        /** @var RootAssociationCategory $fruits */
+        $fruits = $repo->findOneBy(['title' => 'Fruits']);
+        static::assertSame($food->getId(), $fruits->getRoot()->getId());
+        static::assertSame(1, $fruits->getLevel());
+        static::assertSame(2, $fruits->getLeft());
+        static::assertSame(3, $fruits->getRight());
+
+        // Remove node's parent, which should move out the node into a new tree
+        $fruits->setParent(null);
+        $this->em->flush();
+
+        $food = $repo->findOneBy(['title' => 'Food']);
+        static::assertSame($food->getId(), $food->getRoot()->getId());
+        static::assertSame(0, $food->getLevel());
+        static::assertSame(1, $food->getLeft());
+        static::assertSame(8, $food->getRight());
+
+        $fruits = $repo->findOneBy(['title' => 'Fruits']);
+        static::assertSame($fruits->getId(), $fruits->getRoot()->getId());
+        static::assertSame(0, $fruits->getLevel());
+        static::assertSame(1, $fruits->getLeft());
+        static::assertSame(2, $fruits->getRight());
+    }
+
     protected function getUsedEntityFixtures(): array
     {
         return [

--- a/tests/Gedmo/Tree/NestedTreeRootTest.php
+++ b/tests/Gedmo/Tree/NestedTreeRootTest.php
@@ -113,42 +113,42 @@ final class NestedTreeRootTest extends BaseTestCaseORM
 
         static::assertSame(1, $node->getRoot());
         static::assertSame(1, $node->getLeft());
-        static::assertSame(0, $node->getLevel());
+        static::assertSame(1, $node->getLevel());
         static::assertSame(10, $node->getRight());
 
         $node = $repo->findOneBy(['title' => 'Sports']);
 
         static::assertSame(2, $node->getRoot());
         static::assertSame(1, $node->getLeft());
-        static::assertSame(0, $node->getLevel());
+        static::assertSame(1, $node->getLevel());
         static::assertSame(2, $node->getRight());
 
         $node = $repo->findOneBy(['title' => 'Fruits']);
 
         static::assertSame(1, $node->getRoot());
         static::assertSame(2, $node->getLeft());
-        static::assertSame(1, $node->getLevel());
+        static::assertSame(2, $node->getLevel());
         static::assertSame(3, $node->getRight());
 
         $node = $repo->findOneBy(['title' => 'Vegitables']);
 
         static::assertSame(1, $node->getRoot());
         static::assertSame(4, $node->getLeft());
-        static::assertSame(1, $node->getLevel());
+        static::assertSame(2, $node->getLevel());
         static::assertSame(9, $node->getRight());
 
         $node = $repo->findOneBy(['title' => 'Carrots']);
 
         static::assertSame(1, $node->getRoot());
         static::assertSame(5, $node->getLeft());
-        static::assertSame(2, $node->getLevel());
+        static::assertSame(3, $node->getLevel());
         static::assertSame(6, $node->getRight());
 
         $node = $repo->findOneBy(['title' => 'Potatoes']);
 
         static::assertSame(1, $node->getRoot());
         static::assertSame(7, $node->getLeft());
-        static::assertSame(2, $node->getLevel());
+        static::assertSame(3, $node->getLevel());
         static::assertSame(8, $node->getRight());
     }
 
@@ -166,7 +166,7 @@ final class NestedTreeRootTest extends BaseTestCaseORM
         static::assertSame(4, $node->getRoot());
         static::assertSame(1, $node->getLeft());
         static::assertSame(6, $node->getRight());
-        static::assertSame(0, $node->getLevel());
+        static::assertSame(1, $node->getLevel());
     }
 
     public function testTreeUpdateShiftToNextBranch(): void
@@ -189,7 +189,7 @@ final class NestedTreeRootTest extends BaseTestCaseORM
 
         static::assertSame(1, $node->getRoot());
         static::assertSame(2, $node->getLeft());
-        static::assertSame(1, $node->getLevel());
+        static::assertSame(2, $node->getLevel());
         static::assertSame(3, $node->getRight());
 
         $node = $repo->findOneBy(['title' => 'Vegitables']);
@@ -217,14 +217,14 @@ final class NestedTreeRootTest extends BaseTestCaseORM
 
         static::assertSame(4, $node->getRoot());
         static::assertSame(1, $node->getLeft());
-        static::assertSame(0, $node->getLevel());
+        static::assertSame(1, $node->getLevel());
         static::assertSame(6, $node->getRight());
 
         $node = $repo->findOneBy(['title' => 'Potatoes']);
 
         static::assertSame(4, $node->getRoot());
         static::assertSame(4, $node->getLeft());
-        static::assertSame(1, $node->getLevel());
+        static::assertSame(2, $node->getLevel());
         static::assertSame(5, $node->getRight());
     }
 
@@ -248,14 +248,14 @@ final class NestedTreeRootTest extends BaseTestCaseORM
 
         static::assertSame(1, $node->getRoot());
         static::assertSame(2, $node->getLeft());
-        static::assertSame(1, $node->getLevel());
+        static::assertSame(2, $node->getLevel());
         static::assertSame(3, $node->getRight());
 
         $node = $repo->findOneBy(['title' => 'Potatoes']);
 
         static::assertSame(1, $node->getRoot());
         static::assertSame(7, $node->getLeft());
-        static::assertSame(2, $node->getLevel());
+        static::assertSame(3, $node->getLevel());
         static::assertSame(8, $node->getRight());
     }
 
@@ -292,21 +292,21 @@ final class NestedTreeRootTest extends BaseTestCaseORM
 
         static::assertSame(4, $node->getRoot());
         static::assertSame(2, $node->getLeft());
-        static::assertSame(1, $node->getLevel());
+        static::assertSame(2, $node->getLevel());
         static::assertSame(3, $node->getRight());
 
         $node = $repo->findOneBy(['title' => 'Vegitables']);
 
         static::assertSame(4, $node->getRoot());
         static::assertSame(1, $node->getLeft());
-        static::assertSame(0, $node->getLevel());
+        static::assertSame(1, $node->getLevel());
         static::assertSame(6, $node->getRight());
 
         $node = $repo->findOneBy(['title' => 'Sports']);
 
         static::assertSame(1, $node->getRoot());
         static::assertSame(2, $node->getLeft());
-        static::assertSame(1, $node->getLevel());
+        static::assertSame(2, $node->getLevel());
         static::assertSame(3, $node->getRight());
     }
 

--- a/tests/Gedmo/Tree/RepositoryTest.php
+++ b/tests/Gedmo/Tree/RepositoryTest.php
@@ -328,7 +328,7 @@ final class RepositoryTest extends BaseTestCaseORM
         // now lets brake something
 
         $dql = 'UPDATE '.self::CATEGORY.' node';
-        $dql .= ' SET node.lft = 1';
+        $dql .= ' SET node.lft = 1, node.level = 99';
         $dql .= ' WHERE node.id = 8';
         $q = $this->em->createQuery($dql);
         $q->getSingleScalarResult();
@@ -343,14 +343,17 @@ final class RepositoryTest extends BaseTestCaseORM
         static::assertArrayHasKey(0, $result);
         static::assertArrayHasKey(1, $result);
         static::assertArrayHasKey(2, $result);
+        static::assertArrayHasKey(3, $result);
 
         $duplicate = $result[0];
         $missing = $result[1];
         $invalidLeft = $result[2];
+        $invalidLevel = $result[3];
 
         static::assertSame('index [1], duplicate', $duplicate);
         static::assertSame('index [11], missing', $missing);
         static::assertSame('node [8] left is less than parent`s [4] left value', $invalidLeft);
+        static::assertSame('node [8] should be on the level right after its parent`s [4] level', $invalidLevel);
 
         // test recover functionality
         $repo->recover();


### PR DESCRIPTION
- [Tree] [NestedSet] Added "base" property for tree level annotation
- [Tree] [NestedSet] Added 'includeNode' option in getPathQueryBuilder() to specify whether you want the starting node included or not
- [Tree] [NestedSet] Added getPathAsString() method to entity repository
- [Tree] [NestedSet] Added 'treeRootNode' options in verify() in case you want to verify a single tree in a forest
- [Tree] [NestedSet] Added recoverFast() method for where speed is more important than safety and entity manager state
- [Tree] [NestedSet] Added options to recover() for sibling order, tree root in a forest, verification skip and auto-flushing
- [Tree] [NestedSet] Verify and recover wrong levels in nested set
- [Tree] [NestedSet] Added test for removing parent node from tree
