### PR TITLE
Allow PHP 8.2 in CI and Docker environments

### DIFF
--- a/.docker/php/Dockerfile
+++ b/.docker/php/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG PHP_VERSION=8.1-cli
+ARG PHP_VERSION=8.2-cli
 
 FROM composer:2 AS composer
 

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Install PHP with extensions
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: none
           tools: composer:v2, composer-normalize:2
         env:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -28,6 +28,7 @@ jobs:
           - "7.4"
           - "8.0"
           - "8.1"
+          - "8.2"
         deps:
           - "highest"
         dbal-version:
@@ -38,10 +39,10 @@ jobs:
           - deps: "lowest"
             php-version: "7.2"
           - deps: "highest"
-            php-version: "8.1"
+            php-version: "8.2"
             dbal-version: "^2.13.1"
           - deps: "highest"
-            php-version: "8.1"
+            php-version: "8.2"
             dbal-version: "^3.2"
           - deps: "highest"
             php-version: "8.1"
@@ -98,7 +99,7 @@ jobs:
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
-          php-version: "8.1"
+          php-version: "8.2"
           extensions: mongodb
 
       - name: "Install dependencies with Composer"

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install PHP with extensions
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: none
           extensions: mongodb-1.9.0, zip
           tools: composer:v2

--- a/compose.yaml
+++ b/compose.yaml
@@ -4,7 +4,7 @@ services:
       context: .docker/php
       target: php
       args:
-        PHP_VERSION: ${PHP_VERSION:-8.1-cli}
+        PHP_VERSION: ${PHP_VERSION:-8.2-cli}
     volumes:
       - .:/var/www
     working_dir: /var/www


### PR DESCRIPTION
**TODO**:
- [x] Wait for #2547.

~~Some findings from the installed version of PHP-CS-Fixer in the pipeline of this PR were also fixed (settings for `phpdoc_order` and `phpdoc_separation` rules were explicitly configured in order to avoid more changes).~~