### PR TITLE
Allow doctrine/persistence 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ a release.
 ---
 
 ## [Unreleased]
+## Added
+- Add support for doctrine/persistence 3
+
 ## Changed
 - Removed call to deprecated `ClassMetadataFactory::getCacheDriver()` method.
 - Dropped support for doctrine/mongodb-odm < 2.3.

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "doctrine/collections": "^1.0",
         "doctrine/common": "^2.13 || ^3.0",
         "doctrine/event-manager": "^1.0",
-        "doctrine/persistence": "^2.2",
+        "doctrine/persistence": "^2.2 || ^3.0",
         "psr/cache": "^1 || ^2 || ^3",
         "symfony/cache": "^4.4 || ^5.3 || ^6.0"
     },


### PR DESCRIPTION
Apparently the removal of `LifecycleEventArgs::getEntity()` should not be an issue since it uses the `LifecycleEventArgs::getEntity()` from doctrine/orm.

It would be nice to test this on real projects just in case there is something missing.

Closes #2450

