### PR TITLE
Use cache from persisting configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ a release.
 ---
 
 ## [Unreleased]
+## Changed
+- Removed call to deprecated `ClassMetadataFactory::getCacheDriver()` method.
+- Dropped support for doctrine/mongodb-odm < 2.3.
 
 ## [3.6.0] - 2022-03-19
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -51,9 +51,8 @@
     },
     "require-dev": {
         "doctrine/dbal": "^2.13.1 || ^3.2",
-        "doctrine/deprecations": "^0.5.3",
         "doctrine/doctrine-bundle": "^2.3",
-        "doctrine/mongodb-odm": "^2.2",
+        "doctrine/mongodb-odm": "^2.3",
         "doctrine/orm": "^2.10.2",
         "friendsofphp/php-cs-fixer": "~3.4.0",
         "nesbot/carbon": "^2.55",
@@ -68,7 +67,7 @@
     "conflict": {
         "doctrine/cache": "<1.11",
         "doctrine/dbal": "<2.13.1 || ^3.0 <3.2",
-        "doctrine/mongodb-odm": "<2.2",
+        "doctrine/mongodb-odm": "<2.3",
         "doctrine/orm": "<2.10.2",
         "sebastian/comparator": "<2.0"
     },

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -176,11 +176,6 @@ parameters:
 			path: src/Mapping/MappedEventSubscriber.php
 
 		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadataFactory\\<Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\<object\\>\\>\\:\\:getCacheDriver\\(\\)\\.$#"
-			count: 1
-			path: src/Mapping/MappedEventSubscriber.php
-
-		-
 			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\ObjectManager\\:\\:getUnitOfWork\\(\\)\\.$#"
 			count: 1
 			path: src/Mapping/MappedEventSubscriber.php

--- a/src/Mapping/MappedEventSubscriber.php
+++ b/src/Mapping/MappedEventSubscriber.php
@@ -18,6 +18,8 @@ use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Common\Cache\Psr6\CacheAdapter;
 use Doctrine\Common\EventArgs;
 use Doctrine\Common\EventSubscriber;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\ObjectManager;
 use Gedmo\Mapping\Event\AdapterInterface;
@@ -286,16 +288,17 @@ abstract class MappedEventSubscriber implements EventSubscriber
             return $this->cacheItemPool;
         }
 
-        $factory = $objectManager->getMetadataFactory();
-        $cacheDriver = $factory->getCacheDriver();
+        if ($objectManager instanceof EntityManagerInterface || $objectManager instanceof DocumentManager) {
+            $metadataCache = $objectManager->getConfiguration()->getMetadataCache();
 
-        if (null === $cacheDriver) {
-            $this->cacheItemPool = new ArrayAdapter();
+            if (null !== $metadataCache) {
+                $this->cacheItemPool = $metadataCache;
 
-            return $this->cacheItemPool;
+                return $this->cacheItemPool;
+            }
         }
 
-        $this->cacheItemPool = CacheAdapter::wrap($cacheDriver);
+        $this->cacheItemPool = new ArrayAdapter();
 
         return $this->cacheItemPool;
     }

--- a/src/Tree/Strategy/ORM/Closure.php
+++ b/src/Tree/Strategy/ORM/Closure.php
@@ -9,7 +9,6 @@
 
 namespace Gedmo\Tree\Strategy\ORM;
 
-use Doctrine\Common\Cache\Cache;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata as ORMClassMetadata;
@@ -195,15 +194,16 @@ class Closure implements Strategy
         }
 
         if (!$hasTheUserExplicitlyDefinedMapping) {
-            $cacheDriver = $cmf->getCacheDriver();
+            $cacheDriver = $em->getConfiguration()->getMetadataCache();
 
-            if ($cacheDriver instanceof Cache) {
+            if (null !== $cacheDriver) {
                 // @see https://github.com/doctrine/persistence/pull/144
                 // @see \Doctrine\Persistence\Mapping\AbstractClassMetadataFactory::getCacheKey()
-                $cacheDriver->save(
-                    str_replace('\\', '__', $closureMetadata->getName()).'__CLASSMETADATA__',
-                    $closureMetadata
-                );
+                $cacheKey = str_replace('\\', '__', $closureMetadata->getName()).'__CLASSMETADATA__';
+
+                $item = $cacheDriver->getItem($cacheKey);
+
+                $cacheDriver->save($item->set($closureMetadata));
             }
         }
     }

--- a/tests/Gedmo/Mapping/MappingEventSubscriberTest.php
+++ b/tests/Gedmo/Mapping/MappingEventSubscriberTest.php
@@ -13,19 +13,14 @@ namespace Gedmo\Tests\Mapping;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\EventManager;
-use Doctrine\Deprecations\Deprecation;
-use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
-use Doctrine\Persistence\Reflection\TypedNoDefaultReflectionPropertyBase;
+use Gedmo\Mapping\ExtensionMetadataFactory;
 use Gedmo\Sluggable\SluggableListener;
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Gedmo\Tests\Mapping\Fixture\Sluggable;
 
 final class MappingEventSubscriberTest extends ORMMappingTestCase
 {
-    use VerifyDeprecations;
-    use ExpectDeprecationTrait;
-
     /**
      * @var EntityManager
      */
@@ -47,28 +42,25 @@ final class MappingEventSubscriberTest extends ORMMappingTestCase
         $this->em = EntityManager::create($conn, $config, new EventManager());
     }
 
-    /**
-     * @group legacy
-     */
     public function testGetConfigurationCachedFromDoctrine(): void
     {
-        // doctrine/persistence changed from trigger_error to doctrine/deprecations in 2.2.1. In 2.2.2 this trait was
-        // added, this is used to know if the doctrine/persistence version is using trigger_error or
-        // doctrine/deprecations. This "if" check can be removed once we drop support for doctrine/persistence < 2.2.1
-        if (trait_exists(TypedNoDefaultReflectionPropertyBase::class)) {
-            Deprecation::enableWithTriggerError();
+        $cache = $this->em->getConfiguration()->getMetadataCache();
 
-            $this->expectDeprecationWithIdentifier('https://github.com/doctrine/persistence/issues/184');
-        } else {
-            $this->expectDeprecation('Doctrine\Persistence\Mapping\AbstractClassMetadataFactory::getCacheDriver is deprecated. Use getCache() instead.');
-        }
+        $cacheKey = ExtensionMetadataFactory::getCacheId(Sluggable::class, 'Gedmo\Sluggable');
+
+        static::assertFalse($cache->hasItem($cacheKey));
 
         $subscriber = new SluggableListener();
-        $subscriber->getExtensionMetadataFactory($this->em);
+        $classMetadata = $this->em->getClassMetadata(Sluggable::class);
+        $subscriber->getExtensionMetadataFactory($this->em)->getExtensionMetadata($classMetadata);
+
+        static::assertTrue($cache->hasItem($cacheKey));
     }
 
     protected function getUsedEntityFixtures(): array
     {
-        return [];
+        return [
+            Sluggable::class,
+        ];
     }
 }

--- a/tests/Gedmo/Mapping/TreeMappingTest.php
+++ b/tests/Gedmo/Mapping/TreeMappingTest.php
@@ -86,9 +86,9 @@ final class TreeMappingTest extends ORMMappingTestCase
         $this->em->getClassMetadata(self::YAML_CLOSURE_CATEGORY);
         $this->em->getClassMetadata(CategoryClosureWithoutMapping::class);
 
-        $meta = $this->em->getMetadataFactory()->getCacheDriver()->fetch(
+        $meta = $this->em->getConfiguration()->getMetadataCache()->getItem(
             'Gedmo__Tests__Tree__Fixture__Closure__CategoryClosureWithoutMapping__CLASSMETADATA__'
-        );
+        )->get();
         static::assertNotFalse($meta);
         static::assertTrue($meta->hasAssociation('ancestor'));
         static::assertTrue($meta->hasAssociation('descendant'));

--- a/tests/Gedmo/Tool/BaseTestCaseMongoODM.php
+++ b/tests/Gedmo/Tool/BaseTestCaseMongoODM.php
@@ -24,6 +24,7 @@ use Gedmo\SoftDeleteable\SoftDeleteableListener;
 use Gedmo\Timestampable\TimestampableListener;
 use Gedmo\Translatable\TranslatableListener;
 use MongoDB\Client;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 /**
  * Base test case contains common mock objects
@@ -115,6 +116,7 @@ abstract class BaseTestCaseMongoODM extends \PHPUnit\Framework\TestCase
         $config->setAutoGenerateProxyClasses(Configuration::AUTOGENERATE_EVAL);
         $config->setAutoGenerateHydratorClasses(Configuration::AUTOGENERATE_EVAL);
         $config->setMetadataDriverImpl($this->getMetadataDriverImplementation());
+        $config->setMetadataCache(new ArrayAdapter());
 
         return $config;
     }
@@ -131,6 +133,7 @@ abstract class BaseTestCaseMongoODM extends \PHPUnit\Framework\TestCase
         $config->setAutoGenerateProxyClasses(Configuration::AUTOGENERATE_EVAL);
         $config->setAutoGenerateHydratorClasses(Configuration::AUTOGENERATE_EVAL);
         $config->setMetadataDriverImpl($this->getMetadataDefaultDriverImplementation());
+        $config->setMetadataCache(new ArrayAdapter());
 
         return $config;
     }

--- a/tests/Gedmo/Tool/BaseTestCaseOM.php
+++ b/tests/Gedmo/Tool/BaseTestCaseOM.php
@@ -37,6 +37,7 @@ use Gedmo\Timestampable\TimestampableListener;
 use Gedmo\Translatable\TranslatableListener;
 use Gedmo\Tree\TreeListener;
 use MongoDB\Client;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 /**
  * Base test case contains common mock objects
@@ -167,6 +168,7 @@ abstract class BaseTestCaseOM extends \PHPUnit\Framework\TestCase
         $config->setAutoGenerateProxyClasses(Configuration::AUTOGENERATE_EVAL);
         $config->setAutoGenerateHydratorClasses(Configuration::AUTOGENERATE_EVAL);
         $config->setMetadataDriverImpl($mappingDriver);
+        $config->setMetadataCache(new ArrayAdapter());
 
         return $config;
     }
@@ -187,6 +189,7 @@ abstract class BaseTestCaseOM extends \PHPUnit\Framework\TestCase
         $config->setNamingStrategy(new DefaultNamingStrategy());
         $config->setMetadataDriverImpl($mappingDriver ?? $this->getORMDriver());
         $config->setRepositoryFactory(new DefaultRepositoryFactoryORM());
+        $config->setMetadataCache(new ArrayAdapter());
 
         return $config;
     }


### PR DESCRIPTION
Instead of relying on the deprecated `ClassMetadataFactory::getCacheDriver` method, we can get the metadata cache from the configuration since it is the same:

https://github.com/doctrine/orm/blob/8291a7f09b12d14783ed6537b4586583d155869e/lib/Doctrine/ORM/EntityManager.php#L1058-L1067

https://github.com/doctrine/mongodb-odm/blob/1a8b2c37519383424f6f89573845346933af884f/lib/Doctrine/ODM/MongoDB/DocumentManager.php#L185-L188

This will allow to remove one of the blockers for `doctrine/persistence` 3 ([I haven't checked yet other possible issues](https://github.com/doctrine-extensions/DoctrineExtensions/issues/2450#issuecomment-1115060197))