### PR TITLE
[Loggable] Add `LogEntryInterface`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ a release.
 - Tree: Add `Nested::ALLOWED_NODE_POSITIONS` constant in order to expose the available node positions
 - Support for `doctrine/collections` 2.0
 - Support for `doctrine/event-manager` 2.0
+- Loggable: Add `LogEntryInterface` interface in order to be implemented by log entry models
 
 ### Fixed
 - Sortable: Fix return value check of Comparable interface (#2541)
@@ -35,6 +36,9 @@ a release.
 - Deprecate the annotation reader being allowed to be any object.
   In 4.0, a `Doctrine\Common\Annotations\Reader` or `Gedmo\Mapping\Driver\AttributeReader` instance will be required.
 - `Gedmo\DoctrineExtensions::registerAnnotations()` is deprecated and will be removed in 4.0, the method has been no-op'd as all supported `doctrine/annotations` versions support autoloading
+- Loggable: Constants `LoggableListener::ACTION_CREATE`, `LoggableListener::ACTION_UPDATE` and `LoggableListener::ACTION_REMOVE`
+  are deprecated. Use `LogEntryInterface::ACTION_CREATE`, `LogEntryInterface::ACTION_UPDATE` and `LogEntryInterface::ACTION_REMOVE`
+  instead.
 
 ## [3.10.0] - 2022-11-14
 ### Changed

--- a/doc/loggable.md
+++ b/doc/loggable.md
@@ -32,16 +32,16 @@ on how to setup and use the extensions in most optimized way.
 
 ### Loggable annotations:
 
-- **@Gedmo\Mapping\Annotation\Loggable(logEntryClass="my\class")** this class annotation
-will store logs to optionally specified **logEntryClass**. You will still need to specify versioned fields with the following annotation.
+- **@Gedmo\Mapping\Annotation\Loggable(logEntryClass="My\LoggableModel")** this class annotation will store logs to optionally
+  specified **logEntryClass**. The class provided in this annotation MUST implement ``Gedmo\Loggable\LogEntryInterface``. You will
+  still need to specify versioned fields with the following annotation.
 - **@Gedmo\Mapping\Annotation\Versioned** tracks annotated property for changes
-
-**Note:** If you need to use a different class, it must extend ``Gedmo\Loggable\Entity\MappedSuperclass\AbstractLogEntry``.
 
 ### Loggable attributes:
 
-- **\#[Gedmo\Mapping\Annotation\Loggable(logEntryClass: MyClass::class]** this class attribute
-will store logs to optionally specified **logEntryClass**. You will still need to specify versioned fields with the following attribute.
+- **\#[Gedmo\Mapping\Annotation\Loggable(logEntryClass: My\LoggableModel::class]** this class attribute will store logs to optionally
+  specified **logEntryClass**. The class provided in this attribute MUST implement ``Gedmo\Loggable\LogEntryInterface``. You will
+  still need to specify versioned fields with the following attribute.
 - **\#[Gedmo\Mapping\Annotation\Versioned]** tracks attributed property for changes
 
 ### Loggable username:

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -76,12 +76,12 @@ parameters:
 			path: src/Loggable/Document/Repository/LogEntryRepository.php
 
 		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\<object\\>\\:\\:getReflectionProperty\\(\\)\\.$#"
+			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\<Gedmo\\\\Loggable\\\\LogEntryInterface\\>\\:\\:getReflectionProperty\\(\\)\\.$#"
 			count: 1
 			path: src/Loggable/LoggableListener.php
 
 		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\<object\\>\\:\\:newInstance\\(\\)\\.$#"
+			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\<Gedmo\\\\Loggable\\\\LogEntryInterface\\>\\:\\:newInstance\\(\\)\\.$#"
 			count: 1
 			path: src/Loggable/LoggableListener.php
 

--- a/src/Loggable/Document/MappedSuperclass/AbstractLogEntry.php
+++ b/src/Loggable/Document/MappedSuperclass/AbstractLogEntry.php
@@ -11,12 +11,17 @@ namespace Gedmo\Loggable\Document\MappedSuperclass;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoODM;
 use Doctrine\ODM\MongoDB\Types\Type;
+use Gedmo\Loggable\LogEntryInterface;
 
 /**
+ * @phpstan-template T of object
+ *
+ * @phpstan-implements LogEntryInterface<T>
+ *
  * @MongoODM\MappedSuperclass
  */
 #[MongoODM\MappedSuperclass]
-abstract class AbstractLogEntry
+abstract class AbstractLogEntry implements LogEntryInterface
 {
     /**
      * @var string|null
@@ -28,6 +33,8 @@ abstract class AbstractLogEntry
 
     /**
      * @var string|null
+     *
+     * @phpstan-var self::ACTION_CREATE|self::ACTION_UPDATE|self::ACTION_REMOVE|null
      *
      * @MongoODM\Field(type="string")
      */
@@ -52,6 +59,8 @@ abstract class AbstractLogEntry
 
     /**
      * @var string|null
+     *
+     * @phpstan-var class-string<T>|null
      *
      * @MongoODM\Field(type="string")
      */

--- a/src/Loggable/Entity/MappedSuperclass/AbstractLogEntry.php
+++ b/src/Loggable/Entity/MappedSuperclass/AbstractLogEntry.php
@@ -11,12 +11,17 @@ namespace Gedmo\Loggable\Entity\MappedSuperclass;
 
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Loggable\LogEntryInterface;
 
 /**
+ * @phpstan-template T of object
+ *
+ * @phpstan-implements LogEntryInterface<T>
+ *
  * @ORM\MappedSuperclass
  */
 #[ORM\MappedSuperclass]
-abstract class AbstractLogEntry
+abstract class AbstractLogEntry implements LogEntryInterface
 {
     /**
      * @var int|null
@@ -32,6 +37,8 @@ abstract class AbstractLogEntry
 
     /**
      * @var string|null
+     *
+     * @phpstan-var self::ACTION_CREATE|self::ACTION_UPDATE|self::ACTION_REMOVE|null
      *
      * @ORM\Column(type="string", length=8)
      */
@@ -56,6 +63,8 @@ abstract class AbstractLogEntry
 
     /**
      * @var string|null
+     *
+     * @phpstan-var class-string<T>|null
      *
      * @ORM\Column(name="object_class", type="string", length=191)
      */

--- a/src/Loggable/LogEntryInterface.php
+++ b/src/Loggable/LogEntryInterface.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Loggable;
+
+/**
+ * Interface to be implemented by log entry models.
+ *
+ * @phpstan-template T of object
+ *
+ * @author Javier Spagnoletti <phansys@gmail.com>
+ */
+interface LogEntryInterface
+{
+    public const ACTION_CREATE = 'create';
+
+    public const ACTION_UPDATE = 'update';
+
+    public const ACTION_REMOVE = 'remove';
+
+    /**
+     * @phpstan-param self::ACTION_CREATE|self::ACTION_UPDATE|self::ACTION_REMOVE $action
+     *
+     * @return void
+     */
+    public function setAction(string $action);
+
+    /**
+     * @return string|null
+     *
+     * @phpstan-return self::ACTION_CREATE|self::ACTION_UPDATE|self::ACTION_REMOVE|null
+     */
+    public function getAction();
+
+    /**
+     * @return void
+     */
+    public function setUsername(string $username);
+
+    /**
+     * @return string|null
+     */
+    public function getUsername();
+
+    /**
+     * @phpstan-param class-string<T> $objectClass
+     *
+     * @return void
+     */
+    public function setObjectClass(string $objectClass);
+
+    /**
+     * @return string|null
+     *
+     * @phpstan-return class-string<T>
+     */
+    public function getObjectClass();
+
+    /**
+     * @return void
+     */
+    public function setLoggedAt();
+
+    /**
+     * @return \DateTimeInterface|null
+     */
+    public function getLoggedAt();
+
+    /**
+     * @return void
+     */
+    public function setObjectId(string $objectId);
+
+    /**
+     * @return string|null
+     */
+    public function getObjectId();
+
+    /**
+     * @param array<string, mixed> $data
+     *
+     * @return void
+     */
+    public function setData(array $data);
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getData();
+
+    /**
+     * @return void
+     */
+    public function setVersion(int $version);
+
+    /**
+     * @return int|null
+     */
+    public function getVersion();
+}

--- a/src/Mapping/Annotation/Loggable.php
+++ b/src/Mapping/Annotation/Loggable.php
@@ -11,10 +11,13 @@ namespace Gedmo\Mapping\Annotation;
 
 use Attribute;
 use Doctrine\Common\Annotations\Annotation;
+use Gedmo\Loggable\LogEntryInterface;
 use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 
 /**
  * Loggable annotation for Loggable behavioral extension
+ *
+ * @phpstan-template T of LogEntryInterface
  *
  * @Annotation
  * @NamedArgumentConstructor
@@ -27,12 +30,13 @@ final class Loggable implements GedmoAnnotation
 {
     /**
      * @var string|null
-     * @phpstan-var class-string|null
+     *
+     * @phpstan-var class-string<T>|null
      */
     public $logEntryClass;
 
     /**
-     * @phpstan-param class-string|null $logEntryClass
+     * @phpstan-param class-string<T>|null $logEntryClass
      */
     public function __construct(array $data = [], ?string $logEntryClass = null)
     {

--- a/tests/Gedmo/Loggable/Fixture/Document/Article.php
+++ b/tests/Gedmo/Loggable/Fixture/Document/Article.php
@@ -13,6 +13,7 @@ namespace Gedmo\Tests\Loggable\Fixture\Document;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Types\Type;
+use Gedmo\Loggable\Loggable;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
@@ -21,7 +22,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
  */
 #[ODM\Document(collection: 'articles')]
 #[Gedmo\Loggable]
-class Article
+class Article implements Loggable
 {
     /**
      * @var string|null

--- a/tests/Gedmo/Loggable/Fixture/Document/Author.php
+++ b/tests/Gedmo/Loggable/Fixture/Document/Author.php
@@ -13,6 +13,7 @@ namespace Gedmo\Tests\Loggable\Fixture\Document;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Types\Type;
+use Gedmo\Loggable\Loggable;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
@@ -21,7 +22,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
  */
 #[ODM\EmbeddedDocument]
 #[Gedmo\Loggable]
-class Author
+class Author implements Loggable
 {
     /**
      * @var string|null

--- a/tests/Gedmo/Loggable/Fixture/Document/Comment.php
+++ b/tests/Gedmo/Loggable/Fixture/Document/Comment.php
@@ -13,6 +13,7 @@ namespace Gedmo\Tests\Loggable\Fixture\Document;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Types\Type;
+use Gedmo\Loggable\Loggable;
 use Gedmo\Mapping\Annotation as Gedmo;
 use Gedmo\Tests\Loggable\Fixture\Document\Log\Comment as CommentLog;
 
@@ -22,7 +23,7 @@ use Gedmo\Tests\Loggable\Fixture\Document\Log\Comment as CommentLog;
  */
 #[ODM\Document]
 #[Gedmo\Loggable(logEntryClass: CommentLog::class)]
-class Comment
+class Comment implements Loggable
 {
     /**
      * @var string|null

--- a/tests/Gedmo/Loggable/Fixture/Document/RelatedArticle.php
+++ b/tests/Gedmo/Loggable/Fixture/Document/RelatedArticle.php
@@ -14,6 +14,7 @@ namespace Gedmo\Tests\Loggable\Fixture\Document;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Types\Type;
+use Gedmo\Loggable\Loggable;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
@@ -22,7 +23,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
  */
 #[ODM\Document]
 #[Gedmo\Loggable]
-class RelatedArticle
+class RelatedArticle implements Loggable
 {
     /**
      * @var string|null

--- a/tests/Gedmo/Loggable/Fixture/Entity/Address.php
+++ b/tests/Gedmo/Loggable/Fixture/Entity/Address.php
@@ -13,6 +13,7 @@ namespace Gedmo\Tests\Loggable\Fixture\Entity;
 
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Loggable\Loggable;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
@@ -23,7 +24,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
  */
 #[ORM\Entity]
 #[Gedmo\Loggable]
-class Address
+class Address implements Loggable
 {
     /**
      * @var int|null

--- a/tests/Gedmo/Loggable/Fixture/Entity/Article.php
+++ b/tests/Gedmo/Loggable/Fixture/Entity/Article.php
@@ -13,6 +13,7 @@ namespace Gedmo\Tests\Loggable\Fixture\Entity;
 
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Loggable\Loggable;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
@@ -21,7 +22,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
  */
 #[ORM\Entity]
 #[Gedmo\Loggable]
-class Article
+class Article implements Loggable
 {
     /**
      * @var int|null

--- a/tests/Gedmo/Loggable/Fixture/Entity/Comment.php
+++ b/tests/Gedmo/Loggable/Fixture/Entity/Comment.php
@@ -13,6 +13,7 @@ namespace Gedmo\Tests\Loggable\Fixture\Entity;
 
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Loggable\Loggable;
 use Gedmo\Mapping\Annotation as Gedmo;
 use Gedmo\Tests\Loggable\Fixture\Entity\Log\Comment as CommentLog;
 
@@ -22,7 +23,7 @@ use Gedmo\Tests\Loggable\Fixture\Entity\Log\Comment as CommentLog;
  */
 #[ORM\Entity]
 #[Gedmo\Loggable(logEntryClass: CommentLog::class)]
-class Comment
+class Comment implements Loggable
 {
     /**
      * @var int|null

--- a/tests/Gedmo/Loggable/Fixture/Entity/RelatedArticle.php
+++ b/tests/Gedmo/Loggable/Fixture/Entity/RelatedArticle.php
@@ -14,6 +14,7 @@ namespace Gedmo\Tests\Loggable\Fixture\Entity;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Loggable\Loggable;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
@@ -22,7 +23,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
  */
 #[ORM\Entity]
 #[Gedmo\Loggable]
-class RelatedArticle
+class RelatedArticle implements Loggable
 {
     /**
      * @var int|null


### PR DESCRIPTION
* Add `LogEntryInterface` interface in order to be implemented by log entry models;
* Deprecate `LoggableListener::ACTION_CREATE`, `LoggableListener::ACTION_UPDATE` and `LoggableListener::ACTION_REMOVE` constants in favor of `LogEntryInterface::ACTION_CREATE`, `LogEntryInterface::ACTION_UPDATE` and `LogEntryInterface::ACTION_REMOVE`.

These changes are proposed based on the work I made in #2548.