### PR TITLE
Tree: Add `setSibling()` and `getSibling()` methods in the `Node` interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ a release.
 ---
 
 ## [Unreleased]
+### Added
+- Tree: `setSibling()` and `getSibling()` methods in the `Node` interface through the BC `@method` annotation
+
+### Fixed
+- Tree: Creation of dynamic `Node::$sibling` property, which is deprecated as of PHP >= 8.2
+
+### Deprecated
+- Tree: Not implementing `Node` interface in classes that are used as nodes
 
 ## [3.11.1] - 2023-02-20
 ### Fixed

--- a/src/Tree/Node.php
+++ b/src/Tree/Node.php
@@ -14,6 +14,9 @@ namespace Gedmo\Tree;
  * Entities which in some cases needs to be identified as
  * Tree Node
  *
+ * @method void  setSibling(self $node)
+ * @method ?self getSibling()
+ *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
 interface Node
@@ -42,4 +45,10 @@ interface Node
      * @gedmo:TreeLevel
      * level of node.
      */
+
+    // @todo: In the next major release, remove this line and uncomment the method in the next line.
+    // public function setSibling(self $node): void;
+
+    // @todo: In the next major release, remove this line and uncomment the method in the next line.
+    // public function getSibling(): ?self;
 }

--- a/src/Tree/Strategy/ORM/Nested.php
+++ b/src/Tree/Strategy/ORM/Nested.php
@@ -302,6 +302,18 @@ class Nested implements Strategy
         $level = $config['level_base'] ?? 0;
         $treeSize = $right - $left + 1;
         $newRoot = null;
+
+        // @todo: In the next major release, remove all the conditions and use only the following assignment for `$sibling`.
+        // $node->getSibling();
+
+        if (method_exists($node, 'getSibling')) {
+            $sibling = $node->getSibling();
+        } elseif (property_exists($node, 'sibling')) {
+            $sibling = $node->sibling;
+        } else {
+            $sibling = null;
+        }
+
         if ($parent) {    // || (!$parent && isset($config['rootIdentifierMethod']))
             $wrappedParent = AbstractWrapper::wrap($parent, $em);
 
@@ -327,8 +339,8 @@ class Nested implements Strategy
             }
             switch ($position) {
                 case self::PREV_SIBLING:
-                    if (property_exists($node, 'sibling')) {
-                        $wrappedSibling = AbstractWrapper::wrap($node->sibling, $em);
+                    if (null !== $sibling) {
+                        $wrappedSibling = AbstractWrapper::wrap($sibling, $em);
                         $start = $wrappedSibling->getPropertyValue($config['left']);
                         ++$level;
                     } else {
@@ -350,8 +362,8 @@ class Nested implements Strategy
                     break;
 
                 case self::NEXT_SIBLING:
-                    if (property_exists($node, 'sibling')) {
-                        $wrappedSibling = AbstractWrapper::wrap($node->sibling, $em);
+                    if (null !== $sibling) {
+                        $wrappedSibling = AbstractWrapper::wrap($sibling, $em);
                         $start = $wrappedSibling->getPropertyValue($config['right']) + 1;
                         ++$level;
                     } else {
@@ -407,8 +419,8 @@ class Nested implements Strategy
 
             switch ($position) {
                 case self::PREV_SIBLING:
-                    if (property_exists($node, 'sibling')) {
-                        $wrappedSibling = AbstractWrapper::wrap($node->sibling, $em);
+                    if (null !== $sibling) {
+                        $wrappedSibling = AbstractWrapper::wrap($sibling, $em);
                         $start = $wrappedSibling->getPropertyValue($config['left']);
                     } else {
                         $wrapped->setPropertyValue($config['parent'], null);
@@ -419,8 +431,8 @@ class Nested implements Strategy
                     break;
 
                 case self::NEXT_SIBLING:
-                    if (property_exists($node, 'sibling')) {
-                        $wrappedSibling = AbstractWrapper::wrap($node->sibling, $em);
+                    if (null !== $sibling) {
+                        $wrappedSibling = AbstractWrapper::wrap($sibling, $em);
                         $start = $wrappedSibling->getPropertyValue($config['right']) + 1;
                     } else {
                         $wrapped->setPropertyValue($config['parent'], null);

--- a/tests/Gedmo/Sluggable/Fixture/Handler/TreeSlug.php
+++ b/tests/Gedmo/Sluggable/Fixture/Handler/TreeSlug.php
@@ -18,6 +18,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 use Gedmo\Sluggable\Handler\TreeSlugHandler;
 use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
+use Gedmo\Tree\Node;
 
 /**
  * @Gedmo\Tree(type="nested")
@@ -25,7 +26,7 @@ use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
  */
 #[ORM\Entity(repositoryClass: NestedTreeRepository::class)]
 #[Gedmo\Tree(type: 'nested')]
-class TreeSlug
+class TreeSlug implements Node
 {
     /**
      * @var int|null
@@ -120,6 +121,11 @@ class TreeSlug
     #[Gedmo\TreeLevel]
     private $level;
 
+    /**
+     * @var Node|null
+     */
+    private $sibling;
+
     public function __construct()
     {
         $this->children = new ArrayCollection();
@@ -181,5 +187,15 @@ class TreeSlug
     public function getSlug(): ?string
     {
         return $this->slug;
+    }
+
+    public function setSibling(Node $node): void
+    {
+        $this->sibling = $node;
+    }
+
+    public function getSibling(): ?Node
+    {
+        return $this->sibling;
     }
 }

--- a/tests/Gedmo/Tree/Fixture/Category.php
+++ b/tests/Gedmo/Tree/Fixture/Category.php
@@ -107,6 +107,11 @@ class Category implements NodeInterface
     #[ORM\OneToMany(targetEntity: Article::class, mappedBy: 'article')]
     private $comments;
 
+    /**
+     * @var NodeInterface|null
+     */
+    private $sibling;
+
     public function __construct()
     {
         $this->children = new ArrayCollection();
@@ -151,5 +156,15 @@ class Category implements NodeInterface
     public function getLevel(): ?int
     {
         return $this->level;
+    }
+
+    public function setSibling(NodeInterface $node): void
+    {
+        $this->sibling = $node;
+    }
+
+    public function getSibling(): ?NodeInterface
+    {
+        return $this->sibling;
     }
 }

--- a/tests/Gedmo/Tree/Fixture/CategoryUuid.php
+++ b/tests/Gedmo/Tree/Fixture/CategoryUuid.php
@@ -119,6 +119,11 @@ class CategoryUuid implements NodeInterface
     #[ORM\OneToMany(targetEntity: Article::class, mappedBy: 'category')]
     private $comments;
 
+    /**
+     * @var NodeInterface|null
+     */
+    private $sibling;
+
     public function __construct()
     {
         $this->children = new ArrayCollection();
@@ -174,5 +179,15 @@ class CategoryUuid implements NodeInterface
     public function getLevel(): ?int
     {
         return $this->level;
+    }
+
+    public function setSibling(NodeInterface $node): void
+    {
+        $this->sibling = $node;
+    }
+
+    public function getSibling(): ?NodeInterface
+    {
+        return $this->sibling;
     }
 }

--- a/tests/Gedmo/Tree/Fixture/RootCategory.php
+++ b/tests/Gedmo/Tree/Fixture/RootCategory.php
@@ -16,6 +16,7 @@ use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
+use Gedmo\Tree\Node;
 
 /**
  * @ORM\Entity(repositoryClass="Gedmo\Tree\Entity\Repository\NestedTreeRepository")
@@ -23,7 +24,7 @@ use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
  */
 #[ORM\Entity(repositoryClass: NestedTreeRepository::class)]
 #[Gedmo\Tree(type: 'nested')]
-class RootCategory
+class RootCategory implements Node
 {
     /**
      * @var Collection<int, self>
@@ -106,6 +107,11 @@ class RootCategory
     #[Gedmo\TreeLevel(base: 1)]
     private $level;
 
+    /**
+     * @var Node|null
+     */
+    private $sibling;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -165,5 +171,15 @@ class RootCategory
     public function setChildren(Collection $children): void
     {
         $this->children = $children;
+    }
+
+    public function setSibling(Node $node): void
+    {
+        $this->sibling = $node;
+    }
+
+    public function getSibling(): ?Node
+    {
+        return $this->sibling;
     }
 }


### PR DESCRIPTION
In PHP 8.2, [the use of dynamic properties is deprecated](https://www.php.net/manual/en/migration82.deprecated.php#migration82.deprecated.core.dynamic-properties).

See [this action](https://github.com/doctrine-extensions/DoctrineExtensions/actions/runs/3622870152/jobs/6157207902#step:7:32) from #2544.