### PR TITLE
[Uploadable] Fixes issue with metadata when uploading entities of different types #2071

### DIFF
--- a/src/Uploadable/UploadableListener.php
+++ b/src/Uploadable/UploadableListener.php
@@ -122,12 +122,11 @@ class UploadableListener extends MappedEventSubscriber
         $ea = $this->getEventAdapter($args);
         $om = $ea->getObjectManager();
         $uow = $om->getUnitOfWork();
-        $first = reset($this->fileInfoObjects);
-        $meta = $om->getClassMetadata(get_class($first['entity']));
-        $config = $this->getConfiguration($om, $meta->getName());
 
         foreach ($this->fileInfoObjects as $info) {
             $entity = $info['entity'];
+            $meta = $om->getClassMetadata(get_class($entity));
+            $config = $this->getConfiguration($om, $meta->getName());
 
             // If the entity is in the identity map, it means it will be updated. We need to force the
             // "dirty check" here by "modifying" the path. We are actually setting the same value, but


### PR DESCRIPTION
[Uploadable]
If one uploads two entities of different classes then only meta for the first class is loaded which causes `getFilePathFieldValue` to complain because the entity does not match the metadata.

This PR ensures we get the metadata corresponding to the entity being uploaded.