### PR TITLE
Require doctrine/event-manager 1.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "doctrine/annotations": "^1.13",
         "doctrine/collections": "^1.0",
         "doctrine/common": "^2.13 || ^3.0",
-        "doctrine/event-manager": "^1.0",
+        "doctrine/event-manager": "^1.2",
         "doctrine/persistence": "^2.2 || ^3.0",
         "psr/cache": "^1 || ^2 || ^3",
         "symfony/cache": "^4.4 || ^5.3 || ^6.0"

--- a/src/Loggable/Document/Repository/LogEntryRepository.php
+++ b/src/Loggable/Document/Repository/LogEntryRepository.php
@@ -146,7 +146,7 @@ class LogEntryRepository extends DocumentRepository
     private function getLoggableListener(): LoggableListener
     {
         if (null === $this->listener) {
-            foreach ($this->dm->getEventManager()->getListeners() as $event => $listeners) {
+            foreach ($this->dm->getEventManager()->getAllListeners() as $event => $listeners) {
                 foreach ($listeners as $hash => $listener) {
                     if ($listener instanceof LoggableListener) {
                         $this->listener = $listener;

--- a/src/Loggable/Entity/Repository/LogEntryRepository.php
+++ b/src/Loggable/Entity/Repository/LogEntryRepository.php
@@ -147,7 +147,7 @@ class LogEntryRepository extends EntityRepository
     private function getLoggableListener(): LoggableListener
     {
         if (null === $this->listener) {
-            foreach ($this->_em->getEventManager()->getListeners() as $event => $listeners) {
+            foreach ($this->_em->getEventManager()->getAllListeners() as $event => $listeners) {
                 foreach ($listeners as $hash => $listener) {
                     if ($listener instanceof LoggableListener) {
                         $this->listener = $listener;

--- a/src/SoftDeleteable/Filter/ODM/SoftDeleteableFilter.php
+++ b/src/SoftDeleteable/Filter/ODM/SoftDeleteableFilter.php
@@ -101,7 +101,7 @@ class SoftDeleteableFilter extends BsonFilter
             $em = $this->getDocumentManager();
             $evm = $em->getEventManager();
 
-            foreach ($evm->getListeners() as $listeners) {
+            foreach ($evm->getAllListeners() as $listeners) {
                 foreach ($listeners as $listener) {
                     if ($listener instanceof SoftDeleteableListener) {
                         $this->listener = $listener;

--- a/src/SoftDeleteable/Filter/SoftDeleteableFilter.php
+++ b/src/SoftDeleteable/Filter/SoftDeleteableFilter.php
@@ -115,7 +115,7 @@ class SoftDeleteableFilter extends SQLFilter
             $em = $this->getEntityManager();
             $evm = $em->getEventManager();
 
-            foreach ($evm->getListeners() as $listeners) {
+            foreach ($evm->getAllListeners() as $listeners) {
                 foreach ($listeners as $listener) {
                     if ($listener instanceof SoftDeleteableListener) {
                         $this->listener = $listener;

--- a/src/SoftDeleteable/Query/TreeWalker/SoftDeleteableWalker.php
+++ b/src/SoftDeleteable/Query/TreeWalker/SoftDeleteableWalker.php
@@ -136,7 +136,7 @@ class SoftDeleteableWalker extends SqlWalker
         if (null === $this->listener) {
             $em = $this->getEntityManager();
 
-            foreach ($em->getEventManager()->getListeners() as $listeners) {
+            foreach ($em->getEventManager()->getAllListeners() as $listeners) {
                 foreach ($listeners as $listener) {
                     if ($listener instanceof SoftDeleteableListener) {
                         $this->listener = $listener;

--- a/src/Sortable/Entity/Repository/SortableRepository.php
+++ b/src/Sortable/Entity/Repository/SortableRepository.php
@@ -42,7 +42,7 @@ class SortableRepository extends EntityRepository
     {
         parent::__construct($em, $class);
         $sortableListener = null;
-        foreach ($em->getEventManager()->getListeners() as $event => $listeners) {
+        foreach ($em->getEventManager()->getAllListeners() as $event => $listeners) {
             foreach ($listeners as $hash => $listener) {
                 if ($listener instanceof SortableListener) {
                     $sortableListener = $listener;

--- a/src/Translatable/Document/Repository/TranslationRepository.php
+++ b/src/Translatable/Document/Repository/TranslationRepository.php
@@ -238,7 +238,7 @@ class TranslationRepository extends DocumentRepository
     private function getTranslatableListener(): TranslatableListener
     {
         if (null === $this->listener) {
-            foreach ($this->dm->getEventManager()->getListeners() as $event => $listeners) {
+            foreach ($this->dm->getEventManager()->getAllListeners() as $event => $listeners) {
                 foreach ($listeners as $hash => $listener) {
                     if ($listener instanceof TranslatableListener) {
                         return $this->listener = $listener;

--- a/src/Translatable/Entity/Repository/TranslationRepository.php
+++ b/src/Translatable/Entity/Repository/TranslationRepository.php
@@ -234,7 +234,7 @@ class TranslationRepository extends EntityRepository
     private function getTranslatableListener(): TranslatableListener
     {
         if (!$this->listener) {
-            foreach ($this->_em->getEventManager()->getListeners() as $event => $listeners) {
+            foreach ($this->_em->getEventManager()->getAllListeners() as $event => $listeners) {
                 foreach ($listeners as $hash => $listener) {
                     if ($listener instanceof TranslatableListener) {
                         return $this->listener = $listener;

--- a/src/Translatable/Hydrator/ORM/ObjectHydrator.php
+++ b/src/Translatable/Hydrator/ORM/ObjectHydrator.php
@@ -63,7 +63,7 @@ class ObjectHydrator extends BaseObjectHydrator
     protected function getTranslatableListener()
     {
         $translatableListener = null;
-        foreach ($this->_em->getEventManager()->getListeners() as $event => $listeners) {
+        foreach ($this->_em->getEventManager()->getAllListeners() as $event => $listeners) {
             foreach ($listeners as $hash => $listener) {
                 if ($listener instanceof TranslatableListener) {
                     $translatableListener = $listener;

--- a/src/Translatable/Hydrator/ORM/SimpleObjectHydrator.php
+++ b/src/Translatable/Hydrator/ORM/SimpleObjectHydrator.php
@@ -63,7 +63,7 @@ class SimpleObjectHydrator extends BaseSimpleObjectHydrator
     protected function getTranslatableListener()
     {
         $translatableListener = null;
-        foreach ($this->_em->getEventManager()->getListeners() as $event => $listeners) {
+        foreach ($this->_em->getEventManager()->getAllListeners() as $event => $listeners) {
             foreach ($listeners as $hash => $listener) {
                 if ($listener instanceof TranslatableListener) {
                     $translatableListener = $listener;

--- a/src/Translatable/Query/TreeWalker/TranslationWalker.php
+++ b/src/Translatable/Query/TreeWalker/TranslationWalker.php
@@ -410,7 +410,7 @@ class TranslationWalker extends SqlWalker
     private function getTranslatableListener(): TranslatableListener
     {
         $em = $this->getEntityManager();
-        foreach ($em->getEventManager()->getListeners() as $event => $listeners) {
+        foreach ($em->getEventManager()->getAllListeners() as $event => $listeners) {
             foreach ($listeners as $hash => $listener) {
                 if ($listener instanceof TranslatableListener) {
                     return $listener;

--- a/src/Tree/Document/MongoDB/Repository/AbstractTreeRepository.php
+++ b/src/Tree/Document/MongoDB/Repository/AbstractTreeRepository.php
@@ -40,7 +40,7 @@ abstract class AbstractTreeRepository extends DocumentRepository implements Repo
     {
         parent::__construct($em, $uow, $class);
         $treeListener = null;
-        foreach ($em->getEventManager()->getListeners() as $listeners) {
+        foreach ($em->getEventManager()->getAllListeners() as $listeners) {
             foreach ($listeners as $listener) {
                 if ($listener instanceof \Gedmo\Tree\TreeListener) {
                     $treeListener = $listener;

--- a/src/Tree/Entity/Repository/AbstractTreeRepository.php
+++ b/src/Tree/Entity/Repository/AbstractTreeRepository.php
@@ -41,7 +41,7 @@ abstract class AbstractTreeRepository extends EntityRepository implements Reposi
     {
         parent::__construct($em, $class);
         $treeListener = null;
-        foreach ($em->getEventManager()->getListeners() as $listeners) {
+        foreach ($em->getEventManager()->getAllListeners() as $listeners) {
             foreach ($listeners as $listener) {
                 if ($listener instanceof TreeListener) {
                     $treeListener = $listener;

--- a/src/Tree/Hydrator/ORM/TreeObjectHydrator.php
+++ b/src/Tree/Hydrator/ORM/TreeObjectHydrator.php
@@ -252,7 +252,7 @@ class TreeObjectHydrator extends ObjectHydrator
      */
     protected function getTreeListener(EntityManagerInterface $em)
     {
-        foreach ($em->getEventManager()->getListeners() as $listeners) {
+        foreach ($em->getEventManager()->getAllListeners() as $listeners) {
             foreach ($listeners as $listener) {
                 if ($listener instanceof TreeListener) {
                     return $listener;


### PR DESCRIPTION
To avoid [doctrine deprecations using `doctrine/event-manager` 1.2](https://github.com/doctrine/event-manager/pull/50) and it prepares this package to install version 2 which we can't right now because of:
```
gedmo/doctrine-extensions 3.10.x-dev requires doctrine/event-manager (^1.2)
doctrine/mongodb-odm      2.4.2      requires doctrine/event-manager (^1.0)
doctrine/orm              2.13.3     requires doctrine/event-manager (^1.1)
symfony/doctrine-bridge   v6.1.6     requires doctrine/event-manager (~1.0)
```