### PR TITLE
Allow doctrine/annotations 2.0

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -69,6 +69,10 @@ jobs:
         if: "${{ matrix.mongodb-odm-version }}"
         run: "composer require --dev --no-update doctrine/mongodb-odm:${{ matrix.mongodb-odm-version }}"
 
+      # Remove PHP-CS-Fixer to avoid conflicting dependency ranges (i.e. doctrine/annotations)
+      - name: "Remove PHP-CS-Fixer"
+        run: "composer remove --dev --no-update friendsofphp/php-cs-fixer"
+
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v2"
         with:

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "behat/transliterator": "~1.2",
-        "doctrine/annotations": "^1.13",
+        "doctrine/annotations": "^1.13 || ^2.0",
         "doctrine/collections": "^1.2 || ^2.0",
         "doctrine/common": "^2.13 || ^3.0",
         "doctrine/event-manager": "^1.2 || ^2.0",

--- a/tests/Gedmo/Mapping/SluggableMappingTest.php
+++ b/tests/Gedmo/Mapping/SluggableMappingTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace Gedmo\Tests\Mapping;
 
 use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\Common\EventManager;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
@@ -49,10 +48,6 @@ final class SluggableMappingTest extends ORMMappingTestCase
             'Gedmo\Tests\Mapping\Fixture\Yaml'
         );
         $reader = new AnnotationReader();
-        AnnotationRegistry::registerAutoloadNamespace(
-            'Gedmo\\Mapping\\Annotation',
-            dirname(VENDOR_PATH).'/src'
-        );
         $chainDriverImpl->addDriver(
             new \Doctrine\ORM\Mapping\Driver\AnnotationDriver($reader),
             'Gedmo\Tests\Mapping\Fixture'

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -24,7 +24,6 @@ use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 define('TESTS_PATH', __DIR__);
 define('TESTS_TEMP_DIR', sys_get_temp_dir().'/doctrine-extension-tests');
-define('VENDOR_PATH', realpath(dirname(__DIR__).'/vendor'));
 
 require dirname(__DIR__).'/vendor/autoload.php';
 


### PR DESCRIPTION
The ORM's 2.14 release supports it and MongoDB ODM's 2.5 will add support.  The PHP-CS-Fixer tool will block installing the 2.0 version in a dev environment, and if https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/6730 is merged as is as of the time I opened this PR, there won't be a release of that tool supporting both Annotations versions at the same time.