### PR TITLE
[documentation] Updates docker-compose related commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ XML mapping xsd schemas are also versioned and can be used by version suffix:
 
 To set up and run the tests, follow these steps:
 
-- Install [Docker](https://www.docker.com/) and ensure you have `docker compose`
-- From the project root, run `docker compose up -d` to start containers in daemon mode
-- Enter the container via `docker compose exec php bash` and navigate to the root directory: `cd /var/www`
+- Install [Docker](https://www.docker.com/) and ensure you have [docker-compose](https://docs.docker.com/compose/install/)
+- From the project root, run `docker-compose -f ./compose.yaml up -d` to start containers in daemon mode
+- Enter the container via `docker-compose exec php bash` and navigate to the root directory: `cd /var/www`
 - Install Composer dependencies via `composer install`
 - Run the tests: `bin/phpunit -c tests/`
 


### PR DESCRIPTION
Hi,

`docker compose` needs to be changed to `docker-compose` and since you are not using the default `docker-compose.yaml` file then we need to use `-f ./compose.yaml` for commands to work.

Thanks!