### PR TITLE
Remove unnecessary calls to `MappedSubscriber::getEventAdapter`

### DIFF
--- a/src/AbstractTrackingListener.php
+++ b/src/AbstractTrackingListener.php
@@ -52,8 +52,7 @@ abstract class AbstractTrackingListener extends MappedEventSubscriber
      */
     public function loadClassMetadata(EventArgs $eventArgs)
     {
-        $ea = $this->getEventAdapter($eventArgs);
-        $this->loadMetadataForObjectClass($ea->getObjectManager(), $eventArgs->getClassMetadata());
+        $this->loadMetadataForObjectClass($eventArgs->getObjectManager(), $eventArgs->getClassMetadata());
     }
 
     /**

--- a/src/Loggable/LoggableListener.php
+++ b/src/Loggable/LoggableListener.php
@@ -109,8 +109,7 @@ class LoggableListener extends MappedEventSubscriber
      */
     public function loadClassMetadata(EventArgs $eventArgs)
     {
-        $ea = $this->getEventAdapter($eventArgs);
-        $this->loadMetadataForObjectClass($ea->getObjectManager(), $eventArgs->getClassMetadata());
+        $this->loadMetadataForObjectClass($eventArgs->getObjectManager(), $eventArgs->getClassMetadata());
     }
 
     /**

--- a/src/ReferenceIntegrity/ReferenceIntegrityListener.php
+++ b/src/ReferenceIntegrity/ReferenceIntegrityListener.php
@@ -43,8 +43,7 @@ class ReferenceIntegrityListener extends MappedEventSubscriber
      */
     public function loadClassMetadata(EventArgs $eventArgs)
     {
-        $ea = $this->getEventAdapter($eventArgs);
-        $this->loadMetadataForObjectClass($ea->getObjectManager(), $eventArgs->getClassMetadata());
+        $this->loadMetadataForObjectClass($eventArgs->getObjectManager(), $eventArgs->getClassMetadata());
     }
 
     /**

--- a/src/References/ReferencesListener.php
+++ b/src/References/ReferencesListener.php
@@ -46,9 +46,8 @@ class ReferencesListener extends MappedEventSubscriber
      */
     public function loadClassMetadata(EventArgs $eventArgs)
     {
-        $ea = $this->getEventAdapter($eventArgs);
         $this->loadMetadataForObjectClass(
-            $ea->getObjectManager(), $eventArgs->getClassMetadata()
+            $eventArgs->getObjectManager(), $eventArgs->getClassMetadata()
         );
     }
 

--- a/src/Sluggable/SluggableListener.php
+++ b/src/Sluggable/SluggableListener.php
@@ -178,8 +178,7 @@ class SluggableListener extends MappedEventSubscriber
      */
     public function loadClassMetadata(EventArgs $eventArgs)
     {
-        $ea = $this->getEventAdapter($eventArgs);
-        $this->loadMetadataForObjectClass($ea->getObjectManager(), $eventArgs->getClassMetadata());
+        $this->loadMetadataForObjectClass($eventArgs->getObjectManager(), $eventArgs->getClassMetadata());
     }
 
     /**

--- a/src/SoftDeleteable/SoftDeleteableListener.php
+++ b/src/SoftDeleteable/SoftDeleteableListener.php
@@ -109,8 +109,7 @@ class SoftDeleteableListener extends MappedEventSubscriber
      */
     public function loadClassMetadata(EventArgs $eventArgs)
     {
-        $ea = $this->getEventAdapter($eventArgs);
-        $this->loadMetadataForObjectClass($ea->getObjectManager(), $eventArgs->getClassMetadata());
+        $this->loadMetadataForObjectClass($eventArgs->getObjectManager(), $eventArgs->getClassMetadata());
     }
 
     protected function getNamespace()

--- a/src/Translatable/TranslatableListener.php
+++ b/src/Translatable/TranslatableListener.php
@@ -205,8 +205,7 @@ class TranslatableListener extends MappedEventSubscriber
      */
     public function loadClassMetadata(EventArgs $eventArgs)
     {
-        $ea = $this->getEventAdapter($eventArgs);
-        $this->loadMetadataForObjectClass($ea->getObjectManager(), $eventArgs->getClassMetadata());
+        $this->loadMetadataForObjectClass($eventArgs->getObjectManager(), $eventArgs->getClassMetadata());
     }
 
     /**

--- a/src/Tree/TreeListener.php
+++ b/src/Tree/TreeListener.php
@@ -254,8 +254,7 @@ class TreeListener extends MappedEventSubscriber
      */
     public function loadClassMetadata(EventArgs $eventArgs)
     {
-        $ea = $this->getEventAdapter($eventArgs);
-        $om = $ea->getObjectManager();
+        $om = $eventArgs->getObjectManager();
         $meta = $eventArgs->getClassMetadata();
         $this->loadMetadataForObjectClass($om, $meta);
         if (isset(self::$configurations[$this->name][$meta->getName()]) && self::$configurations[$this->name][$meta->getName()]) {

--- a/src/Uploadable/UploadableListener.php
+++ b/src/Uploadable/UploadableListener.php
@@ -521,8 +521,7 @@ class UploadableListener extends MappedEventSubscriber
      */
     public function loadClassMetadata(EventArgs $eventArgs)
     {
-        $ea = $this->getEventAdapter($eventArgs);
-        $this->loadMetadataForObjectClass($ea->getObjectManager(), $eventArgs->getClassMetadata());
+        $this->loadMetadataForObjectClass($eventArgs->getObjectManager(), $eventArgs->getClassMetadata());
     }
 
     /**


### PR DESCRIPTION
The event that receives `loadClassMetadata` is a `LoadClassMetadataEventArgs` instance and it has a `LoadClassMetadataEventArgs::getObjectManager()` method.

https://github.com/doctrine/persistence/blob/2.2.0/lib/Doctrine/Persistence/Event/LoadClassMetadataEventArgs.php#L41-L44

https://github.com/doctrine/persistence/blob/3.0.0/src/Persistence/Event/LoadClassMetadataEventArgs.php#L57

I guess some other can be removed in the `(Pre|Post)(Persist|Update|Remove)` methods, I'll try to take a look in another PR.