### PR TITLE
Drop support for Symfony 5.3 and older

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ a release.
 ## [Unreleased]
 ### Changed
 - Dropped support for PHP < 7.4
+- Dropped support for Symfony < 5.4
 
 ### Deprecated
 - Calling `Gedmo\Mapping\Event\Adapter\ORM::getObjectManager()` and `getObject()` on EventArgs that do not implement `getObjectManager()` and `getObject()` (such as old EventArgs implementing `getEntityManager()` and `getEntity()`) 

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "doctrine/event-manager": "^1.2 || ^2.0",
         "doctrine/persistence": "^2.2 || ^3.0",
         "psr/cache": "^1 || ^2 || ^3",
-        "symfony/cache": "^4.4 || ^5.3 || ^6.0",
+        "symfony/cache": "^5.4 || ^6.0",
         "symfony/deprecation-contracts": "^2.1 || ^3.0"
     },
     "require-dev": {
@@ -64,9 +64,9 @@
         "phpstan/phpstan-phpunit": "^1.0",
         "phpunit/phpunit": "^9.6",
         "rector/rector": "^0.18",
-        "symfony/console": "^4.4 || ^5.3 || ^6.0",
+        "symfony/console": "^5.4 || ^6.0",
         "symfony/phpunit-bridge": "^6.0",
-        "symfony/yaml": "^4.4 || ^5.3 || ^6.0"
+        "symfony/yaml": "^5.4 || ^6.0"
     },
     "conflict": {
         "doctrine/dbal": "<2.13.1 || ^3.0 <3.2",

--- a/example/app/Command/PrintCategoryTranslationTreeCommand.php
+++ b/example/app/Command/PrintCategoryTranslationTreeCommand.php
@@ -27,12 +27,6 @@ final class PrintCategoryTranslationTreeCommand extends Command
     protected static $defaultName = 'app:print-category-translation-tree';
     protected static $defaultDescription = 'Seeds an example category tree with translations and prints the tree.';
 
-    protected function configure(): void
-    {
-        // Kept for compatibility with Symfony 5.2 and older, which do not support lazy descriptions
-        $this->setDescription(self::$defaultDescription);
-    }
-
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         /** @var EntityManagerHelper $helper */


### PR DESCRIPTION
Symfony 4.4 is now only [getting security fixes](https://symfony.com/releases/4.4) and 5.4 is the next LTS.  This will drop support for Symfony 4.4 and 5.3 in the handful of components that are used.