### PR TITLE
fix: possibility to match "MappingDriverChain" for doctrine 2.14.1

### DIFF
--- a/src/Mapping/ExtensionMetadataFactory.php
+++ b/src/Mapping/ExtensionMetadataFactory.php
@@ -168,7 +168,7 @@ class ExtensionMetadataFactory
         $driver = null;
         $className = get_class($omDriver);
         $driverName = substr($className, strrpos($className, '\\') + 1);
-        if ($omDriver instanceof MappingDriverChain || 'DriverChain' === $driverName) {
+        if ($omDriver instanceof MappingDriverChain || strpos($driverName, 'DriverChain')) {
             $driver = new Driver\Chain();
             foreach ($omDriver->getDrivers() as $namespace => $nestedOmDriver) {
                 $driver->addDriver($this->getDriver($nestedOmDriver), $namespace);


### PR DESCRIPTION
with doctrine 2.14.1 the driverName is `MappingDriverChain`, that results in the `MetadataFactory` with exception `... extension driver was not found`