### PR TITLE
Remove @final annotation on TranslatableListener

### DIFF
--- a/src/Translatable/TranslatableListener.php
+++ b/src/Translatable/TranslatableListener.php
@@ -46,8 +46,6 @@ use Gedmo\Translatable\Mapping\Event\TranslatableAdapter;
  * @phpstan-method TranslatableConfiguration getConfiguration(ObjectManager $objectManager, $class)
  *
  * @method TranslatableAdapter getEventAdapter(EventArgs $args)
- *
- * @final since gedmo/doctrine-extensions 3.11
  */
 class TranslatableListener extends MappedEventSubscriber
 {


### PR DESCRIPTION
As discussed with @franmomu on the [Symfony Slack](https://symfony-devs.slack.com/archives/C3FQPE6LE/p1678979387553729) (link if you have access), I propose to remove the `@final` annotation as there is no alternative at the moment to extend the behavior.

Initially my problem was that after upgrading to the latest version, I get a warning because I'm extending a class marked final to change the subscribed events:

```php
<?php

namespace App\Translation;

use Gedmo\Translatable\TranslatableListener as GedmoTranslatableListener;

class TranslatableListener extends GedmoTranslatableListener
{
    /**
     * @return string[]
     */
    public function getSubscribedEvents(): array
    {
        return [
            'postLoad',
            'loadClassMetadata',
        ];
    }
}
```