### PR TITLE
Get cache from MetadataFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ a release.
 - Sluggable: Cast slug to string before passing it as argument 2 to `preg_match()` (#2473)
 - Sortable: [SortableGroup] Fix sorting date columns in SQLite (#2462).
 - PHPDoc of `AbstractMaterializedPath::removeNode()` and `AbstractMaterializedPath::getChildren()`
+- Retrieving the proper metadata cache from Doctrine when using a CacheWarmer.
 
 ## [3.7.0] - 2022-05-17
 ## Added

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -181,6 +181,11 @@ parameters:
 			path: src/Mapping/MappedEventSubscriber.php
 
 		-
+			message: "#^Call to protected method getCache\\(\\) of class Doctrine\\\\Persistence\\\\Mapping\\\\AbstractClassMetadataFactory\\<Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\>\\.$#"
+			count: 1
+			path: src/Mapping/MappedEventSubscriber.php
+
+		-
 			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:getFieldMapping\\(\\)\\.$#"
 			count: 1
 			path: src/ReferenceIntegrity/Mapping/Driver/Annotation.php

--- a/tests/Gedmo/Mapping/MappingEventSubscriberTest.php
+++ b/tests/Gedmo/Mapping/MappingEventSubscriberTest.php
@@ -15,9 +15,11 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\EventManager;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+use Doctrine\Persistence\Mapping\AbstractClassMetadataFactory;
 use Gedmo\Mapping\ExtensionMetadataFactory;
 use Gedmo\Sluggable\SluggableListener;
 use Gedmo\Tests\Mapping\Fixture\Sluggable;
+use Psr\Cache\CacheItemPoolInterface;
 
 final class MappingEventSubscriberTest extends ORMMappingTestCase
 {
@@ -42,9 +44,14 @@ final class MappingEventSubscriberTest extends ORMMappingTestCase
         $this->em = EntityManager::create($conn, $config, new EventManager());
     }
 
-    public function testGetConfigurationCachedFromDoctrine(): void
+    public function testGetMetadataFactoryCacheFromDoctrine(): void
     {
-        $cache = $this->em->getConfiguration()->getMetadataCache();
+        $metadataFactory = $this->em->getMetadataFactory();
+        $getCache = \Closure::bind(static function (AbstractClassMetadataFactory $metadataFactory): ?CacheItemPoolInterface {
+            return $metadataFactory->getCache();
+        }, null, \get_class($metadataFactory));
+
+        $cache = $getCache($metadataFactory);
 
         $cacheKey = ExtensionMetadataFactory::getCacheId(Sluggable::class, 'Gedmo\Sluggable');
 


### PR DESCRIPTION
Fixes https://github.com/doctrine-extensions/DoctrineExtensions/issues/2484 and https://github.com/doctrine-extensions/DoctrineExtensions/issues/2463#issuecomment-1137797451

I don't know other way to access the cache, ideally the cache should be set by the user and this won't be needed, when using the bundle there is https://github.com/stof/StofDoctrineExtensionsBundle/pull/436 to automatically set this cache, but the PR hasn't been reviewed yet, my idea after finishing that PR was to deprecate not setting the cache pool.

cc @ossinkine @dpfaffenbauer