### PR TITLE
Make TimestampableEntity getter type hints nullable

### DIFF
--- a/src/Timestampable/Traits/Timestampable.php
+++ b/src/Timestampable/Traits/Timestampable.php
@@ -17,12 +17,12 @@ namespace Gedmo\Timestampable\Traits;
 trait Timestampable
 {
     /**
-     * @var \DateTime
+     * @var \DateTime|null
      */
     protected $createdAt;
 
     /**
-     * @var \DateTime
+     * @var \DateTime|null
      */
     protected $updatedAt;
 
@@ -41,7 +41,7 @@ trait Timestampable
     /**
      * Returns createdAt.
      *
-     * @return \DateTime
+     * @return \DateTime|null
      */
     public function getCreatedAt()
     {
@@ -63,7 +63,7 @@ trait Timestampable
     /**
      * Returns updatedAt.
      *
-     * @return \DateTime
+     * @return \DateTime|null
      */
     public function getUpdatedAt()
     {

--- a/src/Timestampable/Traits/TimestampableDocument.php
+++ b/src/Timestampable/Traits/TimestampableDocument.php
@@ -21,7 +21,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 trait TimestampableDocument
 {
     /**
-     * @var \DateTime
+     * @var \DateTime|null
      * @Gedmo\Timestampable(on="create")
      * @ODM\Field(type="date")
      */
@@ -30,7 +30,7 @@ trait TimestampableDocument
     protected $createdAt;
 
     /**
-     * @var \DateTime
+     * @var \DateTime|null
      * @Gedmo\Timestampable(on="update")
      * @ODM\Field(type="date")
      */
@@ -53,7 +53,7 @@ trait TimestampableDocument
     /**
      * Returns createdAt.
      *
-     * @return \DateTime
+     * @return \DateTime|null
      */
     public function getCreatedAt()
     {
@@ -75,7 +75,7 @@ trait TimestampableDocument
     /**
      * Returns updatedAt.
      *
-     * @return \Datetime
+     * @return \Datetime|null
      */
     public function getUpdatedAt()
     {

--- a/src/Timestampable/Traits/TimestampableEntity.php
+++ b/src/Timestampable/Traits/TimestampableEntity.php
@@ -53,7 +53,7 @@ trait TimestampableEntity
     /**
      * Returns createdAt.
      *
-     * @return \DateTime
+     * @return \DateTime|null
      */
     public function getCreatedAt()
     {
@@ -75,7 +75,7 @@ trait TimestampableEntity
     /**
      * Returns updatedAt.
      *
-     * @return \DateTime
+     * @return \DateTime|null
      */
     public function getUpdatedAt()
     {

--- a/src/Timestampable/Traits/TimestampableEntity.php
+++ b/src/Timestampable/Traits/TimestampableEntity.php
@@ -21,7 +21,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 trait TimestampableEntity
 {
     /**
-     * @var \DateTime
+     * @var \DateTime|null
      * @Gedmo\Timestampable(on="create")
      * @ORM\Column(type="datetime")
      */
@@ -30,7 +30,7 @@ trait TimestampableEntity
     protected $createdAt;
 
     /**
-     * @var \DateTime
+     * @var \DateTime|null
      * @Gedmo\Timestampable(on="update")
      * @ORM\Column(type="datetime")
      */


### PR DESCRIPTION
Signals nullability for return types of `TimestampableEntity::getCreatedAt()` and `TimestampableEntity::getUpdatedAt()`. They may actually return `null` when they are not yet persisted.

This helps static type checkers understand this trait better.