### PR TITLE
[Tree] Add pre-order and level-order traversals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,7 @@ a release.
 
 ### Added
 - Tree: Add `Nested::ALLOWED_NODE_POSITIONS` constant in order to expose the available node positions
+- Tree: Add pre-order and level-order traversals (#2498). Add `getNextNode()` and `getNextNodes()` methods to traverse the tree
 - Support for `doctrine/collections` 2.0
 - Support for `doctrine/event-manager` 2.0
 - Loggable: Add `LogEntryInterface` interface in order to be implemented by log entry models

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ a release.
 ---
 
 ## [Unreleased]
+### Added
+- Tree: Add pre-order and level-order traversals (#2498). Add `getNextNode()` and `getNextNodes()` methods to traverse the tree
+
 ### Changed
 - All: Removed the dollar sign from the generated cache ID for extension metadata to ensure only characters mandated by [PSR-6](https://www.php-fig.org/psr/psr-6/#definitions) are used, improving compatibility with caching implementations with strict character requirements (#2978)
 
@@ -181,7 +184,6 @@ a release.
 
 ### Added
 - Tree: Add `Nested::ALLOWED_NODE_POSITIONS` constant in order to expose the available node positions
-- Tree: Add pre-order and level-order traversals (#2498). Add `getNextNode()` and `getNextNodes()` methods to traverse the tree
 - Support for `doctrine/collections` 2.0
 - Support for `doctrine/event-manager` 2.0
 - Loggable: Add `LogEntryInterface` interface in order to be implemented by log entry models

--- a/doc/tree.md
+++ b/doc/tree.md
@@ -1249,6 +1249,11 @@ There are repository methods that are available for you in all the strategies:
       * childSort: array || keys allowed: field: field to sort on, dir: direction. 'asc' or 'desc'
   - *includeNode*: Using "true", this argument allows you to include in the result the node you passed as the first argument. Defaults to "false".
 * **setChildrenIndex** / **getChildrenIndex**: These methods allow you to change the default index used to hold the children when you use the **childrenHierarchy** method. Index defaults to "__children".
+* **getNextNode** / **getNextNodes**: These methods allow you to get the next nodes when parsing a nested tree. Arguments:
+  - *root*: Root node use to select (sub-)tree to use.
+  - *node*: Current node. Use "null" to get the first one. Default to "null".
+  - *limit* (only for getNextNodes): Maximum nodes to return. Default to "null".
+  - *traversalStrategy*: Which strategy to use between "pre_order" and "level_order". Default to "NestedTreeRepository::TRAVERSAL_PRE_ORDER".
 
 This list is not complete yet. We're working on including more methods in the common API offered by repositories of all the strategies.
 Soon we'll be adding more helpful methods here.

--- a/src/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/src/Tree/Entity/Repository/NestedTreeRepository.php
@@ -1243,8 +1243,6 @@ class NestedTreeRepository extends AbstractTreeRepository
      * @param object|null       $node              Current node. If null, first node will be returned
      * @param int|null          $limit             Maximum nodes to return. If null, all nodes will be returned
      * @param self::TRAVERSAL_* $traversalStrategy Strategy to use to traverse tree
-     *
-     * @return Query
      */
     public function getNextNodesQuery($root, $node = null, int $limit = null, string $traversalStrategy = self::TRAVERSAL_PRE_ORDER)
     {

--- a/src/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/src/Tree/Entity/Repository/NestedTreeRepository.php
@@ -15,6 +15,7 @@ use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\Proxy;
 use Gedmo\Exception\InvalidArgumentException;
+use Gedmo\Exception\InvalidMappingException;
 use Gedmo\Exception\RuntimeException;
 use Gedmo\Exception\UnexpectedValueException;
 use Gedmo\Tool\ORM\Repository\EntityRepositoryCompat;
@@ -1210,7 +1211,7 @@ class NestedTreeRepository extends AbstractTreeRepository
             }
         } elseif (self::TRAVERSAL_LEVEL_ORDER === $traversalStrategy) {
             if (!isset($config['level'])) {
-                throw new \InvalidArgumentException('TreeLevel must be set to use level order traversal.');
+                throw new InvalidMappingException('Tree level must be set to use level order traversal.');
             }
             $qb = $this->childrenQueryBuilder($root, false, [$config['level'], $config['left']], ['DESC', 'ASC'], true);
             if (null !== $node) {

--- a/src/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/src/Tree/Entity/Repository/NestedTreeRepository.php
@@ -1194,7 +1194,7 @@ class NestedTreeRepository extends AbstractTreeRepository
      *
      * @return QueryBuilder QueryBuilder object
      */
-    public function getNextNodesQueryBuilder($root, $node = null, int $limit = null, string $traversalStrategy = self::TRAVERSAL_PRE_ORDER)
+    public function getNextNodesQueryBuilder($root, $node = null, int $limit = null, string $traversalStrategy = self::TRAVERSAL_PRE_ORDER): QueryBuilder
     {
         $meta = $this->getClassMetadata();
         $config = $this->listener->getConfiguration($this->getEntityManager(), $meta->getName());

--- a/src/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/src/Tree/Entity/Repository/NestedTreeRepository.php
@@ -1185,10 +1185,10 @@ class NestedTreeRepository extends AbstractTreeRepository
     }
 
     /**
-     * @param object            $root              Root node of the parsed tree
-     * @param object|null       $node              Current node. If null, first node will be returned
-     * @param int|null          $limit             Maximum nodes to return. If null, all nodes will be returned
-     * @param string $traversalStrategy Strategy to use to traverse tree
+     * @param object      $root              Root node of the parsed tree
+     * @param object|null $node              Current node. If null, first node will be returned
+     * @param int|null    $limit             Maximum nodes to return. If null, all nodes will be returned
+     * @param string      $traversalStrategy Strategy to use to traverse tree
      *
      * @phpstan-assert self::TRAVERSAL_* $traversalStrategy
      *

--- a/src/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/src/Tree/Entity/Repository/NestedTreeRepository.php
@@ -1191,8 +1191,6 @@ class NestedTreeRepository extends AbstractTreeRepository
      * @param self::TRAVERSAL_* $traversalStrategy Strategy to use to traverse tree
      *
      * @throws InvalidArgumentException if input is invalid
-     *
-     * @return QueryBuilder QueryBuilder object
      */
     public function getNextNodesQueryBuilder($root, $node = null, int $limit = null, string $traversalStrategy = self::TRAVERSAL_PRE_ORDER): QueryBuilder
     {

--- a/src/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/src/Tree/Entity/Repository/NestedTreeRepository.php
@@ -1244,7 +1244,7 @@ class NestedTreeRepository extends AbstractTreeRepository
      * @param int|null          $limit             Maximum nodes to return. If null, all nodes will be returned
      * @param self::TRAVERSAL_* $traversalStrategy Strategy to use to traverse tree
      */
-    public function getNextNodesQuery($root, $node = null, int $limit = null, string $traversalStrategy = self::TRAVERSAL_PRE_ORDER)
+    public function getNextNodesQuery($root, $node = null, int $limit = null, string $traversalStrategy = self::TRAVERSAL_PRE_ORDER): Query
     {
         return $this->getNextNodesQueryBuilder($root, $node, $limit, $traversalStrategy)->getQuery();
     }

--- a/src/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/src/Tree/Entity/Repository/NestedTreeRepository.php
@@ -47,6 +47,9 @@ class NestedTreeRepository extends AbstractTreeRepository
 {
     use EntityRepositoryCompat;
 
+    public const TRAVERSAL_PRE_ORDER = 'pre_order';
+    public const TRAVERSAL_LEVEL_ORDER = 'level_order';
+
     public function getRootNodesQueryBuilder($sortByField = null, $direction = 'asc')
     {
         $meta = $this->getClassMetadata();
@@ -1179,6 +1182,100 @@ class NestedTreeRepository extends AbstractTreeRepository
         }
 
         return parent::__call($method, $args);
+    }
+
+    /**
+     * @param object            $root              Root node of the parsed tree
+     * @param object|null       $node              Current node. If null, first node will be returned
+     * @param int|null          $limit             Maximum nodes to return. If null, all nodes will be returned
+     * @param self::TRAVERSAL_* $traversalStrategy Strategy to use to traverse tree
+     *
+     * @throws InvalidArgumentException if input is invalid
+     *
+     * @return QueryBuilder QueryBuilder object
+     */
+    public function getNextNodesQueryBuilder($root, $node = null, int $limit = null, string $traversalStrategy = self::TRAVERSAL_PRE_ORDER)
+    {
+        $meta = $this->getClassMetadata();
+        $config = $this->listener->getConfiguration($this->getEntityManager(), $meta->getName());
+
+        if (self::TRAVERSAL_PRE_ORDER === $traversalStrategy) {
+            $qb = $this->childrenQueryBuilder($root, false, $config['left'], 'ASC', true);
+            if (null !== $node) {
+                $wrapped = new EntityWrapper($node, $this->getEntityManager());
+                $qb
+                    ->andWhere($qb->expr()->gt('node.'.$config['left'], ':lft'))
+                    ->setParameter('lft', $wrapped->getPropertyValue($config['left']))
+                ;
+            }
+        } elseif (self::TRAVERSAL_LEVEL_ORDER === $traversalStrategy) {
+            if (!isset($config['level'])) {
+                throw new \InvalidArgumentException('TreeLevel must be set to use level order traversal.');
+            }
+            $qb = $this->childrenQueryBuilder($root, false, [$config['level'], $config['left']], ['DESC', 'ASC'], true);
+            if (null !== $node) {
+                $wrapped = new EntityWrapper($node, $this->getEntityManager());
+                $qb
+                    ->andWhere(
+                        $qb->expr()->orX(
+                            $qb->expr()->andX(
+                                $qb->expr()->gt('node.'.$config['left'], ':lft'),
+                                $qb->expr()->eq('node.'.$config['level'], ':lvl')
+                            ),
+                            $qb->expr()->lt('node.'.$config['level'], ':lvl')
+                        )
+                    )
+                    ->setParameter('lvl', $wrapped->getPropertyValue($config['level']))
+                    ->setParameter('lft', $wrapped->getPropertyValue($config['left']))
+                ;
+            }
+        } else {
+            throw new InvalidArgumentException('Invalid traversal strategy.');
+        }
+
+        if (null !== $limit) {
+            $qb->setMaxResults($limit);
+        }
+
+        return $qb;
+    }
+
+    /**
+     * @param object            $root              Root node of the parsed tree
+     * @param object|null       $node              Current node. If null, first node will be returned
+     * @param int|null          $limit             Maximum nodes to return. If null, all nodes will be returned
+     * @param self::TRAVERSAL_* $traversalStrategy Strategy to use to traverse tree
+     *
+     * @return Query
+     */
+    public function getNextNodesQuery($root, $node = null, int $limit = null, string $traversalStrategy = self::TRAVERSAL_PRE_ORDER)
+    {
+        return $this->getNextNodesQueryBuilder($root, $node, $limit, $traversalStrategy)->getQuery();
+    }
+
+    /**
+     * @param object            $root              Root node of the parsed tree
+     * @param object|null       $node              Current node. If null, first node will be returned
+     * @param self::TRAVERSAL_* $traversalStrategy Strategy to use to traverse tree
+     *
+     * @return object|null
+     */
+    public function getNextNode($root, $node = null, string $traversalStrategy = self::TRAVERSAL_PRE_ORDER)
+    {
+        return $this->getNextNodesQuery($root, $node, 1, $traversalStrategy)->getOneOrNullResult();
+    }
+
+    /**
+     * @param object            $root              Root node of the parsed tree
+     * @param object|null       $node              Current node. If null, first node will be returned
+     * @param int|null          $limit             Maximum nodes to return. If null, all nodes will be returned
+     * @param self::TRAVERSAL_* $traversalStrategy Strategy to use to traverse tree
+     *
+     * @return array<object>
+     */
+    public function getNextNodes($root, $node = null, int $limit = null, string $traversalStrategy = self::TRAVERSAL_PRE_ORDER)
+    {
+        return $this->getNextNodesQuery($root, $node, $limit, $traversalStrategy)->getArrayResult();
     }
 
     protected function validate()

--- a/src/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/src/Tree/Entity/Repository/NestedTreeRepository.php
@@ -1194,7 +1194,7 @@ class NestedTreeRepository extends AbstractTreeRepository
      *
      * @throws InvalidArgumentException if input is invalid
      */
-    public function getNextNodesQueryBuilder($root, $node = null, ?int $limit = null, string $traversalStrategy = self::TRAVERSAL_PRE_ORDER): QueryBuilder
+    private function getNextNodesQueryBuilder(object $root, ?object $node = null, ?int $limit = null, string $traversalStrategy = self::TRAVERSAL_PRE_ORDER): QueryBuilder
     {
         $meta = $this->getClassMetadata();
         $config = $this->listener->getConfiguration($this->getEntityManager(), $meta->getName());
@@ -1246,7 +1246,7 @@ class NestedTreeRepository extends AbstractTreeRepository
      * @param int|null          $limit             Maximum nodes to return. If null, all nodes will be returned
      * @param self::TRAVERSAL_* $traversalStrategy Strategy to use to traverse tree
      */
-    public function getNextNodesQuery($root, $node = null, ?int $limit = null, string $traversalStrategy = self::TRAVERSAL_PRE_ORDER): Query
+    public function getNextNodesQuery(object $root, ?object $node = null, ?int $limit = null, string $traversalStrategy = self::TRAVERSAL_PRE_ORDER): Query
     {
         return $this->getNextNodesQueryBuilder($root, $node, $limit, $traversalStrategy)->getQuery();
     }
@@ -1256,7 +1256,7 @@ class NestedTreeRepository extends AbstractTreeRepository
      * @param object|null       $node              Current node. If null, first node will be returned
      * @param self::TRAVERSAL_* $traversalStrategy Strategy to use to traverse tree
      */
-    public function getNextNode($root, $node = null, string $traversalStrategy = self::TRAVERSAL_PRE_ORDER): ?object
+    public function getNextNode(object $root, ?object $node = null, string $traversalStrategy = self::TRAVERSAL_PRE_ORDER): ?object
     {
         return $this->getNextNodesQuery($root, $node, 1, $traversalStrategy)->getOneOrNullResult();
     }

--- a/src/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/src/Tree/Entity/Repository/NestedTreeRepository.php
@@ -1192,7 +1192,7 @@ class NestedTreeRepository extends AbstractTreeRepository
      *
      * @throws InvalidArgumentException if input is invalid
      */
-    public function getNextNodesQueryBuilder($root, $node = null, int $limit = null, string $traversalStrategy = self::TRAVERSAL_PRE_ORDER): QueryBuilder
+    public function getNextNodesQueryBuilder($root, $node = null, ?int $limit = null, string $traversalStrategy = self::TRAVERSAL_PRE_ORDER): QueryBuilder
     {
         $meta = $this->getClassMetadata();
         $config = $this->listener->getConfiguration($this->getEntityManager(), $meta->getName());
@@ -1244,7 +1244,7 @@ class NestedTreeRepository extends AbstractTreeRepository
      * @param int|null          $limit             Maximum nodes to return. If null, all nodes will be returned
      * @param self::TRAVERSAL_* $traversalStrategy Strategy to use to traverse tree
      */
-    public function getNextNodesQuery($root, $node = null, int $limit = null, string $traversalStrategy = self::TRAVERSAL_PRE_ORDER): Query
+    public function getNextNodesQuery($root, $node = null, ?int $limit = null, string $traversalStrategy = self::TRAVERSAL_PRE_ORDER): Query
     {
         return $this->getNextNodesQueryBuilder($root, $node, $limit, $traversalStrategy)->getQuery();
     }
@@ -1267,7 +1267,7 @@ class NestedTreeRepository extends AbstractTreeRepository
      *
      * @return array<object>
      */
-    public function getNextNodes($root, $node = null, int $limit = null, string $traversalStrategy = self::TRAVERSAL_PRE_ORDER): array
+    public function getNextNodes($root, $node = null, ?int $limit = null, string $traversalStrategy = self::TRAVERSAL_PRE_ORDER): array
     {
         return $this->getNextNodesQuery($root, $node, $limit, $traversalStrategy)->getArrayResult();
     }

--- a/src/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/src/Tree/Entity/Repository/NestedTreeRepository.php
@@ -1188,7 +1188,9 @@ class NestedTreeRepository extends AbstractTreeRepository
      * @param object            $root              Root node of the parsed tree
      * @param object|null       $node              Current node. If null, first node will be returned
      * @param int|null          $limit             Maximum nodes to return. If null, all nodes will be returned
-     * @param self::TRAVERSAL_* $traversalStrategy Strategy to use to traverse tree
+     * @param string $traversalStrategy Strategy to use to traverse tree
+     *
+     * @phpstan-assert self::TRAVERSAL_* $traversalStrategy
      *
      * @throws InvalidArgumentException if input is invalid
      */

--- a/src/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/src/Tree/Entity/Repository/NestedTreeRepository.php
@@ -1256,7 +1256,7 @@ class NestedTreeRepository extends AbstractTreeRepository
      *
      * @return object|null
      */
-    public function getNextNode($root, $node = null, string $traversalStrategy = self::TRAVERSAL_PRE_ORDER)
+    public function getNextNode($root, $node = null, string $traversalStrategy = self::TRAVERSAL_PRE_ORDER): ?object
     {
         return $this->getNextNodesQuery($root, $node, 1, $traversalStrategy)->getOneOrNullResult();
     }

--- a/src/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/src/Tree/Entity/Repository/NestedTreeRepository.php
@@ -1269,7 +1269,7 @@ class NestedTreeRepository extends AbstractTreeRepository
      *
      * @return array<object>
      */
-    public function getNextNodes($root, $node = null, int $limit = null, string $traversalStrategy = self::TRAVERSAL_PRE_ORDER)
+    public function getNextNodes($root, $node = null, int $limit = null, string $traversalStrategy = self::TRAVERSAL_PRE_ORDER): array
     {
         return $this->getNextNodesQuery($root, $node, $limit, $traversalStrategy)->getArrayResult();
     }

--- a/src/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/src/Tree/Entity/Repository/NestedTreeRepository.php
@@ -1253,8 +1253,6 @@ class NestedTreeRepository extends AbstractTreeRepository
      * @param object            $root              Root node of the parsed tree
      * @param object|null       $node              Current node. If null, first node will be returned
      * @param self::TRAVERSAL_* $traversalStrategy Strategy to use to traverse tree
-     *
-     * @return object|null
      */
     public function getNextNode($root, $node = null, string $traversalStrategy = self::TRAVERSAL_PRE_ORDER): ?object
     {

--- a/src/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/src/Tree/Entity/Repository/NestedTreeRepository.php
@@ -1090,6 +1090,40 @@ class NestedTreeRepository extends AbstractTreeRepository
     }
 
     /**
+     * @param object            $root              Root node of the parsed tree
+     * @param object|null       $node              Current node. If null, first node will be returned
+     * @param int|null          $limit             Maximum nodes to return. If null, all nodes will be returned
+     * @param self::TRAVERSAL_* $traversalStrategy Strategy to use to traverse tree
+     */
+    public function getNextNodesQuery(object $root, ?object $node = null, ?int $limit = null, string $traversalStrategy = self::TRAVERSAL_PRE_ORDER): Query
+    {
+        return $this->getNextNodesQueryBuilder($root, $node, $limit, $traversalStrategy)->getQuery();
+    }
+
+    /**
+     * @param object            $root              Root node of the parsed tree
+     * @param object|null       $node              Current node. If null, first node will be returned
+     * @param self::TRAVERSAL_* $traversalStrategy Strategy to use to traverse tree
+     */
+    public function getNextNode(object $root, ?object $node = null, string $traversalStrategy = self::TRAVERSAL_PRE_ORDER): ?object
+    {
+        return $this->getNextNodesQuery($root, $node, 1, $traversalStrategy)->getOneOrNullResult();
+    }
+
+    /**
+     * @param object            $root              Root node of the parsed tree
+     * @param object|null       $node              Current node. If null, first node will be returned
+     * @param int|null          $limit             Maximum nodes to return. If null, all nodes will be returned
+     * @param self::TRAVERSAL_* $traversalStrategy Strategy to use to traverse tree
+     *
+     * @return array<object>
+     */
+    public function getNextNodes($root, $node = null, ?int $limit = null, string $traversalStrategy = self::TRAVERSAL_PRE_ORDER): array
+    {
+        return $this->getNextNodesQuery($root, $node, $limit, $traversalStrategy)->getArrayResult();
+    }
+
+    /**
      * Allows the following 'virtual' methods:
      * - persistAsFirstChild($node)
      * - persistAsFirstChildOf($node, $parent)
@@ -1185,6 +1219,11 @@ class NestedTreeRepository extends AbstractTreeRepository
         return parent::__call($method, $args);
     }
 
+    protected function validate()
+    {
+        return Strategy::NESTED === $this->listener->getStrategy($this->getEntityManager(), $this->getClassMetadata()->name)->getName();
+    }
+
     /**
      * @param object      $root              Root node of the parsed tree
      * @param object|null $node              Current node. If null, first node will be returned
@@ -1239,45 +1278,6 @@ class NestedTreeRepository extends AbstractTreeRepository
         }
 
         return $qb;
-    }
-
-    /**
-     * @param object            $root              Root node of the parsed tree
-     * @param object|null       $node              Current node. If null, first node will be returned
-     * @param int|null          $limit             Maximum nodes to return. If null, all nodes will be returned
-     * @param self::TRAVERSAL_* $traversalStrategy Strategy to use to traverse tree
-     */
-    public function getNextNodesQuery(object $root, ?object $node = null, ?int $limit = null, string $traversalStrategy = self::TRAVERSAL_PRE_ORDER): Query
-    {
-        return $this->getNextNodesQueryBuilder($root, $node, $limit, $traversalStrategy)->getQuery();
-    }
-
-    /**
-     * @param object            $root              Root node of the parsed tree
-     * @param object|null       $node              Current node. If null, first node will be returned
-     * @param self::TRAVERSAL_* $traversalStrategy Strategy to use to traverse tree
-     */
-    public function getNextNode(object $root, ?object $node = null, string $traversalStrategy = self::TRAVERSAL_PRE_ORDER): ?object
-    {
-        return $this->getNextNodesQuery($root, $node, 1, $traversalStrategy)->getOneOrNullResult();
-    }
-
-    /**
-     * @param object            $root              Root node of the parsed tree
-     * @param object|null       $node              Current node. If null, first node will be returned
-     * @param int|null          $limit             Maximum nodes to return. If null, all nodes will be returned
-     * @param self::TRAVERSAL_* $traversalStrategy Strategy to use to traverse tree
-     *
-     * @return array<object>
-     */
-    public function getNextNodes($root, $node = null, ?int $limit = null, string $traversalStrategy = self::TRAVERSAL_PRE_ORDER): array
-    {
-        return $this->getNextNodesQuery($root, $node, $limit, $traversalStrategy)->getArrayResult();
-    }
-
-    protected function validate()
-    {
-        return Strategy::NESTED === $this->listener->getStrategy($this->getEntityManager(), $this->getClassMetadata()->name)->getName();
     }
 
     /**

--- a/src/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/src/Tree/Entity/Repository/NestedTreeRepository.php
@@ -1228,7 +1228,7 @@ class NestedTreeRepository extends AbstractTreeRepository
                 ;
             }
         } else {
-            throw new InvalidArgumentException('Invalid traversal strategy.');
+            throw new InvalidArgumentException(\sprintf('Invalid traversal strategy "%s".', $traversalStrategy));
         }
 
         if (null !== $limit) {

--- a/tests/Gedmo/Tree/NestedTreeTraversalTest.php
+++ b/tests/Gedmo/Tree/NestedTreeTraversalTest.php
@@ -46,7 +46,7 @@ final class NestedTreeTraversalTest extends BaseTestCaseORM
         $result = [];
 
         $current = null;
-        while ($current = $repo->getNextNode($lvl1, $current, $strategy)) {
+        while (null !== ($current = $repo->getNextNode($lvl1, $current, $strategy))) {
             $result[] = $current->getTitle();
         }
         static::assertSame($expected, $result);

--- a/tests/Gedmo/Tree/NestedTreeTraversalTest.php
+++ b/tests/Gedmo/Tree/NestedTreeTraversalTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Tree;
+
+use Doctrine\Common\EventManager;
+use Gedmo\Tests\Tool\BaseTestCaseORM;
+use Gedmo\Tests\Tree\Fixture\RootCategory;
+use Gedmo\Tree\TreeListener;
+
+/**
+ * These are tests for Tree traversal
+ */
+final class NestedTreeTraversalTest extends BaseTestCaseORM
+{
+    public const CATEGORY = RootCategory::class;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $evm = new EventManager();
+        $evm->addEventSubscriber(new TreeListener());
+
+        $this->getDefaultMockSqliteEntityManager($evm);
+        $this->populate();
+    }
+
+    /**
+     * @dataProvider provideNextNodes
+     */
+    public function testNextNode(array $expected, string $strategy): void
+    {
+        $repo = $this->em->getRepository(self::CATEGORY);
+        $lvl1 = $repo->findOneBy(['title' => 'Part. 1']);
+
+        $result = [];
+
+        $current = null;
+        while ($current = $repo->getNextNode($lvl1, $current, $strategy)) {
+            $result[] = $current->getTitle();
+        }
+        static::assertSame($expected, $result);
+    }
+
+    /**
+     * @dataProvider provideNextNodes
+     */
+    public function testNextNodes(array $expected, string $strategy): void
+    {
+        $repo = $this->em->getRepository(self::CATEGORY);
+        $lvl1 = $repo->findOneBy(['title' => 'Part. 1']);
+
+        $nextNodes = $repo->getNextNodes($lvl1, null, 10, $strategy);
+
+        static::assertSame($expected, array_column($nextNodes, 'title'));
+    }
+
+    public function provideNextNodes(): iterable
+    {
+        yield 'Pre-order traversal' => [
+            ['Part. 1', 'Part. 1.1', 'Part. 1.2', 'Part. 1.2.1', 'Part. 1.2.2', 'Part. 1.3'],
+            'pre_order',
+        ];
+        yield 'Level-order traversal' => [
+            ['Part. 1.2.1', 'Part. 1.2.2', 'Part. 1.1', 'Part. 1.2', 'Part. 1.3', 'Part. 1'],
+            'level_order',
+        ];
+    }
+
+    protected function getUsedEntityFixtures(): array
+    {
+        return [self::CATEGORY];
+    }
+
+    /**
+     * @throws \Doctrine\ORM\OptimisticLockException
+     */
+    private function populate(): void
+    {
+        $lvl1 = new RootCategory();
+        $lvl1->setTitle('Part. 1');
+
+        $lvl2 = new RootCategory();
+        $lvl2->setTitle('Part. 2');
+
+        $lvl11 = new RootCategory();
+        $lvl11->setTitle('Part. 1.1');
+        $lvl11->setParent($lvl1);
+
+        $lvl12 = new RootCategory();
+        $lvl12->setTitle('Part. 1.2');
+        $lvl12->setParent($lvl1);
+
+        $lvl121 = new RootCategory();
+        $lvl121->setTitle('Part. 1.2.1');
+        $lvl121->setParent($lvl12);
+
+        $lvl122 = new RootCategory();
+        $lvl122->setTitle('Part. 1.2.2');
+        $lvl122->setParent($lvl12);
+
+        $lvl13 = new RootCategory();
+        $lvl13->setTitle('Part. 1.3');
+        $lvl13->setParent($lvl1);
+
+        $lvl21 = new RootCategory();
+        $lvl21->setTitle('Part. 2.1');
+        $lvl21->setParent($lvl2);
+
+        $lvl22 = new RootCategory();
+        $lvl22->setTitle('Part. 2.2');
+        $lvl22->setParent($lvl2);
+
+        $this->em->persist($lvl1);
+        $this->em->persist($lvl2);
+        $this->em->persist($lvl11);
+        $this->em->persist($lvl12);
+        $this->em->persist($lvl121);
+        $this->em->persist($lvl122);
+        $this->em->persist($lvl13);
+        $this->em->persist($lvl21);
+        $this->em->persist($lvl22);
+        $this->em->flush();
+        $this->em->clear();
+    }
+}

--- a/tests/Gedmo/Tree/NestedTreeTraversalTest.php
+++ b/tests/Gedmo/Tree/NestedTreeTraversalTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Gedmo\Tests\Tree;
 
 use Doctrine\Common\EventManager;
+use Doctrine\ORM\OptimisticLockException;
 use Gedmo\Tests\Tool\BaseTestCaseORM;
 use Gedmo\Tests\Tree\Fixture\RootCategory;
 use Gedmo\Tree\TreeListener;
@@ -82,7 +83,7 @@ final class NestedTreeTraversalTest extends BaseTestCaseORM
     }
 
     /**
-     * @throws \Doctrine\ORM\OptimisticLockException
+     * @throws OptimisticLockException
      */
     private function populate(): void
     {


### PR DESCRIPTION
In order to get the next node when traversing a tree, this PRs add new methods `NestedTreeRepository::getNextNode ` and `NestedTreeRepository::getNextNodes`. They take some arguments :
* `$root` is the top node and is used to limit result to this (sub-)tree
* `$node` is the current node (or null for the first call)
* `$limit` (only for `getNextNodes`) can limit nodes count to return
* `$traversalStrategy` accepts `self::TRAVERSAL_PRE_ORDER` (default) or `self::TRAVERSAL_LEVEL_ORDER` and is used to determine which algorithm use (see https://www.geeksforgeeks.org/tree-traversals-inorder-preorder-and-postorder).

These methods can be used, for example, to read a book page after page:
* The History of Middle-earth
  * The Book of Lost Tales 1
    * Chapter 1
      * Page 1
      * Page 2
      * Page 3
      * ...
    * Chapter 2
      * Page 1
      * Page 2
      * Page 3
      * ...
  * The Book of Lost Tales 2
  * ...