### PR TITLE
[WIP][Tree][NestedSet] Fix TreeRoot with rootIdentifierMethod defined and no parent

### DIFF
--- a/src/Tree/Strategy/ORM/Nested.php
+++ b/src/Tree/Strategy/ORM/Nested.php
@@ -125,7 +125,7 @@ class Nested implements Strategy
         }
         if (isset($config['root']) && !$meta->hasAssociation($config['root']) && !isset($config['rootIdentifierMethod'])) {
             $meta->getReflectionProperty($config['root'])->setValue($node, 0);
-        } elseif (isset($config['rootIdentifierMethod']) && null === $meta->getReflectionProperty($config['root'])->getValue($node)) {
+        } elseif (isset($config['rootIdentifierMethod']) && !$meta->hasAssociation($config['root']) && null === $meta->getReflectionProperty($config['root'])->getValue($node)) {
             $meta->getReflectionProperty($config['root'])->setValue($node, 0);
         }
     }
@@ -446,7 +446,6 @@ class Nested implements Strategy
             $start = 1;
             if (isset($config['rootIdentifierMethod'])) {
                 $method = $config['rootIdentifierMethod'];
-                $newRoot = $node->$method();
                 $repo = $em->getRepository($config['useObjectClass']);
 
                 $criteria = new Criteria();
@@ -459,7 +458,9 @@ class Nested implements Strategy
                 $last = array_pop($roots);
 
                 $start = ($last) ? $meta->getFieldValue($last, $config['right']) + 1 : 1;
-            } elseif ($meta->isSingleValuedAssociation($config['root'])) {
+            }
+
+            if ($meta->isSingleValuedAssociation($config['root'])) {
                 $newRoot = $node;
             } else {
                 $newRoot = $wrapped->getIdentifier();

--- a/tests/Gedmo/Tree/Fixture/Issue2215/Category.php
+++ b/tests/Gedmo/Tree/Fixture/Issue2215/Category.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Tree\Fixture\Issue2215;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
+
+/**
+ * @Gedmo\Tree(type="nested")
+ * @ORM\Table(name="categories")
+ * @ORM\Entity(repositoryClass="Gedmo\Tree\Entity\Repository\NestedTreeRepository")
+ */
+#[Gedmo\Tree(type: 'nested')]
+#[ORM\Table(name: 'categories')]
+#[ORM\Entity(repositoryClass: NestedTreeRepository::class)]
+class Category
+{
+    /**
+     * @var int|null
+     *
+     * @ORM\Column(name="id", type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    private $id;
+
+    /**
+     * @var string|null
+     *
+     * @ORM\Column(name="title", type="string", length=64)
+     */
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
+    private $title;
+
+    /**
+     * @var int|null
+     *
+     * @Gedmo\TreeLeft
+     * @ORM\Column(name="lft", type="integer")
+     */
+    #[ORM\Column(name: 'lft', type: Types::INTEGER)]
+    #[Gedmo\TreeLeft]
+    private $lft;
+
+    /**
+     * @var int|null
+     *
+     * @Gedmo\TreeRight
+     * @ORM\Column(name="rgt", type="integer")
+     */
+    #[ORM\Column(name: 'rgt', type: Types::INTEGER)]
+    #[Gedmo\TreeRight]
+    private $rgt;
+
+    /**
+     * @var int|null
+     *
+     * @Gedmo\TreeLevel
+     * @ORM\Column(name="lvl", type="integer")
+     */
+    #[ORM\Column(name: 'lvl', type: Types::INTEGER)]
+    #[Gedmo\TreeLevel]
+    private $lvl;
+
+    /**
+     * @var self|null
+     *
+     * @Gedmo\TreeRoot(identifierMethod="getRoot")
+     * @ORM\ManyToOne(targetEntity="Category")
+     * @ORM\JoinColumn(name="tree_root", referencedColumnName="id", onDelete="CASCADE")
+     */
+    #[Gedmo\TreeRoot(identifierMethod: 'getRoot')]
+    #[ORM\ManyToOne(targetEntity: self::class)]
+    #[ORM\JoinColumn(name: 'tree_root', referencedColumnName: 'id', onDelete: 'CASCADE')]
+    private $root;
+
+    /**
+     * @var self|null
+     *
+     * @Gedmo\TreeParent
+     * @ORM\ManyToOne(targetEntity="Category", inversedBy="children")
+     * @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
+     */
+    #[Gedmo\TreeParent]
+    #[ORM\ManyToOne(targetEntity: self::class, inversedBy: 'children')]
+    #[ORM\JoinColumn(name: 'parent_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
+    private $parent;
+
+    /**
+     * @var Collection<int, Category>
+     *
+     * @ORM\OneToMany(targetEntity="Category", mappedBy="parent")
+     * @ORM\OrderBy({"lft" = "ASC"})
+     */
+    #[ORM\OneToMany(targetEntity: self::class, mappedBy: 'parent')]
+    #[ORM\OrderBy(['lft' => 'ASC'])]
+    private $children;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setTitle(?string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function getRoot(): ?self
+    {
+        return $this->root;
+    }
+
+    public function setParent(self $parent = null): void
+    {
+        $this->parent = $parent;
+    }
+
+    public function getParent(): ?self
+    {
+        return $this->parent;
+    }
+}

--- a/tests/Gedmo/Tree/Issue/Issue2215Test.php
+++ b/tests/Gedmo/Tree/Issue/Issue2215Test.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Tree\Issue;
+
+use Doctrine\Common\EventManager;
+use Gedmo\Tests\Tool\BaseTestCaseORM;
+use Gedmo\Tests\Tree\Fixture\Issue2215\Category;
+use Gedmo\Tree\TreeListener;
+
+final class Issue2215Test extends BaseTestCaseORM
+{
+    /**
+     * @var TreeListener
+     */
+    private $listener;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->listener = new TreeListener();
+
+        $evm = new EventManager();
+        $evm->addEventSubscriber($this->listener);
+
+        $this->getDefaultMockSqliteEntityManager($evm);
+    }
+
+    public function testSettingParentNullWithTreeRootIdentifierMethod(): void
+    {
+        $food = new Category();
+        $food->setTitle('Food');
+
+        $fruits = new Category();
+        $fruits->setTitle('Fruits');
+        $fruits->setParent($food);
+
+        $this->em->persist($food);
+        $this->em->persist($fruits);
+        $this->em->flush();
+
+        $categoryRepository = $this->em->getRepository(Category::class);
+        $verify = $categoryRepository->verify();
+
+        static::assertTrue($verify);
+
+        static::assertNull($food->getParent());
+        static::assertSame($food, $food->getRoot());
+
+        static::assertSame($food, $fruits->getParent());
+        static::assertSame($food, $fruits->getRoot());
+    }
+
+    protected function getUsedEntityFixtures(): array
+    {
+        return [Category::class];
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/doctrine-extensions/DoctrineExtensions/issues/2215

I experienced the same error when attempting to flush an entity with a self-referencing root due to the usage of `identifierMethod: 'getRoot'`.

```php
#[Gedmo\TreeRoot(identifierMethod: 'getRoot')]
#[ORM\ManyToOne(targetEntity: self::class)]
#[ORM\JoinColumn(name: 'tree_root', referencedColumnName: 'id', onDelete: 'CASCADE')]
private $root;
```

This PR fixes it by:
- not setting the value to `0` if the field is an association
- setting the value from itself even if `identifierMethod ` is defined 