### PR TITLE
[Tree] Add `@template` and `@template-extends` annotations to the Tree repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ a release.
 ---
 
 ## [Unreleased]
+### Added
+- Tree: Added `@template` and `@template-extends` annotations to the Tree repositories
+
 ### Changed
 - Dropped support for PHP < 7.4
 - Dropped support for Symfony < 5.4

--- a/example/app/Entity/Repository/CategoryRepository.php
+++ b/example/app/Entity/Repository/CategoryRepository.php
@@ -11,8 +11,12 @@ declare(strict_types=1);
 
 namespace App\Entity\Repository;
 
+use App\Entity\Category;
 use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
 
+/**
+ * @template-extends NestedTreeRepository<Category>
+ */
 final class CategoryRepository extends NestedTreeRepository
 {
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -616,7 +616,7 @@ parameters:
 			path: tests/Gedmo/Timestampable/Fixture/ArticleCarbon.php
 
 		-
-			message: "#^Property Gedmo\\\\Tests\\\\Tree\\\\MaterializedPathODMMongoDBRepositoryTest\\:\\:\\$repo \\(Gedmo\\\\Tree\\\\Document\\\\MongoDB\\\\Repository\\\\MaterializedPathRepository\\) does not accept Doctrine\\\\ORM\\\\EntityRepository\\<Gedmo\\\\Tests\\\\Tree\\\\Fixture\\\\Document\\\\Category\\>\\.$#"
+			message: "#^Property Gedmo\\\\Tests\\\\Tree\\\\MaterializedPathODMMongoDBRepositoryTest\\:\\:\\$repo \\(Gedmo\\\\Tree\\\\Document\\\\MongoDB\\\\Repository\\\\MaterializedPathRepository\\<Gedmo\\\\Tests\\\\Tree\\\\Fixture\\\\Document\\\\Category\\>\\) does not accept Doctrine\\\\ORM\\\\EntityRepository\\<Gedmo\\\\Tests\\\\Tree\\\\Fixture\\\\Document\\\\Category\\>\\.$#"
 			count: 1
 			path: tests/Gedmo/Tree/MaterializedPathODMMongoDBRepositoryTest.php
 

--- a/src/Tree/Document/MongoDB/Repository/AbstractTreeRepository.php
+++ b/src/Tree/Document/MongoDB/Repository/AbstractTreeRepository.php
@@ -22,7 +22,11 @@ use Gedmo\Tree\RepositoryUtilsInterface;
 use Gedmo\Tree\TreeListener;
 
 /**
- * @phpstan-extends DocumentRepository<object>
+ * @template T of object
+ *
+ * @phpstan-extends DocumentRepository<T>
+ *
+ * @phpstan-implements RepositoryInterface<T>
  */
 abstract class AbstractTreeRepository extends DocumentRepository implements RepositoryInterface
 {
@@ -40,6 +44,7 @@ abstract class AbstractTreeRepository extends DocumentRepository implements Repo
      */
     protected $repoUtils;
 
+    /** @param ClassMetadata<T> $class */
     public function __construct(DocumentManager $em, UnitOfWork $uow, ClassMetadata $class)
     {
         parent::__construct($em, $uow, $class);

--- a/src/Tree/Document/MongoDB/Repository/MaterializedPathRepository.php
+++ b/src/Tree/Document/MongoDB/Repository/MaterializedPathRepository.php
@@ -24,6 +24,10 @@ use MongoDB\BSON\Regex;
  *
  * @author Gustavo Falco <comfortablynumb84@gmail.com>
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ *
+ * @template T of object
+ *
+ * @template-extends AbstractTreeRepository<T>
  */
 class MaterializedPathRepository extends AbstractTreeRepository
 {

--- a/src/Tree/Entity/Repository/AbstractTreeRepository.php
+++ b/src/Tree/Entity/Repository/AbstractTreeRepository.php
@@ -23,7 +23,9 @@ use Gedmo\Tree\RepositoryUtilsInterface;
 use Gedmo\Tree\TreeListener;
 
 /**
- * @phpstan-extends EntityRepository<object>
+ * @template T of object
+ *
+ * @template-extends EntityRepository<T>
  */
 abstract class AbstractTreeRepository extends EntityRepository implements RepositoryInterface
 {

--- a/src/Tree/Entity/Repository/AbstractTreeRepository.php
+++ b/src/Tree/Entity/Repository/AbstractTreeRepository.php
@@ -26,6 +26,8 @@ use Gedmo\Tree\TreeListener;
  * @template T of object
  *
  * @template-extends EntityRepository<T>
+ *
+ * @template-implements RepositoryInterface<T>
  */
 abstract class AbstractTreeRepository extends EntityRepository implements RepositoryInterface
 {
@@ -43,6 +45,7 @@ abstract class AbstractTreeRepository extends EntityRepository implements Reposi
      */
     protected $repoUtils;
 
+    /** @param ClassMetadata<T> $class */
     public function __construct(EntityManagerInterface $em, ClassMetadata $class)
     {
         parent::__construct($em, $class);

--- a/src/Tree/Entity/Repository/ClosureTreeRepository.php
+++ b/src/Tree/Entity/Repository/ClosureTreeRepository.php
@@ -23,6 +23,10 @@ use Gedmo\Tree\Strategy;
  *
  * @author Gustavo Adrian <comfortablynumb84@gmail.com>
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ *
+ * @template T of object
+ *
+ * @template-extends AbstractTreeRepository<T>
  */
 class ClosureTreeRepository extends AbstractTreeRepository
 {

--- a/src/Tree/Entity/Repository/MaterializedPathRepository.php
+++ b/src/Tree/Entity/Repository/MaterializedPathRepository.php
@@ -21,6 +21,10 @@ use Gedmo\Tree\Strategy;
  *
  * @author Gustavo Falco <comfortablynumb84@gmail.com>
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ *
+ * @template T of object
+ *
+ * @template-extends AbstractTreeRepository<T>
  */
 class MaterializedPathRepository extends AbstractTreeRepository
 {

--- a/src/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/src/Tree/Entity/Repository/NestedTreeRepository.php
@@ -28,6 +28,10 @@ use Gedmo\Tree\Strategy\ORM\Nested;
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  *
+ * @template T of object
+ *
+ * @template-extends AbstractTreeRepository<T>
+ *
  * @method persistAsFirstChild($node)
  * @method persistAsFirstChildOf($node, $parent)
  * @method persistAsLastChild($node)

--- a/src/Tree/RepositoryInterface.php
+++ b/src/Tree/RepositoryInterface.php
@@ -16,6 +16,8 @@ use Gedmo\Exception\InvalidArgumentException;
  *
  * @author Gustavo Falco <comfortablynumb84@gmail.com>
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ *
+ * @template T of object
  */
 interface RepositoryInterface extends RepositoryUtilsInterface
 {
@@ -26,6 +28,8 @@ interface RepositoryInterface extends RepositoryUtilsInterface
      * @param string $direction
      *
      * @return iterable<int|string, object>
+     *
+     * @phpstan-return iterable<int|string, T>
      */
     public function getRootNodes($sortByField = null, $direction = 'asc');
 
@@ -38,6 +42,10 @@ interface RepositoryInterface extends RepositoryUtilsInterface
      * @param bool                 $includeNode Flag indicating whether the given node should be included in the results
      *
      * @return array<int|string, object>
+     *
+     * @phpstan-param T $node
+     *
+     * @phpstan-return iterable<int|string, T>
      */
     public function getNodesHierarchy($node = null, $direct = false, array $options = [], $includeNode = false);
 
@@ -53,6 +61,9 @@ interface RepositoryInterface extends RepositoryUtilsInterface
      * @return iterable<int|string, object> List of children
      *
      * @phpstan-param 'asc'|'desc'|'ASC'|'DESC'|array<int, 'asc'|'desc'|'ASC'|'DESC'> $direction
+     * @phpstan-param T|null $node
+     *
+     * @phpstan-return iterable<int|string, T>
      */
     public function getChildren($node = null, $direct = false, $sortByField = null, $direction = 'ASC', $includeNode = false);
 

--- a/src/Tree/RepositoryUtils.php
+++ b/src/Tree/RepositoryUtils.php
@@ -19,10 +19,12 @@ use Gedmo\Tool\Wrapper\MongoDocumentWrapper;
 
 /**
  * @final since gedmo/doctrine-extensions 3.11
+ *
+ * @template T of object
  */
 class RepositoryUtils implements RepositoryUtilsInterface
 {
-    /** @var ClassMetadata */
+    /** @var ClassMetadata<T> */
     protected $meta;
 
     /** @var TreeListener */
@@ -31,7 +33,7 @@ class RepositoryUtils implements RepositoryUtilsInterface
     /** @var ObjectManager&(DocumentManager|EntityManagerInterface) */
     protected $om;
 
-    /** @var RepositoryInterface */
+    /** @var RepositoryInterface<T> */
     protected $repo;
 
     /**
@@ -44,8 +46,9 @@ class RepositoryUtils implements RepositoryUtilsInterface
 
     /**
      * @param ObjectManager&(DocumentManager|EntityManagerInterface) $om
+     * @param ClassMetadata<T>                                       $meta
      * @param TreeListener                                           $listener
-     * @param RepositoryInterface                                    $repo
+     * @param RepositoryInterface<T>                                 $repo
      */
     public function __construct(ObjectManager $om, ClassMetadata $meta, $listener, $repo)
     {
@@ -56,7 +59,7 @@ class RepositoryUtils implements RepositoryUtilsInterface
     }
 
     /**
-     * @return ClassMetadata
+     * @return ClassMetadata<T>
      */
     public function getClassMetadata()
     {

--- a/tests/Gedmo/Tree/Fixture/Repository/BehavioralCategoryRepository.php
+++ b/tests/Gedmo/Tree/Fixture/Repository/BehavioralCategoryRepository.php
@@ -11,8 +11,12 @@ declare(strict_types=1);
 
 namespace Gedmo\Tests\Tree\Fixture\Repository;
 
+use Gedmo\Tests\Tree\Fixture\BehavioralCategory;
 use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
 
+/**
+ * @template-extends NestedTreeRepository<BehavioralCategory>
+ */
 final class BehavioralCategoryRepository extends NestedTreeRepository
 {
 }

--- a/tests/Gedmo/Tree/MaterializedPathODMMongoDBRepositoryTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathODMMongoDBRepositoryTest.php
@@ -30,9 +30,9 @@ final class MaterializedPathODMMongoDBRepositoryTest extends BaseTestCaseMongoOD
     private const CATEGORY = Category::class;
 
     /**
-     * @var MaterializedPathRepository
+     * @var MaterializedPathRepository<Category>
      */
-    protected $repo;
+    private MaterializedPathRepository $repo;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Tree/NestedTreeRootRepositoryTest.php
+++ b/tests/Gedmo/Tree/NestedTreeRootRepositoryTest.php
@@ -255,7 +255,6 @@ final class NestedTreeRootRepositoryTest extends BaseTestCaseORM
      */
     public function testGetPathAsStringWithInvalidStringMethod($stringMethod): void
     {
-        /** @var NestedTreeRepository $repo */
         $repo = $this->em->getRepository(self::CATEGORY);
         $carrots = $repo->findOneBy(['title' => 'Carrots']);
 
@@ -278,7 +277,7 @@ final class NestedTreeRootRepositoryTest extends BaseTestCaseORM
 
     public function testShouldHandleBasicRepositoryMethods(): void
     {
-        /** @var NestedTreeRepository $repo */
+        /** @var NestedTreeRepository<RootCategory> $repo */
         $repo = $this->em->getRepository(self::CATEGORY);
         $carrots = $repo->findOneBy(['title' => 'Carrots']);
 
@@ -330,7 +329,7 @@ final class NestedTreeRootRepositoryTest extends BaseTestCaseORM
     public function testShouldHandleAdvancedRepositoryFunctions(): void
     {
         $this->populateMore();
-        /** @var NestedTreeRepository $repo */
+        /** @var NestedTreeRepository<RootCategory> $repo */
         $repo = $this->em->getRepository(self::CATEGORY);
 
         // verification

--- a/tests/Gedmo/Tree/NestedTreeRootTest.php
+++ b/tests/Gedmo/Tree/NestedTreeRootTest.php
@@ -16,7 +16,6 @@ use Doctrine\ORM\OptimisticLockException;
 use Gedmo\Tests\Tool\BaseTestCaseORM;
 use Gedmo\Tests\Tree\Fixture\ForeignRootCategory;
 use Gedmo\Tests\Tree\Fixture\RootCategory;
-use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
 use Gedmo\Tree\TreeListener;
 
 /**
@@ -332,7 +331,6 @@ final class NestedTreeRootTest extends BaseTestCaseORM
     public function testTreeWithRootPointingAtAnotherTable(): void
     {
         // depopulate, i don't want the other stuff in db
-        /** @var NestedTreeRepository $repo */
         $repo = $this->em->getRepository(ForeignRootCategory::class);
         $all = $repo->findAll();
         foreach ($all as $one) {

--- a/tests/Gedmo/Tree/TreeObjectHydratorTest.php
+++ b/tests/Gedmo/Tree/TreeObjectHydratorTest.php
@@ -101,7 +101,7 @@ final class TreeObjectHydratorTest extends BaseTestCaseORM
         $stack = new DebugStack();
         $this->em->getConfiguration()->setSQLLogger($stack);
 
-        /** @var NestedTreeRepository $repo */
+        /** @var NestedTreeRepository<RootCategory> $repo */
         $repo = $this->em->getRepository(self::ROOT_CATEGORY);
 
         $fruits = $repo->findOneBy(['title' => 'Fruits']);
@@ -135,7 +135,7 @@ final class TreeObjectHydratorTest extends BaseTestCaseORM
         $stack = new DebugStack();
         $this->em->getConfiguration()->setSQLLogger($stack);
 
-        /** @var NestedTreeRepository $repo */
+        /** @var NestedTreeRepository<RootCategory> $repo */
         $repo = $this->em->getRepository(self::ROOT_CATEGORY);
 
         $food = $repo->findOneBy(['title' => 'Food']);


### PR DESCRIPTION
I've added `@template T of object` and `@template-extends EntityRepository<T>` annotations to the Tree repositories.

In my code I can do:
```php
/**
 * @template-extends \Doctrine\ORM\EntityRepository<Foo>
 */
class FooRepository extends \Doctrine\ORM\EntityRepository
{
```

This is because `EntityRepository` has a `@template` annotation:
https://github.com/doctrine/orm/blob/f8bf84d1aa8b67f13f9a5c1c538938eb77e66bd6/lib/Doctrine/ORM/EntityRepository.php#L36

Now static analysis and type hints can evaluate that `$fooRepository->find(123)` will return a `Foo` object.

But I can't do the same in my code for any repository extending a Tree repository:
```php
/**
 * @template-extends \Gedmo\Tree\Entity\Repository\NestedTreeRepository<Foo>
 */
class FooRepository extends \Gedmo\Tree\Entity\Repository\NestedTreeRepository
{
```

These changes enable that. If you think this is a good idea, then I could also add `@phpstan-return ?list<T>` on `children()` for example to indicate that it will return an array of `T`.