### PR TITLE
[SoftDeleteable] Fix soft-deleting an object which proxy was not yet initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ a release.
 ---
 
 ## [Unreleased]
+### Fixed
+- SoftDeleteable: Fix issue with soft-deleting objects which proxy was not yet initialized
 
 ## [3.11.1] - 2023-02-20
 ### Fixed


### PR DESCRIPTION
I ran into issues where if an object proxy is not yet initialized ( due to being loaded as a relation, but not yet fetched from the database ) and that object is deleted, the soft-delete listener fails and InvalidArgumentException is thrown with a message: "Document is removed.".

This is because the proxy will be initialized when setValue is called in the listener, the object is initialized which causes it's state to be changed from removed to managed. This then causes problem when the object is persisted ( the document is not removed from the objects scheduled for deletion ). 

This PR fixes this edge-case by checking making sure the object is initialized in the preRemove event.