### PR TITLE
Remove @final annotation from listener class

### DIFF
--- a/src/Loggable/LoggableListener.php
+++ b/src/Loggable/LoggableListener.php
@@ -32,8 +32,6 @@ use Gedmo\Tool\Wrapper\AbstractWrapper;
  * @phpstan-method LoggableConfiguration getConfiguration(ObjectManager $objectManager, $class)
  *
  * @method LoggableAdapter getEventAdapter(EventArgs $args)
- *
- * @final since gedmo/doctrine-extensions 3.11
  */
 class LoggableListener extends MappedEventSubscriber
 {


### PR DESCRIPTION

The `LoggableListener` class has a protected method, which is a clear inheritance extension point:

https://github.com/doctrine-extensions/DoctrineExtensions/blob/a2364710d2f367f74d9f041c3356f2929b8c6690/src/Loggable/LoggableListener.php#L215-L226

Until there is no clear solution offered, to achieve the same goals without inheritance (or copy&pasting code), the simplest solution is to revert the `final`.

See discussion in #2574
