### PR TITLE
[Sortable] Resolve Column Type when fetching Max Position from Database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ a release.
 - [NestedSet] childrenQueryBuilder() to allow specifying sort order separately for each field
 - [NestedSet] Added option to reorder only direct children in reorder() method
 
+### Sortable
+#### Fixed
+- [SortableGroup] Fix sorting date columns in SQLite (#2462).
+
 ## [3.7.0] - 2022-05-17
 ## Added
 - Add support for doctrine/persistence 3

--- a/src/Sortable/Mapping/Event/Adapter/ORM.php
+++ b/src/Sortable/Mapping/Event/Adapter/ORM.php
@@ -35,7 +35,7 @@ final class ORM extends BaseAdapterORM implements SortableAdapter
         $qb = $em->createQueryBuilder();
         $qb->select('MAX(n.'.$config['position'].')')
            ->from($config['useObjectClass'], 'n');
-        $this->addGroupWhere($qb, $groups);
+        $this->addGroupWhere($qb, $meta, $groups);
         $query = $qb->getQuery();
         $query->useQueryCache(false);
         $query->disableResultCache();
@@ -108,7 +108,7 @@ final class ORM extends BaseAdapterORM implements SortableAdapter
         $q->getSingleScalarResult();
     }
 
-    private function addGroupWhere(QueryBuilder $qb, iterable $groups): void
+    private function addGroupWhere(QueryBuilder $qb, ClassMetadata $metadata, iterable $groups): void
     {
         $i = 1;
         foreach ($groups as $group => $value) {
@@ -116,7 +116,7 @@ final class ORM extends BaseAdapterORM implements SortableAdapter
                 $qb->andWhere($qb->expr()->isNull('n.'.$group));
             } else {
                 $qb->andWhere('n.'.$group.' = :group__'.$i);
-                $qb->setParameter('group__'.$i, $value);
+                $qb->setParameter('group__'.$i, $value, $metadata->getTypeOfField($group));
             }
             ++$i;
         }

--- a/tests/Gedmo/Sortable/Fixture/ItemWithDateColumn.php
+++ b/tests/Gedmo/Sortable/Fixture/ItemWithDateColumn.php
@@ -82,34 +82,22 @@ class ItemWithDateColumn
         $this->position = $position;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getDate()
+    public function getDate(): ?\DateTime
     {
         return $this->date;
     }
 
-    /**
-     * @param mixed $date
-     */
-    public function setDate($date): void
+    public function setDate(?\DateTime $date): void
     {
         $this->date = $date;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getUserId()
+    public function getUserId(): ?string
     {
         return $this->userId;
     }
 
-    /**
-     * @param mixed $userId
-     */
-    public function setUserId($userId): void
+    public function setUserId(?string $userId): void
     {
         $this->userId = $userId;
     }

--- a/tests/Gedmo/Sortable/Fixture/ItemWithDateColumn.php
+++ b/tests/Gedmo/Sortable/Fixture/ItemWithDateColumn.php
@@ -45,7 +45,7 @@ class ItemWithDateColumn
      * @ORM\Column(type="date")
      */
     #[Gedmo\SortableGroup]
-    #[ORM\Column(type: 'date')]
+    #[ORM\Column(type: Types::DATE_MUTABLE)]
     private $date;
 
     /**

--- a/tests/Gedmo/Sortable/Fixture/ItemWithDateColumn.php
+++ b/tests/Gedmo/Sortable/Fixture/ItemWithDateColumn.php
@@ -33,6 +33,8 @@ class ItemWithDateColumn
     private $id;
 
     /**
+     * @var int
+     *
      * @Gedmo\SortablePosition
      * @ORM\Column(type="integer")
      */

--- a/tests/Gedmo/Sortable/Fixture/ItemWithDateColumn.php
+++ b/tests/Gedmo/Sortable/Fixture/ItemWithDateColumn.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Gedmo\Tests\Sortable\Fixture;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Gedmo\Sortable\Entity\Repository\SortableRepository;
+
+/**
+ * @ORM\Entity(repositoryClass="Gedmo\Sortable\Entity\Repository\SortableRepository")
+ */
+#[ORM\Entity(repositoryClass: SortableRepository::class)]
+class ItemWithDateColumn
+{
+    /**
+     * @var int|null
+     *
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    private $id;
+
+    /**
+     * @Gedmo\SortablePosition
+     * @ORM\Column(type="integer")
+     */
+    #[Gedmo\SortablePosition]
+    #[ORM\Column(type: 'integer')]
+    //private $position = -1;
+    private $position = 0;
+
+    /**
+     * @Gedmo\SortableGroup
+     * @ORM\Column(type="date")
+     */
+    #[Gedmo\SortableGroup]
+    #[ORM\Column(type: 'date')]
+    private $date;
+
+    /**
+     * @Gedmo\SortableGroup
+     * @ORM\Column(nullable=false)
+     */
+    #[Gedmo\SortableGroup]
+    #[ORM\Column(nullable: false)]
+    private $userId;
+
+    /**
+     * @return int|null
+     */
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param int|null $id
+     */
+    public function setId(?int $id): void
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * @return int
+     */
+    public function getPosition(): int
+    {
+        return $this->position;
+    }
+
+    /**
+     * @param int $position
+     */
+    public function setPosition(int $position): void
+    {
+        $this->position = $position;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getDate()
+    {
+        return $this->date;
+    }
+
+    /**
+     * @param mixed $date
+     */
+    public function setDate($date): void
+    {
+        $this->date = $date;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getUserId()
+    {
+        return $this->userId;
+    }
+
+    /**
+     * @param mixed $userId
+     */
+    public function setUserId($userId): void
+    {
+        $this->userId = $userId;
+    }
+}

--- a/tests/Gedmo/Sortable/Fixture/ItemWithDateColumn.php
+++ b/tests/Gedmo/Sortable/Fixture/ItemWithDateColumn.php
@@ -53,6 +53,8 @@ class ItemWithDateColumn
     private $date;
 
     /**
+     * @var string|null
+     *
      * @Gedmo\SortableGroup
      * @ORM\Column(nullable=false)
      */

--- a/tests/Gedmo/Sortable/Fixture/ItemWithDateColumn.php
+++ b/tests/Gedmo/Sortable/Fixture/ItemWithDateColumn.php
@@ -52,16 +52,6 @@ class ItemWithDateColumn
     #[ORM\Column(type: Types::DATE_MUTABLE)]
     private $date;
 
-    /**
-     * @var string|null
-     *
-     * @Gedmo\SortableGroup
-     * @ORM\Column(nullable=false)
-     */
-    #[Gedmo\SortableGroup]
-    #[ORM\Column(nullable: false)]
-    private $userId;
-
     public function getId(): ?int
     {
         return $this->id;
@@ -90,15 +80,5 @@ class ItemWithDateColumn
     public function setDate(?\DateTime $date): void
     {
         $this->date = $date;
-    }
-
-    public function getUserId(): ?string
-    {
-        return $this->userId;
-    }
-
-    public function setUserId(?string $userId): void
-    {
-        $this->userId = $userId;
     }
 }

--- a/tests/Gedmo/Sortable/Fixture/ItemWithDateColumn.php
+++ b/tests/Gedmo/Sortable/Fixture/ItemWithDateColumn.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Gedmo\Tests\Sortable\Fixture;
 
 use Doctrine\DBAL\Types\Types;
@@ -31,7 +38,6 @@ class ItemWithDateColumn
      */
     #[Gedmo\SortablePosition]
     #[ORM\Column(type: 'integer')]
-    //private $position = -1;
     private $position = 0;
 
     /**
@@ -50,33 +56,21 @@ class ItemWithDateColumn
     #[ORM\Column(nullable: false)]
     private $userId;
 
-    /**
-     * @return int|null
-     */
     public function getId(): ?int
     {
         return $this->id;
     }
 
-    /**
-     * @param int|null $id
-     */
     public function setId(?int $id): void
     {
         $this->id = $id;
     }
 
-    /**
-     * @return int
-     */
     public function getPosition(): int
     {
         return $this->position;
     }
 
-    /**
-     * @param int $position
-     */
     public function setPosition(int $position): void
     {
         $this->position = $position;

--- a/tests/Gedmo/Sortable/Fixture/ItemWithDateColumn.php
+++ b/tests/Gedmo/Sortable/Fixture/ItemWithDateColumn.php
@@ -43,6 +43,8 @@ class ItemWithDateColumn
     private $position = 0;
 
     /**
+     * @var \DateTime|null
+     *
      * @Gedmo\SortableGroup
      * @ORM\Column(type="date")
      */

--- a/tests/Gedmo/Sortable/Fixture/ItemWithDateColumn.php
+++ b/tests/Gedmo/Sortable/Fixture/ItemWithDateColumn.php
@@ -37,7 +37,7 @@ class ItemWithDateColumn
      * @ORM\Column(type="integer")
      */
     #[Gedmo\SortablePosition]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $position = 0;
 
     /**

--- a/tests/Gedmo/Sortable/SortableGroupTest.php
+++ b/tests/Gedmo/Sortable/SortableGroupTest.php
@@ -241,7 +241,7 @@ final class SortableGroupTest extends BaseTestCaseORM
         static::assertSame(30, $position);
     }
 
-    public function testChangePositionWithDateColumn()
+    public function testChangePositionWithDateColumn(): void
     {
         for ($i = 0; $i < 100; ++$i) {
             $object = new ItemWithDateColumn();

--- a/tests/Gedmo/Sortable/SortableGroupTest.php
+++ b/tests/Gedmo/Sortable/SortableGroupTest.php
@@ -243,9 +243,9 @@ final class SortableGroupTest extends BaseTestCaseORM
 
     public function testChangePositionWithDateColumn()
     {
-        for ($i = 0; $i < 100; $i++) {
+        for ($i = 0; $i < 100; ++$i) {
             $object = new ItemWithDateColumn();
-            $today = new \DateTime( '2022-05-22');
+            $today = new \DateTime('2022-05-22');
             $object->setDate($today);
             $object->setUserId($i < 50 ? 'user-1' : 'user-2');
             $object->setPosition($i < 50 ? $i : $i - 50);

--- a/tests/Gedmo/Sortable/SortableGroupTest.php
+++ b/tests/Gedmo/Sortable/SortableGroupTest.php
@@ -247,8 +247,7 @@ final class SortableGroupTest extends BaseTestCaseORM
             $object = new ItemWithDateColumn();
             $today = new \DateTime('2022-05-22');
             $object->setDate($today);
-            $object->setUserId($i < 3 ? 'user-1' : 'user-2');
-            $object->setPosition($i < 3 ? $i : $i - 3);
+            $object->setPosition($i);
             $this->em->persist($object);
         }
         $this->em->flush();
@@ -256,16 +255,16 @@ final class SortableGroupTest extends BaseTestCaseORM
         $repo = $this->em->getRepository(self::ITEM_WITH_DATE_COLUMN);
 
         /** @var ItemWithDateColumn $testItem */
-        $testItem = $repo->findOneBy(['id' => 3, 'userId' => 'user-1']);
+        $testItem = $repo->findOneBy(['id' => 5]);
         $testItem->setPosition(1);
 
         $this->em->persist($testItem);
         $this->em->flush();
 
         /** @var ItemWithDateColumn $freshItem */
-        $freshItem = $repo->findOneBy(['id' => 3, 'userId' => 'user-1']);
+        $freshItem = $repo->findOneBy(['id' => 5]);
         /** @var ItemWithDateColumn $freshPreviousItem */
-        $freshPreviousItem = $repo->findOneBy(['id' => 2, 'userId' => 'user-1']);
+        $freshPreviousItem = $repo->findOneBy(['id' => 2]);
         static::assertSame(1, $freshItem->getPosition());
         static::assertSame(2, $freshPreviousItem->getPosition());
     }

--- a/tests/Gedmo/Sortable/SortableGroupTest.php
+++ b/tests/Gedmo/Sortable/SortableGroupTest.php
@@ -15,6 +15,7 @@ use Doctrine\Common\EventManager;
 use Gedmo\Sortable\SortableListener;
 use Gedmo\Tests\Sortable\Fixture\Category;
 use Gedmo\Tests\Sortable\Fixture\Item;
+use Gedmo\Tests\Sortable\Fixture\ItemWithDateColumn;
 use Gedmo\Tests\Sortable\Fixture\Transport\Bus;
 use Gedmo\Tests\Sortable\Fixture\Transport\Car;
 use Gedmo\Tests\Sortable\Fixture\Transport\Engine;
@@ -36,6 +37,7 @@ final class SortableGroupTest extends BaseTestCaseORM
     public const RESERVATION = Reservation::class;
     public const ITEM = Item::class;
     public const CATEGORY = Category::class;
+    public const ITEM_WITH_DATE_COLUMN = ItemWithDateColumn::class;
 
     public const SEATS = 3;
 
@@ -239,6 +241,35 @@ final class SortableGroupTest extends BaseTestCaseORM
         static::assertSame(30, $position);
     }
 
+    public function testChangePositionWithDateColumn()
+    {
+        for ($i = 0; $i < 100; $i++) {
+            $object = new ItemWithDateColumn();
+            $today = new \DateTime( '2022-05-22');
+            $object->setDate($today);
+            $object->setUserId($i < 50 ? 'user-1' : 'user-2');
+            $object->setPosition($i < 50 ? $i : $i - 50);
+            $this->em->persist($object);
+        }
+        $this->em->flush();
+
+        $repo = $this->em->getRepository(self::ITEM_WITH_DATE_COLUMN);
+
+        /** @var ItemWithDateColumn $testItem */
+        $testItem = $repo->findOneBy(['id' => 49, 'userId' => 'user-1']);
+        $testItem->setPosition(1);
+
+        $this->em->persist($testItem);
+        $this->em->flush();
+
+        /** @var ItemWithDateColumn $freshItem */
+        $freshItem = $repo->findOneBy(['id' => 49, 'userId' => 'user-1']);
+        /** @var ItemWithDateColumn $freshPreviousItem */
+        $freshPreviousItem = $repo->findOneBy(['id' => 2, 'userId' => 'user-1']);
+        static::assertSame(1, $freshItem->getPosition());
+        static::assertSame(2, $freshPreviousItem->getPosition());
+    }
+
     protected function getUsedEntityFixtures(): array
     {
         return [
@@ -249,6 +280,7 @@ final class SortableGroupTest extends BaseTestCaseORM
             self::RESERVATION,
             self::ITEM,
             self::CATEGORY,
+            self::ITEM_WITH_DATE_COLUMN,
         ];
     }
 

--- a/tests/Gedmo/Sortable/SortableGroupTest.php
+++ b/tests/Gedmo/Sortable/SortableGroupTest.php
@@ -243,12 +243,12 @@ final class SortableGroupTest extends BaseTestCaseORM
 
     public function testChangePositionWithDateColumn(): void
     {
-        for ($i = 0; $i < 100; ++$i) {
+        for ($i = 0; $i < 6; ++$i) {
             $object = new ItemWithDateColumn();
             $today = new \DateTime('2022-05-22');
             $object->setDate($today);
-            $object->setUserId($i < 50 ? 'user-1' : 'user-2');
-            $object->setPosition($i < 50 ? $i : $i - 50);
+            $object->setUserId($i < 3 ? 'user-1' : 'user-2');
+            $object->setPosition($i < 3 ? $i : $i - 3);
             $this->em->persist($object);
         }
         $this->em->flush();
@@ -256,14 +256,14 @@ final class SortableGroupTest extends BaseTestCaseORM
         $repo = $this->em->getRepository(self::ITEM_WITH_DATE_COLUMN);
 
         /** @var ItemWithDateColumn $testItem */
-        $testItem = $repo->findOneBy(['id' => 49, 'userId' => 'user-1']);
+        $testItem = $repo->findOneBy(['id' => 3, 'userId' => 'user-1']);
         $testItem->setPosition(1);
 
         $this->em->persist($testItem);
         $this->em->flush();
 
         /** @var ItemWithDateColumn $freshItem */
-        $freshItem = $repo->findOneBy(['id' => 49, 'userId' => 'user-1']);
+        $freshItem = $repo->findOneBy(['id' => 3, 'userId' => 'user-1']);
         /** @var ItemWithDateColumn $freshPreviousItem */
         $freshPreviousItem = $repo->findOneBy(['id' => 2, 'userId' => 'user-1']);
         static::assertSame(1, $freshItem->getPosition());


### PR DESCRIPTION
Hi there!

In SQLite it makes a difference if date columns are queried with '00:00:00' as timestring or without. MySQL seems to ignore the time completely. Unfortunately there is an asymmetry between SQL Types and PHP Objects: 'date' and 'datetime' Column point both to a DateTime Object in PHP. Therefore, we cannot derive the column type from the PHP Object. Luckily we can ask the ClassMetadata in Doctrine for the right type.

IMHO, this change belongs in Doctrine ORM, but it is hard to implement there. Hence we have to work around that limitation.
There are a lot of PRs/Issues on Doctrine side:
- https://github.com/doctrine/orm/pull/1383
- https://github.com/doctrine/orm/pull/7236

to name a few.

