### PR TITLE
Allow install php-cs-fixer > 3.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "doctrine/doctrine-bundle": "^2.3",
         "doctrine/mongodb-odm": "^2.3",
         "doctrine/orm": "^2.10.2",
-        "friendsofphp/php-cs-fixer": "~3.4.0",
+        "friendsofphp/php-cs-fixer": "^3.4.0",
         "nesbot/carbon": "^2.55",
         "phpstan/phpstan": "^1.1",
         "phpstan/phpstan-doctrine": "^1.0",

--- a/example/em.php
+++ b/example/em.php
@@ -89,11 +89,11 @@ $treeListener->setCacheItemPool($cache);
 $eventManager->addEventSubscriber($treeListener);
 
 // Loggable extension, not used in example
-//$loggableListener = new Gedmo\Loggable\LoggableListener;
-//$loggableListener->setAnnotationReader($annotationReader);
-//$loggableListener->setCacheItemPool($cache);
-//$loggableListener->setUsername('admin');
-//$eventManager->addEventSubscriber($loggableListener);
+// $loggableListener = new Gedmo\Loggable\LoggableListener;
+// $loggableListener->setAnnotationReader($annotationReader);
+// $loggableListener->setCacheItemPool($cache);
+// $loggableListener->setUsername('admin');
+// $eventManager->addEventSubscriber($loggableListener);
 
 // Timestampable extension
 $timestampableListener = new Gedmo\Timestampable\TimestampableListener();
@@ -120,10 +120,10 @@ $translatableListener->setCacheItemPool($cache);
 $eventManager->addEventSubscriber($translatableListener);
 
 // Sortable extension, not used in example
-//$sortableListener = new Gedmo\Sortable\SortableListener;
-//$sortableListener->setAnnotationReader($annotationReader);
-//$sortableListener->setCacheItemPool($cache);
-//$eventManager->addEventSubscriber($sortableListener);
+// $sortableListener = new Gedmo\Sortable\SortableListener;
+// $sortableListener->setAnnotationReader($annotationReader);
+// $sortableListener->setCacheItemPool($cache);
+// $eventManager->addEventSubscriber($sortableListener);
 
 // Now we will build our ORM configuration.
 $config = new Doctrine\ORM\Configuration();

--- a/src/Mapping/Driver/Chain.php
+++ b/src/Mapping/Driver/Chain.php
@@ -92,7 +92,7 @@ class Chain implements Driver
         }
 
         // commenting it for customized mapping support, debugging of such cases might get harder
-        //throw new \Gedmo\Exception\UnexpectedValueException('Class ' . $meta->getName() . ' is not a valid entity or mapped super class.');
+        // throw new \Gedmo\Exception\UnexpectedValueException('Class ' . $meta->getName() . ' is not a valid entity or mapped super class.');
     }
 
     /**
@@ -100,6 +100,6 @@ class Chain implements Driver
      */
     public function setOriginalDriver($driver)
     {
-        //not needed here
+        // not needed here
     }
 }

--- a/src/Mapping/Driver/File.php
+++ b/src/Mapping/Driver/File.php
@@ -116,7 +116,7 @@ abstract class File implements Driver
      */
     protected function _getMapping($className)
     {
-        //try loading mapping from original driver first
+        // try loading mapping from original driver first
         $mapping = null;
         if (null !== $this->_originalDriver) {
             if ($this->_originalDriver instanceof FileDriver) {
@@ -124,7 +124,7 @@ abstract class File implements Driver
             }
         }
 
-        //if no mapping found try to load mapping file again
+        // if no mapping found try to load mapping file again
         if (null === $mapping) {
             $yaml = $this->_loadMappingFile($this->locator->findMappingFile($className));
             $mapping = $yaml[$className];

--- a/src/Sluggable/Handler/TreeSlugHandler.php
+++ b/src/Sluggable/Handler/TreeSlugHandler.php
@@ -106,7 +106,7 @@ class TreeSlugHandler implements SlugHandlerWithUniqueCallbackInterface
             if (isset($options['suffix'])) {
                 $suffix = $options['suffix'];
 
-                if (substr($this->parentSlug, -strlen($suffix)) === $suffix) { //endsWith
+                if (substr($this->parentSlug, -strlen($suffix)) === $suffix) { // endsWith
                     $this->parentSlug = substr_replace($this->parentSlug, '', -1 * strlen($suffix));
                 }
             }

--- a/src/SoftDeleteable/SoftDeleteableListener.php
+++ b/src/SoftDeleteable/SoftDeleteableListener.php
@@ -61,7 +61,7 @@ class SoftDeleteableListener extends MappedEventSubscriber
         $uow = $om->getUnitOfWork();
         $evm = $om->getEventManager();
 
-        //getScheduledDocumentDeletions
+        // getScheduledDocumentDeletions
         foreach ($ea->getScheduledObjectDeletions($uow) as $object) {
             $meta = $om->getClassMetadata(get_class($object));
             $config = $this->getConfiguration($om, $meta->getName());

--- a/src/Tree/Strategy/ORM/Closure.php
+++ b/src/Tree/Strategy/ORM/Closure.php
@@ -481,7 +481,7 @@ class Closure implements Strategy
 
             $levelsAssoc = $em->getConnection()->executeQuery($sql, [array_keys($this->pendingNodesLevelProcess)], [$type])->fetchAllNumeric();
 
-            //create key pair array with resultset
+            // create key pair array with resultset
             $levels = [];
             foreach ($levelsAssoc as $level) {
                 $levels[$level[0]] = $level[1];

--- a/tests/Gedmo/Blameable/ChangeTest.php
+++ b/tests/Gedmo/Blameable/ChangeTest.php
@@ -57,7 +57,7 @@ final class ChangeTest extends BaseTestCaseORM
         $this->em->persist($test);
         $this->em->flush();
         $this->em->clear();
-        //Changed
+        // Changed
         static::assertSame('testuser', $test->getChtitle());
 
         $this->listener->setUserValue('otheruser');
@@ -67,7 +67,7 @@ final class ChangeTest extends BaseTestCaseORM
         $this->em->persist($test);
         $this->em->flush();
         $this->em->clear();
-        //Not Changed
+        // Not Changed
         static::assertSame('testuser', $test->getChtitle());
     }
 

--- a/tests/Gedmo/IpTraceable/ChangeTest.php
+++ b/tests/Gedmo/IpTraceable/ChangeTest.php
@@ -59,7 +59,7 @@ final class ChangeTest extends BaseTestCaseORM
         $this->em->persist($test);
         $this->em->flush();
         $this->em->clear();
-        //Changed
+        // Changed
         static::assertSame(self::TEST_IP, $test->getChtitle());
 
         $this->listener->setIpValue('127.0.0.1');
@@ -69,7 +69,7 @@ final class ChangeTest extends BaseTestCaseORM
         $this->em->persist($test);
         $this->em->flush();
         $this->em->clear();
-        //Not Changed
+        // Not Changed
         static::assertSame(self::TEST_IP, $test->getChtitle());
     }
 

--- a/tests/Gedmo/Mapping/MappingTest.php
+++ b/tests/Gedmo/Mapping/MappingTest.php
@@ -32,7 +32,7 @@ final class MappingTest extends \PHPUnit\Framework\TestCase
         $config = new \Doctrine\ORM\Configuration();
         $config->setProxyDir(TESTS_TEMP_DIR);
         $config->setProxyNamespace('Gedmo\Mapping\Proxy');
-        //$this->markTestSkipped('Skipping according to a bug in annotation reader creation.');
+        // $this->markTestSkipped('Skipping according to a bug in annotation reader creation.');
         $config->setMetadataDriverImpl(new \Doctrine\ORM\Mapping\Driver\AnnotationDriver($_ENV['annotation_reader']));
 
         $conn = [

--- a/tests/Gedmo/Mapping/Mock/Extension/Encoder/Mapping/Driver/Annotation.php
+++ b/tests/Gedmo/Mapping/Mock/Extension/Encoder/Mapping/Driver/Annotation.php
@@ -26,7 +26,7 @@ class Annotation implements Driver
     {
         $reader = new AnnotationReader();
         // set annotation namespace and alias
-        //$reader->setAnnotationNamespaceAlias('Gedmo\Tests\Mapping\Mock\Extension\Encoder\Mapping\\', 'ext');
+        // $reader->setAnnotationNamespaceAlias('Gedmo\Tests\Mapping\Mock\Extension\Encoder\Mapping\\', 'ext');
 
         $class = $meta->getReflectionClass();
         // check only property annotations

--- a/tests/Gedmo/SoftDeleteable/SoftDeleteableDocumentTest.php
+++ b/tests/Gedmo/SoftDeleteable/SoftDeleteableDocumentTest.php
@@ -132,7 +132,7 @@ final class SoftDeleteableDocumentTest extends BaseTestCaseMongoODM
 
         $repo = $this->dm->getRepository(self::USER__TIME_AWARE_CLASS);
 
-        //Find entity with deletedAt date in future
+        // Find entity with deletedAt date in future
         $newUser = new User();
         $username = 'test_user';
         $newUser->setUsername($username);
@@ -145,7 +145,7 @@ final class SoftDeleteableDocumentTest extends BaseTestCaseMongoODM
         $this->dm->remove($user);
         $this->dm->flush();
 
-        //Don't find entity with deletedAt date in past
+        // Don't find entity with deletedAt date in past
         $newUser = new User();
         $username = 'test_user';
         $newUser->setUsername($username);

--- a/tests/Gedmo/Sortable/SortableGroupTest.php
+++ b/tests/Gedmo/Sortable/SortableGroupTest.php
@@ -89,11 +89,11 @@ final class SortableGroupTest extends BaseTestCaseORM
         $audi80 = $carRepo->findOneBy(['title' => 'Audi-80']);
         static::assertSame(0, $audi80->getSortByEngine());
 
-        //position 1
+        // position 1
         $audi80s = $carRepo->findOneBy(['title' => 'Audi-80s']);
         static::assertSame(1, $audi80s->getSortByEngine());
 
-        //position 2
+        // position 2
         $icarus = $this->em->getRepository(self::BUS)->findOneBy(['title' => 'Icarus']);
         static::assertSame(2, $icarus->getSortByEngine());
 

--- a/tests/Gedmo/Sortable/SortableTest.php
+++ b/tests/Gedmo/Sortable/SortableTest.php
@@ -563,7 +563,7 @@ final class SortableTest extends BaseTestCaseORM
         static::assertSame(1, $author2->getPosition());
         static::assertSame(0, $author3->getPosition());
 
-        //update position
+        // update position
         $author3->setPaper($paper1);
         $author3->setPosition(0); // same as before, no changes
         $this->em->persist($author3);
@@ -614,7 +614,7 @@ final class SortableTest extends BaseTestCaseORM
         static::assertSame(0, $author1->getPosition());
         static::assertSame(1, $author2->getPosition());
 
-        //update position
+        // update position
         $author2->setPaper($paper2);
         $author2->setPosition(0); // Position has changed author2 was at position 1 in paper1 and now 0 in paper2, so it can be in changeSets
         $this->em->persist($author2);

--- a/tests/Gedmo/Timestampable/ChangeTest.php
+++ b/tests/Gedmo/Timestampable/ChangeTest.php
@@ -63,7 +63,7 @@ final class ChangeTest extends BaseTestCaseORM
         $this->em->persist($test);
         $this->em->flush();
         $this->em->clear();
-        //Changed
+        // Changed
         static::assertSame(
             $currentDate->format('Y-m-d H:i:s'),
             $test->getChtitle()->format('Y-m-d H:i:s')
@@ -82,7 +82,7 @@ final class ChangeTest extends BaseTestCaseORM
         $this->em->persist($test);
         $this->em->flush();
         $this->em->clear();
-        //Not Changed
+        // Not Changed
         static::assertSame(
             $currentDate->format('Y-m-d H:i:s'),
             $test->getChtitle()->format('Y-m-d H:i:s')
@@ -97,7 +97,7 @@ final class ChangeTest extends BaseTestCaseORM
         $this->em->persist($test);
         $this->em->flush();
         $this->em->clear();
-        //Changed
+        // Changed
         static::assertSame(
             $anotherDate->format('Y-m-d H:i:s'),
             $test->getClosed()->format('Y-m-d H:i:s')

--- a/tests/Gedmo/Translatable/AttributeEntityTranslationTableTest.php
+++ b/tests/Gedmo/Translatable/AttributeEntityTranslationTableTest.php
@@ -57,7 +57,7 @@ final class AttributeEntityTranslationTableTest extends BaseTestCaseORM
         $this->em->clear();
 
         $repo = $this->em->getRepository(self::TRANSLATION);
-        static::assertTrue($repo instanceof TranslationRepository);
+        static::assertInstanceOf(TranslationRepository::class, $repo);
 
         $translations = $repo->findTranslations($person);
         // As Translate locale and Default locale are the same, no records should be present in translations table

--- a/tests/Gedmo/Translatable/EntityTranslationTableTest.php
+++ b/tests/Gedmo/Translatable/EntityTranslationTableTest.php
@@ -56,7 +56,7 @@ final class EntityTranslationTableTest extends BaseTestCaseORM
         static::assertInstanceOf(TranslationRepository::class, $repo);
 
         $translations = $repo->findTranslations($person);
-        //As Translate locale and Default locale are the same, no records should be present in translations table
+        // As Translate locale and Default locale are the same, no records should be present in translations table
         static::assertCount(0, $translations);
 
         // test second translations
@@ -69,7 +69,7 @@ final class EntityTranslationTableTest extends BaseTestCaseORM
         $this->em->clear();
 
         $translations = $repo->findTranslations($person);
-        //Only one translation should be present
+        // Only one translation should be present
         static::assertCount(1, $translations);
         static::assertArrayHasKey('de_de', $translations);
 

--- a/tests/Gedmo/Translatable/Issue/Issue114Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue114Test.php
@@ -48,7 +48,7 @@ final class Issue114Test extends BaseTestCaseORM
     {
         $repo = $this->em->getRepository(self::TRANSLATION);
 
-        //Categories
+        // Categories
         $category1 = new Category();
         $category1->setTitle('en category1');
 
@@ -59,7 +59,7 @@ final class Issue114Test extends BaseTestCaseORM
         $this->em->persist($category2);
         $this->em->flush();
 
-        //Articles
+        // Articles
         $article1 = new Article();
         $article1->setTitle('en article1');
         $article1->setCategory($category1);

--- a/tests/Gedmo/Translatable/Issue/Issue138Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue138Test.php
@@ -56,7 +56,7 @@ final class Issue138Test extends BaseTestCaseORM
 
         // array hydration
         $this->translatableListener->setTranslatableLocale('en_us');
-        //die($q->getSQL());
+        // die($q->getSQL());
         $result = $q->getArrayResult();
         static::assertCount(1, $result);
         static::assertSame('Food', $result[0]['title']);

--- a/tests/Gedmo/Translatable/Issue/Issue173Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue173Test.php
@@ -104,7 +104,7 @@ final class Issue173Test extends BaseTestCaseORM
 
     private function populate(): void
     {
-        //Categories
+        // Categories
         $category1 = new Category();
         $category1->setTitle('en category1');
 
@@ -119,12 +119,12 @@ final class Issue173Test extends BaseTestCaseORM
         $this->em->persist($category3);
         $this->em->flush();
 
-        //Articles
+        // Articles
         $article1 = new Article();
         $article1->setTitle('en article1');
         $article1->setCategory($category1);
 
-        //Products
+        // Products
         $product1 = new Product();
         $product1->setTitle('en product1');
         $product1->setCategory($category2);

--- a/tests/Gedmo/Translatable/Issue/Issue2152Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue2152Test.php
@@ -44,16 +44,16 @@ final class Issue2152Test extends BaseTestCaseORM
 
     public function testShouldFindInheritedClassTranslations(): void
     {
-        //Arrange
-        //by default we have English
+        // Arrange
+        // by default we have English
         $title = 'Hello World';
         $isOperating = '1';
 
-        //operating in germany
+        // operating in germany
         $deTitle = 'Hallo Welt';
         $isOperatingInGermany = '0';
 
-        //but in Ukraine not operating, should fallback to default one
+        // but in Ukraine not operating, should fallback to default one
         $uaTitle = null;
         $isOperatingInUkraine = null;
 
@@ -71,11 +71,11 @@ final class Issue2152Test extends BaseTestCaseORM
         $this->em->persist($entity);
         $this->em->flush();
 
-        //Act
+        // Act
         $entityInDe = $this->findUsingQueryBuilder('de');
         $entityInUa = $this->findUsingQueryBuilder('ua');
 
-        //Assert
+        // Assert
 
         static::assertSame($deTitle, $entityInDe->getTitle());
         static::assertSame($isOperatingInGermany, $entityInDe->isOperating());

--- a/tests/Gedmo/Translatable/TranslationQueryWalkerTest.php
+++ b/tests/Gedmo/Translatable/TranslationQueryWalkerTest.php
@@ -183,7 +183,7 @@ final class TranslationQueryWalkerTest extends BaseTestCaseORM
             static::assertSame(1, $this->queryAnalyzer->getNumExecutedQueries());
         }
 
-        //Default translation is en_us, so we expect the results in that locale
+        // Default translation is en_us, so we expect the results in that locale
         static::assertSame('Food', $result[0]->getTitle());
         static::assertSame('about food', $result[0]->getContent());
     }
@@ -232,7 +232,7 @@ final class TranslationQueryWalkerTest extends BaseTestCaseORM
             static::assertSame(1, $this->queryAnalyzer->getNumExecutedQueries());
         }
 
-        //Default translation is en_us, so we expect the results in that locale
+        // Default translation is en_us, so we expect the results in that locale
         static::assertSame('Food', $result[0]['title']);
         static::assertSame('about food', $result[0]['content']);
     }
@@ -285,7 +285,7 @@ final class TranslationQueryWalkerTest extends BaseTestCaseORM
             static::assertSame(1, $this->queryAnalyzer->getNumExecutedQueries());
         }
 
-        //Default translation is en_us, so we expect the results in that locale
+        // Default translation is en_us, so we expect the results in that locale
         static::assertSame('Food', $result[0]->getTitle());
         static::assertSame('John Doe', $result[0]->getAuthor());
         static::assertNull($result[0]->getViews()); // optional fallback is false,  thus no translation required
@@ -399,7 +399,7 @@ final class TranslationQueryWalkerTest extends BaseTestCaseORM
             static::assertSame(1, $this->queryAnalyzer->getNumExecutedQueries());
         }
 
-        //Default translation is en_us, so we expect the results in that locale
+        // Default translation is en_us, so we expect the results in that locale
         static::assertSame('Food', $result[0]->getTitle());
         static::assertSame('about food', $result[0]->getContent());
 
@@ -408,7 +408,7 @@ final class TranslationQueryWalkerTest extends BaseTestCaseORM
         $q->setHint(TranslatableListener::HINT_FALLBACK, 1);
 
         $result = $q->getResult();
-        //Default translation is en_us, so we expect the results in that locale
+        // Default translation is en_us, so we expect the results in that locale
         static::assertSame('Food', $result[0]->getTitle());
         static::assertSame('about food', $result[0]->getContent());
 
@@ -417,7 +417,7 @@ final class TranslationQueryWalkerTest extends BaseTestCaseORM
         $q->setHint(TranslatableListener::HINT_FALLBACK, 0);
 
         $result = $q->getResult();
-        //Default translation is en_us, so we expect the results in that locale
+        // Default translation is en_us, so we expect the results in that locale
         static::assertNull($result[0]->getTitle());
         static::assertNull($result[0]->getContent());
     }

--- a/tests/Gedmo/Translator/Fixture/Person.php
+++ b/tests/Gedmo/Translator/Fixture/Person.php
@@ -131,9 +131,9 @@ class Person
         }
 
         return new \Gedmo\Translator\TranslationProxy($this,
-        /* Locale                            */ $locale,
-        /* List of translatable properties:  */ ['name', 'lastName'],
-        /* Translation entity class:         */ PersonTranslation::class,
+        /* Locale */ $locale,
+        /* List of translatable properties: */ ['name', 'lastName'],
+        /* Translation entity class: */ PersonTranslation::class,
         /* Translations collection property: */ $this->translations
         );
     }

--- a/tests/Gedmo/Translator/Fixture/PersonCustom.php
+++ b/tests/Gedmo/Translator/Fixture/PersonCustom.php
@@ -95,9 +95,9 @@ class PersonCustom
         }
 
         return new CustomProxy($this,
-        /* Locale                            */ $locale,
-        /* List of translatable properties:  */ ['name'],
-        /* Translation entity class:         */ PersonCustomTranslation::class,
+        /* Locale */ $locale,
+        /* List of translatable properties: */ ['name'],
+        /* Translation entity class: */ PersonCustomTranslation::class,
         /* Translations collection property: */ $this->translations
         );
     }

--- a/tests/Gedmo/Tree/MultiInheritanceTest.php
+++ b/tests/Gedmo/Tree/MultiInheritanceTest.php
@@ -67,7 +67,7 @@ final class MultiInheritanceTest extends BaseTestCaseORM
         $repo = $this->em->getRepository(self::NODE);
         $vegies = $repo->findOneBy(['title' => 'Vegitables']);
 
-        $count = $repo->childCount($vegies, true/*direct*/);
+        $count = $repo->childCount($vegies, true/* direct */);
         static::assertSame(3, $count);
 
         $children = $repo->children($vegies, true);

--- a/tests/Gedmo/Tree/NestedTreePositionTest.php
+++ b/tests/Gedmo/Tree/NestedTreePositionTest.php
@@ -94,13 +94,13 @@ final class NestedTreePositionTest extends BaseTestCaseORM
         static::assertSame(7, $oranges->getLeft());
         static::assertSame(8, $oranges->getRight());
 
-        //Normal test that pass
+        // Normal test that pass
         static::assertSame(9, $meat->getLeft());
         static::assertSame(10, $meat->getRight());
 
         // Raw query to show the issue #108 with wrong left value by Doctrine
         $dql = 'SELECT c FROM '.self::ROOT_CATEGORY.' c';
-        $dql .= ' WHERE c.id = 5'; //5 == meat
+        $dql .= ' WHERE c.id = 5'; // 5 == meat
         $meat_array = $this->em->createQuery($dql)->getScalarResult();
 
         static::assertSame(9, $meat_array[0]['c_lft']);
@@ -126,13 +126,13 @@ final class NestedTreePositionTest extends BaseTestCaseORM
         static::assertSame(7, $oranges->getLeft());
         static::assertSame(8, $oranges->getRight());
 
-        //Normal test that pass
+        // Normal test that pass
         static::assertSame(9, $milk->getLeft());
         static::assertSame(10, $milk->getRight());
 
         // Raw query to show the issue #108 with wrong left value by Doctrine
         $dql = 'SELECT c FROM '.self::ROOT_CATEGORY.' c';
-        $dql .= ' WHERE c.id = 4 '; //4 == Milk
+        $dql .= ' WHERE c.id = 4 '; // 4 == Milk
         $milk_array = $this->em->createQuery($dql)->getScalarResult();
         static::assertSame(9, $milk_array[0]['c_lft']);
         static::assertSame(10, $milk_array[0]['c_rgt']);

--- a/tests/Gedmo/Tree/TreeTest.php
+++ b/tests/Gedmo/Tree/TreeTest.php
@@ -168,7 +168,7 @@ final class TreeTest extends BaseTestCaseORM
         $this->em->persist($yetAnotherChild);
         $yetAnotherChild->setTitle('yetanotherchild');
         $yetAnotherChild->setParent($root);
-        //$this->em->persist($yetAnotherChild);
+        // $this->em->persist($yetAnotherChild);
         $this->em->flush();
         $this->em->clear();
 
@@ -363,7 +363,7 @@ final class TreeTest extends BaseTestCaseORM
         $this->em->persist($yetAnotherChild);
         $yetAnotherChild->setTitle('yetanotherchild');
         $yetAnotherChild->setParent($root);
-        //$this->em->persist($yetAnotherChild);
+        // $this->em->persist($yetAnotherChild);
         $this->em->flush();
         $this->em->clear();
 


### PR DESCRIPTION
It was restricted in https://github.com/doctrine-extensions/DoctrineExtensions/pull/2418, but the issue was fixed.