### PR TITLE
Make doctrine/cache optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ a release.
 ## Changed
 - Removed call to deprecated `ClassMetadataFactory::getCacheDriver()` method.
 - Dropped support for doctrine/mongodb-odm < 2.3.
+- Make doctrine/cache an optional dependency.
 
 ## [3.6.0] - 2022-03-19
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,6 @@
         "php": "^7.2 || ^8.0",
         "behat/transliterator": "~1.2",
         "doctrine/annotations": "^1.13",
-        "doctrine/cache": "^1.11 || ^2.0",
         "doctrine/collections": "^1.0",
         "doctrine/common": "^2.13 || ^3.0",
         "doctrine/event-manager": "^1.0",
@@ -50,6 +49,7 @@
         "symfony/cache": "^4.4 || ^5.3 || ^6.0"
     },
     "require-dev": {
+        "doctrine/cache": "^1.11 || ^2.0",
         "doctrine/dbal": "^2.13.1 || ^3.2",
         "doctrine/doctrine-bundle": "^2.3",
         "doctrine/mongodb-odm": "^2.3",


### PR DESCRIPTION
Since https://github.com/doctrine-extensions/DoctrineExtensions/pull/2451 we don't need `doctrine/cache` to be required.