### PR TITLE
[Tree] `recover()` supports multiple fields in sortByField and sortDirection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ a release.
 ## [Unreleased]
 ### Added
 - Tree: `setSibling()` and `getSibling()` methods in the `Node` interface through the BC `@method` annotation
+- Tree: Support array of fields and directions in the `$sortByField` and `$direction` parameters at `AbstractTreeRepository::recover()`
 
 ### Changed
 - Named arguments have precedence over the values passed in the `$data` array in annotation classes at `Gedmo\Mapping\Annotation\`

--- a/doc/tree.md
+++ b/doc/tree.md
@@ -1224,8 +1224,8 @@ And that's it!
 There are repository methods that are available for you in all the strategies:
 
 * **getRootNodes** / **getRootNodesQuery** / **getRootNodesQueryBuilder**: Returns an array with the available root nodes. Arguments:
-  - *sortByField*: An optional field to order the root nodes. Defaults to "null".
-  - *direction*: In case the first argument is used, you can pass the direction here: "asc" or "desc". Defaults to "asc".
+  - *sortByField*: array<string> || string - An optional array of fields or field to order the root nodes. Defaults to "null".
+  - *direction*: array<string> || string - In case the first argument is used, you can pass the direction here: array of values or single value: "asc" or "desc". Defaults to "asc".
 * **getChildren** / **getChildrenQuery** / **getChildrenQueryBuilder**: Returns an array of children nodes. Arguments:
   - *node*: If you pass a node, the method will return its children. Defaults to "null" (this means it will return ALL nodes).
   - *direct*: If you pass true as a value for this argument, you'll get only the direct children of the node

--- a/src/Tree/Entity/Repository/AbstractTreeRepository.php
+++ b/src/Tree/Entity/Repository/AbstractTreeRepository.php
@@ -165,8 +165,8 @@ abstract class AbstractTreeRepository extends EntityRepository implements Reposi
     /**
      * Get all root nodes query builder
      *
-     * @param string|null $sortByField Sort by field
-     * @param string      $direction   Sort direction ("asc" or "desc")
+     * @param string|string[]|null $sortByField Sort by field
+     * @param string|string[]      $direction   Sort direction ("asc" or "desc")
      *
      * @return QueryBuilder QueryBuilder object
      */
@@ -175,8 +175,8 @@ abstract class AbstractTreeRepository extends EntityRepository implements Reposi
     /**
      * Get all root nodes query
      *
-     * @param string|null $sortByField Sort by field
-     * @param string      $direction   Sort direction ("asc" or "desc")
+     * @param string|string[]|null $sortByField Sort by field
+     * @param string|string[]      $direction   Sort direction ("asc" or "desc")
      *
      * @return Query Query object
      */

--- a/src/Tree/Entity/Repository/ClosureTreeRepository.php
+++ b/src/Tree/Entity/Repository/ClosureTreeRepository.php
@@ -38,8 +38,15 @@ class ClosureTreeRepository extends AbstractTreeRepository
             ->from($config['useObjectClass'], 'node')
             ->where('node.'.$config['parent'].' IS NULL');
 
-        if ($sortByField) {
-            $qb->orderBy('node.'.$sortByField, 'asc' === strtolower($direction) ? 'asc' : 'desc');
+        if (null !== $sortByField) {
+            $sortByField = (array) $sortByField;
+            $direction = (array) $direction;
+            foreach ($sortByField as $key => $field) {
+                $fieldDirection = $direction[$key] ?? 'asc';
+                if ($meta->hasField($field) || $meta->isSingleValuedAssociation($field)) {
+                    $qb->addOrderBy('node.'.$field, 'asc' === strtolower($fieldDirection) ? 'asc' : 'desc');
+                }
+            }
         }
 
         return $qb;

--- a/src/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/src/Tree/Entity/Repository/NestedTreeRepository.php
@@ -140,7 +140,14 @@ class NestedTreeRepository extends AbstractTreeRepository
         ;
 
         if (null !== $sortByField) {
-            $qb->orderBy('node.'.$sortByField, 'asc' === strtolower($direction) ? 'asc' : 'desc');
+            $sortByField = (array) $sortByField;
+            $direction = (array) $direction;
+            foreach ($sortByField as $key => $field) {
+                $fieldDirection = $direction[$key] ?? 'asc';
+                if ($meta->hasField($field) || $meta->isSingleValuedAssociation($field)) {
+                    $qb->addOrderBy('node.'.$field, 'asc' === strtolower($fieldDirection) ? 'asc' : 'desc');
+                }
+            }
         } else {
             $qb->orderBy('node.'.$config['left'], 'ASC');
         }

--- a/tests/Gedmo/Tree/NestedTreeRootRepositoryTest.php
+++ b/tests/Gedmo/Tree/NestedTreeRootRepositoryTest.php
@@ -482,6 +482,29 @@ final class NestedTreeRootRepositoryTest extends BaseTestCaseORM
         static::assertSame(2, $potatoes->getLeft());
         static::assertSame(3, $potatoes->getRight());
 
+        // recover with specified order with multiple fields
+
+        $repo->recover([
+            'flush' => true,
+            'treeRootNode' => $repo->find(1),
+            'skipVerify' => true,
+            'sortByField' => [
+                0 => 'title',
+                1 => 'title',
+            ],
+            'sortDirection' => [
+                0 => 'ASC',
+                1 => 'DESC',
+            ],
+        ]);
+        static::assertTrue($repo->verify());
+
+        $this->em->clear();
+        $potatoes = $repo->findOneBy(['title' => 'Potatoes']);
+
+        static::assertSame(8, $potatoes->getLeft());
+        static::assertSame(9, $potatoes->getRight());
+
         // test fast recover
 
         $dql = 'UPDATE '.self::CATEGORY.' node';


### PR DESCRIPTION
[Tree] `recover()` supports multiple fields in `sortByField` and `sortDirection` option