### PR TITLE
Force load proxy

### DIFF
--- a/src/Sortable/SortableListener.php
+++ b/src/Sortable/SortableListener.php
@@ -15,6 +15,7 @@ use Doctrine\Common\Util\ClassUtils;
 use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\ObjectManager;
+use Doctrine\Persistence\Proxy;
 use Gedmo\Mapping\MappedEventSubscriber;
 use Gedmo\Sortable\Mapping\Event\SortableAdapter;
 use ProxyManager\Proxy\GhostObjectInterface;
@@ -234,6 +235,10 @@ class SortableListener extends MappedEventSubscriber
                     foreach ($objects as $object) {
                         if ($object instanceof GhostObjectInterface && !$object->isProxyInitialized()) {
                             continue;
+                        }
+
+                        if ($object instanceof Proxy && !$object->__isInitialized()) {
+                            $object->__load();
                         }
 
                         $changeSet = $ea->getObjectChangeSet($uow, $object);


### PR DESCRIPTION
If where are some relocations while update and object is proxy it is impossible to get value on line 260 - it always return `null`

Finally it cause the error
```
//vendor/gedmo/doctrine-extensions/src/Mapping/MappedEventSubscriber.php:264
Cannot call recomputeSingleEntityChangeSet before computeChangeSet on an entity.
```

```
$pos = $meta->getReflectionProperty($config['position'])->getValue($object);
```
![image](https://user-images.githubusercontent.com/661654/207279309-226f71ee-e76c-431b-946d-4f163e8248a0.png)


After entry is force-loaded I've got what expected
![image](https://user-images.githubusercontent.com/661654/207279496-386500aa-4506-4154-99f8-b43209638e5a.png)
