### PR TITLE
handle null   abs($levelDelta)

### DIFF
--- a/src/Tree/Strategy/ORM/Nested.php
+++ b/src/Tree/Strategy/ORM/Nested.php
@@ -647,7 +647,7 @@ class Nested implements Strategy
         $sign = ($delta >= 0) ? ' + ' : ' - ';
         $absDelta = abs($delta);
         $levelSign = ($levelDelta >= 0) ? ' + ' : ' - ';
-        $absLevelDelta = $levelDelta ? abs($levelDelta) : 0;
+        $absLevelDelta = null !== $levelDelta ? abs($levelDelta) : 0;
 
         $qb = $em->createQueryBuilder();
         $qb->update($config['useObjectClass'], 'node')

--- a/src/Tree/Strategy/ORM/Nested.php
+++ b/src/Tree/Strategy/ORM/Nested.php
@@ -647,7 +647,7 @@ class Nested implements Strategy
         $sign = ($delta >= 0) ? ' + ' : ' - ';
         $absDelta = abs($delta);
         $levelSign = ($levelDelta >= 0) ? ' + ' : ' - ';
-        $absLevelDelta = abs($levelDelta);
+        $absLevelDelta = $levelDelta ? abs($levelDelta) : 0;
 
         $qb = $em->createQueryBuilder();
         $qb->update($config['useObjectClass'], 'node')


### PR DESCRIPTION
passing null to abs is deprecated, this handles the null case.  

Alternatively, the default value in the signature could be 0, and type-hinted as an int.  This PR is the smallest change, though, and gets rid of the 

06:00:24 INFO      [php] Deprecated: abs(): Passing null to parameter #1 ($num) of type int|float is deprecated ["exception" => ErrorException { …}]


messages.