### PR TITLE
Don't wrap the reader if it is already an attribute reader

### DIFF
--- a/src/Mapping/ExtensionMetadataFactory.php
+++ b/src/Mapping/ExtensionMetadataFactory.php
@@ -205,7 +205,11 @@ class ExtensionMetadataFactory
             }
 
             if ($driver instanceof AttributeDriverInterface) {
-                $driver->setAnnotationReader(new AttributeAnnotationReader(new AttributeReader(), $this->annotationReader));
+                if ($this->annotationReader instanceof AttributeReader) {
+                    $driver->setAnnotationReader($this->annotationReader);
+                } else {
+                    $driver->setAnnotationReader(new AttributeAnnotationReader(new AttributeReader(), $this->annotationReader));
+                }
             } elseif ($driver instanceof AnnotationDriverInterface) {
                 $driver->setAnnotationReader($this->annotationReader);
             }

--- a/tests/Gedmo/Loggable/AnnotationLoggableEntityTest.php
+++ b/tests/Gedmo/Loggable/AnnotationLoggableEntityTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Loggable;
+
+use Doctrine\Common\EventManager;
+use Gedmo\Tests\Loggable\LoggableEntityTest;
+
+/**
+ * These are tests for loggable behavior with an annotation reader (created by the listener by default)
+ *
+ * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ */
+final class AnnotationLoggableEntityTest extends LoggableEntityTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $evm = new EventManager();
+        $loggableListener = new LoggableListener();
+        $loggableListener->setUsername('jules');
+        $evm->addEventSubscriber($loggableListener);
+
+        $this->em = $this->getDefaultMockSqliteEntityManager($evm);
+    }
+}

--- a/tests/Gedmo/Loggable/AttributeLoggableEntityTest.php
+++ b/tests/Gedmo/Loggable/AttributeLoggableEntityTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Loggable;
+
+use Doctrine\Common\EventManager;
+use Gedmo\Mapping\Driver\AttributeReader;
+use Gedmo\Tests\Loggable\LoggableEntityTest;
+
+/**
+ * These are tests for loggable behavior with an attribute reader
+ *
+ * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ */
+final class AttributeLoggableEntityTest extends LoggableEntityTest
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (PHP_VERSION_ID < 80000) {
+            static::markTestSkipped('Test requires PHP 8');
+        }
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $evm = new EventManager();
+        $loggableListener = new LoggableListener();
+        $loggableListener->setAnnotationReader(new AttributeReader());
+        $loggableListener->setUsername('jules');
+        $evm->addEventSubscriber($loggableListener);
+
+        $this->em = $this->getDefaultMockSqliteEntityManager($evm);
+    }
+}

--- a/tests/Gedmo/Loggable/AttributeLoggableEntityTest.php
+++ b/tests/Gedmo/Loggable/AttributeLoggableEntityTest.php
@@ -18,17 +18,12 @@ use Gedmo\Tests\Loggable\LoggableEntityTest;
 /**
  * These are tests for loggable behavior with an attribute reader
  *
+ * @requires PHP >= 8.0
+ *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
 final class AttributeLoggableEntityTest extends LoggableEntityTest
 {
-    public static function setUpBeforeClass(): void
-    {
-        if (PHP_VERSION_ID < 80000) {
-            static::markTestSkipped('Test requires PHP 8');
-        }
-    }
-
     protected function setUp(): void
     {
         parent::setUp();

--- a/tests/Gedmo/Loggable/LoggableEntityTest.php
+++ b/tests/Gedmo/Loggable/LoggableEntityTest.php
@@ -11,9 +11,7 @@ declare(strict_types=1);
 
 namespace Gedmo\Tests\Loggable;
 
-use Doctrine\Common\EventManager;
 use Gedmo\Loggable\Entity\LogEntry;
-use Gedmo\Loggable\LoggableListener;
 use Gedmo\Tests\Loggable\Fixture\Entity\Address;
 use Gedmo\Tests\Loggable\Fixture\Entity\Article;
 use Gedmo\Tests\Loggable\Fixture\Entity\Comment;
@@ -27,24 +25,12 @@ use Gedmo\Tests\Tool\BaseTestCaseORM;
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
-final class LoggableEntityTest extends BaseTestCaseORM
+abstract class LoggableEntityTest extends BaseTestCaseORM
 {
     public const ARTICLE = Article::class;
     public const COMMENT = Comment::class;
     public const RELATED_ARTICLE = RelatedArticle::class;
     public const COMMENT_LOG = \Gedmo\Tests\Loggable\Fixture\Entity\Log\Comment::class;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $evm = new EventManager();
-        $loggableListener = new LoggableListener();
-        $loggableListener->setUsername('jules');
-        $evm->addEventSubscriber($loggableListener);
-
-        $this->em = $this->getDefaultMockSqliteEntityManager($evm);
-    }
 
     public function testShouldHandleClonedEntity(): void
     {


### PR DESCRIPTION
`Gedmo\Mapping\ExtensionMetadataFactory` will handle pushing a reader into the mapping driver when it's working with an attribute or annotation reader.  When an attribute driver is detected, it tries to provide a `Gedmo\Mapping\Driver\AttributeAnnotationReader` with the injected reader.  However, the second argument of the `Gedmo\Mapping\Driver\AttributeAnnotationReader` constructor requires a `Doctrine\Common\Annotations\Reader`.  So if the extension metadata factory is instantiated with a `Gedmo\Mapping\Driver\AttributeReader` passed through its constructor, things fail with a type error:

```sh
Gedmo\Mapping\Driver\AttributeAnnotationReader::__construct(): Argument #2 ($annotationReader) must be of type Doctrine\Common\Annotations\Reader, Gedmo\Mapping\Driver\AttributeReader given, called in /app/vendor/gedmo/doctrine-extensions/src/Mapping/ExtensionMetadataFactory.php on line 208
```

This adds a check to determine if the reader needs to be wrapped; if a `Gedmo\Mapping\Driver\AttributeReader` was provided, then we don't need to wrap the reader.