### PR TITLE
Allow `Gedmo\DoctrineExtensions` to use an attribute driver

### DIFF
--- a/example/app/Entity/Category.php
+++ b/example/app/Entity/Category.php
@@ -11,7 +11,9 @@ declare(strict_types=1);
 
 namespace App\Entity;
 
+use App\Entity\Repository\CategoryRepository;
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
@@ -23,6 +25,10 @@ use Gedmo\Mapping\Annotation as Gedmo;
  *
  * @Gedmo\TranslationEntity(class="App\Entity\CategoryTranslation")
  */
+#[Gedmo\Tree(type: 'nested')]
+#[ORM\Table(name: 'ext_categories')]
+#[ORM\Entity(repositoryClass: CategoryRepository::class)]
+#[Gedmo\TranslationEntity(class: CategoryTranslation::class)]
 class Category
 {
     /**
@@ -30,6 +36,9 @@ class Category
      * @ORM\Id
      * @ORM\GeneratedValue
      */
+    #[ORM\Column(type: Types::INTEGER)]
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
     private $id;
 
     /**
@@ -39,6 +48,8 @@ class Category
      *
      * @ORM\Column(length=64)
      */
+    #[Gedmo\Translatable]
+    #[ORM\Column(length: 64)]
     private $title;
 
     /**
@@ -48,6 +59,8 @@ class Category
      *
      * @ORM\Column(type="text", nullable=true)
      */
+    #[Gedmo\Translatable]
+    #[ORM\Column(type: Types::TEXT, nullable: true)]
     private $description;
 
     /**
@@ -58,6 +71,9 @@ class Category
      *
      * @ORM\Column(length=64, unique=true)
      */
+    #[Gedmo\Translatable]
+    #[Gedmo\Slug(fields: ['created', 'title'])]
+    #[ORM\Column(length: 64, unique: true)]
     private $slug;
 
     /**
@@ -65,6 +81,8 @@ class Category
      *
      * @ORM\Column(type="integer")
      */
+    #[Gedmo\TreeLeft]
+    #[ORM\Column(type: Types::INTEGER)]
     private $lft;
 
     /**
@@ -72,6 +90,8 @@ class Category
      *
      * @ORM\Column(type="integer")
      */
+    #[Gedmo\TreeRight]
+    #[ORM\Column(type: Types::INTEGER)]
     private $rgt;
 
     /**
@@ -80,6 +100,9 @@ class Category
      * @ORM\ManyToOne(targetEntity="Category", inversedBy="children")
      * @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
      */
+    #[Gedmo\TreeParent]
+    #[ORM\ManyToOne(targetEntity: self::class, inversedBy: 'children')]
+    #[ORM\JoinColumn(name: 'parent_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
     private $parent;
 
     /**
@@ -87,6 +110,8 @@ class Category
      *
      * @ORM\Column(type="integer", nullable=true)
      */
+    #[Gedmo\TreeRoot]
+    #[ORM\Column(type: Types::INTEGER, nullable: true)]
     private $root;
 
     /**
@@ -94,11 +119,14 @@ class Category
      *
      * @ORM\Column(name="lvl", type="integer")
      */
+    #[Gedmo\TreeLevel]
+    #[ORM\Column(name: 'lvl', type: Types::INTEGER)]
     private $level;
 
     /**
      * @ORM\OneToMany(targetEntity="Category", mappedBy="parent")
      */
+    #[ORM\OneToMany(targetEntity: self::class, mappedBy: 'parent')]
     private Collection $children;
 
     /**
@@ -106,6 +134,8 @@ class Category
      *
      * @ORM\Column(type="datetime")
      */
+    #[Gedmo\Timestampable(on: 'create')]
+    #[ORM\Column(type: Types::DATETIME_MUTABLE)]
     private $created;
 
     /**
@@ -113,6 +143,8 @@ class Category
      *
      * @ORM\Column(type="datetime")
      */
+    #[Gedmo\Timestampable(on: 'update')]
+    #[ORM\Column(type: Types::DATETIME_MUTABLE)]
     private $updated;
 
     /**
@@ -120,6 +152,8 @@ class Category
      *
      * @ORM\Column(type="string")
      */
+    #[Gedmo\Blameable(on: 'create')]
+    #[ORM\Column(type: Types::STRING)]
     private $createdBy;
 
     /**
@@ -127,6 +161,8 @@ class Category
      *
      * @ORM\Column(type="string")
      */
+    #[Gedmo\Blameable(on: 'update')]
+    #[ORM\Column(type: Types::STRING)]
     private $updatedBy;
 
     /**
@@ -136,6 +172,7 @@ class Category
      *     cascade={"persist", "remove"}
      * )
      */
+    #[ORM\OneToMany(targetEntity: CategoryTranslation::class, mappedBy: 'object', cascade: ['persist', 'remove'])]
     private $translations;
 
     public function __construct()

--- a/example/app/Entity/CategoryTranslation.php
+++ b/example/app/Entity/CategoryTranslation.php
@@ -22,16 +22,21 @@ use Gedmo\Translatable\Entity\MappedSuperclass\AbstractPersonalTranslation;
  *     })}
  * )
  */
+#[ORM\Entity]
+#[ORM\Table(name: 'category_translations')]
+#[ORM\UniqueConstraint(name: 'lookup_unique_idx', columns: ['locale', 'object_id', 'field'])]
 class CategoryTranslation extends AbstractPersonalTranslation
 {
     /**
      * @ORM\ManyToOne(targetEntity="Category", inversedBy="translations")
      * @ORM\JoinColumn(name="object_id", referencedColumnName="id", onDelete="CASCADE")
      */
+    #[ORM\ManyToOne(targetEntity: Category::class, inversedBy: 'translations')]
+    #[ORM\JoinColumn(name: 'object_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
     protected $object;
 
     /**
-     * Convinient constructor
+     * Convenient constructor
      *
      * @param string $locale
      * @param string $field

--- a/tests/Gedmo/DoctrineExtensionsTest.php
+++ b/tests/Gedmo/DoctrineExtensionsTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\ODM\MongoDB\Mapping\Driver as DriverMongodbODM;
+use Doctrine\ORM\Mapping\Driver as DriverORM;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
+use Gedmo\DoctrineExtensions;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * This test covers the driver registration helpers in the {@see DoctrineExtensions} class.
+ */
+final class DoctrineExtensionsTest extends TestCase
+{
+    /**
+     * @requires PHP >= 8.0
+     */
+    public function testRegistersAttributeDriverForConcreteOrmEntitiesToChain(): void
+    {
+        $chain = new MappingDriverChain();
+
+        DoctrineExtensions::registerMappingIntoDriverChainORM($chain);
+
+        $drivers = $chain->getDrivers();
+
+        static::assertArrayHasKey('Gedmo', $drivers);
+        static::assertInstanceOf(DriverORM\AttributeDriver::class, $drivers['Gedmo'], 'The attribute driver should be registered to the chain on PHP 8');
+    }
+
+    public function testRegistersAnnotationDriverForConcreteOrmEntitiesToChain(): void
+    {
+        if (\PHP_VERSION_ID >= 80000 || !class_exists(AnnotationReader::class)) {
+            static::markTestSkipped('Test only applies to PHP 7 and requires the doctrine/annotations package');
+        }
+
+        $chain = new MappingDriverChain();
+
+        DoctrineExtensions::registerMappingIntoDriverChainORM($chain);
+
+        $drivers = $chain->getDrivers();
+
+        static::assertArrayHasKey('Gedmo', $drivers);
+        static::assertInstanceOf(DriverORM\AnnotationDriver::class, $drivers['Gedmo'], 'The annotations driver should be registered to the chain on PHP 7');
+    }
+
+    /**
+     * @requires PHP >= 8.0
+     */
+    public function testRegistersAttributeDriverForAbstractOrmSuperclassesToChain(): void
+    {
+        $chain = new MappingDriverChain();
+
+        DoctrineExtensions::registerAbstractMappingIntoDriverChainORM($chain);
+
+        $drivers = $chain->getDrivers();
+
+        static::assertArrayHasKey('Gedmo', $drivers);
+        static::assertInstanceOf(DriverORM\AttributeDriver::class, $drivers['Gedmo'], 'The attribute driver should be registered to the chain on PHP 8');
+    }
+
+    public function testRegistersAnnotationDriverForAbstractOrmSuperclassesToChain(): void
+    {
+        if (\PHP_VERSION_ID >= 80000 || !class_exists(AnnotationReader::class)) {
+            static::markTestSkipped('Test only applies to PHP 7 and requires the doctrine/annotations package');
+        }
+
+        $chain = new MappingDriverChain();
+
+        DoctrineExtensions::registerAbstractMappingIntoDriverChainORM($chain);
+
+        $drivers = $chain->getDrivers();
+
+        static::assertArrayHasKey('Gedmo', $drivers);
+        static::assertInstanceOf(DriverORM\AnnotationDriver::class, $drivers['Gedmo'], 'The annotations driver should be registered to the chain on PHP 7');
+    }
+
+    /**
+     * @requires PHP >= 8.0
+     */
+    public function testRegistersAttributeDriverForConcreteOdmDocumentsToChain(): void
+    {
+        if (!class_exists(DriverMongodbODM\AttributeDriver::class)) {
+            static::markTestSkipped('Test requires the attribute mapping driver from the doctrine/mongodb-odm package');
+        }
+
+        $chain = new MappingDriverChain();
+
+        DoctrineExtensions::registerMappingIntoDriverChainMongodbODM($chain);
+
+        $drivers = $chain->getDrivers();
+
+        static::assertArrayHasKey('Gedmo', $drivers);
+        static::assertInstanceOf(DriverMongodbODM\AttributeDriver::class, $drivers['Gedmo'], 'The attribute driver should be registered to the chain on PHP 8');
+    }
+
+    public function testRegistersAnnotationDriverForConcreteOdmDocumentsToChain(): void
+    {
+        if (\PHP_VERSION_ID >= 80000 || !class_exists(AnnotationReader::class)) {
+            static::markTestSkipped('Test only applies to PHP 7 and requires the doctrine/annotations package');
+        }
+
+        $chain = new MappingDriverChain();
+
+        DoctrineExtensions::registerMappingIntoDriverChainMongodbODM($chain);
+
+        $drivers = $chain->getDrivers();
+
+        static::assertArrayHasKey('Gedmo', $drivers);
+        static::assertInstanceOf(DriverMongodbODM\AnnotationDriver::class, $drivers['Gedmo'], 'The annotations driver should be registered to the chain on PHP 7');
+    }
+
+    /**
+     * @requires PHP >= 8.0
+     */
+    public function testRegistersAttributeDriverForAbstractOdmSuperclassesToChain(): void
+    {
+        if (!class_exists(DriverMongodbODM\AttributeDriver::class)) {
+            static::markTestSkipped('Test requires the attribute mapping driver from the doctrine/mongodb-odm package');
+        }
+
+        $chain = new MappingDriverChain();
+
+        DoctrineExtensions::registerAbstractMappingIntoDriverChainMongodbODM($chain);
+
+        $drivers = $chain->getDrivers();
+
+        static::assertArrayHasKey('Gedmo', $drivers);
+        static::assertInstanceOf(DriverMongodbODM\AttributeDriver::class, $drivers['Gedmo'], 'The attribute driver should be registered to the chain on PHP 8');
+    }
+
+    public function testRegistersAnnotationDriverForAbstractOdmSuperclassesToChain(): void
+    {
+        if (\PHP_VERSION_ID >= 80000 || !class_exists(AnnotationReader::class)) {
+            static::markTestSkipped('Test only applies to PHP 7 and requires the doctrine/annotations package');
+        }
+
+        $chain = new MappingDriverChain();
+
+        DoctrineExtensions::registerAbstractMappingIntoDriverChainMongodbODM($chain);
+
+        $drivers = $chain->getDrivers();
+
+        static::assertArrayHasKey('Gedmo', $drivers);
+        static::assertInstanceOf(DriverMongodbODM\AnnotationDriver::class, $drivers['Gedmo'], 'The annotations driver should be registered to the chain on PHP 7');
+    }
+}


### PR DESCRIPTION
Ref: #2554

Changes the `Gedmo\DoctrineExtensions` class to conditionally use an annotation or attribute driver based on the runtime PHP version, with the attribute driver automatically being used on PHP 8.0 or later.

And because Codecov was yelling about the drop in coverage, the `Gedmo\DoctrineExtensions` class now has tests.