### PR TITLE
[Sluggable] Cast slug to string before passing it as argument 2 to `preg_match()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ a release.
 - Tree: In `ClosureTreeRepository::removeFromTree()` and `NestedTreeRepository::removeFromTree()` when something fails in the transaction, it uses the `code` from the original exception to construct the `\Gedmo\Exception\RuntimeException` instance instead of `null`.
 
 #### Fixed
+- Sluggable: Cast slug to string before passing it as argument 2 to `preg_match()` (#2473)
 - Sortable: [SortableGroup] Fix sorting date columns in SQLite (#2462).
 - PHPDoc of `AbstractMaterializedPath::removeNode()` and `AbstractMaterializedPath::getChildren()`
 

--- a/src/Sluggable/Handler/InversedRelativeSlugHandler.php
+++ b/src/Sluggable/Handler/InversedRelativeSlugHandler.php
@@ -106,7 +106,7 @@ class InversedRelativeSlugHandler implements SlugHandlerInterface
                             continue;
                         }
 
-                        $objectSlug = $meta->getReflectionProperty($mappedByConfig['slug'])->getValue($object);
+                        $objectSlug = (string) $meta->getReflectionProperty($mappedByConfig['slug'])->getValue($object);
                         if (preg_match("@^{$oldSlug}@smi", $objectSlug)) {
                             $objectSlug = str_replace($oldSlug, $slug, $objectSlug);
                             $meta->getReflectionProperty($mappedByConfig['slug'])->setValue($object, $objectSlug);

--- a/src/Sluggable/Handler/TreeSlugHandler.php
+++ b/src/Sluggable/Handler/TreeSlugHandler.php
@@ -146,7 +146,7 @@ class TreeSlugHandler implements SlugHandlerWithUniqueCallbackInterface
                         continue;
                     }
 
-                    $objectSlug = $meta->getReflectionProperty($config['slug'])->getValue($object);
+                    $objectSlug = (string) $meta->getReflectionProperty($config['slug'])->getValue($object);
                     if (preg_match("@^{$target}{$config['pathSeparator']}@smi", $objectSlug)) {
                         $objectSlug = str_replace($target, $slug, $objectSlug);
                         $meta->getReflectionProperty($config['slug'])->setValue($object, $objectSlug);


### PR DESCRIPTION
Fixes #2473.