### PR TITLE
chore: fix deprecation message for node12 for github action "stale"

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,18 +10,18 @@ jobs:
 
     steps:
       - name: Close stale issues and pull requests
-        uses: actions/stale@v1.1.0
+        uses: actions/stale@v8
         with:
           days-before-close: 30
           days-before-stale: 180
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          exempt-issue-label: Still Relevant
-          stale-issue-label: Stale
+          exempt-issue-labels: 'Still Relevant'
+          stale-issue-label: 'Stale'
           stale-issue-message: >
             This issue has been automatically marked as stale because it has not had
             recent activity. It will be closed if no further activity occurs. Thank you
             for your contributions.
-          stale-pr-label: Stale
+          stale-pr-label: 'Stale'
           stale-pr-message: >
             This pull request has been automatically marked as stale because it has not had
             recent activity. It will be closed if no further activity occurs. Thank you


### PR DESCRIPTION
It looks like this is changes from single to multiple values allowed
https://github.com/actions/stale#exempt-issue-labels

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

I am not sure how to test it.