### PR TITLE
Specify array configuration in extensions

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -631,31 +631,6 @@ parameters:
 			path: src/Translatable/TranslatableListener.php
 
 		-
-			message: "#^Call to an undefined method Gedmo\\\\Mapping\\\\Event\\\\AdapterInterface\\:\\:insertTranslationRecord\\(\\)\\.$#"
-			count: 1
-			path: src/Translatable/TranslatableListener.php
-
-		-
-			message: "#^Call to an undefined method Gedmo\\\\Mapping\\\\Event\\\\AdapterInterface\\:\\:loadTranslations\\(\\)\\.$#"
-			count: 1
-			path: src/Translatable/TranslatableListener.php
-
-		-
-			message: "#^Call to an undefined method Gedmo\\\\Mapping\\\\Event\\\\AdapterInterface\\:\\:removeAssociatedTranslations\\(\\)\\.$#"
-			count: 1
-			path: src/Translatable/TranslatableListener.php
-
-		-
-			message: "#^Call to an undefined method Gedmo\\\\Mapping\\\\Event\\\\AdapterInterface\\:\\:setTranslationValue\\(\\)\\.$#"
-			count: 1
-			path: src/Translatable/TranslatableListener.php
-
-		-
-			message: "#^Call to an undefined method Gedmo\\\\Mapping\\\\Event\\\\AdapterInterface\\:\\:usesPersonalTranslation\\(\\)\\.$#"
-			count: 2
-			path: src/Translatable/TranslatableListener.php
-
-		-
 			message: "#^Negated boolean expression is always false\\.$#"
 			count: 1
 			path: src/Translatable/TranslatableListener.php

--- a/src/Loggable/LoggableListener.php
+++ b/src/Loggable/LoggableListener.php
@@ -11,6 +11,7 @@ namespace Gedmo\Loggable;
 
 use Doctrine\Common\EventArgs;
 use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
+use Doctrine\Persistence\ObjectManager;
 use Gedmo\Loggable\Mapping\Event\LoggableAdapter;
 use Gedmo\Mapping\MappedEventSubscriber;
 use Gedmo\Tool\Wrapper\AbstractWrapper;
@@ -20,6 +21,17 @@ use Gedmo\Tool\Wrapper\AbstractWrapper;
  *
  * @author Boussekeyt Jules <jules.boussekeyt@gmail.com>
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ *
+ * @phpstan-type LoggableConfiguration = array{
+ *   loggable?: bool,
+ *   logEntryClass?: class-string,
+ *   useObjectClass?: class-string,
+ *   versioned?: string[],
+ * }
+ *
+ * @phpstan-method LoggableConfiguration getConfiguration(ObjectManager $objectManager, $class)
+ *
+ * @method LoggableAdapter getEventAdapter(EventArgs $args)
  */
 class LoggableListener extends MappedEventSubscriber
 {

--- a/src/References/ReferencesListener.php
+++ b/src/References/ReferencesListener.php
@@ -21,6 +21,24 @@ use Gedmo\Mapping\MappedEventSubscriber;
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  * @author Bulat Shakirzyanov <mallluhuct@gmail.com>
  * @author Jonathan H. Wage <jonwage@gmail.com>
+ *
+ * @phpstan-type ReferenceConfiguration = array{
+ *   field?: string,
+ *   type?: string,
+ *   class?: class-string,
+ *   identifier?: string,
+ *   mappedBy?: string,
+ *   inversedBy?: string,
+ * }
+ *
+ * @phpstan-type ReferencesConfiguration = array{
+ *   referenceMany?: array<string, ReferenceConfiguration>,
+ *   referenceManyEmbed?: array<string, ReferenceConfiguration>,
+ *   referenceOne?: array<string, ReferenceConfiguration>,
+ *   useObjectClass?: class-string,
+ * }
+ *
+ * @phpstan-method ReferencesConfiguration getConfiguration(ObjectManager $objectManager, $class)
  */
 class ReferencesListener extends MappedEventSubscriber
 {

--- a/src/Sluggable/Mapping/Event/SluggableAdapter.php
+++ b/src/Sluggable/Mapping/Event/SluggableAdapter.php
@@ -11,11 +11,14 @@ namespace Gedmo\Sluggable\Mapping\Event;
 
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Gedmo\Mapping\Event\AdapterInterface;
+use Gedmo\Sluggable\SluggableListener;
 
 /**
  * Doctrine event adapter for the Sluggable extension.
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ *
+ * @phpstan-import-type SluggableConfiguration from SluggableListener
  */
 interface SluggableAdapter extends AdapterInterface
 {
@@ -25,6 +28,7 @@ interface SluggableAdapter extends AdapterInterface
      * @param object        $object
      * @param ClassMetadata $meta
      * @param string        $slug
+     * @phpstan-param SluggableConfiguration $config
      *
      * @return array
      */
@@ -36,6 +40,7 @@ interface SluggableAdapter extends AdapterInterface
      * @param object $object
      * @param string $target
      * @param string $replacement
+     * @phpstan-param SluggableConfiguration $config
      *
      * @return int the number of updated records
      */
@@ -48,6 +53,7 @@ interface SluggableAdapter extends AdapterInterface
      * @param object $object
      * @param string $target
      * @param string $replacement
+     * @phpstan-param SluggableConfiguration $config
      *
      * @return int the number of updated records
      */

--- a/src/Sluggable/SluggableListener.php
+++ b/src/Sluggable/SluggableListener.php
@@ -27,6 +27,39 @@ use Gedmo\Sluggable\Util\Urlizer;
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  * @author Klein Florian <florian.klein@free.fr>
+ *
+ * @phpstan-type SluggableConfiguration = array{
+ *   mappedBy?: string,
+ *   pathSeparator?: string,
+ *   slug?: string,
+ *   slugs?: array<string, array{
+ *     fields?: string[],
+ *     slug?: string,
+ *     style?: string,
+ *     dateFormat?: string,
+ *     updatable?: bool,
+ *     unique?: bool,
+ *     unique_base?: string,
+ *     separator?: string,
+ *     prefix?: string,
+ *     suffix?: string,
+ *     handlers?: array<class-string, array{
+ *       mappedBy?: string,
+ *       inverseSlugField?: string,
+ *       parentRelationField?: string,
+ *       relationClass?: class-string,
+ *       relationField?: string,
+ *       relationSlugField?: string,
+ *       separator?: string,
+ *     }>,
+ *   }>,
+ *   unique?: bool,
+ *   useObjectClass?: class-string,
+ * }
+ *
+ * @phpstan-method SluggableConfiguration getConfiguration(ObjectManager $objectManager, $class)
+ *
+ * @method SluggableAdapter getEventAdapter(EventArgs $args)
  */
 class SluggableListener extends MappedEventSubscriber
 {

--- a/src/Sortable/Mapping/Event/Adapter/ORM.php
+++ b/src/Sortable/Mapping/Event/Adapter/ORM.php
@@ -13,12 +13,15 @@ use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Gedmo\Mapping\Event\Adapter\ORM as BaseAdapterORM;
 use Gedmo\Sortable\Mapping\Event\SortableAdapter;
+use Gedmo\Sortable\SortableListener;
 
 /**
  * Doctrine event adapter for ORM adapted
  * for sortable behavior
  *
  * @author Lukas Botsch <lukas.botsch@gmail.com>
+ *
+ * @phpstan-import-type SortableRelocation from SortableListener
  */
 final class ORM extends BaseAdapterORM implements SortableAdapter
 {
@@ -48,6 +51,7 @@ final class ORM extends BaseAdapterORM implements SortableAdapter
      * @param array $relocation
      * @param array $delta
      * @param array $config
+     * @phpstan-param SortableRelocation $relocation
      *
      * @return void
      */

--- a/src/Sortable/SortableListener.php
+++ b/src/Sortable/SortableListener.php
@@ -14,6 +14,7 @@ use Doctrine\Common\EventArgs;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
 use Doctrine\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\ObjectManager;
 use Gedmo\Mapping\MappedEventSubscriber;
 use Gedmo\Sortable\Mapping\Event\SortableAdapter;
 use ProxyManager\Proxy\GhostObjectInterface;
@@ -26,11 +27,33 @@ use ProxyManager\Proxy\GhostObjectInterface;
  * since it does some additional calculations on persisted objects.
  *
  * @author Lukas Botsch <lukas.botsch@gmail.com>
+ *
+ * @phpstan-type SortableConfiguration = array{
+ *   groups?: string[],
+ *   position?: string,
+ *   useObjectClass?: class-string,
+ * }
+ *
+ * @phpstan-type SortableRelocation = array{
+ *   name?: class-string,
+ *   groups?: mixed[],
+ *   deltas?: array<array{
+ *     delta: int,
+ *     exclude: int[],
+ *     start: int,
+ *     stop: int,
+ *   }>,
+ * }
+ *
+ * @phpstan-method SortableConfiguration getConfiguration(ObjectManager $objectManager, $class)
+ *
+ * @method SortableAdapter getEventAdapter(EventArgs $args)
  */
 class SortableListener extends MappedEventSubscriber
 {
     /**
      * @var array<string, array<string, mixed>>
+     * @phpstan-var array<string, SortableRelocation>
      */
     private $relocations = [];
 

--- a/src/Translatable/Entity/Repository/TranslationRepository.php
+++ b/src/Translatable/Entity/Repository/TranslationRepository.php
@@ -164,6 +164,7 @@ class TranslationRepository extends EntityRepository
      * @param string $field
      * @param string $value
      * @param string $class
+     * @phpstan-param class-string $class
      *
      * @return object instance of $class or null if not found
      */

--- a/src/Translatable/TranslatableListener.php
+++ b/src/Translatable/TranslatableListener.php
@@ -14,6 +14,7 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ORM\ORMInvalidArgumentException;
 use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
 use Doctrine\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\ObjectManager;
 use Gedmo\Mapping\MappedEventSubscriber;
 use Gedmo\Tool\Wrapper\AbstractWrapper;
 use Gedmo\Translatable\Mapping\Event\TranslatableAdapter;
@@ -31,6 +32,18 @@ use Gedmo\Translatable\Mapping\Event\TranslatableAdapter;
  * the caching is activated for metadata
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ *
+ * @phpstan-type TranslatableConfiguration = array{
+ *   fields?: string[],
+ *   fallback?: array<string, bool>,
+ *   locale?: string,
+ *   translationClass?: class-string,
+ *   useObjectClass?: class-string,
+ * }
+ *
+ * @phpstan-method TranslatableConfiguration getConfiguration(ObjectManager $objectManager, $class)
+ *
+ * @method TranslatableAdapter getEventAdapter(EventArgs $args)
  */
 class TranslatableListener extends MappedEventSubscriber
 {

--- a/src/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/src/Tree/Entity/Repository/NestedTreeRepository.php
@@ -921,13 +921,9 @@ class NestedTreeRepository extends AbstractTreeRepository
 
         $identifier = $meta->getSingleIdentifierFieldName();
         if (isset($config['root'])) {
-            if (isset($config['root'])) {
-                $rootId = $meta->getReflectionProperty($config['root'])->getValue($root);
-                if (is_object($rootId)) {
-                    $rootId = $meta->getReflectionProperty($identifier)->getValue($rootId);
-                }
-            } else {
-                $rootId = null;
+            $rootId = $meta->getReflectionProperty($config['root'])->getValue($root);
+            if (is_object($rootId)) {
+                $rootId = $meta->getReflectionProperty($identifier)->getValue($rootId);
             }
         } else {
             $rootId = null;

--- a/src/Tree/TreeListener.php
+++ b/src/Tree/TreeListener.php
@@ -13,6 +13,7 @@ use Doctrine\Common\EventArgs;
 use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
 use Doctrine\Persistence\ObjectManager;
 use Gedmo\Mapping\MappedEventSubscriber;
+use Gedmo\Tree\Mapping\Event\TreeAdapter;
 
 /**
  * The tree listener handles the synchronization of
@@ -20,6 +21,32 @@ use Gedmo\Mapping\MappedEventSubscriber;
  * strategies on handling the tree.
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ *
+ * @phpstan-type TreeConfiguration = array{
+ *   activate_locking?: bool,
+ *   closure?: class-string,
+ *   left?: string,
+ *   level?: string,
+ *   lock_time?: string,
+ *   locking_timeout?: int,
+ *   parent?: string,
+ *   path?: string,
+ *   path_source?: string,
+ *   path_separator?: string,
+ *   path_append_id?: bool,
+ *   path_starts_with_separator?: bool,
+ *   path_ends_with_separator?: bool,
+ *   path_hash?: string,
+ *   right?: string,
+ *   root?: string,
+ *   rootIdentifierMethod?: string,
+ *   strategy?: string,
+ *   useObjectClass?: class-string,
+ * }
+ *
+ * @phpstan-method TreeConfiguration getConfiguration(ObjectManager $objectManager, $class)
+ *
+ * @method TreeAdapter getEventAdapter(EventArgs $args)
  */
 class TreeListener extends MappedEventSubscriber
 {


### PR DESCRIPTION
I was trying to see errors using PHPStan level 5 and most of the are because when calling `SomeListener::getConfiguration()` it doesn't know what that array contains and also calling `SomeListener::getEventAdapter()` it doesn't know that if it's a custom event adapter.

This PR tries to let PHPStan understand these calls overriding PHPDoc, ideally it should infer it from the code, but I can't think of an easy way to do that.

In level 5 it goes from 75 errors to 33 (I probably have missed some, I'll check the other extensions if this is a right approach).