### PR TITLE
Minor typing improvements

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21,17 +21,12 @@ parameters:
 			path: src/AbstractTrackingListener.php
 
 		-
-			message: "#^Access to an undefined property Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:\\$isMappedSuperclass\\.$#"
-			count: 1
-			path: src/Blameable/Mapping/Driver/Annotation.php
-
-		-
 			message: "#^Access to an undefined property object\\:\\:\\$value\\.$#"
 			count: 1
 			path: src/Blameable/Mapping/Driver/Annotation.php
 
 		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:isInheritedField\\(\\)\\.$#"
+			message: "#^Access to offset 'inherited' on an unknown class Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\AssociationFieldMapping\\.$#"
 			count: 1
 			path: src/Blameable/Mapping/Driver/Annotation.php
 
@@ -46,17 +41,12 @@ parameters:
 			path: src/Blameable/Mapping/Driver/Yaml.php
 
 		-
-			message: "#^Access to an undefined property Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:\\$isMappedSuperclass\\.$#"
-			count: 1
-			path: src/IpTraceable/Mapping/Driver/Annotation.php
-
-		-
 			message: "#^Access to an undefined property object\\:\\:\\$value\\.$#"
 			count: 1
 			path: src/IpTraceable/Mapping/Driver/Annotation.php
 
 		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:isInheritedField\\(\\)\\.$#"
+			message: "#^Access to offset 'inherited' on an unknown class Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\AssociationFieldMapping\\.$#"
 			count: 1
 			path: src/IpTraceable/Mapping/Driver/Annotation.php
 
@@ -69,11 +59,6 @@ parameters:
 			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:getFieldMapping\\(\\)\\.$#"
 			count: 1
 			path: src/IpTraceable/Mapping/Driver/Yaml.php
-
-		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:getFieldMapping\\(\\)\\.$#"
-			count: 1
-			path: src/Loggable/Document/Repository/LogEntryRepository.php
 
 		-
 			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\<Gedmo\\\\Loggable\\\\LogEntryInterface\\>\\:\\:getReflectionProperty\\(\\)\\.$#"
@@ -91,24 +76,9 @@ parameters:
 			path: src/Loggable/LoggableListener.php
 
 		-
-			message: "#^Access to an undefined property Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:\\$isMappedSuperclass\\.$#"
-			count: 2
-			path: src/Loggable/Mapping/Driver/Annotation.php
-
-		-
 			message: "#^Access to an undefined property Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:\\$associationMappings\\.$#"
 			count: 1
 			path: src/Loggable/Mapping/Driver/Xml.php
-
-		-
-			message: "#^Access to an undefined property Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:\\$isMappedSuperclass\\.$#"
-			count: 1
-			path: src/Loggable/Mapping/Driver/Xml.php
-
-		-
-			message: "#^Access to an undefined property Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:\\$isMappedSuperclass\\.$#"
-			count: 1
-			path: src/Loggable/Mapping/Driver/Yaml.php
 
 		-
 			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:getFieldMapping\\(\\)\\.$#"
@@ -186,11 +156,6 @@ parameters:
 			path: src/Mapping/MappedEventSubscriber.php
 
 		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:getFieldMapping\\(\\)\\.$#"
-			count: 1
-			path: src/ReferenceIntegrity/Mapping/Driver/Annotation.php
-
-		-
 			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\<object\\>\\:\\:getFieldMapping\\(\\)\\.$#"
 			count: 1
 			path: src/ReferenceIntegrity/ReferenceIntegrityListener.php
@@ -211,12 +176,7 @@ parameters:
 			path: src/ReferenceIntegrity/ReferenceIntegrityListener.php
 
 		-
-			message: "#^Access to an undefined property Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:\\$isMappedSuperclass\\.$#"
-			count: 1
-			path: src/References/Mapping/Driver/Annotation.php
-
-		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:isInheritedField\\(\\)\\.$#"
+			message: "#^Access to offset 'inherited' on an unknown class Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\AssociationFieldMapping\\.$#"
 			count: 1
 			path: src/References/Mapping/Driver/Annotation.php
 
@@ -336,12 +296,7 @@ parameters:
 			path: src/Sluggable/Handler/TreeSlugHandler.php
 
 		-
-			message: "#^Access to an undefined property Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:\\$isMappedSuperclass\\.$#"
-			count: 1
-			path: src/Sluggable/Mapping/Driver/Annotation.php
-
-		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:isInheritedField\\(\\)\\.$#"
+			message: "#^Access to offset 'inherited' on an unknown class Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\AssociationFieldMapping\\.$#"
 			count: 1
 			path: src/Sluggable/Mapping/Driver/Annotation.php
 
@@ -369,16 +324,6 @@ parameters:
 			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:getFieldMapping\\(\\)\\.$#"
 			count: 1
 			path: src/Sluggable/Mapping/Driver/Yaml.php
-
-		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:getAssociationMapping\\(\\)\\.$#"
-			count: 1
-			path: src/Sluggable/Mapping/Event/Adapter/ORM.php
-
-		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:getAssociationMappings\\(\\)\\.$#"
-			count: 1
-			path: src/Sluggable/Mapping/Event/Adapter/ORM.php
 
 		-
 			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\<object\\>\\:\\:getFieldMapping\\(\\)\\.$#"
@@ -416,29 +361,14 @@ parameters:
 			path: src/SoftDeleteable/SoftDeleteableListener.php
 
 		-
-			message: "#^Access to an undefined property Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:\\$isMappedSuperclass\\.$#"
-			count: 2
-			path: src/Sortable/Mapping/Driver/Annotation.php
-
-		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:isInheritedField\\(\\)\\.$#"
+			message: "#^Access to offset 'inherited' on an unknown class Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\AssociationFieldMapping\\.$#"
 			count: 1
 			path: src/Sortable/Mapping/Driver/Annotation.php
-
-		-
-			message: "#^Access to an undefined property Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:\\$isMappedSuperclass\\.$#"
-			count: 1
-			path: src/Sortable/Mapping/Driver/Xml.php
 
 		-
 			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:getFieldMapping\\(\\)\\.$#"
 			count: 1
 			path: src/Sortable/Mapping/Driver/Xml.php
-
-		-
-			message: "#^Access to an undefined property Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:\\$isMappedSuperclass\\.$#"
-			count: 1
-			path: src/Sortable/Mapping/Driver/Yaml.php
 
 		-
 			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:getFieldMapping\\(\\)\\.$#"
@@ -476,17 +406,12 @@ parameters:
 			path: src/Sortable/SortableListener.php
 
 		-
-			message: "#^Access to an undefined property Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:\\$isMappedSuperclass\\.$#"
-			count: 1
-			path: src/Timestampable/Mapping/Driver/Annotation.php
-
-		-
 			message: "#^Access to an undefined property object\\:\\:\\$value\\.$#"
 			count: 1
 			path: src/Timestampable/Mapping/Driver/Annotation.php
 
 		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:isInheritedField\\(\\)\\.$#"
+			message: "#^Access to offset 'inherited' on an unknown class Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\AssociationFieldMapping\\.$#"
 			count: 1
 			path: src/Timestampable/Mapping/Driver/Annotation.php
 
@@ -506,47 +431,12 @@ parameters:
 			path: src/Timestampable/Mapping/Event/Adapter/ORM.php
 
 		-
-			message: "#^Access to an undefined property Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:\\$identifier\\.$#"
-			count: 1
-			path: src/Tool/Wrapper/EntityWrapper.php
-
-		-
-			message: "#^Access to an undefined property Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:\\$rootEntityName\\.$#"
-			count: 1
-			path: src/Tool/Wrapper/EntityWrapper.php
-
-		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:getReflectionProperty\\(\\)\\.$#"
-			count: 2
-			path: src/Tool/Wrapper/EntityWrapper.php
-
-		-
 			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\ObjectManager\\:\\:getUnitOfWork\\(\\)\\.$#"
 			count: 1
 			path: src/Tool/Wrapper/EntityWrapper.php
 
 		-
-			message: "#^Access to an undefined property Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:\\$identifier\\.$#"
-			count: 1
-			path: src/Tool/Wrapper/MongoDocumentWrapper.php
-
-		-
-			message: "#^Access to an undefined property Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:\\$rootDocumentName\\.$#"
-			count: 1
-			path: src/Tool/Wrapper/MongoDocumentWrapper.php
-
-		-
 			message: "#^Access to an undefined property ProxyManager\\\\Proxy\\\\GhostObjectInterface\\:\\:\\$identifier\\.$#"
-			count: 1
-			path: src/Tool/Wrapper/MongoDocumentWrapper.php
-
-		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:getReflectionProperty\\(\\)\\.$#"
-			count: 2
-			path: src/Tool/Wrapper/MongoDocumentWrapper.php
-
-		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:isSingleValuedEmbed\\(\\)\\.$#"
 			count: 1
 			path: src/Tool/Wrapper/MongoDocumentWrapper.php
 
@@ -571,43 +461,28 @@ parameters:
 			path: src/Translatable/Entity/Repository/TranslationRepository.php
 
 		-
-			message: "#^Access to an undefined property Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:\\$isMappedSuperclass\\.$#"
+			message: "#^Access to offset 'inherited' on an unknown class Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\AssociationFieldMapping\\.$#"
+			count: 1
+			path: src/Translatable/Mapping/Driver/Annotation.php
+
+		-
+			message: "#^Access to offset 'association' on an unknown class Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\FieldMapping\\.$#"
 			count: 2
-			path: src/Translatable/Mapping/Driver/Annotation.php
+			path: src/Translatable/Mapping/Event/Adapter/ODM.php
 
 		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:isInheritedEmbeddedClass\\(\\)\\.$#"
-			count: 1
-			path: src/Translatable/Mapping/Driver/Annotation.php
-
-		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:isInheritedField\\(\\)\\.$#"
-			count: 1
-			path: src/Translatable/Mapping/Driver/Annotation.php
-
-		-
-			message: "#^Access to an undefined property Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:\\$isMappedSuperclass\\.$#"
-			count: 1
-			path: src/Translatable/Mapping/Driver/Xml.php
-
-		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:isInheritedEmbeddedClass\\(\\)\\.$#"
-			count: 1
-			path: src/Translatable/Mapping/Driver/Xml.php
-
-		-
-			message: "#^Access to an undefined property Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:\\$isMappedSuperclass\\.$#"
-			count: 1
-			path: src/Translatable/Mapping/Driver/Yaml.php
-
-		-
-			message: "#^Access to an undefined property Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:\\$fieldMappings\\.$#"
+			message: "#^Access to offset 'fieldName' on an unknown class Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\FieldMapping\\.$#"
 			count: 1
 			path: src/Translatable/Mapping/Event/Adapter/ODM.php
 
 		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:getFieldMapping\\(\\)\\.$#"
-			count: 2
+			message: "#^Access to offset 'mappedBy' on an unknown class Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\FieldMapping\\.$#"
+			count: 1
+			path: src/Translatable/Mapping/Event/Adapter/ODM.php
+
+		-
+			message: "#^Access to offset 'targetDocument' on an unknown class Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\FieldMapping\\.$#"
+			count: 1
 			path: src/Translatable/Mapping/Event/Adapter/ODM.php
 
 		-
@@ -676,24 +551,9 @@ parameters:
 			path: src/Tree/Entity/Repository/NestedTreeRepository.php
 
 		-
-			message: "#^Access to an undefined property Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:\\$isMappedSuperclass\\.$#"
-			count: 2
-			path: src/Tree/Mapping/Driver/Annotation.php
-
-		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:isInheritedField\\(\\)\\.$#"
+			message: "#^Access to offset 'inherited' on an unknown class Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\AssociationFieldMapping\\.$#"
 			count: 1
 			path: src/Tree/Mapping/Driver/Annotation.php
-
-		-
-			message: "#^Access to an undefined property Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:\\$isMappedSuperclass\\.$#"
-			count: 1
-			path: src/Tree/Mapping/Driver/Xml.php
-
-		-
-			message: "#^Access to an undefined property Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:\\$isMappedSuperclass\\.$#"
-			count: 1
-			path: src/Tree/Mapping/Driver/Yaml.php
 
 		-
 			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:getFieldMapping\\(\\)\\.$#"
@@ -811,17 +671,7 @@ parameters:
 			path: tests/Gedmo/Mapping/Mock/Extension/Encoder/EncoderListener.php
 
 		-
-			message: "#^Access to an undefined property Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:\\$isMappedSuperclass\\.$#"
-			count: 1
-			path: tests/Gedmo/Mapping/Mock/Extension/Encoder/Mapping/Driver/Annotation.php
-
-		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:getFieldMapping\\(\\)\\.$#"
-			count: 1
-			path: tests/Gedmo/Mapping/Mock/Extension/Encoder/Mapping/Driver/Annotation.php
-
-		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:isInheritedField\\(\\)\\.$#"
+			message: "#^Access to offset 'inherited' on an unknown class Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\AssociationFieldMapping\\.$#"
 			count: 1
 			path: tests/Gedmo/Mapping/Mock/Extension/Encoder/Mapping/Driver/Annotation.php
 

--- a/src/Blameable/Mapping/Driver/Annotation.php
+++ b/src/Blameable/Mapping/Driver/Annotation.php
@@ -33,7 +33,7 @@ class Annotation extends AbstractAnnotationDriver
     /**
      * List of types which are valid for blame
      *
-     * @var array
+     * @var string[]
      */
     protected $validTypes = [
         'one',

--- a/src/Blameable/Mapping/Driver/Xml.php
+++ b/src/Blameable/Mapping/Driver/Xml.php
@@ -28,9 +28,9 @@ class Xml extends BaseXml
     /**
      * List of types which are valid for blame
      *
-     * @var array
+     * @var string[]
      */
-    private $validTypes = [
+    private const VALID_TYPES = [
         'one',
         'string',
         'int',
@@ -124,6 +124,6 @@ class Xml extends BaseXml
     {
         $mapping = $meta->getFieldMapping($field);
 
-        return $mapping && in_array($mapping['type'], $this->validTypes, true);
+        return $mapping && in_array($mapping['type'], self::VALID_TYPES, true);
     }
 }

--- a/src/Blameable/Mapping/Driver/Yaml.php
+++ b/src/Blameable/Mapping/Driver/Yaml.php
@@ -29,22 +29,22 @@ use Gedmo\Mapping\Driver\File;
 class Yaml extends File implements Driver
 {
     /**
+     * List of types which are valid for blameable
+     *
+     * @var string[]
+     */
+    private const VALID_TYPES = [
+        'one',
+        'string',
+        'int',
+    ];
+
+    /**
      * File extension
      *
      * @var string
      */
     protected $_extension = '.dcm.yml';
-
-    /**
-     * List of types which are valid for blameable
-     *
-     * @var array
-     */
-    private $validTypes = [
-        'one',
-        'string',
-        'int',
-    ];
 
     public function readExtendedMetadata($meta, array &$config)
     {
@@ -130,6 +130,6 @@ class Yaml extends File implements Driver
     {
         $mapping = $meta->getFieldMapping($field);
 
-        return $mapping && in_array($mapping['type'], $this->validTypes, true);
+        return $mapping && in_array($mapping['type'], self::VALID_TYPES, true);
     }
 }

--- a/src/IpTraceable/Mapping/Driver/Annotation.php
+++ b/src/IpTraceable/Mapping/Driver/Annotation.php
@@ -33,7 +33,7 @@ class Annotation extends AbstractAnnotationDriver
     /**
      * List of types which are valid for IP
      *
-     * @var array
+     * @var string[]
      */
     protected $validTypes = [
         'string',

--- a/src/IpTraceable/Mapping/Driver/Xml.php
+++ b/src/IpTraceable/Mapping/Driver/Xml.php
@@ -30,9 +30,9 @@ class Xml extends BaseXml
     /**
      * List of types which are valid for IP
      *
-     * @var array
+     * @var string[]
      */
-    private $validTypes = [
+    private const VALID_TYPES = [
         'string',
     ];
 
@@ -128,6 +128,6 @@ class Xml extends BaseXml
     {
         $mapping = $meta->getFieldMapping($field);
 
-        return $mapping && in_array($mapping['type'], $this->validTypes, true);
+        return $mapping && in_array($mapping['type'], self::VALID_TYPES, true);
     }
 }

--- a/src/IpTraceable/Mapping/Driver/Yaml.php
+++ b/src/IpTraceable/Mapping/Driver/Yaml.php
@@ -29,20 +29,20 @@ use Gedmo\Mapping\Driver\File;
 class Yaml extends File implements Driver
 {
     /**
+     * List of types which are valid for IP
+     *
+     * @var string[]
+     */
+    private const VALID_TYPES = [
+        'string',
+    ];
+
+    /**
      * File extension
      *
      * @var string
      */
     protected $_extension = '.dcm.yml';
-
-    /**
-     * List of types which are valid for IP
-     *
-     * @var array
-     */
-    private $validTypes = [
-        'string',
-    ];
 
     public function readExtendedMetadata($meta, array &$config)
     {
@@ -128,6 +128,6 @@ class Yaml extends File implements Driver
     {
         $mapping = $meta->getFieldMapping($field);
 
-        return $mapping && in_array($mapping['type'], $this->validTypes, true);
+        return $mapping && in_array($mapping['type'], self::VALID_TYPES, true);
     }
 }

--- a/src/Mapping/Driver.php
+++ b/src/Mapping/Driver.php
@@ -9,6 +9,8 @@
 
 namespace Gedmo\Mapping;
 
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata as OdmClassMetadata;
+use Doctrine\ORM\Mapping\ClassMetadata as OrmClassMetadata;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Gedmo\Exception\InvalidMappingException;
@@ -24,7 +26,7 @@ interface Driver
     /**
      * Read the extended metadata configuration for a single mapped class.
      *
-     * @param ClassMetadata $meta
+     * @param ClassMetadata&(OdmClassMetadata|OrmClassMetadata) $meta
      *
      * @return void
      *

--- a/src/Mapping/Driver/AbstractAnnotationDriver.php
+++ b/src/Mapping/Driver/AbstractAnnotationDriver.php
@@ -40,7 +40,7 @@ abstract class AbstractAnnotationDriver implements AnnotationDriverInterface
     /**
      * List of types which are valid for extension
      *
-     * @var array
+     * @var string[]
      */
     protected $validTypes = [];
 

--- a/src/Mapping/ExtensionMetadataFactory.php
+++ b/src/Mapping/ExtensionMetadataFactory.php
@@ -11,7 +11,8 @@ namespace Gedmo\Mapping;
 
 use Doctrine\Bundle\DoctrineBundle\Mapping\MappingDriver as DoctrineBundleMappingDriver;
 use Doctrine\Common\Annotations\Reader;
-use Doctrine\Common\Cache\Cache;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata as DocumentClassMetadata;
+use Doctrine\ORM\Mapping\ClassMetadataInfo as EntityClassMetadata;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\Driver\DefaultFileLocator;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
@@ -45,7 +46,7 @@ class ExtensionMetadataFactory
     /**
      * Object manager, entity or document
      *
-     * @var object
+     * @var ObjectManager
      */
     protected $objectManager;
 
@@ -59,8 +60,7 @@ class ExtensionMetadataFactory
     /**
      * Custom annotation reader
      *
-     * @var object
-     * @phpstan-var Reader|AttributeReader
+     * @var Reader|AttributeReader|object
      */
     protected $annotationReader;
 
@@ -113,6 +113,7 @@ class ExtensionMetadataFactory
             foreach (array_reverse(class_parents($meta->getName())) as $parentClass) {
                 // read only inherited mapped classes
                 if ($cmf->hasMetadataFor($parentClass)) {
+                    /** @var DocumentClassMetadata|EntityClassMetadata $class */
                     $class = $this->objectManager->getClassMetadata($parentClass);
                     $this->driver->readExtendedMetadata($class, $config);
                     $isBaseInheritanceLevel = !$class->isInheritanceTypeNone()

--- a/src/Mapping/MappedEventSubscriber.php
+++ b/src/Mapping/MappedEventSubscriber.php
@@ -46,7 +46,8 @@ abstract class MappedEventSubscriber implements EventSubscriber
      * leaving it static for reasons to look into
      * other listener configuration
      *
-     * @var array
+     * @var array<string, array<string, array<string, mixed>>>
+     *
      * @phpstan-var array<string, array<class-string, array<string, mixed>>>
      */
     protected static $configurations = [];
@@ -172,8 +173,7 @@ abstract class MappedEventSubscriber implements EventSubscriber
      *     getPropertyAnnotations([reflectionProperty])
      *     getPropertyAnnotation([reflectionProperty], [name])
      *
-     * @param object $reader
-     * @phpstan-param Reader|AttributeReader $reader
+     * @param Reader|AttributeReader|object $reader
      *
      * @return void
      *

--- a/src/References/Mapping/Driver/Annotation.php
+++ b/src/References/Mapping/Driver/Annotation.php
@@ -9,11 +9,13 @@
 
 namespace Gedmo\References\Mapping\Driver;
 
+use Doctrine\Common\Annotations\Reader;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Gedmo\Mapping\Annotation\ReferenceMany;
 use Gedmo\Mapping\Annotation\ReferenceManyEmbed;
 use Gedmo\Mapping\Annotation\ReferenceOne;
 use Gedmo\Mapping\Driver\AnnotationDriverInterface;
+use Gedmo\Mapping\Driver\AttributeReader;
 
 /**
  * This is an annotation mapping driver for References
@@ -43,6 +45,15 @@ class Annotation implements AnnotationDriverInterface
     public const REFERENCE_MANY_EMBED = ReferenceManyEmbed::class;
 
     /**
+     * @var array<string, self::REFERENCE_ONE|self::REFERENCE_MANY|self::REFERENCE_MANY_EMBED>
+     */
+    private const ANNOTATIONS = [
+        'referenceOne' => self::REFERENCE_ONE,
+        'referenceMany' => self::REFERENCE_MANY,
+        'referenceManyEmbed' => self::REFERENCE_MANY_EMBED,
+    ];
+
+    /**
      * original driver if it is available
      *
      * @var MappingDriver
@@ -50,18 +61,9 @@ class Annotation implements AnnotationDriverInterface
     protected $_originalDriver;
 
     /**
-     * @var string[]
-     */
-    private $annotations = [
-        'referenceOne' => self::REFERENCE_ONE,
-        'referenceMany' => self::REFERENCE_MANY,
-        'referenceManyEmbed' => self::REFERENCE_MANY_EMBED,
-    ];
-
-    /**
      * Annotation reader instance
      *
-     * @var object
+     * @var Reader|AttributeReader|object
      */
     private $reader;
 
@@ -73,7 +75,7 @@ class Annotation implements AnnotationDriverInterface
     public function readExtendedMetadata($meta, array &$config)
     {
         $class = $meta->getReflectionClass();
-        foreach ($this->annotations as $key => $annotation) {
+        foreach (self::ANNOTATIONS as $key => $annotation) {
             $config[$key] = [];
             foreach ($class->getProperties() as $property) {
                 if ($meta->isMappedSuperclass && !$property->isPrivate() ||

--- a/src/References/Mapping/Driver/Xml.php
+++ b/src/References/Mapping/Driver/Xml.php
@@ -25,15 +25,15 @@ use Gedmo\Mapping\Driver\Xml as BaseXml;
 class Xml extends BaseXml
 {
     /**
-     * @var array
+     * @var string[]
      */
-    private $validTypes = [
+    private const VALID_TYPES = [
         'document',
         'entity',
     ];
 
     /**
-     * @var array
+     * @var string[]
      */
     private $validReferences = [
         'referenceOne',
@@ -62,8 +62,8 @@ class Xml extends BaseXml
                     }
 
                     $type = $this->_getAttribute($element, 'type');
-                    if (!in_array($type, $this->validTypes, true)) {
-                        throw new InvalidMappingException($type.' is not a valid reference type, valid types are: '.implode(', ', $this->validTypes));
+                    if (!in_array($type, self::VALID_TYPES, true)) {
+                        throw new InvalidMappingException($type.' is not a valid reference type, valid types are: '.implode(', ', self::VALID_TYPES));
                     }
 
                     $reference = $this->_getAttribute($element, 'reference');

--- a/src/Sluggable/Mapping/Driver/Annotation.php
+++ b/src/Sluggable/Mapping/Driver/Annotation.php
@@ -47,7 +47,7 @@ class Annotation extends AbstractAnnotationDriver
     /**
      * List of types which are valid for slug and sluggable fields
      *
-     * @var array
+     * @var string[]
      */
     protected $validTypes = [
         'string',

--- a/src/Sluggable/Mapping/Driver/Xml.php
+++ b/src/Sluggable/Mapping/Driver/Xml.php
@@ -29,9 +29,9 @@ class Xml extends BaseXml
     /**
      * List of types which are valid for slug and sluggable fields
      *
-     * @var array
+     * @var string[]
      */
-    private $validTypes = [
+    private const VALID_TYPES = [
         'string',
         'text',
         'integer',
@@ -74,7 +74,7 @@ class Xml extends BaseXml
     {
         $mapping = $meta->getFieldMapping($field);
 
-        return $mapping && in_array($mapping['type'], $this->validTypes, true);
+        return $mapping && in_array($mapping['type'], self::VALID_TYPES, true);
     }
 
     private function buildFieldConfiguration(ClassMetadata $meta, string $field, \SimpleXMLElement $mapping, array &$config): void

--- a/src/Sluggable/Mapping/Driver/Yaml.php
+++ b/src/Sluggable/Mapping/Driver/Yaml.php
@@ -29,18 +29,11 @@ use Gedmo\Mapping\Driver\File;
 class Yaml extends File implements Driver
 {
     /**
-     * File extension
-     *
-     * @var string
-     */
-    protected $_extension = '.dcm.yml';
-
-    /**
      * List of types which are valid for slug and sluggable fields
      *
-     * @var array
+     * @var string[]
      */
-    private $validTypes = [
+    private const VALID_TYPES = [
         'string',
         'text',
         'integer',
@@ -48,6 +41,13 @@ class Yaml extends File implements Driver
         'datetime',
         'citext',
     ];
+
+    /**
+     * File extension
+     *
+     * @var string
+     */
+    protected $_extension = '.dcm.yml';
 
     public function readExtendedMetadata($meta, array &$config)
     {
@@ -83,7 +83,7 @@ class Yaml extends File implements Driver
     {
         $mapping = $meta->getFieldMapping($field);
 
-        return $mapping && in_array($mapping['type'], $this->validTypes, true);
+        return $mapping && in_array($mapping['type'], self::VALID_TYPES, true);
     }
 
     private function buildFieldConfiguration(string $field, array $fieldMapping, ClassMetadata $meta, array &$config): void

--- a/src/Sluggable/Mapping/Event/Adapter/ORM.php
+++ b/src/Sluggable/Mapping/Event/Adapter/ORM.php
@@ -14,6 +14,7 @@ use Doctrine\ORM\Query;
 use Gedmo\Mapping\Event\Adapter\ORM as BaseAdapterORM;
 use Gedmo\Sluggable\Mapping\Event\SluggableAdapter;
 use Gedmo\Tool\Wrapper\AbstractWrapper;
+use Gedmo\Tool\Wrapper\EntityWrapper;
 
 /**
  * Doctrine event adapter for ORM adapted
@@ -28,6 +29,7 @@ class ORM extends BaseAdapterORM implements SluggableAdapter
     public function getSimilarSlugs($object, $meta, array $config, $slug)
     {
         $em = $this->getObjectManager();
+        /** @var EntityWrapper $wrapped */
         $wrapped = AbstractWrapper::wrap($object, $em);
         $qb = $em->createQueryBuilder();
         $qb->select('rec.'.$config['slug'])

--- a/src/Sortable/Mapping/Driver/Annotation.php
+++ b/src/Sortable/Mapping/Driver/Annotation.php
@@ -39,7 +39,7 @@ class Annotation extends AbstractAnnotationDriver
     /**
      * List of types which are valid for position fields
      *
-     * @var array
+     * @var string[]
      */
     protected $validTypes = [
         'int',

--- a/src/Sortable/Mapping/Driver/Xml.php
+++ b/src/Sortable/Mapping/Driver/Xml.php
@@ -28,9 +28,9 @@ class Xml extends BaseXml
     /**
      * List of types which are valid for position field
      *
-     * @var array
+     * @var string[]
      */
-    private $validTypes = [
+    private const VALID_TYPES = [
         'int',
         'integer',
         'smallint',
@@ -88,7 +88,7 @@ class Xml extends BaseXml
     {
         $mapping = $meta->getFieldMapping($field);
 
-        return $mapping && in_array($mapping['type'], $this->validTypes, true);
+        return $mapping && in_array($mapping['type'], self::VALID_TYPES, true);
     }
 
     private function readSortableGroups(\SimpleXMLElement $mapping, array &$config, string $fieldAttr = 'field'): void

--- a/src/Sortable/Mapping/Driver/Yaml.php
+++ b/src/Sortable/Mapping/Driver/Yaml.php
@@ -29,23 +29,23 @@ use Gedmo\Mapping\Driver\File;
 class Yaml extends File implements Driver
 {
     /**
-     * File extension
-     *
-     * @var string
-     */
-    protected $_extension = '.dcm.yml';
-
-    /**
      * List of types which are valid for position fields
      *
-     * @var array
+     * @var string[]
      */
-    private $validTypes = [
+    private const VALID_TYPES = [
         'int',
         'integer',
         'smallint',
         'bigint',
     ];
+
+    /**
+     * File extension
+     *
+     * @var string
+     */
+    protected $_extension = '.dcm.yml';
 
     public function readExtendedMetadata($meta, array &$config)
     {
@@ -95,7 +95,7 @@ class Yaml extends File implements Driver
     {
         $mapping = $meta->getFieldMapping($field);
 
-        return $mapping && in_array($mapping['type'], $this->validTypes, true);
+        return $mapping && in_array($mapping['type'], self::VALID_TYPES, true);
     }
 
     private function readSortableGroups(iterable $mapping, array &$config): void

--- a/src/Timestampable/Mapping/Driver/Annotation.php
+++ b/src/Timestampable/Mapping/Driver/Annotation.php
@@ -33,7 +33,7 @@ class Annotation extends AbstractAnnotationDriver
     /**
      * List of types which are valid for timestamp
      *
-     * @var array
+     * @var string[]
      */
     protected $validTypes = [
         'date',

--- a/src/Timestampable/Mapping/Driver/Xml.php
+++ b/src/Timestampable/Mapping/Driver/Xml.php
@@ -29,9 +29,9 @@ class Xml extends BaseXml
     /**
      * List of types which are valid for timestamp
      *
-     * @var array
+     * @var string[]
      */
-    private $validTypes = [
+    private const VALID_TYPES = [
         'date',
         'date_immutable',
         'time',
@@ -103,6 +103,6 @@ class Xml extends BaseXml
     {
         $mapping = $meta->getFieldMapping($field);
 
-        return $mapping && in_array($mapping['type'], $this->validTypes, true);
+        return $mapping && in_array($mapping['type'], self::VALID_TYPES, true);
     }
 }

--- a/src/Timestampable/Mapping/Driver/Yaml.php
+++ b/src/Timestampable/Mapping/Driver/Yaml.php
@@ -29,18 +29,11 @@ use Gedmo\Mapping\Driver\File;
 class Yaml extends File implements Driver
 {
     /**
-     * File extension
-     *
-     * @var string
-     */
-    protected $_extension = '.dcm.yml';
-
-    /**
      * List of types which are valid for timestamp
      *
-     * @var array
+     * @var string[]
      */
-    private $validTypes = [
+    private const VALID_TYPES = [
         'date',
         'date_immutable',
         'time',
@@ -53,6 +46,13 @@ class Yaml extends File implements Driver
         'vardatetime',
         'integer',
     ];
+
+    /**
+     * File extension
+     *
+     * @var string
+     */
+    protected $_extension = '.dcm.yml';
 
     public function readExtendedMetadata($meta, array &$config)
     {
@@ -107,6 +107,6 @@ class Yaml extends File implements Driver
     {
         $mapping = $meta->getFieldMapping($field);
 
-        return $mapping && in_array($mapping['type'], $this->validTypes, true);
+        return $mapping && in_array($mapping['type'], self::VALID_TYPES, true);
     }
 }

--- a/src/Tool/Wrapper/AbstractWrapper.php
+++ b/src/Tool/Wrapper/AbstractWrapper.php
@@ -10,7 +10,9 @@
 namespace Gedmo\Tool\Wrapper;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata as OdmClassMetadata;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata as OrmClassMetadata;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\ObjectManager;
 use Gedmo\Exception\UnsupportedObjectManagerException;
@@ -20,6 +22,10 @@ use Gedmo\Tool\WrapperInterface;
  * Wraps entity or proxy for more convenient
  * manipulation
  *
+ * @phpstan-template TClassMetadata of ClassMetadata
+ *
+ * @phpstan-implements WrapperInterface<TClassMetadata>
+ *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
 abstract class AbstractWrapper implements WrapperInterface
@@ -27,7 +33,9 @@ abstract class AbstractWrapper implements WrapperInterface
     /**
      * Object metadata
      *
-     * @var ClassMetadata
+     * @var ClassMetadata&(OrmClassMetadata|OdmClassMetadata)
+     *
+     * @phpstan-var TClassMetadata
      */
     protected $meta;
 
@@ -52,7 +60,7 @@ abstract class AbstractWrapper implements WrapperInterface
      *
      * @throws \Gedmo\Exception\UnsupportedObjectManagerException
      *
-     * @return \Gedmo\Tool\WrapperInterface
+     * @return WrapperInterface
      */
     public static function wrap($object, ObjectManager $om)
     {

--- a/src/Tool/Wrapper/EntityWrapper.php
+++ b/src/Tool/Wrapper/EntityWrapper.php
@@ -10,12 +10,15 @@
 namespace Gedmo\Tool\Wrapper;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Proxy\Proxy;
 use Doctrine\Persistence\Proxy as PersistenceProxy;
 
 /**
  * Wraps entity or proxy for more convenient
  * manipulation
+ *
+ * @phpstan-extends AbstractWrapper<ClassMetadata>
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  *

--- a/src/Tool/Wrapper/MongoDocumentWrapper.php
+++ b/src/Tool/Wrapper/MongoDocumentWrapper.php
@@ -10,11 +10,14 @@
 namespace Gedmo\Tool\Wrapper;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use ProxyManager\Proxy\GhostObjectInterface;
 
 /**
  * Wraps document or proxy for more convenient
  * manipulation
+ *
+ * @phpstan-extends AbstractWrapper<ClassMetadata>
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  *

--- a/src/Tool/WrapperInterface.php
+++ b/src/Tool/WrapperInterface.php
@@ -14,6 +14,8 @@ use Doctrine\Persistence\Mapping\ClassMetadata;
 /**
  * Interface for a wrapper of a managed object.
  *
+ * @phpstan-template TClassMetadata of ClassMetadata
+ *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
 interface WrapperInterface
@@ -64,6 +66,8 @@ interface WrapperInterface
      * Get the object metadata.
      *
      * @return ClassMetadata
+     *
+     * @phpstan-return TClassMetadata
      */
     public function getMetadata();
 

--- a/src/Translatable/Mapping/Event/Adapter/ODM.php
+++ b/src/Translatable/Mapping/Event/Adapter/ODM.php
@@ -14,6 +14,7 @@ use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Types\Type;
 use Gedmo\Mapping\Event\Adapter\ODM as BaseAdapterODM;
 use Gedmo\Tool\Wrapper\AbstractWrapper;
+use Gedmo\Tool\Wrapper\MongoDocumentWrapper;
 use Gedmo\Translatable\Document\MappedSuperclass\AbstractPersonalTranslation;
 use Gedmo\Translatable\Document\Translation;
 use Gedmo\Translatable\Mapping\Event\TranslatableAdapter;
@@ -45,6 +46,7 @@ final class ODM extends BaseAdapterODM implements TranslatableAdapter
     {
         $dm = $this->getObjectManager();
         $wrapped = AbstractWrapper::wrap($object, $dm);
+        assert($wrapped instanceof MongoDocumentWrapper);
         $result = [];
 
         if ($this->usesPersonalTranslation($translationClass)) {
@@ -157,6 +159,7 @@ final class ODM extends BaseAdapterODM implements TranslatableAdapter
     {
         $dm = $this->getObjectManager();
         $wrapped = AbstractWrapper::wrap($object, $dm);
+        assert($wrapped instanceof MongoDocumentWrapper);
         $meta = $wrapped->getMetadata();
         $mapping = $meta->getFieldMapping($field);
         $type = $this->getType($mapping['type']);
@@ -171,6 +174,7 @@ final class ODM extends BaseAdapterODM implements TranslatableAdapter
     {
         $dm = $this->getObjectManager();
         $wrapped = AbstractWrapper::wrap($object, $dm);
+        assert($wrapped instanceof MongoDocumentWrapper);
         $meta = $wrapped->getMetadata();
         $mapping = $meta->getFieldMapping($field);
         $type = $this->getType($mapping['type']);

--- a/src/Tree/Mapping/Validator.php
+++ b/src/Tree/Mapping/Validator.php
@@ -28,9 +28,9 @@ class Validator
     /**
      * List of types which are valid for tree fields
      *
-     * @var array
+     * @var string[]
      */
-    private $validTypes = [
+    private const VALID_TYPES = [
         'integer',
         'smallint',
         'bigint',
@@ -40,7 +40,7 @@ class Validator
     /**
      * List of types which are valid for the path (materialized path strategy)
      *
-     * @var array
+     * @var string[]
      */
     private $validPathTypes = [
         'string',
@@ -50,7 +50,7 @@ class Validator
     /**
      * List of types which are valid for the path source (materialized path strategy)
      *
-     * @var array
+     * @var string[]
      */
     private $validPathSourceTypes = [
         'id',
@@ -65,7 +65,7 @@ class Validator
     /**
      * List of types which are valid for the path hash (materialized path strategy)
      *
-     * @var array
+     * @var string[]
      */
     private $validPathHashTypes = [
         'string',
@@ -74,7 +74,7 @@ class Validator
     /**
      * List of types which are valid for the path source (materialized path strategy)
      *
-     * @var array
+     * @var string[]
      */
     private $validRootTypes = [
         'integer',
@@ -97,7 +97,7 @@ class Validator
     {
         $mapping = $meta->getFieldMapping($field);
 
-        return $mapping && in_array($mapping['type'], $this->validTypes, true);
+        return $mapping && in_array($mapping['type'], self::VALID_TYPES, true);
     }
 
     /**

--- a/src/Tree/Strategy/ORM/Nested.php
+++ b/src/Tree/Strategy/ORM/Nested.php
@@ -261,8 +261,7 @@ class Nested implements Strategy
     }
 
     /**
-     * Update the $node with a diferent $parent
-     * destination
+     * Update the $node with a different $parent destination
      *
      * @param Node|object $node     target node
      * @param Node|object $parent   destination node

--- a/tests/Gedmo/Mapping/MultiManagerMappingTest.php
+++ b/tests/Gedmo/Mapping/MultiManagerMappingTest.php
@@ -71,7 +71,7 @@ final class MultiManagerMappingTest extends BaseTestCaseOM
         $this->dm1 = $this->getMockDocumentManager('gedmo_extensions_test');
     }
 
-    public function testTwoDiferentManager(): void
+    public function testTwoDifferentManagers(): void
     {
         $meta = $this->dm1->getClassMetadata(Article::class);
         $dmArticle = new \Gedmo\Tests\Sluggable\Fixture\Document\Article();

--- a/tests/Gedmo/SoftDeleteable/SoftDeleteableDocumentTest.php
+++ b/tests/Gedmo/SoftDeleteable/SoftDeleteableDocumentTest.php
@@ -156,7 +156,6 @@ final class SoftDeleteableDocumentTest extends BaseTestCaseMongoODM
         $user = $repo->findOneBy(['username' => $username]);
 
         static::assertNull($user);
-        $this->dm->remove($user);
         $this->dm->flush();
     }
 

--- a/tests/Gedmo/Timestampable/Fixture/Comment.php
+++ b/tests/Gedmo/Timestampable/Fixture/Comment.php
@@ -78,7 +78,10 @@ class Comment implements Timestampable
     #[Gedmo\Timestampable(on: 'update')]
     private $modified;
 
-    public function setArticle(?Article $article): void
+    /**
+     * @param Article|ArticleCarbon $article
+     */
+    public function setArticle(?Timestampable $article): void
     {
         $this->article = $article;
     }


### PR DESCRIPTION
* ~~`Doctrine\Common\Annotations\Reader` was declared were possible, as the interface is currently available in all the supported versions of [`doctrine/annotations`](https://github.com/doctrine/annotations/blob/03cb2123a67d4be806554fe670d0adc298199808/lib/Doctrine/Common/Annotations/Reader.php#L12)~~.
   This change should wait for #2258;
* Private and read only properties `$validTypes` were replaced by `VALID_TYPES` private constants.