### PR TITLE
feat: fix deprecation for AbstractPlatform->getIsNullExpression()

### DIFF
--- a/src/SoftDeleteable/Filter/SoftDeleteableFilter.php
+++ b/src/SoftDeleteable/Filter/SoftDeleteableFilter.php
@@ -71,7 +71,7 @@ class SoftDeleteableFilter extends SQLFilter
 
         $column = $quoteStrategy->getColumnName($config['fieldName'], $targetEntity, $platform);
 
-        $addCondSql = $targetTableAlias.'.'.$column . ' IS NULL';
+        $addCondSql = $targetTableAlias.'.'.$column.' IS NULL';
         if (isset($config['timeAware']) && $config['timeAware']) {
             $addCondSql = "({$addCondSql} OR {$targetTableAlias}.{$column} > {$platform->getCurrentTimestampSQL()})";
         }

--- a/src/SoftDeleteable/Filter/SoftDeleteableFilter.php
+++ b/src/SoftDeleteable/Filter/SoftDeleteableFilter.php
@@ -71,7 +71,7 @@ class SoftDeleteableFilter extends SQLFilter
 
         $column = $quoteStrategy->getColumnName($config['fieldName'], $targetEntity, $platform);
 
-        $addCondSql = $platform->getIsNullExpression($targetTableAlias.'.'.$column);
+        $addCondSql = $targetTableAlias.'.'.$column . ' IS NULL';
         if (isset($config['timeAware']) && $config['timeAware']) {
             $addCondSql = "({$addCondSql} OR {$targetTableAlias}.{$column} > {$platform->getCurrentTimestampSQL()})";
         }


### PR DESCRIPTION
User Deprecated: AbstractPlatform::getIsNullExpression() is deprecated. Use IS NULL in SQL instead. (AbstractPlatform.php:1180 called by SoftDeleteableFilter.php:73, https://github.com/doctrine/dbal/pull/4724, package doctrine/dbal)