### PR TITLE
Prioritize the values from the named arguments in the annotation classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ a release.
 - Tree: `setSibling()` and `getSibling()` methods in the `Node` interface through the BC `@method` annotation
 
 ### Changed
-- Removed conflict against "doctrine/cache" < 1.11, as this library is not used.
+- Named arguments have precedence over the values passed in the `$data` array in annotation classes at `Gedmo\Mapping\Annotation\`
+  namespace
+- Removed conflict against "doctrine/cache" < 1.11, as this library is not used
 
 ### Fixed
 - Tree: Creation of dynamic `Node::$sibling` property, which is deprecated as of PHP >= 8.2

--- a/src/Mapping/Annotation/Blameable.php
+++ b/src/Mapping/Annotation/Blameable.php
@@ -25,6 +25,8 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class Blameable implements GedmoAnnotation
 {
+    use ForwardCompatibilityTrait;
+
     /** @var string */
     public $on = 'update';
     /** @var string|string[] */
@@ -43,10 +45,18 @@ final class Blameable implements GedmoAnnotation
                 'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
                 __METHOD__
             ), E_USER_DEPRECATED);
+
+            $args = func_get_args();
+
+            $this->on = $this->getAttributeValue($data, 'on', $args, 1, $on);
+            $this->field = $this->getAttributeValue($data, 'field', $args, 2, $field);
+            $this->value = $this->getAttributeValue($data, 'value', $args, 3, $value);
+
+            return;
         }
 
-        $this->on = $data['on'] ?? $on;
-        $this->field = $data['field'] ?? $field;
-        $this->value = $data['value'] ?? $value;
+        $this->on = $on;
+        $this->field = $field;
+        $this->value = $value;
     }
 }

--- a/src/Mapping/Annotation/ForwardCompatibilityTrait.php
+++ b/src/Mapping/Annotation/ForwardCompatibilityTrait.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Mapping\Annotation;
+
+/**
+ * @todo Remove this trait when support for array based attributes is removed.
+ *
+ * @internal
+ */
+trait ForwardCompatibilityTrait
+{
+    /**
+     * @param array<string, mixed> $data
+     * @param array<int, mixed>    $args
+     * @param mixed                $value
+     *
+     * @return mixed
+     */
+    private function getAttributeValue(array $data, string $attributeName, array $args, int $argumentNum, $value)
+    {
+        if (array_key_exists($argumentNum, $args)) {
+            return $args[$argumentNum];
+        }
+
+        if (array_key_exists($attributeName, $data)) {
+            return $data[$attributeName];
+        }
+
+        return $value;
+    }
+}

--- a/src/Mapping/Annotation/IpTraceable.php
+++ b/src/Mapping/Annotation/IpTraceable.php
@@ -25,6 +25,8 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class IpTraceable implements GedmoAnnotation
 {
+    use ForwardCompatibilityTrait;
+
     /** @var string */
     public $on = 'update';
     /** @var string|string[]|null */
@@ -43,10 +45,18 @@ final class IpTraceable implements GedmoAnnotation
                 'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
                 __METHOD__
             ), E_USER_DEPRECATED);
+
+            $args = func_get_args();
+
+            $this->on = $this->getAttributeValue($data, 'on', $args, 1, $on);
+            $this->field = $this->getAttributeValue($data, 'field', $args, 2, $field);
+            $this->value = $this->getAttributeValue($data, 'value', $args, 3, $value);
+
+            return;
         }
 
-        $this->on = $data['on'] ?? $on;
-        $this->field = $data['field'] ?? $field;
-        $this->value = $data['value'] ?? $value;
+        $this->on = $on;
+        $this->field = $field;
+        $this->value = $value;
     }
 }

--- a/src/Mapping/Annotation/Loggable.php
+++ b/src/Mapping/Annotation/Loggable.php
@@ -28,6 +28,8 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 #[Attribute(Attribute::TARGET_CLASS)]
 final class Loggable implements GedmoAnnotation
 {
+    use ForwardCompatibilityTrait;
+
     /**
      * @var string|null
      *
@@ -45,8 +47,14 @@ final class Loggable implements GedmoAnnotation
                 'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
                 __METHOD__
             ), E_USER_DEPRECATED);
+
+            $args = func_get_args();
+
+            $this->logEntryClass = $this->getAttributeValue($data, 'logEntryClass', $args, 1, $logEntryClass);
+
+            return;
         }
 
-        $this->logEntryClass = $data['logEntryClass'] ?? $logEntryClass;
+        $this->logEntryClass = $logEntryClass;
     }
 }

--- a/src/Mapping/Annotation/Reference.php
+++ b/src/Mapping/Annotation/Reference.php
@@ -21,6 +21,8 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  */
 abstract class Reference implements GedmoAnnotation
 {
+    use ForwardCompatibilityTrait;
+
     /**
      * @var string|null
      * @phpstan-var 'entity'|'document'|null
@@ -64,12 +66,22 @@ abstract class Reference implements GedmoAnnotation
                 'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
                 __METHOD__
             ), E_USER_DEPRECATED);
+
+            $args = func_get_args();
+
+            $this->type = $this->getAttributeValue($data, 'type', $args, 1, $type);
+            $this->class = $this->getAttributeValue($data, 'class', $args, 2, $class);
+            $this->identifier = $this->getAttributeValue($data, 'identifier', $args, 3, $identifier);
+            $this->mappedBy = $this->getAttributeValue($data, 'mappedBy', $args, 4, $mappedBy);
+            $this->inversedBy = $this->getAttributeValue($data, 'inversedBy', $args, 5, $inversedBy);
+
+            return;
         }
 
-        $this->type = $data['type'] ?? $type;
-        $this->class = $data['class'] ?? $class;
-        $this->identifier = $data['identifier'] ?? $identifier;
-        $this->mappedBy = $data['mappedBy'] ?? $mappedBy;
-        $this->inversedBy = $data['inversedBy'] ?? $inversedBy;
+        $this->type = $type;
+        $this->class = $class;
+        $this->identifier = $identifier;
+        $this->mappedBy = $mappedBy;
+        $this->inversedBy = $inversedBy;
     }
 }

--- a/src/Mapping/Annotation/ReferenceIntegrity.php
+++ b/src/Mapping/Annotation/ReferenceIntegrity.php
@@ -25,6 +25,8 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class ReferenceIntegrity implements GedmoAnnotation
 {
+    use ForwardCompatibilityTrait;
+
     /** @var string|null */
     public $value;
 
@@ -34,14 +36,20 @@ final class ReferenceIntegrity implements GedmoAnnotation
     public function __construct($data = [], ?string $value = null)
     {
         if (is_string($data)) {
-            $data = ['value' => $data];
+            $value = $data;
         } elseif ([] !== $data) {
             @trigger_error(sprintf(
                 'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
                 __METHOD__
             ), E_USER_DEPRECATED);
+
+            $args = func_get_args();
+
+            $this->value = $this->getAttributeValue($data, 'value', $args, 1, $value);
+
+            return;
         }
 
-        $this->value = $data['value'] ?? $value;
+        $this->value = $value;
     }
 }

--- a/src/Mapping/Annotation/Slug.php
+++ b/src/Mapping/Annotation/Slug.php
@@ -25,6 +25,8 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class Slug implements GedmoAnnotation
 {
+    use ForwardCompatibilityTrait;
+
     /** @var string[] @Required */
     public $fields = [];
     /** @var bool */
@@ -68,17 +70,32 @@ final class Slug implements GedmoAnnotation
                 'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
                 __METHOD__
             ), E_USER_DEPRECATED);
+
+            $args = func_get_args();
+
+            $this->fields = $this->getAttributeValue($data, 'fields', $args, 1, $fields);
+            $this->updatable = $this->getAttributeValue($data, 'updatable', $args, 2, $updatable);
+            $this->style = $this->getAttributeValue($data, 'style', $args, 3, $style);
+            $this->unique = $this->getAttributeValue($data, 'unique', $args, 4, $unique);
+            $this->unique_base = $this->getAttributeValue($data, 'unique_base', $args, 5, $unique_base);
+            $this->separator = $this->getAttributeValue($data, 'separator', $args, 6, $separator);
+            $this->prefix = $this->getAttributeValue($data, 'prefix', $args, 7, $prefix);
+            $this->suffix = $this->getAttributeValue($data, 'suffix', $args, 8, $suffix);
+            $this->handlers = $this->getAttributeValue($data, 'handlers', $args, 9, $handlers);
+            $this->dateFormat = $this->getAttributeValue($data, 'dateFormat', $args, 10, $dateFormat);
+
+            return;
         }
 
-        $this->fields = $data['fields'] ?? $fields;
-        $this->updatable = $data['updatable'] ?? $updatable;
-        $this->style = $data['style'] ?? $style;
-        $this->unique = $data['unique'] ?? $unique;
-        $this->unique_base = $data['unique_base'] ?? $unique_base;
-        $this->separator = $data['separator'] ?? $separator;
-        $this->prefix = $data['prefix'] ?? $prefix;
-        $this->suffix = $data['suffix'] ?? $suffix;
-        $this->handlers = $data['handlers'] ?? $handlers;
-        $this->dateFormat = $data['dateFormat'] ?? $dateFormat;
+        $this->fields = $fields;
+        $this->updatable = $updatable;
+        $this->style = $style;
+        $this->unique = $unique;
+        $this->unique_base = $unique_base;
+        $this->separator = $separator;
+        $this->prefix = $prefix;
+        $this->suffix = $suffix;
+        $this->handlers = $handlers;
+        $this->dateFormat = $dateFormat;
     }
 }

--- a/src/Mapping/Annotation/SlugHandler.php
+++ b/src/Mapping/Annotation/SlugHandler.php
@@ -25,6 +25,8 @@ use Gedmo\Sluggable\Handler\SlugHandlerInterface;
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 final class SlugHandler implements GedmoAnnotation
 {
+    use ForwardCompatibilityTrait;
+
     /**
      * @var string
      * @phpstan-var string|class-string<SlugHandlerInterface>
@@ -49,9 +51,16 @@ final class SlugHandler implements GedmoAnnotation
                 'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
                 __METHOD__
             ), E_USER_DEPRECATED);
+
+            $args = func_get_args();
+
+            $this->class = $this->getAttributeValue($data, 'class', $args, 1, $class);
+            $this->options = $this->getAttributeValue($data, 'options', $args, 2, $options);
+
+            return;
         }
 
-        $this->class = $data['class'] ?? $class;
-        $this->options = $data['options'] ?? $options;
+        $this->class = $class;
+        $this->options = $options;
     }
 }

--- a/src/Mapping/Annotation/SlugHandlerOption.php
+++ b/src/Mapping/Annotation/SlugHandlerOption.php
@@ -22,6 +22,8 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  */
 final class SlugHandlerOption implements GedmoAnnotation
 {
+    use ForwardCompatibilityTrait;
+
     /**
      * @var string
      */
@@ -45,9 +47,16 @@ final class SlugHandlerOption implements GedmoAnnotation
                 'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
                 __METHOD__
             ), E_USER_DEPRECATED);
+
+            $args = func_get_args();
+
+            $this->name = $this->getAttributeValue($data, 'name', $args, 1, $name);
+            $this->value = $this->getAttributeValue($data, 'value', $args, 2, $value);
+
+            return;
         }
 
-        $this->name = $data['name'] ?? $name;
-        $this->value = $data['value'] ?? $value;
+        $this->name = $name;
+        $this->value = $value;
     }
 }

--- a/src/Mapping/Annotation/SoftDeleteable.php
+++ b/src/Mapping/Annotation/SoftDeleteable.php
@@ -25,6 +25,8 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 #[Attribute(Attribute::TARGET_CLASS)]
 final class SoftDeleteable implements GedmoAnnotation
 {
+    use ForwardCompatibilityTrait;
+
     /** @var string */
     public $fieldName = 'deletedAt';
 
@@ -41,10 +43,18 @@ final class SoftDeleteable implements GedmoAnnotation
                 'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
                 __METHOD__
             ), E_USER_DEPRECATED);
+
+            $args = func_get_args();
+
+            $this->fieldName = $this->getAttributeValue($data, 'fieldName', $args, 1, $fieldName);
+            $this->timeAware = $this->getAttributeValue($data, 'timeAware', $args, 2, $timeAware);
+            $this->hardDelete = $this->getAttributeValue($data, 'hardDelete', $args, 3, $hardDelete);
+
+            return;
         }
 
-        $this->fieldName = $data['fieldName'] ?? $fieldName;
-        $this->timeAware = $data['timeAware'] ?? $timeAware;
-        $this->hardDelete = $data['hardDelete'] ?? $hardDelete;
+        $this->fieldName = $fieldName;
+        $this->timeAware = $timeAware;
+        $this->hardDelete = $hardDelete;
     }
 }

--- a/src/Mapping/Annotation/Timestampable.php
+++ b/src/Mapping/Annotation/Timestampable.php
@@ -25,6 +25,8 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class Timestampable implements GedmoAnnotation
 {
+    use ForwardCompatibilityTrait;
+
     /** @var string */
     public $on = 'update';
     /** @var string|string[] */
@@ -43,10 +45,18 @@ final class Timestampable implements GedmoAnnotation
                 'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
                 __METHOD__
             ), E_USER_DEPRECATED);
+
+            $args = func_get_args();
+
+            $this->on = $this->getAttributeValue($data, 'on', $args, 1, $on);
+            $this->field = $this->getAttributeValue($data, 'field', $args, 2, $field);
+            $this->value = $this->getAttributeValue($data, 'value', $args, 3, $value);
+
+            return;
         }
 
-        $this->on = $data['on'] ?? $on;
-        $this->field = $data['field'] ?? $field;
-        $this->value = $data['value'] ?? $value;
+        $this->on = $on;
+        $this->field = $field;
+        $this->value = $value;
     }
 }

--- a/src/Mapping/Annotation/Translatable.php
+++ b/src/Mapping/Annotation/Translatable.php
@@ -25,6 +25,8 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class Translatable implements GedmoAnnotation
 {
+    use ForwardCompatibilityTrait;
+
     /** @var bool|null */
     public $fallback;
 
@@ -35,8 +37,14 @@ final class Translatable implements GedmoAnnotation
                 'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
                 __METHOD__
             ), E_USER_DEPRECATED);
+
+            $args = func_get_args();
+
+            $this->fallback = $this->getAttributeValue($data, 'fallback', $args, 1, $fallback);
+
+            return;
         }
 
-        $this->fallback = $data['fallback'] ?? $fallback;
+        $this->fallback = $fallback;
     }
 }

--- a/src/Mapping/Annotation/TranslationEntity.php
+++ b/src/Mapping/Annotation/TranslationEntity.php
@@ -25,6 +25,8 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 #[Attribute(Attribute::TARGET_CLASS)]
 final class TranslationEntity implements GedmoAnnotation
 {
+    use ForwardCompatibilityTrait;
+
     /** @var string @Required */
     public $class;
 
@@ -35,8 +37,14 @@ final class TranslationEntity implements GedmoAnnotation
                 'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
                 __METHOD__
             ), E_USER_DEPRECATED);
+
+            $args = func_get_args();
+
+            $this->class = $this->getAttributeValue($data, 'class', $args, 1, $class);
+
+            return;
         }
 
-        $this->class = $data['class'] ?? $class;
+        $this->class = $class;
     }
 }

--- a/src/Mapping/Annotation/Tree.php
+++ b/src/Mapping/Annotation/Tree.php
@@ -25,6 +25,8 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 #[Attribute(Attribute::TARGET_CLASS)]
 final class Tree implements GedmoAnnotation
 {
+    use ForwardCompatibilityTrait;
+
     /**
      * @var string
      * @phpstan-var 'closure'|'materializedPath'|'nested'
@@ -62,11 +64,20 @@ final class Tree implements GedmoAnnotation
                 'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
                 __METHOD__
             ), E_USER_DEPRECATED);
+
+            $args = func_get_args();
+
+            $this->type = $this->getAttributeValue($data, 'type', $args, 1, $type);
+            $this->activateLocking = $this->getAttributeValue($data, 'activateLocking', $args, 2, $activateLocking);
+            $this->lockingTimeout = $this->getAttributeValue($data, 'lockingTimeout', $args, 3, $lockingTimeout);
+            $this->identifierMethod = $this->getAttributeValue($data, 'identifierMethod', $args, 4, $identifierMethod);
+
+            return;
         }
 
-        $this->type = $data['type'] ?? $type;
-        $this->activateLocking = $data['activateLocking'] ?? $activateLocking;
-        $this->lockingTimeout = $data['lockingTimeout'] ?? $lockingTimeout;
-        $this->identifierMethod = $data['identifierMethod'] ?? $identifierMethod;
+        $this->type = $type;
+        $this->activateLocking = $activateLocking;
+        $this->lockingTimeout = $lockingTimeout;
+        $this->identifierMethod = $identifierMethod;
     }
 }

--- a/src/Mapping/Annotation/TreeClosure.php
+++ b/src/Mapping/Annotation/TreeClosure.php
@@ -26,6 +26,8 @@ use Gedmo\Tree\Entity\MappedSuperclass\AbstractClosure;
 #[Attribute(Attribute::TARGET_CLASS)]
 final class TreeClosure implements GedmoAnnotation
 {
+    use ForwardCompatibilityTrait;
+
     /**
      * @var string
      * @phpstan-var string|class-string<AbstractClosure>
@@ -42,8 +44,14 @@ final class TreeClosure implements GedmoAnnotation
                 'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
                 __METHOD__
             ), E_USER_DEPRECATED);
+
+            $args = func_get_args();
+
+            $this->class = $this->getAttributeValue($data, 'class', $args, 1, $class);
+
+            return;
         }
 
-        $this->class = $data['class'] ?? $class;
+        $this->class = $class;
     }
 }

--- a/src/Mapping/Annotation/TreeLevel.php
+++ b/src/Mapping/Annotation/TreeLevel.php
@@ -25,6 +25,8 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class TreeLevel implements GedmoAnnotation
 {
+    use ForwardCompatibilityTrait;
+
     /**
      * The level which root nodes will have
      *
@@ -41,8 +43,14 @@ final class TreeLevel implements GedmoAnnotation
                 'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
                 __METHOD__
             ), E_USER_DEPRECATED);
+
+            $args = func_get_args();
+
+            $this->base = $this->getAttributeValue($data, 'base', $args, 1, $base);
+
+            return;
         }
 
-        $this->base = $data['base'] ?? $base;
+        $this->base = $base;
     }
 }

--- a/src/Mapping/Annotation/TreePath.php
+++ b/src/Mapping/Annotation/TreePath.php
@@ -27,6 +27,8 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class TreePath implements GedmoAnnotation
 {
+    use ForwardCompatibilityTrait;
+
     /** @var string */
     public $separator = ',';
 
@@ -51,11 +53,20 @@ final class TreePath implements GedmoAnnotation
                 'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
                 __METHOD__
             ), E_USER_DEPRECATED);
+
+            $args = func_get_args();
+
+            $this->separator = $this->getAttributeValue($data, 'separator', $args, 1, $separator);
+            $this->appendId = $this->getAttributeValue($data, 'appendId', $args, 2, $appendId);
+            $this->startsWithSeparator = $this->getAttributeValue($data, 'startsWithSeparator', $args, 3, $startsWithSeparator);
+            $this->endsWithSeparator = $this->getAttributeValue($data, 'endsWithSeparator', $args, 4, $endsWithSeparator);
+
+            return;
         }
 
-        $this->separator = $data['separator'] ?? $separator;
-        $this->appendId = $data['appendId'] ?? $appendId;
-        $this->startsWithSeparator = $data['startsWithSeparator'] ?? $startsWithSeparator;
-        $this->endsWithSeparator = $data['endsWithSeparator'] ?? $endsWithSeparator;
+        $this->separator = $separator;
+        $this->appendId = $appendId;
+        $this->startsWithSeparator = $startsWithSeparator;
+        $this->endsWithSeparator = $endsWithSeparator;
     }
 }

--- a/src/Mapping/Annotation/TreeRoot.php
+++ b/src/Mapping/Annotation/TreeRoot.php
@@ -25,6 +25,8 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class TreeRoot implements GedmoAnnotation
 {
+    use ForwardCompatibilityTrait;
+
     /** @var string|null */
     public $identifierMethod;
 
@@ -35,8 +37,14 @@ final class TreeRoot implements GedmoAnnotation
                 'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
                 __METHOD__
             ), E_USER_DEPRECATED);
+
+            $args = func_get_args();
+
+            $this->identifierMethod = $this->getAttributeValue($data, 'identifierMethod', $args, 1, $identifierMethod);
+
+            return;
         }
 
-        $this->identifierMethod = $data['identifierMethod'] ?? $identifierMethod;
+        $this->identifierMethod = $identifierMethod;
     }
 }

--- a/src/Mapping/Annotation/Uploadable.php
+++ b/src/Mapping/Annotation/Uploadable.php
@@ -28,6 +28,8 @@ use Gedmo\Uploadable\Mapping\Validator;
 #[Attribute(Attribute::TARGET_CLASS)]
 final class Uploadable implements GedmoAnnotation
 {
+    use ForwardCompatibilityTrait;
+
     /**
      * @var bool
      */
@@ -92,16 +94,30 @@ final class Uploadable implements GedmoAnnotation
                 'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
                 __METHOD__
             ), E_USER_DEPRECATED);
+
+            $args = func_get_args();
+
+            $this->allowOverwrite = $this->getAttributeValue($data, 'allowOverwrite', $args, 1, $allowOverwrite);
+            $this->appendNumber = $this->getAttributeValue($data, 'appendNumber', $args, 2, $appendNumber);
+            $this->path = $this->getAttributeValue($data, 'path', $args, 3, $path);
+            $this->pathMethod = $this->getAttributeValue($data, 'pathMethod', $args, 4, $pathMethod);
+            $this->callback = $this->getAttributeValue($data, 'callback', $args, 5, $callback);
+            $this->filenameGenerator = $this->getAttributeValue($data, 'filenameGenerator', $args, 6, $filenameGenerator);
+            $this->maxSize = $this->getAttributeValue($data, 'maxSize', $args, 7, $maxSize);
+            $this->allowedTypes = $this->getAttributeValue($data, 'allowedTypes', $args, 8, $allowedTypes);
+            $this->disallowedTypes = $this->getAttributeValue($data, 'disallowedTypes', $args, 9, $disallowedTypes);
+
+            return;
         }
 
-        $this->allowOverwrite = $data['allowOverwrite'] ?? $allowOverwrite;
-        $this->appendNumber = $data['appendNumber'] ?? $appendNumber;
-        $this->path = $data['path'] ?? $path;
-        $this->pathMethod = $data['pathMethod'] ?? $pathMethod;
-        $this->callback = $data['callback'] ?? $callback;
-        $this->filenameGenerator = $data['filenameGenerator'] ?? $filenameGenerator;
-        $this->maxSize = $data['maxSize'] ?? $maxSize;
-        $this->allowedTypes = $data['allowedTypes'] ?? $allowedTypes;
-        $this->disallowedTypes = $data['disallowedTypes'] ?? $disallowedTypes;
+        $this->allowOverwrite = $allowOverwrite;
+        $this->appendNumber = $appendNumber;
+        $this->path = $path;
+        $this->pathMethod = $pathMethod;
+        $this->callback = $callback;
+        $this->filenameGenerator = $filenameGenerator;
+        $this->maxSize = $maxSize;
+        $this->allowedTypes = $allowedTypes;
+        $this->disallowedTypes = $disallowedTypes;
     }
 }

--- a/tests/Gedmo/Mapping/Annotation/AnnotationArgumentsTest.php
+++ b/tests/Gedmo/Mapping/Annotation/AnnotationArgumentsTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Mapping\Annotation;
+
+use Gedmo\Mapping\Annotation\Annotation;
+use Gedmo\Mapping\Annotation\Blameable;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+
+/**
+ * Remove this class when support for array based attributes in annotation classes is removed.
+ *
+ * @group legacy
+ */
+final class AnnotationArgumentsTest extends TestCase
+{
+    use ExpectDeprecationTrait;
+
+    /**
+     * @param array<string, mixed> $expected
+     * @param mixed[]              $args
+     *
+     * @dataProvider getGedmoAnnotations
+     *
+     * @param class-string<Annotation> $class
+     */
+    public function testArguments(array $expected, string $class, array $args, ?string $expectedDeprecation = null): void
+    {
+        if (null !== $expectedDeprecation) {
+            $this->expectDeprecation($expectedDeprecation);
+        }
+
+        $annotation = new $class(...$args);
+
+        foreach ($expected as $attribute => $value) {
+            static::assertSame($value, $annotation->$attribute);
+        }
+    }
+
+    public function getGedmoAnnotations(): iterable
+    {
+        yield 'args_without_data' => [['on' => 'delete', 'field' => 'some'], Blameable::class, [[], 'delete', 'some']];
+        yield 'default_values_without_args' => [['on' => 'update', 'field' => null, 'value' => null], Blameable::class, []];
+        yield 'default_values_with_args' => [['on' => 'update', 'field' => null, 'value' => null], Blameable::class, [[], 'update']];
+
+        yield 'args_with_data' => [
+            ['on' => 'delete', 'field' => 'some'],
+            Blameable::class, [['on' => 'change', 'field' => 'id'], 'delete', 'some'],
+            'Passing an array as first argument to "Gedmo\Mapping\Annotation\%s::__construct()" is deprecated. Use named arguments instead.',
+        ];
+        yield 'data_without_args' => [
+            ['on' => 'change', 'field' => 'id'],
+            Blameable::class, [['on' => 'change', 'field' => 'id']],
+            'Passing an array as first argument to "Gedmo\Mapping\Annotation\%s::__construct()" is deprecated. Use named arguments instead.',
+        ];
+        yield 'default_values_with_args_and_data' => [
+            ['on' => 'update', 'field' => null, 'value' => null],
+            Blameable::class, [['on' => 'change'], 'update'],
+            'Passing an array as first argument to "Gedmo\Mapping\Annotation\%s::__construct()" is deprecated. Use named arguments instead.',
+        ];
+    }
+}


### PR DESCRIPTION
Named arguments have precedence over the values passed in the `$data` array in annotation classes at `Gedmo\Mapping\Annotation\`  namespace.