### PR TITLE
Deprecate DoctrineExtensions::registerAnnotations()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ a release.
 - Sortable: Accepting a return type other than "integer" from `Comparable::compareTo()` is deprecated in `SortableListener::postFlush()`. This will not be accepted in version 4.0.
 - Deprecate the annotation reader being allowed to be any object.
   In 4.0, a `Doctrine\Common\Annotations\Reader` or `Gedmo\Mapping\Driver\AttributeReader` instance will be required.
+- `Gedmo\DoctrineExtensions::registerAnnotations()` is deprecated and will be removed in 4.0, the method has been no-op'd as all supported `doctrine/annotations` versions support autoloading
 
 ## [3.10.0] - 2022-11-14
 ### Changed

--- a/example/em.php
+++ b/example/em.php
@@ -37,11 +37,6 @@ $loader = require __DIR__.'/../vendor/autoload.php';
 // Register the example app with the autoloader
 $loader->addPsr4('App\\', __DIR__.'/app');
 
-// Ensure standard Doctrine annotations are registered
-Doctrine\Common\Annotations\AnnotationRegistry::registerFile(
-    __DIR__.'/../vendor/doctrine/orm/lib/Doctrine/ORM/Mapping/Driver/DoctrineAnnotations.php'
-);
-
 // Define our global cache backend for the application.
 // For larger applications, you may use multiple cache pools to store cacheable data in different locations.
 $cache = new \Symfony\Component\Cache\Adapter\ArrayAdapter();

--- a/src/DoctrineExtensions.php
+++ b/src/DoctrineExtensions.php
@@ -12,7 +12,6 @@ namespace Gedmo;
 use function class_exists;
 
 use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\Common\Annotations\PsrCachedReader;
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\Cache\ArrayCache;
@@ -41,7 +40,6 @@ final class DoctrineExtensions
      */
     public static function registerMappingIntoDriverChainORM(MappingDriverChain $driverChain, Reader $reader = null): void
     {
-        self::registerAnnotations();
         if (!$reader) {
             $reader = self::createAnnotationReader();
         }
@@ -59,7 +57,6 @@ final class DoctrineExtensions
      */
     public static function registerAbstractMappingIntoDriverChainORM(MappingDriverChain $driverChain, Reader $reader = null): void
     {
-        self::registerAnnotations();
         if (!$reader) {
             $reader = self::createAnnotationReader();
         }
@@ -77,7 +74,6 @@ final class DoctrineExtensions
      */
     public static function registerMappingIntoDriverChainMongodbODM(MappingDriverChain $driverChain, Reader $reader = null): void
     {
-        self::registerAnnotations();
         if (!$reader) {
             $reader = self::createAnnotationReader();
         }
@@ -94,7 +90,6 @@ final class DoctrineExtensions
      */
     public static function registerAbstractMappingIntoDriverChainMongodbODM(MappingDriverChain $driverChain, Reader $reader = null): void
     {
-        self::registerAnnotations();
         if (!$reader) {
             $reader = self::createAnnotationReader();
         }
@@ -107,10 +102,17 @@ final class DoctrineExtensions
 
     /**
      * Registers all extension annotations.
+     *
+     * @deprecated to be removed in 4.0, annotation classes are autoloaded instead
      */
     public static function registerAnnotations(): void
     {
-        AnnotationRegistry::registerFile(__DIR__.'/Mapping/Annotation/All.php');
+        @trigger_error(sprintf(
+            '"%s()" is deprecated since gedmo/doctrine-extensions 3.11 and will be removed in version 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
+        // Purposefully no-op'd, all supported versions of `doctrine/annotations` support autoloading
     }
 
     private static function createAnnotationReader(): AnnotationReader

--- a/src/Mapping/Annotation/All.php
+++ b/src/Mapping/Annotation/All.php
@@ -7,6 +7,11 @@
  * file that was distributed with this source code.
  */
 
+@trigger_error(sprintf(
+    'Requiring the file at "%s" is deprecated since gedmo/doctrine-extensions 3.11, this file will be removed in version 4.0.',
+    __FILE__
+), E_USER_DEPRECATED);
+
 // Contains all annotations for extensions
 // NOTE: should be included with require_once
 foreach (glob(__DIR__.'/*.php') as $filename) {

--- a/src/Mapping/MappedEventSubscriber.php
+++ b/src/Mapping/MappedEventSubscriber.php
@@ -12,7 +12,6 @@ namespace Gedmo\Mapping;
 use function class_exists;
 
 use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\Common\Annotations\PsrCachedReader;
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\Cache\ArrayCache;
@@ -287,8 +286,6 @@ abstract class MappedEventSubscriber implements EventSubscriber
     private function getDefaultAnnotationReader(): Reader
     {
         if (null === self::$defaultAnnotationReader) {
-            AnnotationRegistry::registerAutoloadNamespace('Gedmo\\Mapping\\Annotation', __DIR__.'/../../');
-
             $reader = new AnnotationReader();
 
             if (class_exists(ArrayAdapter::class)) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
  */
 
 use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\Common\Annotations\PsrCachedReader;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
@@ -27,10 +26,7 @@ define('TESTS_PATH', __DIR__);
 define('TESTS_TEMP_DIR', sys_get_temp_dir().'/doctrine-extension-tests');
 define('VENDOR_PATH', realpath(dirname(__DIR__).'/vendor'));
 
-$loader = require dirname(__DIR__).'/vendor/autoload.php';
-
-AnnotationRegistry::registerLoader([$loader, 'loadClass']);
-Gedmo\DoctrineExtensions::registerAnnotations();
+require dirname(__DIR__).'/vendor/autoload.php';
 
 $reader = new AnnotationReader();
 $reader = new PsrCachedReader($reader, new ArrayAdapter());


### PR DESCRIPTION
The `Gedmo\DoctrineExtensions::registerAnnotations()` method is used to manually load this package's annotation classes.  Since `doctrine/annotations` 1.10, the package has supported autoloading in full and deprecated these manual loading mechanisms, with them removed in the Annotations 2.0 release.

This PR, therefore, deprecates `Gedmo\DoctrineExtensions::registerAnnotations()` in order to remove it in 4.0 as it no longer serves a purpose.  It also no-op's the method to help unblock Annotations 2.0 support, and removes the uses of this newly deprecated method and the deprecated Annotations loader methods in the example app and test bootstrap.