### PR TITLE
fix on documentation about slug attribute and unique property

### DIFF
--- a/doc/sluggable.md
+++ b/doc/sluggable.md
@@ -271,7 +271,7 @@ echo $article->getSlug();
 
 - **fields** (required, default=[]) - list of fields for slug
 - **updatable** (optional, default=true) - **true** to update the slug on sluggable field changes, **false** - otherwise
-- **unique** (optional, default=true) - **true** if slug should be unique and if identical it will be prefixed, **false** - otherwise
+- **unique** (optional, default=true) - **true** if slug should be unique and if identical it will be suffixed, **false** - otherwise
 - **unique_base** (optional, default=null) - used in conjunction with **unique**. The name of the entity property that should be used as a key when doing a uniqueness check.
 - **separator** (optional, default="-") - separator which will separate words in slug
 - **prefix** (optional, default="") - prefix which will be added to the generated slug


### PR DESCRIPTION
on slug annotation, when property "unique" is true, it become suffixed and not prefixed