### PR TITLE
feat: allow friendsofphp/php-cs-fixer >= 3.10

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -52,6 +52,7 @@ return (new PhpCsFixer\Config())
         'no_homoglyph_names' => true,
         'no_null_property_initialization' => true,
         'no_superfluous_elseif' => true,
+        'no_superfluous_phpdoc_tags' => false,
         'no_unset_on_property' => true,
         'no_useless_else' => true,
         'nullable_type_declaration_for_default_null_value' => ['use_nullable_type_declaration' => true],

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -58,6 +58,12 @@ return (new PhpCsFixer\Config())
         'nullable_type_declaration_for_default_null_value' => ['use_nullable_type_declaration' => true],
         'ordered_class_elements' => true,
         'ordered_imports' => ['sort_algorithm' => 'alpha'],
+        'phpdoc_order' => ['order' => ['param', 'throws', 'return']],
+        'phpdoc_separation' => ['groups' => [
+            ['Gedmo\\*'],
+            ['ODM\\*'],
+            ['ORM\\*'],
+        ]],
         'phpdoc_summary' => false,
         'phpdoc_to_comment' => false,
         'php_unit_construct' => true,

--- a/composer.json
+++ b/composer.json
@@ -98,6 +98,7 @@
         }
     },
     "scripts": {
-        "fix-cs": "php-cs-fixer fix --config=.php-cs-fixer.dist.php"
+        "fix-cs": "php-cs-fixer fix",
+        "fix-cs-test": "php-cs-fixer fix --ansi --verbose --diff --dry-run"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "doctrine/doctrine-bundle": "^2.3",
         "doctrine/mongodb-odm": "^2.3",
         "doctrine/orm": "^2.14.0",
-        "friendsofphp/php-cs-fixer": "^3.4.0",
+        "friendsofphp/php-cs-fixer": "^3.14.0",
         "nesbot/carbon": "^2.55",
         "phpstan/phpstan": "^1.10.2",
         "phpstan/phpstan-doctrine": "^1.0",
@@ -98,7 +98,6 @@
         }
     },
     "scripts": {
-        "fix-cs": "php-cs-fixer fix",
-        "fix-cs-test": "php-cs-fixer fix --ansi --verbose --diff --dry-run"
+        "fix-cs": "php-cs-fixer fix --config=.php-cs-fixer.dist.php"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "doctrine/doctrine-bundle": "^2.3",
         "doctrine/mongodb-odm": "^2.3",
         "doctrine/orm": "^2.14.0",
-        "friendsofphp/php-cs-fixer": "^3.4.0 <3.10",
+        "friendsofphp/php-cs-fixer": "^3.4.0",
         "nesbot/carbon": "^2.55",
         "phpstan/phpstan": "^1.10.2",
         "phpstan/phpstan-doctrine": "^1.0",

--- a/example/app/Entity/Category.php
+++ b/example/app/Entity/Category.php
@@ -17,8 +17,10 @@ use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @Gedmo\Tree(type="nested")
+ *
  * @ORM\Table(name="ext_categories")
  * @ORM\Entity(repositoryClass="App\Entity\Repository\CategoryRepository")
+ *
  * @Gedmo\TranslationEntity(class="App\Entity\CategoryTranslation")
  */
 class Category
@@ -34,6 +36,7 @@ class Category
      * @var string|null
      *
      * @Gedmo\Translatable
+     *
      * @ORM\Column(length=64)
      */
     private $title;
@@ -42,6 +45,7 @@ class Category
      * @var string|null
      *
      * @Gedmo\Translatable
+     *
      * @ORM\Column(type="text", nullable=true)
      */
     private $description;
@@ -51,24 +55,28 @@ class Category
      *
      * @Gedmo\Translatable
      * @Gedmo\Slug(fields={"created", "title"})
+     *
      * @ORM\Column(length=64, unique=true)
      */
     private $slug;
 
     /**
      * @Gedmo\TreeLeft
+     *
      * @ORM\Column(type="integer")
      */
     private $lft;
 
     /**
      * @Gedmo\TreeRight
+     *
      * @ORM\Column(type="integer")
      */
     private $rgt;
 
     /**
      * @Gedmo\TreeParent
+     *
      * @ORM\ManyToOne(targetEntity="Category", inversedBy="children")
      * @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
      */
@@ -76,12 +84,14 @@ class Category
 
     /**
      * @Gedmo\TreeRoot
+     *
      * @ORM\Column(type="integer", nullable=true)
      */
     private $root;
 
     /**
      * @Gedmo\TreeLevel
+     *
      * @ORM\Column(name="lvl", type="integer")
      */
     private $level;
@@ -93,24 +103,28 @@ class Category
 
     /**
      * @Gedmo\Timestampable(on="create")
+     *
      * @ORM\Column(type="datetime")
      */
     private $created;
 
     /**
      * @Gedmo\Timestampable(on="update")
+     *
      * @ORM\Column(type="datetime")
      */
     private $updated;
 
     /**
      * @Gedmo\Blameable(on="create")
+     *
      * @ORM\Column(type="string")
      */
     private $createdBy;
 
     /**
      * @Gedmo\Blameable(on="update")
+     *
      * @ORM\Column(type="string")
      */
     private $updatedBy;

--- a/src/AbstractTrackingListener.php
+++ b/src/AbstractTrackingListener.php
@@ -47,6 +47,7 @@ abstract class AbstractTrackingListener extends MappedEventSubscriber
      * Maps additional metadata for the object.
      *
      * @param LoadClassMetadataEventArgs $eventArgs
+     *
      * @phpstan-param LoadClassMetadataEventArgs<ClassMetadata<object>, ObjectManager> $eventArgs
      *
      * @return void

--- a/src/Blameable/Mapping/Driver/Annotation.php
+++ b/src/Blameable/Mapping/Driver/Annotation.php
@@ -46,9 +46,9 @@ class Annotation extends AbstractAnnotationDriver
         $class = $this->getMetaReflectionClass($meta);
         // property annotations
         foreach ($class->getProperties() as $property) {
-            if ($meta->isMappedSuperclass && !$property->isPrivate() ||
-                $meta->isInheritedField($property->name) ||
-                isset($meta->associationMappings[$property->name]['inherited'])
+            if ($meta->isMappedSuperclass && !$property->isPrivate()
+                || $meta->isInheritedField($property->name)
+                || isset($meta->associationMappings[$property->name]['inherited'])
             ) {
                 continue;
             }

--- a/src/Blameable/Traits/BlameableDocument.php
+++ b/src/Blameable/Traits/BlameableDocument.php
@@ -22,7 +22,9 @@ trait BlameableDocument
 {
     /**
      * @var string
+     *
      * @Gedmo\Blameable(on="create")
+     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: Type::STRING)]
@@ -31,7 +33,9 @@ trait BlameableDocument
 
     /**
      * @var string
+     *
      * @Gedmo\Blameable(on="update")
+     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: Type::STRING)]

--- a/src/Blameable/Traits/BlameableEntity.php
+++ b/src/Blameable/Traits/BlameableEntity.php
@@ -21,7 +21,9 @@ trait BlameableEntity
 {
     /**
      * @var string
+     *
      * @Gedmo\Blameable(on="create")
+     *
      * @ORM\Column(nullable=true)
      */
     #[ORM\Column(nullable: true)]
@@ -30,7 +32,9 @@ trait BlameableEntity
 
     /**
      * @var string
+     *
      * @Gedmo\Blameable(on="update")
+     *
      * @ORM\Column(nullable=true)
      */
     #[ORM\Column(nullable: true)]

--- a/src/IpTraceable/Mapping/Driver/Annotation.php
+++ b/src/IpTraceable/Mapping/Driver/Annotation.php
@@ -44,9 +44,9 @@ class Annotation extends AbstractAnnotationDriver
         $class = $this->getMetaReflectionClass($meta);
         // property annotations
         foreach ($class->getProperties() as $property) {
-            if ($meta->isMappedSuperclass && !$property->isPrivate() ||
-                $meta->isInheritedField($property->name) ||
-                isset($meta->associationMappings[$property->name]['inherited'])
+            if ($meta->isMappedSuperclass && !$property->isPrivate()
+                || $meta->isInheritedField($property->name)
+                || isset($meta->associationMappings[$property->name]['inherited'])
             ) {
                 continue;
             }

--- a/src/IpTraceable/Traits/IpTraceableDocument.php
+++ b/src/IpTraceable/Traits/IpTraceableDocument.php
@@ -22,7 +22,9 @@ trait IpTraceableDocument
 {
     /**
      * @var string
+     *
      * @Gedmo\IpTraceable(on="create")
+     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: Type::STRING)]
@@ -31,7 +33,9 @@ trait IpTraceableDocument
 
     /**
      * @var string
+     *
      * @Gedmo\IpTraceable(on="update")
+     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: Type::STRING)]

--- a/src/IpTraceable/Traits/IpTraceableEntity.php
+++ b/src/IpTraceable/Traits/IpTraceableEntity.php
@@ -21,7 +21,9 @@ trait IpTraceableEntity
 {
     /**
      * @var string
+     *
      * @Gedmo\IpTraceable(on="create")
+     *
      * @ORM\Column(length=45, nullable=true)
      */
     #[ORM\Column(length: 45, nullable: true)]
@@ -30,7 +32,9 @@ trait IpTraceableEntity
 
     /**
      * @var string
+     *
      * @Gedmo\IpTraceable(on="update")
+     *
      * @ORM\Column(length=45, nullable=true)
      */
     #[ORM\Column(length: 45, nullable: true)]

--- a/src/Loggable/Document/LogEntry.php
+++ b/src/Loggable/Document/LogEntry.php
@@ -18,6 +18,7 @@ use Gedmo\Loggable\Loggable;
  * Gedmo\Loggable\Document\LogEntry
  *
  * @MongoODM\Document(repositoryClass="Gedmo\Loggable\Document\Repository\LogEntryRepository")
+ *
  * @MongoODM\Index(keys={"objectId": "asc", "objectClass": "asc", "version": "asc"})
  * @MongoODM\Index(keys={"loggedAt": "asc"})
  * @MongoODM\Index(keys={"objectClass": "asc"})

--- a/src/Loggable/LoggableListener.php
+++ b/src/Loggable/LoggableListener.php
@@ -126,6 +126,7 @@ class LoggableListener extends MappedEventSubscriber
      * Maps additional metadata
      *
      * @param LoadClassMetadataEventArgs $eventArgs
+     *
      * @phpstan-param LoadClassMetadataEventArgs<ClassMetadata<object>, ObjectManager> $eventArgs
      *
      * @return void
@@ -209,9 +210,11 @@ class LoggableListener extends MappedEventSubscriber
      * Get the LogEntry class
      *
      * @param string $class
+     *
      * @phpstan-param class-string $class
      *
      * @return string
+     *
      * @phpstan-return class-string<LogEntryInterface<T>>
      */
     protected function getLogEntryClass(LoggableAdapter $ea, $class)

--- a/src/Loggable/Mapping/Event/LoggableAdapter.php
+++ b/src/Loggable/Mapping/Event/LoggableAdapter.php
@@ -23,6 +23,7 @@ interface LoggableAdapter extends AdapterInterface
      * Get the default object class name used to store the log entries.
      *
      * @return string
+     *
      * @phpstan-return class-string
      */
     public function getDefaultLogEntryClass();

--- a/src/Mapping/Annotation/Blameable.php
+++ b/src/Mapping/Annotation/Blameable.php
@@ -16,7 +16,9 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * Blameable annotation for Blameable behavioral extension
  *
  * @Annotation
+ *
  * @NamedArgumentConstructor
+ *
  * @Target("PROPERTY")
  *
  * @author David Buchmann <mail@davidbu.ch>

--- a/src/Mapping/Annotation/IpTraceable.php
+++ b/src/Mapping/Annotation/IpTraceable.php
@@ -16,7 +16,9 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * IpTraceable annotation for IpTraceable behavioral extension
  *
  * @Annotation
+ *
  * @NamedArgumentConstructor
+ *
  * @Target("PROPERTY")
  *
  * @author Pierre-Charles Bertineau <pc.bertineau@alterphp.com>

--- a/src/Mapping/Annotation/Language.php
+++ b/src/Mapping/Annotation/Language.php
@@ -16,6 +16,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * Language annotation for Translatable behavioral extension
  *
  * @Annotation
+ *
  * @Target("PROPERTY")
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>

--- a/src/Mapping/Annotation/Locale.php
+++ b/src/Mapping/Annotation/Locale.php
@@ -16,6 +16,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * Locale annotation for Translatable behavioral extension
  *
  * @Annotation
+ *
  * @Target("PROPERTY")
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>

--- a/src/Mapping/Annotation/Loggable.php
+++ b/src/Mapping/Annotation/Loggable.php
@@ -19,7 +19,9 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * @phpstan-template T of LogEntryInterface
  *
  * @Annotation
+ *
  * @NamedArgumentConstructor
+ *
  * @Target("CLASS")
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>

--- a/src/Mapping/Annotation/Reference.php
+++ b/src/Mapping/Annotation/Reference.php
@@ -17,6 +17,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * to be user like "@ReferenceMany(type="entity", class="MyEntity", identifier="entity_id")"
  *
  * @author Bulat Shakirzyanov <mallluhuct@gmail.com>
+ *
  * @Annotation
  */
 abstract class Reference implements GedmoAnnotation
@@ -25,12 +26,14 @@ abstract class Reference implements GedmoAnnotation
 
     /**
      * @var string|null
+     *
      * @phpstan-var 'entity'|'document'|null
      */
     public $type;
 
     /**
      * @var string|null
+     *
      * @phpstan-var class-string|null
      */
     public $class;

--- a/src/Mapping/Annotation/ReferenceIntegrity.php
+++ b/src/Mapping/Annotation/ReferenceIntegrity.php
@@ -16,7 +16,9 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * ReferenceIntegrity annotation for ReferenceIntegrity behavioral extension
  *
  * @Annotation
+ *
  * @NamedArgumentConstructor
+ *
  * @Target("PROPERTY")
  *
  * @author Evert Harmeling <evert.harmeling@freshheads.com>

--- a/src/Mapping/Annotation/ReferenceMany.php
+++ b/src/Mapping/Annotation/ReferenceMany.php
@@ -14,7 +14,9 @@ namespace Gedmo\Mapping\Annotation;
  * to be user like "@ReferenceMany(type="entity", class="MyEntity", identifier="entity_id")"
  *
  * @author Bulat Shakirzyanov <mallluhuct@gmail.com>
+ *
  * @NamedArgumentConstructor
+ *
  * @Annotation
  *
  * @final since gedmo/doctrine-extensions 3.11

--- a/src/Mapping/Annotation/ReferenceManyEmbed.php
+++ b/src/Mapping/Annotation/ReferenceManyEmbed.php
@@ -11,6 +11,7 @@ namespace Gedmo\Mapping\Annotation;
 
 /**
  * @NamedArgumentConstructor
+ *
  * @Annotation
  *
  * @final since gedmo/doctrine-extensions 3.11

--- a/src/Mapping/Annotation/Slug.php
+++ b/src/Mapping/Annotation/Slug.php
@@ -16,7 +16,9 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * Slug annotation for Sluggable behavioral extension
  *
  * @Annotation
+ *
  * @NamedArgumentConstructor
+ *
  * @Target("PROPERTY")
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>

--- a/src/Mapping/Annotation/SlugHandler.php
+++ b/src/Mapping/Annotation/SlugHandler.php
@@ -17,6 +17,7 @@ use Gedmo\Sluggable\Handler\SlugHandlerInterface;
  * SlugHandler annotation for Sluggable behavioral extension
  *
  * @Annotation
+ *
  * @NamedArgumentConstructor
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>

--- a/src/Mapping/Annotation/SlugHandlerOption.php
+++ b/src/Mapping/Annotation/SlugHandlerOption.php
@@ -16,6 +16,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * SlugHandlerOption annotation for Sluggable behavioral extension
  *
  * @Annotation
+ *
  * @NamedArgumentConstructor
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>

--- a/src/Mapping/Annotation/SoftDeleteable.php
+++ b/src/Mapping/Annotation/SoftDeleteable.php
@@ -18,7 +18,9 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * @author Gustavo Falco <comfortablynumb84@gmail.com>
  *
  * @Annotation
+ *
  * @NamedArgumentConstructor
+ *
  * @Target("CLASS")
  */
 #[\Attribute(\Attribute::TARGET_CLASS)]

--- a/src/Mapping/Annotation/SortableGroup.php
+++ b/src/Mapping/Annotation/SortableGroup.php
@@ -18,6 +18,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * @author Lukas Botsch <lukas.botsch@gmail.com>
  *
  * @Annotation
+ *
  * @Target("PROPERTY")
  */
 #[\Attribute(\Attribute::TARGET_PROPERTY)]

--- a/src/Mapping/Annotation/SortablePosition.php
+++ b/src/Mapping/Annotation/SortablePosition.php
@@ -18,6 +18,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * @author Lukas Botsch <lukas.botsch@gmail.com>
  *
  * @Annotation
+ *
  * @Target("PROPERTY")
  */
 #[\Attribute(\Attribute::TARGET_PROPERTY)]

--- a/src/Mapping/Annotation/Timestampable.php
+++ b/src/Mapping/Annotation/Timestampable.php
@@ -16,7 +16,9 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * Timestampable annotation for Timestampable behavioral extension
  *
  * @Annotation
+ *
  * @NamedArgumentConstructor
+ *
  * @Target("PROPERTY")
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>

--- a/src/Mapping/Annotation/Translatable.php
+++ b/src/Mapping/Annotation/Translatable.php
@@ -16,7 +16,9 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * Translatable annotation for Translatable behavioral extension
  *
  * @Annotation
+ *
  * @NamedArgumentConstructor
+ *
  * @Target("PROPERTY")
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>

--- a/src/Mapping/Annotation/TranslationEntity.php
+++ b/src/Mapping/Annotation/TranslationEntity.php
@@ -16,7 +16,9 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * TranslationEntity annotation for Translatable behavioral extension
  *
  * @Annotation
+ *
  * @NamedArgumentConstructor
+ *
  * @Target("CLASS")
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>

--- a/src/Mapping/Annotation/Tree.php
+++ b/src/Mapping/Annotation/Tree.php
@@ -16,7 +16,9 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * Tree annotation for Tree behavioral extension
  *
  * @Annotation
+ *
  * @NamedArgumentConstructor
+ *
  * @Target("CLASS")
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>

--- a/src/Mapping/Annotation/TreeClosure.php
+++ b/src/Mapping/Annotation/TreeClosure.php
@@ -17,7 +17,9 @@ use Gedmo\Tree\Entity\MappedSuperclass\AbstractClosure;
  * TreeClosure annotation for Tree behavioral extension
  *
  * @Annotation
+ *
  * @NamedArgumentConstructor
+ *
  * @Target("CLASS")
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>

--- a/src/Mapping/Annotation/TreeLeft.php
+++ b/src/Mapping/Annotation/TreeLeft.php
@@ -16,6 +16,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * TreeLeft annotation for Tree behavioral extension
  *
  * @Annotation
+ *
  * @Target("PROPERTY")
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>

--- a/src/Mapping/Annotation/TreeLevel.php
+++ b/src/Mapping/Annotation/TreeLevel.php
@@ -16,7 +16,9 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * TreeLevel annotation for Tree behavioral extension
  *
  * @Annotation
+ *
  * @NamedArgumentConstructor
+ *
  * @Target("PROPERTY")
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>

--- a/src/Mapping/Annotation/TreeLockTime.php
+++ b/src/Mapping/Annotation/TreeLockTime.php
@@ -16,6 +16,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * TreeLockTime annotation for Tree behavioral extension
  *
  * @Annotation
+ *
  * @Target("PROPERTY")
  *
  * @author Gustavo Falco <comfortablynumb84@gmail.com>

--- a/src/Mapping/Annotation/TreeParent.php
+++ b/src/Mapping/Annotation/TreeParent.php
@@ -16,6 +16,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * TreeParent annotation for Tree behavioral extension
  *
  * @Annotation
+ *
  * @Target("PROPERTY")
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>

--- a/src/Mapping/Annotation/TreePath.php
+++ b/src/Mapping/Annotation/TreePath.php
@@ -16,7 +16,9 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * TreePath annotation for Tree behavioral extension
  *
  * @Annotation
+ *
  * @NamedArgumentConstructor
+ *
  * @Target("PROPERTY")
  *
  * @author Gustavo Falco <comfortablynumb84@gmail.com>

--- a/src/Mapping/Annotation/TreePathHash.php
+++ b/src/Mapping/Annotation/TreePathHash.php
@@ -16,6 +16,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * TreePath annotation for Tree behavioral extension
  *
  * @Annotation
+ *
  * @Target("PROPERTY")
  *
  * @author <rocco@roccosportal.com>

--- a/src/Mapping/Annotation/TreePathSource.php
+++ b/src/Mapping/Annotation/TreePathSource.php
@@ -16,6 +16,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * TreePath annotation for Tree behavioral extension
  *
  * @Annotation
+ *
  * @Target("PROPERTY")
  *
  * @author Gustavo Falco <comfortablynumb84@gmail.com>

--- a/src/Mapping/Annotation/TreeRight.php
+++ b/src/Mapping/Annotation/TreeRight.php
@@ -16,6 +16,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * TreeRight annotation for Tree behavioral extension
  *
  * @Annotation
+ *
  * @Target("PROPERTY")
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>

--- a/src/Mapping/Annotation/TreeRoot.php
+++ b/src/Mapping/Annotation/TreeRoot.php
@@ -16,7 +16,9 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * TreeRoot annotation for Tree behavioral extension
  *
  * @Annotation
+ *
  * @NamedArgumentConstructor
+ *
  * @Target("PROPERTY")
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>

--- a/src/Mapping/Annotation/Uploadable.php
+++ b/src/Mapping/Annotation/Uploadable.php
@@ -18,7 +18,9 @@ use Gedmo\Uploadable\Mapping\Validator;
  * Uploadable annotation for Uploadable behavioral extension
  *
  * @Annotation
+ *
  * @NamedArgumentConstructor
+ *
  * @Target("CLASS")
  *
  * @author Gustavo Falco <comfortablynumb84@gmail.com>

--- a/src/Mapping/Annotation/UploadableFileMimeType.php
+++ b/src/Mapping/Annotation/UploadableFileMimeType.php
@@ -16,6 +16,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * UploadableFileMimeType Annotation for Uploadable behavioral extension
  *
  * @Annotation
+ *
  * @Target("PROPERTY")
  *
  * @author Gustavo Falco <comfortablynumb84@gmail.com>

--- a/src/Mapping/Annotation/UploadableFileName.php
+++ b/src/Mapping/Annotation/UploadableFileName.php
@@ -16,6 +16,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * UploadableFileName Annotation for Uploadable behavioral extension
  *
  * @Annotation
+ *
  * @Target("PROPERTY")
  *
  * @author tiger-seo <tiger.seo@gmail.com>

--- a/src/Mapping/Annotation/UploadableFilePath.php
+++ b/src/Mapping/Annotation/UploadableFilePath.php
@@ -16,6 +16,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * UploadableFilePath Annotation for Uploadable behavioral extension
  *
  * @Annotation
+ *
  * @Target("PROPERTY")
  *
  * @author Gustavo Falco <comfortablynumb84@gmail.com>

--- a/src/Mapping/Annotation/UploadableFileSize.php
+++ b/src/Mapping/Annotation/UploadableFileSize.php
@@ -16,6 +16,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * UploadableFileSize Annotation for Uploadable behavioral extension
  *
  * @Annotation
+ *
  * @Target("PROPERTY")
  *
  * @author Gustavo Falco <comfortablynumb84@gmail.com>

--- a/src/Mapping/Annotation/Versioned.php
+++ b/src/Mapping/Annotation/Versioned.php
@@ -16,7 +16,9 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * Versioned annotation for Loggable behavioral extension
  *
  * @Annotation
+ *
  * @NamedArgumentConstructor
+ *
  * @Target("PROPERTY")
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>

--- a/src/Mapping/Driver.php
+++ b/src/Mapping/Driver.php
@@ -31,9 +31,9 @@ interface Driver
      * @param ClassMetadata        $meta
      * @param array<string, mixed> $config
      *
-     * @return void
-     *
      * @throws InvalidMappingException if the mapping configuration is invalid
+     *
+     * @return void
      *
      * @phpstan-param ClassMetadata&(OdmClassMetadata|OrmClassMetadata) $meta
      */

--- a/src/Mapping/Driver/AbstractAnnotationDriver.php
+++ b/src/Mapping/Driver/AbstractAnnotationDriver.php
@@ -79,6 +79,7 @@ abstract class AbstractAnnotationDriver implements AnnotationDriverInterface
      * @param ClassMetadata $meta
      *
      * @return \ReflectionClass
+     *
      * @phpstan-return \ReflectionClass<object>
      */
     public function getMetaReflectionClass($meta)

--- a/src/Mapping/Driver/AttributeAnnotationReader.php
+++ b/src/Mapping/Driver/AttributeAnnotationReader.php
@@ -14,6 +14,7 @@ use Gedmo\Mapping\Annotation\Annotation;
 
 /**
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ *
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  *
  * @internal

--- a/src/Mapping/Driver/AttributeReader.php
+++ b/src/Mapping/Driver/AttributeReader.php
@@ -62,6 +62,7 @@ final class AttributeReader
 
     /**
      * @param iterable<\ReflectionAttribute> $attributes
+     *
      * @phpstan-param iterable<\ReflectionAttribute<object>> $attributes
      *
      * @return array<string, Annotation|Annotation[]>

--- a/src/Mapping/Event/AdapterInterface.php
+++ b/src/Mapping/Event/AdapterInterface.php
@@ -65,6 +65,7 @@ interface AdapterInterface
      * @param ClassMetadata $meta
      *
      * @return string
+     *
      * @phpstan-return class-string
      */
     public function getRootObjectClass($meta);

--- a/src/ReferenceIntegrity/ReferenceIntegrityListener.php
+++ b/src/ReferenceIntegrity/ReferenceIntegrityListener.php
@@ -42,6 +42,7 @@ class ReferenceIntegrityListener extends MappedEventSubscriber
      * Maps additional metadata for the Document
      *
      * @param LoadClassMetadataEventArgs $eventArgs
+     *
      * @phpstan-param LoadClassMetadataEventArgs<ClassMetadata<object>, ObjectManager> $eventArgs
      *
      * @return void

--- a/src/References/Mapping/Driver/Annotation.php
+++ b/src/References/Mapping/Driver/Annotation.php
@@ -78,9 +78,9 @@ class Annotation implements AnnotationDriverInterface
         foreach (self::ANNOTATIONS as $key => $annotation) {
             $config[$key] = [];
             foreach ($class->getProperties() as $property) {
-                if ($meta->isMappedSuperclass && !$property->isPrivate() ||
-                    $meta->isInheritedField($property->name) ||
-                    isset($meta->associationMappings[$property->name]['inherited'])
+                if ($meta->isMappedSuperclass && !$property->isPrivate()
+                    || $meta->isInheritedField($property->name)
+                    || isset($meta->associationMappings[$property->name]['inherited'])
                 ) {
                     continue;
                 }

--- a/src/References/ReferencesListener.php
+++ b/src/References/ReferencesListener.php
@@ -31,7 +31,6 @@ use Gedmo\Mapping\MappedEventSubscriber;
  *   mappedBy?: string,
  *   inversedBy?: string,
  * }
- *
  * @phpstan-type ReferencesConfiguration = array{
  *   referenceMany?: array<string, ReferenceConfiguration>,
  *   referenceManyEmbed?: array<string, ReferenceConfiguration>,
@@ -62,6 +61,7 @@ class ReferencesListener extends MappedEventSubscriber
 
     /**
      * @param LoadClassMetadataEventArgs $eventArgs
+     *
      * @phpstan-param LoadClassMetadataEventArgs<ClassMetadata<object>, ObjectManager> $eventArgs
      *
      * @return void

--- a/src/Sluggable/Mapping/Driver/Annotation.php
+++ b/src/Sluggable/Mapping/Driver/Annotation.php
@@ -68,9 +68,9 @@ class Annotation extends AbstractAnnotationDriver
         $class = $this->getMetaReflectionClass($meta);
         // property annotations
         foreach ($class->getProperties() as $property) {
-            if ($meta->isMappedSuperclass && !$property->isPrivate() ||
-                $meta->isInheritedField($property->name) ||
-                isset($meta->associationMappings[$property->name]['inherited'])
+            if ($meta->isMappedSuperclass && !$property->isPrivate()
+                || $meta->isInheritedField($property->name)
+                || isset($meta->associationMappings[$property->name]['inherited'])
             ) {
                 continue;
             }

--- a/src/Sluggable/Mapping/Event/SluggableAdapter.php
+++ b/src/Sluggable/Mapping/Event/SluggableAdapter.php
@@ -28,6 +28,7 @@ interface SluggableAdapter extends AdapterInterface
      * @param object        $object
      * @param ClassMetadata $meta
      * @param string        $slug
+     *
      * @phpstan-param SluggableConfiguration $config
      *
      * @return array<int, array<string, mixed>>
@@ -40,6 +41,7 @@ interface SluggableAdapter extends AdapterInterface
      * @param object $object
      * @param string $target
      * @param string $replacement
+     *
      * @phpstan-param SluggableConfiguration $config
      *
      * @return int the number of updated records
@@ -53,6 +55,7 @@ interface SluggableAdapter extends AdapterInterface
      * @param object $object
      * @param string $target
      * @param string $replacement
+     *
      * @phpstan-param SluggableConfiguration $config
      *
      * @return int the number of updated records

--- a/src/Sluggable/SluggableListener.php
+++ b/src/Sluggable/SluggableListener.php
@@ -226,6 +226,7 @@ class SluggableListener extends MappedEventSubscriber
      * Mapps additional metadata
      *
      * @param LoadClassMetadataEventArgs $eventArgs
+     *
      * @phpstan-param LoadClassMetadataEventArgs<ClassMetadata<object>, ObjectManager> $eventArgs
      *
      * @return void

--- a/src/SoftDeleteable/Filter/ODM/SoftDeleteableFilter.php
+++ b/src/SoftDeleteable/Filter/ODM/SoftDeleteableFilter.php
@@ -77,6 +77,7 @@ class SoftDeleteableFilter extends BsonFilter
 
     /**
      * @param string $class
+     *
      * @phpstan-param class-string $class
      *
      * @return void
@@ -88,6 +89,7 @@ class SoftDeleteableFilter extends BsonFilter
 
     /**
      * @param string $class
+     *
      * @phpstan-param class-string $class
      *
      * @return void

--- a/src/SoftDeleteable/Filter/SoftDeleteableFilter.php
+++ b/src/SoftDeleteable/Filter/SoftDeleteableFilter.php
@@ -39,6 +39,7 @@ class SoftDeleteableFilter extends SQLFilter
 
     /**
      * @var array<string, bool>
+     *
      * @phpstan-var array<class-string, bool>
      */
     protected $disabled = [];
@@ -46,9 +47,9 @@ class SoftDeleteableFilter extends SQLFilter
     /**
      * @param string $targetTableAlias
      *
-     * @return string
-     *
      * @throws Exception
+     *
+     * @return string
      */
     public function addFilterConstraint(ClassMetadata $targetEntity, $targetTableAlias)
     {
@@ -108,9 +109,9 @@ class SoftDeleteableFilter extends SQLFilter
     }
 
     /**
-     * @return SoftDeleteableListener
-     *
      * @throws \RuntimeException
+     *
+     * @return SoftDeleteableListener
      */
     protected function getListener()
     {

--- a/src/SoftDeleteable/SoftDeleteableListener.php
+++ b/src/SoftDeleteable/SoftDeleteableListener.php
@@ -110,6 +110,7 @@ class SoftDeleteableListener extends MappedEventSubscriber
      * Maps additional metadata
      *
      * @param LoadClassMetadataEventArgs $eventArgs
+     *
      * @phpstan-param LoadClassMetadataEventArgs<ClassMetadata<object>, ObjectManager> $eventArgs
      *
      * @return void

--- a/src/Sortable/Mapping/Driver/Annotation.php
+++ b/src/Sortable/Mapping/Driver/Annotation.php
@@ -54,9 +54,9 @@ class Annotation extends AbstractAnnotationDriver
 
         // property annotations
         foreach ($class->getProperties() as $property) {
-            if ($meta->isMappedSuperclass && !$property->isPrivate() ||
-                $meta->isInheritedField($property->name) ||
-                isset($meta->associationMappings[$property->name]['inherited'])
+            if ($meta->isMappedSuperclass && !$property->isPrivate()
+                || $meta->isInheritedField($property->name)
+                || isset($meta->associationMappings[$property->name]['inherited'])
             ) {
                 continue;
             }

--- a/src/Sortable/Mapping/Event/Adapter/ORM.php
+++ b/src/Sortable/Mapping/Event/Adapter/ORM.php
@@ -52,6 +52,7 @@ final class ORM extends BaseAdapterORM implements SortableAdapter
      * @param array<string, mixed> $relocation
      * @param array<string, mixed> $delta
      * @param array<string, mixed> $config
+     *
      * @phpstan-param SortableRelocation $relocation
      *
      * @return void

--- a/src/Sortable/SortableListener.php
+++ b/src/Sortable/SortableListener.php
@@ -33,7 +33,6 @@ use ProxyManager\Proxy\GhostObjectInterface;
  *   position?: string,
  *   useObjectClass?: class-string,
  * }
- *
  * @phpstan-type SortableRelocation = array{
  *   name?: class-string,
  *   groups?: mixed[],
@@ -55,6 +54,7 @@ class SortableListener extends MappedEventSubscriber
 {
     /**
      * @var array<string, array<string, mixed>>
+     *
      * @phpstan-var array<string, SortableRelocation>
      */
     private array $relocations = [];
@@ -86,6 +86,7 @@ class SortableListener extends MappedEventSubscriber
      * Maps additional metadata
      *
      * @param LoadClassMetadataEventArgs $args
+     *
      * @phpstan-param LoadClassMetadataEventArgs<ClassMetadata<object>, ObjectManager> $args
      *
      * @return void

--- a/src/Timestampable/Mapping/Driver/Annotation.php
+++ b/src/Timestampable/Mapping/Driver/Annotation.php
@@ -54,9 +54,9 @@ class Annotation extends AbstractAnnotationDriver
         $class = $this->getMetaReflectionClass($meta);
         // property annotations
         foreach ($class->getProperties() as $property) {
-            if ($meta->isMappedSuperclass && !$property->isPrivate() ||
-                $meta->isInheritedField($property->name) ||
-                isset($meta->associationMappings[$property->name]['inherited'])
+            if ($meta->isMappedSuperclass && !$property->isPrivate()
+                || $meta->isInheritedField($property->name)
+                || isset($meta->associationMappings[$property->name]['inherited'])
             ) {
                 continue;
             }

--- a/src/Timestampable/Mapping/Driver/Attribute.php
+++ b/src/Timestampable/Mapping/Driver/Attribute.php
@@ -18,6 +18,7 @@ use Gedmo\Mapping\Driver\AttributeDriverInterface;
  * extension.
  *
  * @author Kevin Mian Kraiker <kevin.mian@gmail.com>
+ *
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  *
  * @internal

--- a/src/Timestampable/Traits/TimestampableDocument.php
+++ b/src/Timestampable/Traits/TimestampableDocument.php
@@ -22,7 +22,9 @@ trait TimestampableDocument
 {
     /**
      * @var \DateTime|null
+     *
      * @Gedmo\Timestampable(on="create")
+     *
      * @ODM\Field(type="date")
      */
     #[Gedmo\Timestampable(on: 'create')]
@@ -31,7 +33,9 @@ trait TimestampableDocument
 
     /**
      * @var \DateTime|null
+     *
      * @Gedmo\Timestampable(on="update")
+     *
      * @ODM\Field(type="date")
      */
     #[Gedmo\Timestampable(on: 'update')]

--- a/src/Timestampable/Traits/TimestampableEntity.php
+++ b/src/Timestampable/Traits/TimestampableEntity.php
@@ -22,7 +22,9 @@ trait TimestampableEntity
 {
     /**
      * @var \DateTime|null
+     *
      * @Gedmo\Timestampable(on="create")
+     *
      * @ORM\Column(type="datetime")
      */
     #[Gedmo\Timestampable(on: 'create')]
@@ -31,7 +33,9 @@ trait TimestampableEntity
 
     /**
      * @var \DateTime|null
+     *
      * @Gedmo\Timestampable(on="update")
+     *
      * @ORM\Column(type="datetime")
      */
     #[Gedmo\Timestampable(on: 'update')]

--- a/src/Tool/WrapperInterface.php
+++ b/src/Tool/WrapperInterface.php
@@ -88,6 +88,7 @@ interface WrapperInterface
      * Get the root object class name.
      *
      * @return string
+     *
      * @phpstan-return class-string
      */
     public function getRootObjectName();

--- a/src/Translatable/Document/Repository/TranslationRepository.php
+++ b/src/Translatable/Document/Repository/TranslationRepository.php
@@ -164,6 +164,7 @@ class TranslationRepository extends DocumentRepository
      * @param string $field
      * @param string $value
      * @param string $class
+     *
      * @phpstan-param class-string $class
      *
      * @return object|null instance of $class or null if not found

--- a/src/Translatable/Entity/Repository/TranslationRepository.php
+++ b/src/Translatable/Entity/Repository/TranslationRepository.php
@@ -94,8 +94,8 @@ class TranslationRepository extends EntityRepository
                 $transMeta->getReflectionProperty('field')->setValue($trans, $field);
                 $transMeta->getReflectionProperty('locale')->setValue($trans, $locale);
             }
-            if ($listener->getDefaultLocale() != $listener->getTranslatableLocale($entity, $meta, $this->getEntityManager()) &&
-                $locale === $listener->getDefaultLocale()) {
+            if ($listener->getDefaultLocale() != $listener->getTranslatableLocale($entity, $meta, $this->getEntityManager())
+                && $locale === $listener->getDefaultLocale()) {
                 $listener->setTranslationInDefaultLocale(spl_object_id($entity), $field, $trans);
                 $needsPersist = $listener->getPersistDefaultLocaleTranslation();
             }
@@ -167,6 +167,7 @@ class TranslationRepository extends EntityRepository
      * @param string $field
      * @param string $value
      * @param string $class
+     *
      * @phpstan-param class-string $class
      *
      * @return object instance of $class or null if not found

--- a/src/Translatable/Entity/Translation.php
+++ b/src/Translatable/Entity/Translation.php
@@ -23,6 +23,7 @@ use Gedmo\Translatable\Entity\Repository\TranslationRepository;
  *     name="ext_translations",
  *     options={"row_format": "DYNAMIC"},
  *     indexes={
+ *
  *         @Index(name="translations_lookup_idx", columns={
  *             "locale", "object_class", "foreign_key"
  *         }),
@@ -34,6 +35,7 @@ use Gedmo\Translatable\Entity\Repository\TranslationRepository;
  *         "locale", "object_class", "field", "foreign_key"
  *     })}
  * )
+ *
  * @Entity(repositoryClass="Gedmo\Translatable\Entity\Repository\TranslationRepository")
  */
 #[Entity(repositoryClass: TranslationRepository::class)]

--- a/src/Translatable/Mapping/Driver/Annotation.php
+++ b/src/Translatable/Mapping/Driver/Annotation.php
@@ -63,9 +63,9 @@ class Annotation extends AbstractAnnotationDriver
 
         // property annotations
         foreach ($class->getProperties() as $property) {
-            if ($meta->isMappedSuperclass && !$property->isPrivate() ||
-                $meta->isInheritedField($property->name) ||
-                isset($meta->associationMappings[$property->name]['inherited'])
+            if ($meta->isMappedSuperclass && !$property->isPrivate()
+                || $meta->isInheritedField($property->name)
+                || isset($meta->associationMappings[$property->name]['inherited'])
             ) {
                 continue;
             }

--- a/src/Translatable/Mapping/Event/Adapter/ORM.php
+++ b/src/Translatable/Mapping/Event/Adapter/ORM.php
@@ -234,6 +234,7 @@ final class ORM extends BaseAdapterORM implements TranslatableAdapter
      *
      * @param mixed  $key       foreign key value
      * @param string $className translation class name
+     *
      * @phpstan-param class-string $className translation class name
      *
      * @return int|string transformed foreign key

--- a/src/Translatable/Mapping/Event/TranslatableAdapter.php
+++ b/src/Translatable/Mapping/Event/TranslatableAdapter.php
@@ -35,6 +35,7 @@ interface TranslatableAdapter extends AdapterInterface
      * Get the default translation class used to store translations.
      *
      * @return string
+     *
      * @phpstan-return class-string
      */
     public function getDefaultTranslationClass();

--- a/src/Translatable/Query/TreeWalker/TranslationWalker.php
+++ b/src/Translatable/Query/TreeWalker/TranslationWalker.php
@@ -351,10 +351,10 @@ class TranslationWalker extends SqlWalker
 
                 // Treat translation as original field type
                 $fieldMapping = $meta->getFieldMapping($field);
-                if ((($this->platform instanceof MySQLPlatform) &&
-                    in_array($fieldMapping['type'], ['decimal'], true)) ||
-                    (!($this->platform instanceof MySQLPlatform) &&
-                    !in_array($fieldMapping['type'], ['datetime', 'datetimetz', 'date', 'time'], true))) {
+                if ((($this->platform instanceof MySQLPlatform)
+                    && in_array($fieldMapping['type'], ['decimal'], true))
+                    || (!($this->platform instanceof MySQLPlatform)
+                    && !in_array($fieldMapping['type'], ['datetime', 'datetimetz', 'date', 'time'], true))) {
                     $type = Type::getType($fieldMapping['type']);
                     $substituteField = 'CAST('.$substituteField.' AS '.$type->getSQLDeclaration($fieldMapping, $this->platform).')';
                 }
@@ -467,7 +467,7 @@ class TranslationWalker extends SqlWalker
                 case 'string':
                 case 'guid':
                     // need to cast to VARCHAR
-                    $component = $component.'::VARCHAR';
+                    $component .= '::VARCHAR';
 
                     break;
             }

--- a/src/Translatable/TranslatableListener.php
+++ b/src/Translatable/TranslatableListener.php
@@ -207,6 +207,7 @@ class TranslatableListener extends MappedEventSubscriber
      * Maps additional metadata
      *
      * @param LoadClassMetadataEventArgs $eventArgs
+     *
      * @phpstan-param LoadClassMetadataEventArgs<ClassMetadata<object>, ObjectManager> $eventArgs
      *
      * @return void
@@ -221,9 +222,11 @@ class TranslatableListener extends MappedEventSubscriber
      * for the object $class
      *
      * @param string $class
+     *
      * @phpstan-param class-string $class
      *
      * @return string
+     *
      * @phpstan-return class-string
      */
     public function getTranslationClass(TranslatableAdapter $ea, $class)
@@ -353,7 +356,7 @@ class TranslatableListener extends MappedEventSubscriber
                 $locale = $value;
             }
         } elseif ($om instanceof DocumentManager) {
-            [ , $parentObject] = $om->getUnitOfWork()->getParentAssociation($object);
+            [, $parentObject] = $om->getUnitOfWork()->getParentAssociation($object);
             if (null !== $parentObject) {
                 $parentMeta = $om->getClassMetadata(get_class($parentObject));
                 $locale = $this->getTranslatableLocale($parentObject, $parentMeta, $om);

--- a/src/Translator/Entity/Translation.php
+++ b/src/Translator/Entity/Translation.php
@@ -30,7 +30,9 @@ abstract class Translation extends BaseTranslation
      * @var int
      *
      * @Column(type="integer")
+     *
      * @Id
+     *
      * @GeneratedValue
      */
     #[Column(type: Types::INTEGER)]

--- a/src/Tree/Entity/Repository/ClosureTreeRepository.php
+++ b/src/Tree/Entity/Repository/ClosureTreeRepository.php
@@ -399,8 +399,8 @@ class ClosureTreeRepository extends AbstractTreeRepository
         $defaultOptions = [];
         $options = array_merge($defaultOptions, $options);
 
-        if (isset($options['childSort']) && is_array($options['childSort']) &&
-            isset($options['childSort']['field'], $options['childSort']['dir'])) {
+        if (isset($options['childSort']) && is_array($options['childSort'])
+            && isset($options['childSort']['field'], $options['childSort']['dir'])) {
             $q->addOrderBy(
                 'node.'.$options['childSort']['field'],
                 'asc' === strtolower($options['childSort']['dir']) ? 'asc' : 'desc'

--- a/src/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/src/Tree/Entity/Repository/NestedTreeRepository.php
@@ -169,14 +169,15 @@ class NestedTreeRepository extends AbstractTreeRepository
      * Get the Tree path query builder by given $node
      *
      * @param object $node
+     *
      * @phpstan-param array{includeNode?: bool} $options
      *
      * options:
      * - includeNode: (bool) Whether to include the node itself. Defaults to true.
      *
-     * @return QueryBuilder
-     *
      * @throws InvalidArgumentException if input is not valid
+     *
+     * @return QueryBuilder
      */
     public function getPathQueryBuilder($node/* , array $options = [] */) // @phpstan-ignore-line
     {
@@ -226,6 +227,7 @@ class NestedTreeRepository extends AbstractTreeRepository
      * Get the Tree path query by given $node
      *
      * @param object $node
+     *
      * @phpstan-param array{includeNode?: bool} $options
      *
      * options:
@@ -247,6 +249,7 @@ class NestedTreeRepository extends AbstractTreeRepository
      * Get the Tree path of Nodes by given $node
      *
      * @param object $node
+     *
      * @phpstan-param array{includeNode?: bool} $options
      *
      * options:
@@ -524,9 +527,9 @@ class NestedTreeRepository extends AbstractTreeRepository
      * @param object $node
      * @param bool   $includeSelf include the node itself
      *
-     * @return QueryBuilder
-     *
      * @throws InvalidArgumentException if input is invalid
+     *
+     * @return QueryBuilder
      */
     public function getNextSiblingsQueryBuilder($node, $includeSelf = false)
     {
@@ -604,9 +607,9 @@ class NestedTreeRepository extends AbstractTreeRepository
      * @param object $node
      * @param bool   $includeSelf include the node itself
      *
-     * @return QueryBuilder
-     *
      * @throws InvalidArgumentException if input is invalid
+     *
+     * @return QueryBuilder
      */
     public function getPrevSiblingsQueryBuilder($node, $includeSelf = false)
     {
@@ -655,9 +658,9 @@ class NestedTreeRepository extends AbstractTreeRepository
      * @param object $node
      * @param bool   $includeSelf include the node itself
      *
-     * @return Query
-     *
      * @throws InvalidArgumentException if input is invalid
+     *
+     * @return Query
      */
     public function getPrevSiblingsQuery($node, $includeSelf = false)
     {

--- a/src/Tree/Hydrator/ORM/TreeObjectHydrator.php
+++ b/src/Tree/Hydrator/ORM/TreeObjectHydrator.php
@@ -203,6 +203,7 @@ class TreeObjectHydrator extends ObjectHydrator
 
     /**
      * @param string $entityClass
+     *
      * @phpstan-param class-string $entityClass
      *
      * @return string
@@ -228,6 +229,7 @@ class TreeObjectHydrator extends ObjectHydrator
 
     /**
      * @param string $entityClass
+     *
      * @phpstan-param class-string $entityClass
      *
      * @return string

--- a/src/Tree/Mapping/Driver/Annotation.php
+++ b/src/Tree/Mapping/Driver/Annotation.php
@@ -129,9 +129,9 @@ class Annotation extends AbstractAnnotationDriver
 
         // property annotations
         foreach ($class->getProperties() as $property) {
-            if ($meta->isMappedSuperclass && !$property->isPrivate() ||
-                $meta->isInheritedField($property->name) ||
-                isset($meta->associationMappings[$property->name]['inherited'])
+            if ($meta->isMappedSuperclass && !$property->isPrivate()
+                || $meta->isInheritedField($property->name)
+                || isset($meta->associationMappings[$property->name]['inherited'])
             ) {
                 continue;
             }

--- a/src/Tree/Mapping/Driver/Attribute.php
+++ b/src/Tree/Mapping/Driver/Attribute.php
@@ -18,6 +18,7 @@ use Gedmo\Mapping\Driver\AttributeDriverInterface;
  * extension.
  *
  * @author Kevin Mian Kraiker <kevin.mian@gmail.com>
+ *
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  *
  * @internal

--- a/src/Tree/RepositoryInterface.php
+++ b/src/Tree/RepositoryInterface.php
@@ -62,9 +62,9 @@ interface RepositoryInterface extends RepositoryUtilsInterface
      * @param object|null $node   The object to count children for; if null, all nodes will be counted
      * @param bool        $direct Flag indicating whether only direct children should be counted
      *
-     * @return int
-     *
      * @throws InvalidArgumentException if the input is invalid
+     *
+     * @return int
      */
     public function childCount($node = null, $direct = false);
 }

--- a/src/Tree/RepositoryUtils.php
+++ b/src/Tree/RepositoryUtils.php
@@ -44,8 +44,8 @@ class RepositoryUtils implements RepositoryUtilsInterface
 
     /**
      * @param ObjectManager&(DocumentManager|EntityManagerInterface) $om
-     * @param TreeListener        $listener
-     * @param RepositoryInterface $repo
+     * @param TreeListener                                           $listener
+     * @param RepositoryInterface                                    $repo
      */
     public function __construct(ObjectManager $om, ClassMetadata $meta, $listener, $repo)
     {

--- a/src/Tree/RepositoryUtilsInterface.php
+++ b/src/Tree/RepositoryUtilsInterface.php
@@ -30,9 +30,9 @@ interface RepositoryUtilsInterface
      *                                          - childSort: array || keys allowed: field: field to sort on, dir: direction. 'asc' or 'desc'
      * @param bool                 $includeNode Flag indicating whether the given node should be included in the results
      *
-     * @return array<int, array<string, mixed>>|string
-     *
      * @throws InvalidArgumentException
+     *
+     * @return array<int, array<string, mixed>>|string
      */
     public function childrenHierarchy($node = null, $direct = false, array $options = [], $includeNode = false);
 
@@ -52,9 +52,9 @@ interface RepositoryUtilsInterface
      *                                           - childOpen: string || Closure ('<li>') - start of node, Closure will be given $node as a parameter
      *                                           - childClose: string ('</li>') - close of node
      *
-     * @return array<int, array<string, mixed>>|string
-     *
      * @throws InvalidArgumentException
+     *
+     * @return array<int, array<string, mixed>>|string
      */
     public function buildTree(array $nodes, array $options = []);
 

--- a/src/Tree/Strategy/AbstractMaterializedPath.php
+++ b/src/Tree/Strategy/AbstractMaterializedPath.php
@@ -440,8 +440,8 @@ abstract class AbstractMaterializedPath implements Strategy
                     throw new \InvalidArgumentException(sprintf('"%s" is not a valid action.', $action));
             }
 
-            if (empty($this->pendingObjectsToInsert) && empty($this->pendingObjectsToUpdate) &&
-                empty($this->pendingObjectsToRemove)) {
+            if (empty($this->pendingObjectsToInsert) && empty($this->pendingObjectsToUpdate)
+                && empty($this->pendingObjectsToRemove)) {
                 $this->releaseTreeLocks($om, $ea);
             }
         }

--- a/src/Tree/Strategy/ORM/Nested.php
+++ b/src/Tree/Strategy/ORM/Nested.php
@@ -406,8 +406,8 @@ class Nested implements Strategy
                 $wrapped->setPropertyValue($config['right'], $right);
             }
             $newRoot = $parentRoot;
-        } elseif (!isset($config['root']) ||
-            ($meta->isSingleValuedAssociation($config['root']) && null !== $parent && ($newRoot = $meta->getFieldValue($node, $config['root'])))) {
+        } elseif (!isset($config['root'])
+            || ($meta->isSingleValuedAssociation($config['root']) && null !== $parent && ($newRoot = $meta->getFieldValue($node, $config['root'])))) {
             if (!isset($this->treeEdges[$meta->getName()])) {
                 $this->treeEdges[$meta->getName()] = $this->max($em, $config['useObjectClass'], $newRoot) + 1;
             }

--- a/src/Tree/Traits/NestedSetEntity.php
+++ b/src/Tree/Traits/NestedSetEntity.php
@@ -22,7 +22,9 @@ trait NestedSetEntity
 {
     /**
      * @var int
+     *
      * @Gedmo\TreeRoot
+     *
      * @ORM\Column(name="root", type="integer", nullable=true)
      */
     #[ORM\Column(name: 'root', type: Types::INTEGER, nullable: true)]
@@ -31,7 +33,9 @@ trait NestedSetEntity
 
     /**
      * @var int
+     *
      * @Gedmo\TreeLevel
+     *
      * @ORM\Column(name="lvl", type="integer")
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER)]
@@ -40,7 +44,9 @@ trait NestedSetEntity
 
     /**
      * @var int
+     *
      * @Gedmo\TreeLeft
+     *
      * @ORM\Column(name="lft", type="integer")
      */
     #[ORM\Column(name: 'lft', type: Types::INTEGER)]
@@ -49,7 +55,9 @@ trait NestedSetEntity
 
     /**
      * @var int
+     *
      * @Gedmo\TreeRight
+     *
      * @ORM\Column(name="rgt", type="integer")
      */
     #[ORM\Column(name: 'rgt', type: Types::INTEGER)]

--- a/src/Tree/Traits/NestedSetEntityUuid.php
+++ b/src/Tree/Traits/NestedSetEntityUuid.php
@@ -24,7 +24,9 @@ trait NestedSetEntityUuid
 
     /**
      * @var string
+     *
      * @Gedmo\TreeRoot
+     *
      * @ORM\Column(name="root", type="string", nullable=true)
      */
     #[ORM\Column(name: 'root', type: Types::STRING, nullable: true)]

--- a/src/Uploadable/UploadableListener.php
+++ b/src/Uploadable/UploadableListener.php
@@ -378,8 +378,6 @@ class UploadableListener extends MappedEventSubscriber
      * @param bool        $appendNumber
      * @param object      $object
      *
-     * @return array<string, int|string|null>
-     *
      * @throws UploadableUploadException
      * @throws UploadableNoFileException
      * @throws UploadableExtensionException
@@ -389,6 +387,8 @@ class UploadableListener extends MappedEventSubscriber
      * @throws UploadablePartialException
      * @throws UploadableNoTmpDirException
      * @throws UploadableCantWriteException
+     *
+     * @return array<string, int|string|null>
      *
      * @phpstan-param class-string|false $filenameGeneratorClass
      */
@@ -560,8 +560,8 @@ class UploadableListener extends MappedEventSubscriber
      */
     public function setDefaultFileInfoClass($defaultFileInfoClass)
     {
-        if (!is_string($defaultFileInfoClass) || !class_exists($defaultFileInfoClass) ||
-            !is_subclass_of($defaultFileInfoClass, FileInfoInterface::class)
+        if (!is_string($defaultFileInfoClass) || !class_exists($defaultFileInfoClass)
+            || !is_subclass_of($defaultFileInfoClass, FileInfoInterface::class)
         ) {
             throw new InvalidArgumentException(sprintf('Default FileInfo class must be a valid class, and it must implement "%s".', FileInfoInterface::class));
         }
@@ -644,9 +644,9 @@ class UploadableListener extends MappedEventSubscriber
      * @param array<string, mixed> $config
      * @param object               $object Entity
      *
-     * @return string
-     *
      * @throws UploadableNoPathDefinedException
+     *
+     * @return string
      */
     protected function getPath(ClassMetadata $meta, array $config, $object)
     {

--- a/tests/Gedmo/Blameable/Fixture/Document/Article.php
+++ b/tests/Gedmo/Blameable/Fixture/Document/Article.php
@@ -43,6 +43,7 @@ class Article
 
     /**
      * @ODM\Field(type="string")
+     *
      * @Gedmo\Blameable(on="create")
      */
     #[ODM\Field(type: MongoDBType::STRING)]
@@ -51,6 +52,7 @@ class Article
 
     /**
      * @ODM\Field(type="string")
+     *
      * @Gedmo\Blameable
      */
     #[ODM\Field(type: MongoDBType::STRING)]
@@ -59,6 +61,7 @@ class Article
 
     /**
      * @ODM\ReferenceOne(targetDocument="User")
+     *
      * @Gedmo\Blameable(on="create")
      */
     #[ODM\ReferenceOne(targetDocument: User::class)]
@@ -67,6 +70,7 @@ class Article
 
     /**
      * @ODM\Field(type="string")
+     *
      * @Gedmo\Blameable(on="change", field="type.title", value="Published")
      */
     #[Gedmo\Blameable(on: 'change', field: 'type.title', value: 'Published')]

--- a/tests/Gedmo/Blameable/Fixture/Entity/Article.php
+++ b/tests/Gedmo/Blameable/Fixture/Entity/Article.php
@@ -52,6 +52,7 @@ class Article implements Blameable
 
     /**
      * @Gedmo\Blameable(on="create")
+     *
      * @ORM\Column(name="created", type="string")
      */
     #[ORM\Column(name: 'created', type: Types::STRING)]
@@ -60,6 +61,7 @@ class Article implements Blameable
 
     /**
      * @ORM\Column(name="updated", type="string")
+     *
      * @Gedmo\Blameable
      */
     #[Gedmo\Blameable]
@@ -68,6 +70,7 @@ class Article implements Blameable
 
     /**
      * @ORM\Column(name="published", type="string", nullable=true)
+     *
      * @Gedmo\Blameable(on="change", field="type.title", value="Published")
      */
     #[ORM\Column(name: 'published', type: Types::STRING, nullable: true)]

--- a/tests/Gedmo/Blameable/Fixture/Entity/Comment.php
+++ b/tests/Gedmo/Blameable/Fixture/Entity/Comment.php
@@ -56,6 +56,7 @@ class Comment implements Blameable
      * @var string|null
      *
      * @ORM\Column(name="closed", type="string", nullable=true)
+     *
      * @Gedmo\Blameable(on="change", field="status", value=1)
      */
     #[ORM\Column(name: 'closed', type: Types::STRING, nullable: true)]
@@ -66,6 +67,7 @@ class Comment implements Blameable
      * @var string|null
      *
      * @ORM\Column(name="modified", type="string")
+     *
      * @Gedmo\Blameable(on="update")
      */
     #[ORM\Column(name: 'modified', type: Types::STRING)]

--- a/tests/Gedmo/Blameable/Fixture/Entity/MappedSupperClass.php
+++ b/tests/Gedmo/Blameable/Fixture/Entity/MappedSupperClass.php
@@ -45,6 +45,7 @@ class MappedSupperClass
      * @var string|null
      *
      * @Gedmo\Translatable
+     *
      * @ORM\Column(name="name", type="string", length=191)
      */
     #[Gedmo\Translatable]
@@ -55,6 +56,7 @@ class MappedSupperClass
      * @var string|null
      *
      * @ORM\Column(name="created_by", type="string")
+     *
      * @Gedmo\Blameable(on="create")
      */
     #[ORM\Column(name: 'created_by', type: Types::STRING)]

--- a/tests/Gedmo/Blameable/Fixture/Entity/SupperClassExtension.php
+++ b/tests/Gedmo/Blameable/Fixture/Entity/SupperClassExtension.php
@@ -22,6 +22,7 @@ class SupperClassExtension extends MappedSupperClass
 {
     /**
      * @ORM\Column(length=128)
+     *
      * @Gedmo\Translatable
      */
     #[ORM\Column(length: 128)]

--- a/tests/Gedmo/Blameable/Fixture/Entity/TitledArticle.php
+++ b/tests/Gedmo/Blameable/Fixture/Entity/TitledArticle.php
@@ -46,6 +46,7 @@ class TitledArticle implements Blameable
 
     /**
      * @ORM\Column(name="chtext", type="string", nullable=true)
+     *
      * @Gedmo\Blameable(on="change", field="text")
      */
     #[ORM\Column(name: 'chtext', type: Types::STRING, nullable: true)]
@@ -54,6 +55,7 @@ class TitledArticle implements Blameable
 
     /**
      * @ORM\Column(name="chtitle", type="string", nullable=true)
+     *
      * @Gedmo\Blameable(on="change", field="title")
      */
     #[ORM\Column(name: 'chtitle', type: Types::STRING, nullable: true)]

--- a/tests/Gedmo/Blameable/Fixture/Entity/WithoutInterface.php
+++ b/tests/Gedmo/Blameable/Fixture/Entity/WithoutInterface.php
@@ -43,6 +43,7 @@ class WithoutInterface
      * @var string|null
      *
      * @Gedmo\Blameable(on="create")
+     *
      * @ORM\Column(type="string")
      */
     #[ORM\Column(type: Types::STRING)]
@@ -53,6 +54,7 @@ class WithoutInterface
      * @var string|null
      *
      * @ORM\Column(type="string")
+     *
      * @Gedmo\Blameable(on="update")
      */
     #[ORM\Column(type: Types::STRING)]

--- a/tests/Gedmo/IpTraceable/Fixture/Article.php
+++ b/tests/Gedmo/IpTraceable/Fixture/Article.php
@@ -52,6 +52,7 @@ class Article implements IpTraceable
 
     /**
      * @Gedmo\IpTraceable(on="create")
+     *
      * @ORM\Column(name="created", type="string", length=45)
      */
     #[ORM\Column(name: 'created', type: Types::STRING, length: 45)]
@@ -60,6 +61,7 @@ class Article implements IpTraceable
 
     /**
      * @ORM\Column(name="updated", type="string", length=45)
+     *
      * @Gedmo\IpTraceable
      */
     #[ORM\Column(name: 'updated', type: Types::STRING, length: 45)]
@@ -68,6 +70,7 @@ class Article implements IpTraceable
 
     /**
      * @ORM\Column(name="published", type="string", length=45, nullable=true)
+     *
      * @Gedmo\IpTraceable(on="change", field="type.title", value="Published")
      */
     #[ORM\Column(name: 'published', type: Types::STRING, length: 45, nullable: true)]
@@ -76,6 +79,7 @@ class Article implements IpTraceable
 
     /**
      * @ORM\Column(name="content_changed", type="string", length=45, nullable=true)
+     *
      * @Gedmo\IpTraceable(on="change", field={"title", "body"})
      */
     #[ORM\Column(name: 'content_changed', type: Types::STRING, length: 45, nullable: true)]

--- a/tests/Gedmo/IpTraceable/Fixture/Comment.php
+++ b/tests/Gedmo/IpTraceable/Fixture/Comment.php
@@ -56,6 +56,7 @@ class Comment implements IpTraceable
      * @var string|null
      *
      * @ORM\Column(name="closed", type="string", length=45, nullable=true)
+     *
      * @Gedmo\IpTraceable(on="change", field="status", value=1)
      */
     #[ORM\Column(name: 'closed', type: Types::STRING, length: 45, nullable: true)]
@@ -66,6 +67,7 @@ class Comment implements IpTraceable
      * @var string|null
      *
      * @ORM\Column(name="modified", type="string", length=45)
+     *
      * @Gedmo\IpTraceable(on="update")
      */
     #[ORM\Column(name: 'modified', type: Types::STRING, length: 45)]

--- a/tests/Gedmo/IpTraceable/Fixture/Document/Article.php
+++ b/tests/Gedmo/IpTraceable/Fixture/Document/Article.php
@@ -23,6 +23,7 @@ class Article
 {
     /**
      * @var string|null
+     *
      * @ODM\Id
      */
     #[ODM\Id]
@@ -42,6 +43,7 @@ class Article
 
     /**
      * @ODM\Field(type="string")
+     *
      * @Gedmo\IpTraceable(on="create")
      */
     #[ODM\Field(type: MongoDBType::STRING)]
@@ -50,6 +52,7 @@ class Article
 
     /**
      * @ODM\Field(type="string")
+     *
      * @Gedmo\IpTraceable
      */
     #[ODM\Field(type: MongoDBType::STRING)]
@@ -58,6 +61,7 @@ class Article
 
     /**
      * @ODM\Field(type="string")
+     *
      * @Gedmo\IpTraceable(on="change", field="type.title", value="Published")
      */
     #[ODM\Field(type: MongoDBType::STRING)]
@@ -66,6 +70,7 @@ class Article
 
     /**
      * @ODM\Field(type="string")
+     *
      * @Gedmo\IpTraceable(on="change", field="isReady", value=true)
      */
     #[ODM\Field(type: MongoDBType::STRING)]

--- a/tests/Gedmo/IpTraceable/Fixture/MappedSupperClass.php
+++ b/tests/Gedmo/IpTraceable/Fixture/MappedSupperClass.php
@@ -45,6 +45,7 @@ class MappedSupperClass
      * @var string|null
      *
      * @Gedmo\Translatable
+     *
      * @ORM\Column(name="name", type="string", length=191)
      */
     #[Gedmo\Translatable]
@@ -55,6 +56,7 @@ class MappedSupperClass
      * @var string|null
      *
      * @ORM\Column(name="created_at", type="string", length=45)
+     *
      * @Gedmo\IpTraceable(on="create")
      */
     #[ORM\Column(name: 'created_at', type: Types::STRING, length: 45)]

--- a/tests/Gedmo/IpTraceable/Fixture/SupperClassExtension.php
+++ b/tests/Gedmo/IpTraceable/Fixture/SupperClassExtension.php
@@ -22,6 +22,7 @@ class SupperClassExtension extends MappedSupperClass
 {
     /**
      * @ORM\Column(length=128)
+     *
      * @Gedmo\Translatable
      */
     #[ORM\Column(length: 128)]

--- a/tests/Gedmo/IpTraceable/Fixture/TitledArticle.php
+++ b/tests/Gedmo/IpTraceable/Fixture/TitledArticle.php
@@ -46,6 +46,7 @@ class TitledArticle implements IpTraceable
 
     /**
      * @ORM\Column(name="chtext", type="string", length=45, nullable=true)
+     *
      * @Gedmo\IpTraceable(on="change", field="text")
      */
     #[ORM\Column(name: 'chtext', type: Types::STRING, length: 45, nullable: true)]
@@ -54,6 +55,7 @@ class TitledArticle implements IpTraceable
 
     /**
      * @ORM\Column(name="chtitle", type="string", length=45, nullable=true)
+     *
      * @Gedmo\IpTraceable(on="change", field="title")
      */
     #[ORM\Column(name: 'chtitle', type: Types::STRING, length: 45, nullable: true)]

--- a/tests/Gedmo/IpTraceable/Fixture/WithoutInterface.php
+++ b/tests/Gedmo/IpTraceable/Fixture/WithoutInterface.php
@@ -41,7 +41,9 @@ class WithoutInterface
 
     /**
      * @var string|null
+     *
      * @Gedmo\IpTraceable(on="create")
+     *
      * @ORM\Column(type="string", length=45)
      */
     #[ORM\Column(type: Types::STRING, length: 45)]
@@ -50,7 +52,9 @@ class WithoutInterface
 
     /**
      * @var string|null
+     *
      * @ORM\Column(type="string", length=45)
+     *
      * @Gedmo\IpTraceable(on="update")
      */
     #[ORM\Column(type: Types::STRING, length: 45)]

--- a/tests/Gedmo/Loggable/Fixture/Document/Article.php
+++ b/tests/Gedmo/Loggable/Fixture/Document/Article.php
@@ -18,6 +18,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ODM\Document(collection="articles")
+ *
  * @Gedmo\Loggable
  */
 #[ODM\Document(collection: 'articles')]
@@ -26,6 +27,7 @@ class Article implements Loggable
 {
     /**
      * @var string|null
+     *
      * @ODM\Id
      */
     #[ODM\Id]
@@ -33,6 +35,7 @@ class Article implements Loggable
 
     /**
      * @Gedmo\Versioned
+     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: Type::STRING)]
@@ -41,6 +44,7 @@ class Article implements Loggable
 
     /**
      * @ODM\EmbedOne(targetDocument="Gedmo\Tests\Loggable\Fixture\Document\Author")
+     *
      * @Gedmo\Versioned
      */
     #[ODM\EmbedOne(targetDocument: Author::class)]

--- a/tests/Gedmo/Loggable/Fixture/Document/Author.php
+++ b/tests/Gedmo/Loggable/Fixture/Document/Author.php
@@ -18,6 +18,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ODM\EmbeddedDocument
+ *
  * @Gedmo\Loggable
  */
 #[ODM\EmbeddedDocument]
@@ -26,6 +27,7 @@ class Author implements Loggable
 {
     /**
      * @Gedmo\Versioned
+     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: Type::STRING)]
@@ -34,6 +36,7 @@ class Author implements Loggable
 
     /**
      * @Gedmo\Versioned
+     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: Type::STRING)]

--- a/tests/Gedmo/Loggable/Fixture/Document/Comment.php
+++ b/tests/Gedmo/Loggable/Fixture/Document/Comment.php
@@ -19,6 +19,7 @@ use Gedmo\Tests\Loggable\Fixture\Document\Log\Comment as CommentLog;
 
 /**
  * @ODM\Document
+ *
  * @Gedmo\Loggable(logEntryClass="Gedmo\Tests\Loggable\Fixture\Document\Log\Comment")
  */
 #[ODM\Document]
@@ -27,6 +28,7 @@ class Comment implements Loggable
 {
     /**
      * @var string|null
+     *
      * @ODM\Id
      */
     #[ODM\Id]
@@ -34,6 +36,7 @@ class Comment implements Loggable
 
     /**
      * @Gedmo\Versioned
+     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: Type::STRING)]
@@ -42,6 +45,7 @@ class Comment implements Loggable
 
     /**
      * @Gedmo\Versioned
+     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: Type::STRING)]
@@ -50,6 +54,7 @@ class Comment implements Loggable
 
     /**
      * @Gedmo\Versioned
+     *
      * @ODM\ReferenceOne(targetDocument="Gedmo\Tests\Loggable\Fixture\Document\RelatedArticle", inversedBy="comments")
      */
     #[ODM\ReferenceOne(targetDocument: RelatedArticle::class, inversedBy: 'comments')]
@@ -58,6 +63,7 @@ class Comment implements Loggable
 
     /**
      * @ODM\EmbedOne(targetDocument="Gedmo\Tests\Loggable\Fixture\Document\Author")
+     *
      * @Gedmo\Versioned
      */
     #[ODM\EmbedOne(targetDocument: Author::class)]

--- a/tests/Gedmo/Loggable/Fixture/Document/RelatedArticle.php
+++ b/tests/Gedmo/Loggable/Fixture/Document/RelatedArticle.php
@@ -20,6 +20,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ODM\Document
+ *
  * @Gedmo\Loggable
  */
 #[ODM\Document]
@@ -28,6 +29,7 @@ class RelatedArticle implements Loggable
 {
     /**
      * @var string|null
+     *
      * @ODM\Id
      */
     #[ODM\Id]
@@ -35,6 +37,7 @@ class RelatedArticle implements Loggable
 
     /**
      * @Gedmo\Versioned
+     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: Type::STRING)]
@@ -43,6 +46,7 @@ class RelatedArticle implements Loggable
 
     /**
      * @Gedmo\Versioned
+     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: Type::STRING)]
@@ -51,6 +55,7 @@ class RelatedArticle implements Loggable
 
     /**
      * @var Collection<int, Comment>
+     *
      * @ODM\ReferenceMany(targetDocument="Gedmo\Tests\Loggable\Fixture\Document\Comment", mappedBy="article")
      */
     #[ODM\ReferenceMany(targetDocument: Comment::class, mappedBy: 'article')]

--- a/tests/Gedmo/Loggable/Fixture/Entity/Address.php
+++ b/tests/Gedmo/Loggable/Fixture/Entity/Address.php
@@ -20,6 +20,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
  * @author Fabian Sabau <fabian.sabau@socialbit.de>
  *
  * @ORM\Entity
+ *
  * @Gedmo\Loggable
  */
 #[ORM\Entity]
@@ -28,6 +29,7 @@ class Address implements Loggable
 {
     /**
      * @var int|null
+     *
      * @ORM\Id
      * @ORM\Column(name="id", type="integer")
      * @ORM\GeneratedValue(strategy="AUTO")
@@ -39,7 +41,9 @@ class Address implements Loggable
 
     /**
      * @var string|null
+     *
      * @ORM\Column(type="string", length=191)
+     *
      * @Gedmo\Versioned
      */
     #[ORM\Column(type: Types::STRING, length: 191)]
@@ -48,7 +52,9 @@ class Address implements Loggable
 
     /**
      * @var string|null
+     *
      * @ORM\Column(type="string", length=191)
+     *
      * @Gedmo\Versioned
      */
     #[ORM\Column(type: Types::STRING, length: 191)]
@@ -57,7 +63,9 @@ class Address implements Loggable
 
     /**
      * @var Geo|null
+     *
      * @ORM\Embedded(class="Gedmo\Tests\Loggable\Fixture\Entity\Geo")
+     *
      * @Gedmo\Versioned
      */
     #[ORM\Embedded(class: Geo::class)]

--- a/tests/Gedmo/Loggable/Fixture/Entity/Article.php
+++ b/tests/Gedmo/Loggable/Fixture/Entity/Article.php
@@ -18,6 +18,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
+ *
  * @Gedmo\Loggable
  */
 #[ORM\Entity]
@@ -38,6 +39,7 @@ class Article implements Loggable
 
     /**
      * @Gedmo\Versioned
+     *
      * @ORM\Column(name="title", type="string", length=8)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 8)]

--- a/tests/Gedmo/Loggable/Fixture/Entity/Comment.php
+++ b/tests/Gedmo/Loggable/Fixture/Entity/Comment.php
@@ -19,6 +19,7 @@ use Gedmo\Tests\Loggable\Fixture\Entity\Log\Comment as CommentLog;
 
 /**
  * @ORM\Entity
+ *
  * @Gedmo\Loggable(logEntryClass="Gedmo\Tests\Loggable\Fixture\Entity\Log\Comment")
  */
 #[ORM\Entity]
@@ -27,6 +28,7 @@ class Comment implements Loggable
 {
     /**
      * @var int|null
+     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -38,6 +40,7 @@ class Comment implements Loggable
 
     /**
      * @Gedmo\Versioned
+     *
      * @ORM\Column(length=128)
      */
     #[ORM\Column(length: 128)]
@@ -46,6 +49,7 @@ class Comment implements Loggable
 
     /**
      * @Gedmo\Versioned
+     *
      * @ORM\Column(type="text")
      */
     #[ORM\Column(type: Types::TEXT)]
@@ -54,6 +58,7 @@ class Comment implements Loggable
 
     /**
      * @Gedmo\Versioned
+     *
      * @ORM\ManyToOne(targetEntity="RelatedArticle", inversedBy="comments")
      */
     #[ORM\ManyToOne(targetEntity: RelatedArticle::class, inversedBy: 'comments')]

--- a/tests/Gedmo/Loggable/Fixture/Entity/Composite.php
+++ b/tests/Gedmo/Loggable/Fixture/Entity/Composite.php
@@ -15,6 +15,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
+ *
  * @Gedmo\Loggable
  */
 #[ORM\Entity]
@@ -39,6 +40,7 @@ class Composite
 
     /**
      * @ORM\Column(length=8)
+     *
      * @Gedmo\Versioned
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 8)]

--- a/tests/Gedmo/Loggable/Fixture/Entity/CompositeRelation.php
+++ b/tests/Gedmo/Loggable/Fixture/Entity/CompositeRelation.php
@@ -15,6 +15,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
+ *
  * @Gedmo\Loggable
  */
 #[ORM\Entity]
@@ -39,6 +40,7 @@ class CompositeRelation
 
     /**
      * @ORM\Column(length=8)
+     *
      * @Gedmo\Versioned
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 8)]

--- a/tests/Gedmo/Loggable/Fixture/Entity/Geo.php
+++ b/tests/Gedmo/Loggable/Fixture/Entity/Geo.php
@@ -27,8 +27,11 @@ class Geo
 {
     /**
      * @var string|null
+     *
      * @phpstan-var numeric-string|null
+     *
      * @ORM\Column(type="decimal", precision=9, scale=6)
+     *
      * @Gedmo\Versioned
      */
     #[ORM\Column(type: Types::DECIMAL, precision: 9, scale: 6)]
@@ -37,8 +40,11 @@ class Geo
 
     /**
      * @var string|null
+     *
      * @phpstan-var numeric-string|null
+     *
      * @ORM\Column(type="decimal", precision=9, scale=6)
+     *
      * @Gedmo\Versioned
      */
     #[ORM\Column(type: Types::DECIMAL, precision: 9, scale: 6)]
@@ -47,7 +53,9 @@ class Geo
 
     /**
      * @var GeoLocation
+     *
      * @ORM\Embedded(class="Gedmo\Tests\Loggable\Fixture\Entity\GeoLocation")
+     *
      * @Gedmo\Versioned
      */
     #[ORM\Embedded(class: GeoLocation::class)]

--- a/tests/Gedmo/Loggable/Fixture/Entity/GeoLocation.php
+++ b/tests/Gedmo/Loggable/Fixture/Entity/GeoLocation.php
@@ -27,7 +27,9 @@ class GeoLocation
 {
     /**
      * @var string
+     *
      * @ORM\Column(type="string")
+     *
      * @Gedmo\Versioned
      */
     #[ORM\Column(type: Types::STRING)]

--- a/tests/Gedmo/Loggable/Fixture/Entity/RelatedArticle.php
+++ b/tests/Gedmo/Loggable/Fixture/Entity/RelatedArticle.php
@@ -20,6 +20,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
+ *
  * @Gedmo\Loggable
  */
 #[ORM\Entity]
@@ -28,6 +29,7 @@ class RelatedArticle implements Loggable
 {
     /**
      * @var int|null
+     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -39,6 +41,7 @@ class RelatedArticle implements Loggable
 
     /**
      * @Gedmo\Versioned
+     *
      * @ORM\Column(length=128)
      */
     #[ORM\Column(length: 128)]
@@ -47,6 +50,7 @@ class RelatedArticle implements Loggable
 
     /**
      * @Gedmo\Versioned
+     *
      * @ORM\Column(type="text")
      */
     #[ORM\Column(Types::TEXT)]
@@ -55,6 +59,7 @@ class RelatedArticle implements Loggable
 
     /**
      * @var Collection<int, Comment>
+     *
      * @ORM\OneToMany(targetEntity="Comment", mappedBy="article")
      */
     #[ORM\OneToMany(targetEntity: Comment::class, mappedBy: 'article')]

--- a/tests/Gedmo/Mapping/Annotation/BaseClassAnnotationTestCase.php
+++ b/tests/Gedmo/Mapping/Annotation/BaseClassAnnotationTestCase.php
@@ -19,6 +19,7 @@ abstract class BaseClassAnnotationTestCase extends TestCase
 {
     /**
      * @requires PHP 8
+     *
      * @dataProvider getValidParameters
      *
      * @param mixed $expectedReturn

--- a/tests/Gedmo/Mapping/Annotation/BasePropertyAnnotationTestCase.php
+++ b/tests/Gedmo/Mapping/Annotation/BasePropertyAnnotationTestCase.php
@@ -19,6 +19,7 @@ abstract class BasePropertyAnnotationTestCase extends TestCase
 {
     /**
      * @requires PHP 8
+     *
      * @dataProvider getValidParameters
      *
      * @param mixed $expectedReturn

--- a/tests/Gedmo/Mapping/Fixture/Document/User.php
+++ b/tests/Gedmo/Mapping/Fixture/Document/User.php
@@ -28,12 +28,14 @@ class User
 
     /**
      * @Ext\Encode(type="sha1", secret="xxx")
+     *
      * @ODM\Field(type="string")
      */
     private ?string $name = null;
 
     /**
      * @Ext\Encode(type="md5")
+     *
      * @ODM\Field(type="string")
      */
     private ?string $password = null;

--- a/tests/Gedmo/Mapping/Fixture/Loggable.php
+++ b/tests/Gedmo/Mapping/Fixture/Loggable.php
@@ -14,6 +14,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
+ *
  * @Gedmo\Loggable
  */
 class Loggable
@@ -29,6 +30,7 @@ class Loggable
 
     /**
      * @ORM\Column(name="title", type="string", length=64)
+     *
      * @Gedmo\Versioned
      */
     private ?string $title = null;

--- a/tests/Gedmo/Mapping/Fixture/LoggableComposite.php
+++ b/tests/Gedmo/Mapping/Fixture/LoggableComposite.php
@@ -14,6 +14,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
+ *
  * @Gedmo\Loggable
  */
 class LoggableComposite
@@ -36,6 +37,7 @@ class LoggableComposite
 
     /**
      * @ORM\Column(name="title", type="string", length=64)
+     *
      * @Gedmo\Versioned
      */
     private ?string $title = null;

--- a/tests/Gedmo/Mapping/Fixture/LoggableCompositeRelation.php
+++ b/tests/Gedmo/Mapping/Fixture/LoggableCompositeRelation.php
@@ -14,6 +14,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
+ *
  * @Gedmo\Loggable
  */
 class LoggableCompositeRelation
@@ -36,6 +37,7 @@ class LoggableCompositeRelation
 
     /**
      * @ORM\Column(name="title", type="string", length=64)
+     *
      * @Gedmo\Versioned
      */
     private ?string $title = null;

--- a/tests/Gedmo/Mapping/Fixture/MappedSuperClass.php
+++ b/tests/Gedmo/Mapping/Fixture/MappedSuperClass.php
@@ -35,6 +35,7 @@ class MappedSuperClass
 
     /**
      * @ORM\Column(length=32)
+     *
      * @Ext\Encode(type="md5")
      */
     #[ORM\Column(length: 32)]

--- a/tests/Gedmo/Mapping/Fixture/Sluggable.php
+++ b/tests/Gedmo/Mapping/Fixture/Sluggable.php
@@ -61,6 +61,7 @@ class Sluggable
      *         @Gedmo\SlugHandlerOption(name="separator", value="/")
      *     })
      * }, separator="-", updatable=false, fields={"title", "code"})
+     *
      * @ORM\Column(name="slug", type="string", length=64, unique=true)
      */
     #[Gedmo\Slug(separator: '-', updatable: false, fields: ['title', 'code'])]

--- a/tests/Gedmo/Mapping/Fixture/SoftDeleteable.php
+++ b/tests/Gedmo/Mapping/Fixture/SoftDeleteable.php
@@ -16,6 +16,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
+ *
  * @Gedmo\SoftDeleteable(fieldName="deletedAt")
  */
 class SoftDeleteable

--- a/tests/Gedmo/Mapping/Fixture/Unmapped/Timestampable.php
+++ b/tests/Gedmo/Mapping/Fixture/Unmapped/Timestampable.php
@@ -22,6 +22,7 @@ class Timestampable
 
     /**
      * @var \DateTime
+     *
      * @Tmsp(on="create")
      */
     private $created;

--- a/tests/Gedmo/Mapping/Fixture/User.php
+++ b/tests/Gedmo/Mapping/Fixture/User.php
@@ -37,6 +37,7 @@ class User
 
     /**
      * @Ext\Encode(type="sha1", secret="xxx")
+     *
      * @ORM\Column(length=64)
      */
     #[ORM\Column(length: 64)]
@@ -44,6 +45,7 @@ class User
 
     /**
      * @Ext\Encode(type="md5")
+     *
      * @ORM\Column(length=32)
      */
     #[ORM\Column(length: 32)]

--- a/tests/Gedmo/Mapping/Mock/Extension/Encoder/Mapping/Driver/Annotation.php
+++ b/tests/Gedmo/Mapping/Mock/Extension/Encoder/Mapping/Driver/Annotation.php
@@ -35,9 +35,9 @@ class Annotation implements Driver
         // check only property annotations
         foreach ($class->getProperties() as $property) {
             // skip inherited properties
-            if ($meta->isMappedSuperclass && !$property->isPrivate() ||
-                $meta->isInheritedField($property->name) ||
-                isset($meta->associationMappings[$property->name]['inherited'])
+            if ($meta->isMappedSuperclass && !$property->isPrivate()
+                || $meta->isInheritedField($property->name)
+                || isset($meta->associationMappings[$property->name]['inherited'])
             ) {
                 continue;
             }

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyNullify/Type.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyNullify/Type.php
@@ -27,6 +27,7 @@ class Type
      * @var Collection<int, Article>
      *
      * @ODM\ReferenceMany(targetDocument="Gedmo\Tests\ReferenceIntegrity\Fixture\Document\ManyNullify\Article", mappedBy="type")
+     *
      * @Gedmo\ReferenceIntegrity("nullify")
      */
     #[ODM\ReferenceMany(targetDocument: Article::class, mappedBy: 'type')]

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyPull/Type.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyPull/Type.php
@@ -27,6 +27,7 @@ class Type
      * @var Collection<int, Article>
      *
      * @ODM\ReferenceMany(targetDocument="Gedmo\Tests\ReferenceIntegrity\Fixture\Document\ManyPull\Article", mappedBy="types")
+     *
      * @Gedmo\ReferenceIntegrity("pull")
      */
     #[ODM\ReferenceMany(targetDocument: Article::class, mappedBy: 'types')]

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyRestrict/Type.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyRestrict/Type.php
@@ -27,6 +27,7 @@ class Type
      * @var Collection<int, Article>
      *
      * @ODM\ReferenceMany(targetDocument="Gedmo\Tests\ReferenceIntegrity\Fixture\Document\ManyRestrict\Article", mappedBy="type")
+     *
      * @Gedmo\ReferenceIntegrity("restrict")
      */
     #[ODM\ReferenceMany(targetDocument: Article::class, mappedBy: 'type')]

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OneNullify/Type.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OneNullify/Type.php
@@ -25,6 +25,7 @@ class Type
      * @var Article
      *
      * @ODM\ReferenceOne(targetDocument="Gedmo\Tests\ReferenceIntegrity\Fixture\Document\OneNullify\Article", mappedBy="type")
+     *
      * @Gedmo\ReferenceIntegrity("nullify")
      */
     #[ODM\ReferenceOne(targetDocument: Article::class, mappedBy: 'type')]

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OnePull/Type.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OnePull/Type.php
@@ -25,6 +25,7 @@ class Type
      * @var Article|null
      *
      * @ODM\ReferenceOne(targetDocument="Gedmo\Tests\ReferenceIntegrity\Fixture\Document\OnePull\Article", mappedBy="types")
+     *
      * @Gedmo\ReferenceIntegrity("pull")
      */
     #[ODM\ReferenceOne(targetDocument: Article::class, mappedBy: 'types')]

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OneRestrict/Type.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OneRestrict/Type.php
@@ -25,6 +25,7 @@ class Type
      * @var Article|null
      *
      * @ODM\ReferenceOne(targetDocument="Gedmo\Tests\ReferenceIntegrity\Fixture\Document\OneRestrict\Article", mappedBy="type")
+     *
      * @Gedmo\ReferenceIntegrity("restrict")
      */
     #[ODM\ReferenceOne(targetDocument: Article::class, mappedBy: 'type')]

--- a/tests/Gedmo/Sluggable/Fixture/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Article.php
@@ -48,6 +48,7 @@ class Article implements Sluggable
 
     /**
      * @Gedmo\Slug(separator="-", updatable=true, fields={"title", "code"})
+     *
      * @ORM\Column(name="slug", type="string", length=64, unique=true)
      */
     #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title', 'code'])]

--- a/tests/Gedmo/Sluggable/Fixture/ArticleWithoutFields.php
+++ b/tests/Gedmo/Sluggable/Fixture/ArticleWithoutFields.php
@@ -36,6 +36,7 @@ class ArticleWithoutFields implements Sluggable
 
     /**
      * @Gedmo\Slug(separator="-", updatable=true)
+     *
      * @ORM\Column(name="slug", type="string", length=64, unique=true)
      */
     #[Gedmo\Slug(separator: '-', updatable: true)]

--- a/tests/Gedmo/Sluggable/Fixture/ConfigurationArticle.php
+++ b/tests/Gedmo/Sluggable/Fixture/ConfigurationArticle.php
@@ -48,6 +48,7 @@ class ConfigurationArticle implements Sluggable
 
     /**
      * @Gedmo\Slug(updatable=false, unique=false, unique_base=null, fields={"title", "code"})
+     *
      * @ORM\Column(name="slug", type="string", length=32)
      */
     #[Gedmo\Slug(updatable: false, unique: false, unique_base: null, fields: ['title', 'code'])]

--- a/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDate.php
+++ b/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDate.php
@@ -48,6 +48,7 @@ class ArticleDate implements Sluggable
 
     /**
      * @Gedmo\Slug(separator="-", updatable=true, fields={"title", "createdAt"}, dateFormat="Y-m-d")
+     *
      * @ORM\Column(name="slug", type="string", length=64, unique=true)
      */
     #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title', 'createdAt'], dateFormat: 'Y-m-d')]

--- a/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateImmutable.php
+++ b/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateImmutable.php
@@ -48,6 +48,7 @@ class ArticleDateImmutable implements Sluggable
 
     /**
      * @Gedmo\Slug(separator="-", updatable=true, fields={"title", "createdAt"}, dateFormat="Y-m-d")
+     *
      * @ORM\Column(name="slug", type="string", length=64, unique=true)
      */
     #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title', 'createdAt'], dateFormat: 'Y-m-d')]

--- a/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateTime.php
+++ b/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateTime.php
@@ -48,6 +48,7 @@ class ArticleDateTime implements Sluggable
 
     /**
      * @Gedmo\Slug(separator="-", updatable=true, fields={"title", "createdAt"}, dateFormat="Y-m-d")
+     *
      * @ORM\Column(name="slug", type="string", length=64, unique=true)
      */
     #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title', 'createdAt'], dateFormat: 'Y-m-d')]

--- a/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateTimeImmutable.php
+++ b/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateTimeImmutable.php
@@ -48,6 +48,7 @@ class ArticleDateTimeImmutable implements Sluggable
 
     /**
      * @Gedmo\Slug(separator="-", updatable=true, fields={"title", "createdAt"}, dateFormat="Y-m-d")
+     *
      * @ORM\Column(name="slug", type="string", length=64, unique=true)
      */
     #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title', 'createdAt'], dateFormat: 'Y-m-d')]

--- a/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateTimeTz.php
+++ b/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateTimeTz.php
@@ -48,6 +48,7 @@ class ArticleDateTimeTz implements Sluggable
 
     /**
      * @Gedmo\Slug(separator="-", updatable=true, fields={"title", "createdAt"}, dateFormat="Y-m-d")
+     *
      * @ORM\Column(name="slug", type="string", length=64, unique=true)
      */
     #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title', 'createdAt'], dateFormat: 'Y-m-d')]

--- a/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateTimeTzImmutable.php
+++ b/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateTimeTzImmutable.php
@@ -48,6 +48,7 @@ class ArticleDateTimeTzImmutable implements Sluggable
 
     /**
      * @Gedmo\Slug(separator="-", updatable=true, fields={"title", "createdAt"}, dateFormat="Y-m-d")
+     *
      * @ORM\Column(name="slug", type="string", length=64, unique=true)
      */
     #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title', 'createdAt'], dateFormat: 'Y-m-d')]

--- a/tests/Gedmo/Sluggable/Fixture/Document/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Document/Article.php
@@ -45,6 +45,7 @@ class Article
      * @var string|null
      *
      * @Gedmo\Slug(separator="-", updatable=true, fields={"title", "code"})
+     *
      * @ODM\Field(type="string")
      */
     #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title', 'code'])]

--- a/tests/Gedmo/Sluggable/Fixture/Document/Handler/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Document/Handler/Article.php
@@ -52,6 +52,7 @@ class Article
      *         @Gedmo\SlugHandlerOption(name="inverseSlugField", value="alias")
      *     })
      * }, separator="-", updatable=true, fields={"title", "code"})
+     *
      * @ODM\Field(type="string")
      */
     #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title', 'code'])]

--- a/tests/Gedmo/Sluggable/Fixture/Document/Handler/RelativeSlug.php
+++ b/tests/Gedmo/Sluggable/Fixture/Document/Handler/RelativeSlug.php
@@ -46,6 +46,7 @@ class RelativeSlug
      *         @Gedmo\SlugHandlerOption(name="separator", value="/")
      *     })
      * }, separator="-", updatable=true, fields={"title"})
+     *
      * @ODM\Field(type="string")
      */
     #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title'])]

--- a/tests/Gedmo/Sluggable/Fixture/Document/Handler/TreeSlug.php
+++ b/tests/Gedmo/Sluggable/Fixture/Document/Handler/TreeSlug.php
@@ -45,6 +45,7 @@ class TreeSlug
      *         @Gedmo\SlugHandlerOption(name="separator", value="/")
      *     })
      * }, separator="-", updatable=true, fields={"title"})
+     *
      * @ODM\Field(type="string")
      */
     #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title'])]

--- a/tests/Gedmo/Sluggable/Fixture/Handler/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Handler/Article.php
@@ -57,6 +57,7 @@ class Article implements Sluggable
      *         @Gedmo\SlugHandlerOption(name="inverseSlugField", value="slug")
      *     })
      * }, separator="-", updatable=true, fields={"title", "code"})
+     *
      * @ORM\Column(name="slug", type="string", length=64, unique=true)
      */
     #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title', 'code'])]

--- a/tests/Gedmo/Sluggable/Fixture/Handler/ArticleRelativeSlug.php
+++ b/tests/Gedmo/Sluggable/Fixture/Handler/ArticleRelativeSlug.php
@@ -50,6 +50,7 @@ class ArticleRelativeSlug
      *         @Gedmo\SlugHandlerOption(name="separator", value="/")
      *     })
      * }, separator="-", updatable=true, fields={"title"})
+     *
      * @ORM\Column(name="slug", type="string", length=64, unique=true)
      */
     #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title'])]

--- a/tests/Gedmo/Sluggable/Fixture/Handler/Company.php
+++ b/tests/Gedmo/Sluggable/Fixture/Handler/Company.php
@@ -50,6 +50,7 @@ class Company
      *         @Gedmo\SlugHandlerOption(name="inverseSlugField", value="slug")
      *     })
      * }, fields={"title"})
+     *
      * @ORM\Column(length=64, unique=true)
      */
     #[Gedmo\Slug(fields: ['title'])]

--- a/tests/Gedmo/Sluggable/Fixture/Handler/People/Occupation.php
+++ b/tests/Gedmo/Sluggable/Fixture/Handler/People/Occupation.php
@@ -22,6 +22,7 @@ use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
 
 /**
  * @Gedmo\Tree(type="nested")
+ *
  * @ORM\Entity(repositoryClass="Gedmo\Tree\Entity\Repository\NestedTreeRepository")
  */
 #[ORM\Entity(repositoryClass: NestedTreeRepository::class)]
@@ -60,6 +61,7 @@ class Occupation
      *         @Gedmo\SlugHandlerOption(name="inverseSlugField", value="slug")
      *     })
      * }, fields={"title"})
+     *
      * @ORM\Column(length=64, unique=true)
      */
     #[Gedmo\Slug(fields: ['title'])]
@@ -70,6 +72,7 @@ class Occupation
 
     /**
      * @Gedmo\TreeParent
+     *
      * @ORM\ManyToOne(targetEntity="Occupation")
      * @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
      */
@@ -87,6 +90,7 @@ class Occupation
      * @var int|null
      *
      * @Gedmo\TreeLeft
+     *
      * @ORM\Column(type="integer")
      */
     #[ORM\Column(type: Types::INTEGER)]
@@ -97,6 +101,7 @@ class Occupation
      * @var int|null
      *
      * @Gedmo\TreeRight
+     *
      * @ORM\Column(type="integer")
      */
     #[ORM\Column(type: Types::INTEGER)]
@@ -107,6 +112,7 @@ class Occupation
      * @var int|null
      *
      * @Gedmo\TreeRoot
+     *
      * @ORM\Column(type="integer")
      */
     #[ORM\Column(type: Types::INTEGER)]
@@ -117,6 +123,7 @@ class Occupation
      * @var int|null
      *
      * @Gedmo\TreeLevel
+     *
      * @ORM\Column(name="lvl", type="integer")
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER)]

--- a/tests/Gedmo/Sluggable/Fixture/Handler/People/Person.php
+++ b/tests/Gedmo/Sluggable/Fixture/Handler/People/Person.php
@@ -50,6 +50,7 @@ class Person
      *         @Gedmo\SlugHandlerOption(name="separator", value="/")
      *     })
      * }, separator="-", updatable=true, fields={"name"})
+     *
      * @ORM\Column(name="slug", type="string", length=64, unique=true)
      */
     #[Gedmo\Slug(separator: '-', updatable: true, fields: ['name'])]

--- a/tests/Gedmo/Sluggable/Fixture/Handler/TreeSlug.php
+++ b/tests/Gedmo/Sluggable/Fixture/Handler/TreeSlug.php
@@ -22,6 +22,7 @@ use Gedmo\Tree\Node;
 
 /**
  * @Gedmo\Tree(type="nested")
+ *
  * @ORM\Entity(repositoryClass="Gedmo\Tree\Entity\Repository\NestedTreeRepository")
  */
 #[ORM\Entity(repositoryClass: NestedTreeRepository::class)]
@@ -55,6 +56,7 @@ class TreeSlug implements Node
      *         @Gedmo\SlugHandlerOption(name="separator", value="/")
      *     })
      * }, separator="-", updatable=true)
+     *
      * @ORM\Column(name="slug", type="string", length=64, unique=true)
      */
     #[Gedmo\Slug(fields: ['title'], separator: '-', updatable: true)]
@@ -64,6 +66,7 @@ class TreeSlug implements Node
 
     /**
      * @Gedmo\TreeParent
+     *
      * @ORM\ManyToOne(targetEntity="TreeSlug")
      * @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
      */
@@ -81,6 +84,7 @@ class TreeSlug implements Node
      * @var int|null
      *
      * @Gedmo\TreeLeft
+     *
      * @ORM\Column(type="integer")
      */
     #[ORM\Column(type: Types::INTEGER)]
@@ -91,6 +95,7 @@ class TreeSlug implements Node
      * @var int|null
      *
      * @Gedmo\TreeRight
+     *
      * @ORM\Column(type="integer")
      */
     #[ORM\Column(type: Types::INTEGER)]
@@ -101,6 +106,7 @@ class TreeSlug implements Node
      * @var int|null
      *
      * @Gedmo\TreeRoot
+     *
      * @ORM\Column(type="integer")
      */
     #[ORM\Column(type: Types::INTEGER)]
@@ -111,6 +117,7 @@ class TreeSlug implements Node
      * @var int|null
      *
      * @Gedmo\TreeLevel
+     *
      * @ORM\Column(name="lvl", type="integer")
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER)]

--- a/tests/Gedmo/Sluggable/Fixture/Handler/TreeSlugPrefixSuffix.php
+++ b/tests/Gedmo/Sluggable/Fixture/Handler/TreeSlugPrefixSuffix.php
@@ -21,6 +21,7 @@ use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
 
 /**
  * @Gedmo\Tree(type="nested")
+ *
  * @ORM\Entity(repositoryClass="Gedmo\Tree\Entity\Repository\NestedTreeRepository")
  */
 #[ORM\Entity(repositoryClass: NestedTreeRepository::class)]
@@ -56,6 +57,7 @@ class TreeSlugPrefixSuffix
      *         @Gedmo\SlugHandlerOption(name="suffix", value=".suffix")
      *     })
      * }, separator="-", updatable=true)
+     *
      * @ORM\Column(name="slug", type="string", length=64, unique=true)
      */
     #[Gedmo\Slug(fields: ['title'], separator: '-', updatable: true)]
@@ -65,6 +67,7 @@ class TreeSlugPrefixSuffix
 
     /**
      * @Gedmo\TreeParent
+     *
      * @ORM\ManyToOne(targetEntity="TreeSlugPrefixSuffix")
      * @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
      */
@@ -82,6 +85,7 @@ class TreeSlugPrefixSuffix
      * @var int|null
      *
      * @Gedmo\TreeLeft
+     *
      * @ORM\Column(type="integer")
      */
     #[ORM\Column(type: Types::INTEGER)]
@@ -92,6 +96,7 @@ class TreeSlugPrefixSuffix
      * @var int|null
      *
      * @Gedmo\TreeRight
+     *
      * @ORM\Column(type="integer")
      */
     #[ORM\Column(type: Types::INTEGER)]
@@ -102,6 +107,7 @@ class TreeSlugPrefixSuffix
      * @var int|null
      *
      * @Gedmo\TreeRoot
+     *
      * @ORM\Column(type="integer")
      */
     #[ORM\Column(type: Types::INTEGER)]
@@ -112,6 +118,7 @@ class TreeSlugPrefixSuffix
      * @var int|null
      *
      * @Gedmo\TreeLevel
+     *
      * @ORM\Column(name="lvl", type="integer")
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER)]

--- a/tests/Gedmo/Sluggable/Fixture/Handler/User.php
+++ b/tests/Gedmo/Sluggable/Fixture/Handler/User.php
@@ -50,6 +50,7 @@ class User
      *         @Gedmo\SlugHandlerOption(name="separator", value="/")
      *     })
      * }, separator="-", updatable=true, fields={"username"})
+     *
      * @ORM\Column(length=64, unique=true)
      */
     #[Gedmo\Slug(separator: '-', updatable: true, fields: ['username'])]

--- a/tests/Gedmo/Sluggable/Fixture/Identifier.php
+++ b/tests/Gedmo/Sluggable/Fixture/Identifier.php
@@ -24,7 +24,9 @@ class Identifier
      * @var string|null
      *
      * @ORM\Id
+     *
      * @Gedmo\Slug(separator="_", updatable=false, fields={"title"})
+     *
      * @ORM\Column(length=32, unique=true)
      */
     #[ORM\Id]

--- a/tests/Gedmo/Sluggable/Fixture/Inheritance/Vehicle.php
+++ b/tests/Gedmo/Sluggable/Fixture/Inheritance/Vehicle.php
@@ -52,6 +52,7 @@ class Vehicle
      * @var string|null
      *
      * @Gedmo\Slug(fields={"title"})
+     *
      * @ORM\Column(length=128, unique=true)
      */
     #[Gedmo\Slug(fields: ['title'])]

--- a/tests/Gedmo/Sluggable/Fixture/Inheritance2/Car.php
+++ b/tests/Gedmo/Sluggable/Fixture/Inheritance2/Car.php
@@ -38,6 +38,7 @@ class Car extends Vehicle
      * @var string|null
      *
      * @Gedmo\Slug(fields={"title"})
+     *
      * @ORM\Column(length=128, unique=true)
      */
     #[Gedmo\Slug(fields: ['title'])]

--- a/tests/Gedmo/Sluggable/Fixture/Issue104/Icarus.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue104/Icarus.php
@@ -30,6 +30,7 @@ class Icarus extends Bus
      * @var string|null
      *
      * @Gedmo\Slug(fields={"title"})
+     *
      * @ORM\Column(length=128, unique=true)
      */
     #[Gedmo\Slug(fields: ['title'])]

--- a/tests/Gedmo/Sluggable/Fixture/Issue104/Vehicle.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue104/Vehicle.php
@@ -45,6 +45,7 @@ class Vehicle
      * @var string|null
      *
      * @Gedmo\Slug(fields={"title"})
+     *
      * @ORM\Column(length=128, unique=true)
      */
     #[Gedmo\Slug(fields: ['title'])]

--- a/tests/Gedmo/Sluggable/Fixture/Issue1058/Page.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue1058/Page.php
@@ -49,6 +49,7 @@ class Page
 
     /**
      * @Gedmo\Slug(separator="-", fields={"title"}, unique=true, unique_base="user")
+     *
      * @ORM\Column(name="slug", type="string", length=64)
      */
     #[Gedmo\Slug(separator: '-', unique: true, unique_base: 'user', fields: ['title'])]

--- a/tests/Gedmo/Sluggable/Fixture/Issue1151/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue1151/Article.php
@@ -35,6 +35,7 @@ class Article
 
     /**
      * @Gedmo\Slug(separator="-", updatable=true, fields={"title"})
+     *
      * @ODM\Field(type="string")
      */
     #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title'])]

--- a/tests/Gedmo/Sluggable/Fixture/Issue1177/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue1177/Article.php
@@ -42,6 +42,7 @@ class Article implements Sluggable
 
     /**
      * @Gedmo\Slug(separator="-", updatable=true, fields={"title"})
+     *
      * @ORM\Column(name="slug", type="string", length=64, unique=true)
      */
     #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title'])]

--- a/tests/Gedmo/Sluggable/Fixture/Issue1240/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue1240/Article.php
@@ -42,6 +42,7 @@ class Article implements Sluggable
 
     /**
      * @Gedmo\Slug(separator="+", updatable=true, fields={"title"})
+     *
      * @ORM\Column(name="slug", type="string", length=64, unique=true)
      */
     #[Gedmo\Slug(separator: '+', updatable: true, fields: ['title'])]
@@ -50,6 +51,7 @@ class Article implements Sluggable
 
     /**
      * @Gedmo\Slug(separator="+", updatable=true, fields={"title"}, style="camel")
+     *
      * @ORM\Column(name="camel_slug", type="string", length=64, unique=true)
      */
     #[ORM\Column(name: 'camel_slug', type: Types::STRING, length: 64, unique: true)]

--- a/tests/Gedmo/Sluggable/Fixture/Issue131/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue131/Article.php
@@ -43,6 +43,7 @@ class Article
      * @var string|null
      *
      * @Gedmo\Slug(updatable=true, unique=true, fields={"title"})
+     *
      * @ORM\Column(length=64, unique=true, nullable=true)
      */
     #[Gedmo\Slug(updatable: true, unique: true, fields: ['title'])]

--- a/tests/Gedmo/Sluggable/Fixture/Issue449/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue449/Article.php
@@ -18,6 +18,7 @@ use Gedmo\Sluggable\Sluggable;
 
 /**
  * @ORM\Entity
+ *
  * @Gedmo\SoftDeleteable(fieldName="deletedAt")
  */
 #[ORM\Entity]
@@ -50,6 +51,7 @@ class Article implements Sluggable
 
     /**
      * @Gedmo\Slug(separator="-", updatable=true, fields={"title", "code"})
+     *
      * @ORM\Column(name="slug", type="string", length=64, unique=true)
      */
     #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title', 'code'])]

--- a/tests/Gedmo/Sluggable/Fixture/Issue633/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue633/Article.php
@@ -49,6 +49,7 @@ class Article
      * @var string|null
      *
      * @Gedmo\Slug(updatable=true, unique=true, unique_base="code", fields={"title"})
+     *
      * @ORM\Column(length=64, nullable=true)
      */
     #[Gedmo\Slug(updatable: true, unique: true, unique_base: 'code', fields: ['title'])]

--- a/tests/Gedmo/Sluggable/Fixture/Issue827/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue827/Article.php
@@ -51,6 +51,7 @@ class Article
      * @var string|null
      *
      * @Gedmo\Slug(updatable=true, unique=true, unique_base="category", fields={"title"})
+     *
      * @ORM\Column(length=64, nullable=true)
      */
     #[Gedmo\Slug(updatable: true, unique: true, unique_base: 'category', fields: ['title'])]

--- a/tests/Gedmo/Sluggable/Fixture/Issue827/Category.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue827/Category.php
@@ -45,6 +45,7 @@ class Category
      * @var string|null
      *
      * @Gedmo\Slug(updatable=true, unique=true, fields={"title"})
+     *
      * @ORM\Column(length=64, nullable=true)
      */
     #[Gedmo\Slug(updatable: true, unique: true, fields: ['title'])]

--- a/tests/Gedmo/Sluggable/Fixture/Issue827/Comment.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue827/Comment.php
@@ -55,6 +55,7 @@ class Comment
      * @var string|null
      *
      * @Gedmo\Slug(updatable=true, unique=true, unique_base="post", fields={"title"})
+     *
      * @ORM\Column(length=64, nullable=true)
      */
     #[Gedmo\Slug(updatable: true, unique: true, unique_base: 'post', fields: ['title'])]

--- a/tests/Gedmo/Sluggable/Fixture/Issue827/Post.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue827/Post.php
@@ -34,7 +34,9 @@ class Post
      * @var string|null
      *
      * @ORM\Id
+     *
      * @Gedmo\Slug(updatable=true, unique=true, fields={"title"})
+     *
      * @ORM\Column(length=64, nullable=true)
      */
     #[ORM\Id]

--- a/tests/Gedmo/Sluggable/Fixture/Issue939/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue939/Article.php
@@ -51,6 +51,7 @@ class Article
      * @var string|null
      *
      * @Gedmo\Slug(updatable=true, unique=true, unique_base="category", fields={"title"})
+     *
      * @ORM\Column(length=64, nullable=true)
      */
     #[Gedmo\Slug(updatable: true, unique: true, unique_base: 'category', fields: ['title'])]

--- a/tests/Gedmo/Sluggable/Fixture/Issue939/Category.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue939/Category.php
@@ -45,6 +45,7 @@ class Category
      * @var string|null
      *
      * @Gedmo\Slug(updatable=true, unique=true, fields={"title"})
+     *
      * @ORM\Column(length=64, nullable=true)
      */
     #[Gedmo\Slug(updatable: true, unique: true, fields: ['title'])]

--- a/tests/Gedmo/Sluggable/Fixture/MappedSuperclass/Vehicle.php
+++ b/tests/Gedmo/Sluggable/Fixture/MappedSuperclass/Vehicle.php
@@ -35,6 +35,7 @@ class Vehicle
      * @var string|null
      *
      * @Gedmo\Slug(fields={"title"}, updatable=false)
+     *
      * @ORM\Column(length=128, unique=true)
      */
     #[Gedmo\Slug(updatable: false, fields: ['title'])]

--- a/tests/Gedmo/Sluggable/Fixture/Page.php
+++ b/tests/Gedmo/Sluggable/Fixture/Page.php
@@ -45,6 +45,7 @@ class Page
      * @var string|null
      *
      * @Gedmo\Slug(style="camel", separator="_", fields={"content"})
+     *
      * @ORM\Column(type="string", length=128)
      */
     #[Gedmo\Slug(style: 'camel', separator: '_', fields: ['content'])]

--- a/tests/Gedmo/Sluggable/Fixture/Position.php
+++ b/tests/Gedmo/Sluggable/Fixture/Position.php
@@ -69,6 +69,7 @@ class Position
      * @var string|null
      *
      * @Gedmo\Slug(fields={"code", "other", "title", "prop"})
+     *
      * @ORM\Column(length=64, unique=true)
      */
     #[Gedmo\Slug(fields: ['code', 'other', 'title', 'prop'])]

--- a/tests/Gedmo/Sluggable/Fixture/Prefix.php
+++ b/tests/Gedmo/Sluggable/Fixture/Prefix.php
@@ -44,6 +44,7 @@ class Prefix implements Sluggable
 
     /**
      * @Gedmo\Slug(separator="-", updatable=true, fields={"title"}, prefix="test-")
+     *
      * @ORM\Column(name="slug", type="string", length=64, unique=true)
      */
     #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title'], prefix: 'test-')]

--- a/tests/Gedmo/Sluggable/Fixture/PrefixWithTreeHandler.php
+++ b/tests/Gedmo/Sluggable/Fixture/PrefixWithTreeHandler.php
@@ -20,6 +20,7 @@ use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
 
 /**
  * @ORM\Entity(repositoryClass="Gedmo\Tree\Entity\Repository\NestedTreeRepository")
+ *
  * @Gedmo\Tree(type="nested")
  *
  * @author Dirk Luijk <dirk@luijkwebcreations.nl>
@@ -53,6 +54,7 @@ class PrefixWithTreeHandler implements Sluggable
      *         @Gedmo\SlugHandlerOption(name="separator", value="/")
      *     })
      * }, separator="-", updatable=true, fields={"title"}, prefix="test.")
+     *
      * @ORM\Column(name="slug", type="string", length=64, unique=true)
      */
     #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title'], prefix: 'test.')]
@@ -62,6 +64,7 @@ class PrefixWithTreeHandler implements Sluggable
 
     /**
      * @Gedmo\TreeParent
+     *
      * @ORM\ManyToOne(targetEntity="PrefixWithTreeHandler")
      * @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
      */
@@ -72,6 +75,7 @@ class PrefixWithTreeHandler implements Sluggable
 
     /**
      * @Gedmo\TreeLeft
+     *
      * @ORM\Column(name="lft", type="integer")
      */
     #[ORM\Column(name: 'lft', type: Types::INTEGER)]
@@ -80,6 +84,7 @@ class PrefixWithTreeHandler implements Sluggable
 
     /**
      * @Gedmo\TreeLevel
+     *
      * @ORM\Column(name="lvl", type="integer")
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER)]
@@ -88,6 +93,7 @@ class PrefixWithTreeHandler implements Sluggable
 
     /**
      * @Gedmo\TreeRight
+     *
      * @ORM\Column(name="rgt", type="integer")
      */
     #[ORM\Column(name: 'rgt', type: Types::INTEGER)]
@@ -96,6 +102,7 @@ class PrefixWithTreeHandler implements Sluggable
 
     /**
      * @Gedmo\TreeRoot
+     *
      * @ORM\Column(name="root", type="integer", nullable=true)
      */
     #[ORM\Column(name: 'root', type: Types::INTEGER, nullable: true)]

--- a/tests/Gedmo/Sluggable/Fixture/Suffix.php
+++ b/tests/Gedmo/Sluggable/Fixture/Suffix.php
@@ -44,6 +44,7 @@ class Suffix implements Sluggable
 
     /**
      * @Gedmo\Slug(separator="-", updatable=true, fields={"title"}, suffix=".test")
+     *
      * @ORM\Column(name="slug", type="string", length=64, unique=true)
      */
     #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title'], suffix: '.test')]

--- a/tests/Gedmo/Sluggable/Fixture/SuffixWithTreeHandler.php
+++ b/tests/Gedmo/Sluggable/Fixture/SuffixWithTreeHandler.php
@@ -20,6 +20,7 @@ use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
 
 /**
  * @ORM\Entity(repositoryClass="Gedmo\Tree\Entity\Repository\NestedTreeRepository")
+ *
  * @Gedmo\Tree(type="nested")
  *
  * @author Dirk Luijk <dirk@luijkwebcreations.nl>
@@ -53,6 +54,7 @@ class SuffixWithTreeHandler implements Sluggable
      *         @Gedmo\SlugHandlerOption(name="separator", value="/")
      *     })
      * }, separator="-", updatable=true, fields={"title"}, suffix=".test")
+     *
      * @ORM\Column(name="slug", type="string", length=64, unique=true)
      */
     #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title'], suffix: '.test')]
@@ -62,6 +64,7 @@ class SuffixWithTreeHandler implements Sluggable
 
     /**
      * @Gedmo\TreeParent
+     *
      * @ORM\ManyToOne(targetEntity="SuffixWithTreeHandler")
      * @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
      */
@@ -72,6 +75,7 @@ class SuffixWithTreeHandler implements Sluggable
 
     /**
      * @Gedmo\TreeLeft
+     *
      * @ORM\Column(name="lft", type="integer")
      */
     #[ORM\Column(name: 'lft', type: Types::INTEGER)]
@@ -80,6 +84,7 @@ class SuffixWithTreeHandler implements Sluggable
 
     /**
      * @Gedmo\TreeLevel
+     *
      * @ORM\Column(name="lvl", type="integer")
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER)]
@@ -88,6 +93,7 @@ class SuffixWithTreeHandler implements Sluggable
 
     /**
      * @Gedmo\TreeRight
+     *
      * @ORM\Column(name="rgt", type="integer")
      */
     #[ORM\Column(name: 'rgt', type: Types::INTEGER)]
@@ -96,6 +102,7 @@ class SuffixWithTreeHandler implements Sluggable
 
     /**
      * @Gedmo\TreeRoot
+     *
      * @ORM\Column(name="root", type="integer", nullable=true)
      */
     #[ORM\Column(name: 'root', type: Types::INTEGER, nullable: true)]

--- a/tests/Gedmo/Sluggable/Fixture/TransArticleManySlug.php
+++ b/tests/Gedmo/Sluggable/Fixture/TransArticleManySlug.php
@@ -39,6 +39,7 @@ class TransArticleManySlug implements Sluggable, Translatable
 
     /**
      * @Gedmo\Translatable
+     *
      * @ORM\Column(type="string", length=64)
      */
     #[ORM\Column(type: Types::STRING, length: 64)]
@@ -55,6 +56,7 @@ class TransArticleManySlug implements Sluggable, Translatable
      * @var string|null
      *
      * @Gedmo\Slug(fields={"uniqueTitle"})
+     *
      * @ORM\Column(type="string", length=128)
      */
     #[Gedmo\Slug(fields: ['uniqueTitle'])]
@@ -63,6 +65,7 @@ class TransArticleManySlug implements Sluggable, Translatable
 
     /**
      * @Gedmo\Translatable
+     *
      * @ORM\Column(type="string", length=16)
      */
     #[ORM\Column(type: Types::STRING, length: 16)]
@@ -74,6 +77,7 @@ class TransArticleManySlug implements Sluggable, Translatable
      *
      * @Gedmo\Translatable
      * @Gedmo\Slug(fields={"title", "code"})
+     *
      * @ORM\Column(type="string", length=128)
      */
     #[ORM\Column(type: Types::STRING, length: 128)]

--- a/tests/Gedmo/Sluggable/Fixture/TranslatableArticle.php
+++ b/tests/Gedmo/Sluggable/Fixture/TranslatableArticle.php
@@ -39,6 +39,7 @@ class TranslatableArticle implements Sluggable, Translatable
 
     /**
      * @Gedmo\Translatable
+     *
      * @ORM\Column(type="string", length=64)
      */
     #[ORM\Column(type: Types::STRING, length: 64)]
@@ -47,6 +48,7 @@ class TranslatableArticle implements Sluggable, Translatable
 
     /**
      * @Gedmo\Translatable
+     *
      * @ORM\Column(type="string", length=16)
      */
     #[ORM\Column(type: Types::STRING, length: 16)]
@@ -58,6 +60,7 @@ class TranslatableArticle implements Sluggable, Translatable
      *
      * @Gedmo\Translatable
      * @Gedmo\Slug(fields={"title", "code"})
+     *
      * @ORM\Column(type="string", length=128)
      */
     #[ORM\Column(type: Types::STRING, length: 128)]

--- a/tests/Gedmo/SoftDeleteable/Fixture/Document/User.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Document/User.php
@@ -17,6 +17,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ODM\Document(collection="users")
+ *
  * @Gedmo\SoftDeleteable(fieldName="deletedAt")
  */
 #[ODM\Document(collection: 'users')]

--- a/tests/Gedmo/SoftDeleteable/Fixture/Document/UserTimeAware.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Document/UserTimeAware.php
@@ -17,6 +17,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ODM\Document(collection="users")
+ *
  * @Gedmo\SoftDeleteable(fieldName="deletedAt", timeAware=true)
  */
 #[ODM\Document(collection: 'users')]

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/Address.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/Address.php
@@ -17,6 +17,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
+ *
  * @Gedmo\SoftDeleteable(fieldName="deletedAt")
  */
 #[ORM\Entity]

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/Article.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/Article.php
@@ -19,6 +19,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
+ *
  * @Gedmo\SoftDeleteable(fieldName="deletedAt")
  */
 #[ORM\Entity]

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/Comment.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/Comment.php
@@ -17,6 +17,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
+ *
  * @Gedmo\SoftDeleteable(fieldName="deletedAt")
  */
 #[ORM\Entity]

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/MappedSuperclass.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/MappedSuperclass.php
@@ -17,6 +17,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\MappedSuperclass
+ *
  * @Gedmo\SoftDeleteable(fieldName="deletedAt")
  */
 #[ORM\MappedSuperclass]

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/Module.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/Module.php
@@ -17,6 +17,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
+ *
  * @Gedmo\SoftDeleteable(fieldName="deletedAt")
  */
 #[ORM\Entity]

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/OtherArticle.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/OtherArticle.php
@@ -19,6 +19,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
+ *
  * @Gedmo\SoftDeleteable(fieldName="deletedAt")
  */
 #[ORM\Entity]

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/Page.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/Page.php
@@ -22,6 +22,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
  * @ORM\InheritanceType("JOINED")
  * @ORM\DiscriminatorColumn(name="discr", type="string")
  * @ORM\DiscriminatorMap({"page": "Page", "mega_page": "MegaPage"})
+ *
  * @Gedmo\SoftDeleteable(fieldName="deletedAt")
  */
 #[ORM\Entity]

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/Person.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/Person.php
@@ -17,6 +17,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
+ *
  * @Gedmo\SoftDeleteable(fieldName="deletedAt", timeAware=true)
  */
 #[ORM\Entity]

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/User.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/User.php
@@ -17,6 +17,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
+ *
  * @Gedmo\SoftDeleteable(fieldName="deletedAt")
  */
 #[ORM\Entity]

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/UserNoHardDelete.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/UserNoHardDelete.php
@@ -17,6 +17,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
+ *
  * @Gedmo\SoftDeleteable(fieldName="deletedAt", hardDelete=false)
  */
 #[ORM\Entity]

--- a/tests/Gedmo/Sortable/Fixture/AbstractNode.php
+++ b/tests/Gedmo/Sortable/Fixture/AbstractNode.php
@@ -45,6 +45,7 @@ class AbstractNode
      * @var string|null
      *
      * @Gedmo\SortableGroup
+     *
      * @ORM\Column(type="string", length=191)
      */
     #[Gedmo\SortableGroup]
@@ -55,6 +56,7 @@ class AbstractNode
      * @var int|null
      *
      * @Gedmo\SortablePosition
+     *
      * @ORM\Column(type="integer")
      */
     #[Gedmo\SortablePosition]

--- a/tests/Gedmo/Sortable/Fixture/Author.php
+++ b/tests/Gedmo/Sortable/Fixture/Author.php
@@ -42,6 +42,7 @@ class Author
 
     /**
      * @Gedmo\SortableGroup
+     *
      * @ORM\ManyToOne(targetEntity="Paper", inversedBy="authors")
      */
     #[Gedmo\SortableGroup]
@@ -50,6 +51,7 @@ class Author
 
     /**
      * @Gedmo\SortablePosition
+     *
      * @ORM\Column(name="position", type="integer")
      */
     #[Gedmo\SortablePosition]

--- a/tests/Gedmo/Sortable/Fixture/CustomerType.php
+++ b/tests/Gedmo/Sortable/Fixture/CustomerType.php
@@ -49,6 +49,7 @@ class CustomerType
 
     /**
      * @Gedmo\SortablePosition
+     *
      * @ORM\Column(name="position", type="integer")
      */
     #[Gedmo\SortablePosition]

--- a/tests/Gedmo/Sortable/Fixture/Document/Article.php
+++ b/tests/Gedmo/Sortable/Fixture/Document/Article.php
@@ -25,6 +25,7 @@ class Article
      * @var int|null
      *
      * @Gedmo\SortablePosition
+     *
      * @ODM\Field(type="int")
      */
     #[Gedmo\SortablePosition]

--- a/tests/Gedmo/Sortable/Fixture/Document/Kid.php
+++ b/tests/Gedmo/Sortable/Fixture/Document/Kid.php
@@ -25,6 +25,7 @@ class Kid
      * @var int|null
      *
      * @Gedmo\SortablePosition
+     *
      * @ODM\Field(type="int")
      */
     #[Gedmo\SortablePosition]
@@ -35,6 +36,7 @@ class Kid
      * @var \DateTime|null
      *
      * @Gedmo\SortableGroup
+     *
      * @ODM\Field(type="date")
      */
     #[Gedmo\SortableGroup]

--- a/tests/Gedmo/Sortable/Fixture/Document/Post.php
+++ b/tests/Gedmo/Sortable/Fixture/Document/Post.php
@@ -25,6 +25,7 @@ class Post
      * @var int|null
      *
      * @Gedmo\SortablePosition
+     *
      * @ODM\Field(type="int")
      */
     #[Gedmo\SortablePosition]
@@ -35,6 +36,7 @@ class Post
      * @var Category|null
      *
      * @Gedmo\SortableGroup
+     *
      * @ODM\ReferenceOne(targetDocument="Gedmo\Tests\Sortable\Fixture\Document\Category")
      */
     #[Gedmo\SortableGroup]

--- a/tests/Gedmo/Sortable/Fixture/Event.php
+++ b/tests/Gedmo/Sortable/Fixture/Event.php
@@ -36,6 +36,7 @@ class Event
 
     /**
      * @Gedmo\SortableGroup
+     *
      * @ORM\Column(type="datetime")
      */
     #[Gedmo\SortableGroup]
@@ -50,6 +51,7 @@ class Event
 
     /**
      * @Gedmo\SortablePosition
+     *
      * @ORM\Column(type="integer")
      */
     #[Gedmo\SortablePosition]

--- a/tests/Gedmo/Sortable/Fixture/Item.php
+++ b/tests/Gedmo/Sortable/Fixture/Item.php
@@ -42,6 +42,7 @@ class Item
 
     /**
      * @Gedmo\SortablePosition
+     *
      * @ORM\Column(type="integer")
      */
     #[Gedmo\SortablePosition]
@@ -50,6 +51,7 @@ class Item
 
     /**
      * @Gedmo\SortableGroup
+     *
      * @ORM\ManyToOne(targetEntity="Category", inversedBy="items")
      */
     #[Gedmo\SortableGroup]

--- a/tests/Gedmo/Sortable/Fixture/ItemWithDateColumn.php
+++ b/tests/Gedmo/Sortable/Fixture/ItemWithDateColumn.php
@@ -32,6 +32,7 @@ class ItemWithDateColumn
 
     /**
      * @Gedmo\SortablePosition
+     *
      * @ORM\Column(type="integer")
      */
     #[Gedmo\SortablePosition]
@@ -40,6 +41,7 @@ class ItemWithDateColumn
 
     /**
      * @Gedmo\SortableGroup
+     *
      * @ORM\Column(type="date")
      */
     #[Gedmo\SortableGroup]

--- a/tests/Gedmo/Sortable/Fixture/SimpleListItem.php
+++ b/tests/Gedmo/Sortable/Fixture/SimpleListItem.php
@@ -42,6 +42,7 @@ class SimpleListItem
 
     /**
      * @Gedmo\SortablePosition
+     *
      * @ORM\Column(type="integer")
      */
     #[Gedmo\SortablePosition]

--- a/tests/Gedmo/Sortable/Fixture/Transport/Reservation.php
+++ b/tests/Gedmo/Sortable/Fixture/Transport/Reservation.php
@@ -43,6 +43,7 @@ class Reservation
      * Bus destination
      *
      * @Gedmo\SortableGroup
+     *
      * @ORM\Column(length=191)
      */
     #[Gedmo\SortableGroup]
@@ -51,6 +52,7 @@ class Reservation
 
     /**
      * @Gedmo\SortableGroup
+     *
      * @ORM\Column(type="datetime")
      */
     #[Gedmo\SortableGroup]
@@ -59,6 +61,7 @@ class Reservation
 
     /**
      * @Gedmo\SortablePosition
+     *
      * @ORM\Column(type="integer")
      */
     #[Gedmo\SortablePosition]

--- a/tests/Gedmo/Sortable/Fixture/Transport/Vehicle.php
+++ b/tests/Gedmo/Sortable/Fixture/Transport/Vehicle.php
@@ -45,6 +45,7 @@ class Vehicle
 
     /**
      * @Gedmo\SortableGroup
+     *
      * @ORM\ManyToOne(targetEntity="Engine")
      */
     #[Gedmo\SortableGroup]
@@ -59,6 +60,7 @@ class Vehicle
 
     /**
      * @Gedmo\SortablePosition
+     *
      * @ORM\Column(type="integer")
      */
     #[Gedmo\SortablePosition]

--- a/tests/Gedmo/Timestampable/Fixture/Article.php
+++ b/tests/Gedmo/Timestampable/Fixture/Article.php
@@ -64,6 +64,7 @@ class Article implements Timestampable
 
     /**
      * @Gedmo\Timestampable(on="create")
+     *
      * @ORM\Column(name="created", type="date")
      */
     #[Gedmo\Timestampable(on: 'create')]
@@ -72,6 +73,7 @@ class Article implements Timestampable
 
     /**
      * @ORM\Column(name="updated", type="datetime")
+     *
      * @Gedmo\Timestampable
      */
     #[ORM\Column(name: 'updated', type: Types::DATETIME_MUTABLE)]
@@ -80,6 +82,7 @@ class Article implements Timestampable
 
     /**
      * @ORM\Column(name="published", type="datetime", nullable=true)
+     *
      * @Gedmo\Timestampable(on="change", field="type.title", value="Published")
      */
     #[ORM\Column(name: 'published', type: Types::DATETIME_MUTABLE, nullable: true)]
@@ -88,6 +91,7 @@ class Article implements Timestampable
 
     /**
      * @ORM\Column(name="content_changed", type="datetime", nullable=true)
+     *
      * @Gedmo\Timestampable(on="change", field={"title", "body"})
      */
     #[ORM\Column(name: 'content_changed', type: Types::DATETIME_MUTABLE, nullable: true)]
@@ -97,6 +101,7 @@ class Article implements Timestampable
      * @var \DateTime|null
      *
      * @ORM\Column(name="author_changed", type="datetime", nullable=true)
+     *
      * @Gedmo\Timestampable(on="change", field={"author.name", "author.email"})
      */
     #[ORM\Column(name: 'author_changed', type: Types::DATETIME_MUTABLE, nullable: true)]
@@ -121,6 +126,7 @@ class Article implements Timestampable
      * @var \DateTimeInterface|null
      *
      * @ORM\Column(name="reached_relevant_level", type="datetime", nullable=true)
+     *
      * @Gedmo\Timestampable(on="change", field="level", value="10")
      */
     #[ORM\Column(name: 'reached_relevant_level', type: Types::DATE_MUTABLE, nullable: true)]

--- a/tests/Gedmo/Timestampable/Fixture/ArticleCarbon.php
+++ b/tests/Gedmo/Timestampable/Fixture/ArticleCarbon.php
@@ -68,6 +68,7 @@ class ArticleCarbon implements Timestampable
      * @var \DateTime|Carbon|null
      *
      * @Gedmo\Timestampable(on="create")
+     *
      * @ORM\Column(name="created", type="date")
      */
     #[Gedmo\Timestampable(on: 'create')]
@@ -78,6 +79,7 @@ class ArticleCarbon implements Timestampable
      * @var \DateTime|CarbonImmutable|null
      *
      * @ORM\Column(name="updated", type="datetime")
+     *
      * @Gedmo\Timestampable
      */
     #[ORM\Column(name: 'updated', type: Types::DATETIME_MUTABLE)]
@@ -88,6 +90,7 @@ class ArticleCarbon implements Timestampable
      * @var \DateTime|CarbonImmutable|null
      *
      * @ORM\Column(name="published", type="datetime", nullable=true)
+     *
      * @Gedmo\Timestampable(on="change", field="type.title", value="Published")
      */
     #[ORM\Column(name: 'published', type: Types::DATETIME_MUTABLE, nullable: true)]
@@ -98,6 +101,7 @@ class ArticleCarbon implements Timestampable
      * @var \DateTime|CarbonImmutable|null
      *
      * @ORM\Column(name="content_changed", type="datetime", nullable=true)
+     *
      * @Gedmo\Timestampable(on="change", field={"title", "body"})
      */
     #[ORM\Column(name: 'content_changed', type: Types::DATETIME_MUTABLE, nullable: true)]
@@ -108,6 +112,7 @@ class ArticleCarbon implements Timestampable
      * @var CarbonImmutable|null
      *
      * @ORM\Column(name="author_changed", type="datetime", nullable=true)
+     *
      * @Gedmo\Timestampable(on="change", field={"author.name", "author.email"})
      */
     #[ORM\Column(name: 'author_changed', type: Types::DATETIME_MUTABLE, nullable: true)]
@@ -132,6 +137,7 @@ class ArticleCarbon implements Timestampable
      * @var \DateTimeInterface|null
      *
      * @ORM\Column(name="reached_relevant_level", type="datetime", nullable=true)
+     *
      * @Gedmo\Timestampable(on="change", field="level", value="10")
      */
     #[ORM\Column(name: 'reached_relevant_level', type: Types::DATE_MUTABLE, nullable: true)]

--- a/tests/Gedmo/Timestampable/Fixture/Comment.php
+++ b/tests/Gedmo/Timestampable/Fixture/Comment.php
@@ -58,6 +58,7 @@ class Comment implements Timestampable
      * @var \DateTime|null
      *
      * @ORM\Column(name="closed", type="datetime", nullable=true)
+     *
      * @Gedmo\Timestampable(on="change", field="status", value=1)
      */
     #[ORM\Column(name: 'closed', type: Types::DATETIME_MUTABLE, nullable: true)]
@@ -68,6 +69,7 @@ class Comment implements Timestampable
      * @var \DateTime|null
      *
      * @ORM\Column(name="modified", type="time")
+     *
      * @Gedmo\Timestampable(on="update")
      */
     #[ORM\Column(name: 'modified', type: Types::TIME_MUTABLE)]

--- a/tests/Gedmo/Timestampable/Fixture/CommentCarbon.php
+++ b/tests/Gedmo/Timestampable/Fixture/CommentCarbon.php
@@ -57,6 +57,7 @@ class CommentCarbon implements Timestampable
      * @var CarbonImmutable|null
      *
      * @ORM\Column(name="closed", type="datetime", nullable=true)
+     *
      * @Gedmo\Timestampable(on="change", field="status", value=1)
      */
     #[ORM\Column(name: 'closed', type: Types::DATETIME_MUTABLE, nullable: true)]
@@ -67,6 +68,7 @@ class CommentCarbon implements Timestampable
      * @var \DateTime|null
      *
      * @ORM\Column(name="modified", type="time")
+     *
      * @Gedmo\Timestampable(on="update")
      */
     #[ORM\Column(name: 'modified', type: Types::TIME_MUTABLE)]

--- a/tests/Gedmo/Timestampable/Fixture/Document/Article.php
+++ b/tests/Gedmo/Timestampable/Fixture/Document/Article.php
@@ -46,6 +46,7 @@ class Article
      * @var int|Timestamp|null
      *
      * @ODM\Field(type="timestamp")
+     *
      * @Gedmo\Timestampable(on="create")
      */
     #[Gedmo\Timestampable(on: 'create')]
@@ -54,6 +55,7 @@ class Article
 
     /**
      * @ODM\Field(type="date")
+     *
      * @Gedmo\Timestampable
      */
     #[Gedmo\Timestampable]
@@ -62,6 +64,7 @@ class Article
 
     /**
      * @ODM\Field(type="date")
+     *
      * @Gedmo\Timestampable(on="change", field="type.title", value="Published")
      */
     #[Gedmo\Timestampable(on: 'change', field: 'type.title', value: 'Published')]
@@ -70,6 +73,7 @@ class Article
 
     /**
      * @ODM\Field(type="date")
+     *
      * @Gedmo\Timestampable(on="change", field="isReady", value=true)
      */
     #[Gedmo\Timestampable(on: 'change', field: 'isReady', value: true)]

--- a/tests/Gedmo/Timestampable/Fixture/Document/Tag.php
+++ b/tests/Gedmo/Timestampable/Fixture/Document/Tag.php
@@ -31,6 +31,7 @@ class Tag
 
     /**
      * @ODM\Field(type="date")
+     *
      * @Gedmo\Timestampable(on="create")
      *
      * @var \DateTime
@@ -41,6 +42,7 @@ class Tag
 
     /**
      * @ODM\Field(type="date")
+     *
      * @Gedmo\Timestampable
      *
      * @var \DateTime

--- a/tests/Gedmo/Timestampable/Fixture/MappedSupperClass.php
+++ b/tests/Gedmo/Timestampable/Fixture/MappedSupperClass.php
@@ -45,6 +45,7 @@ class MappedSupperClass
      * @var string|null
      *
      * @Gedmo\Translatable
+     *
      * @ORM\Column(name="name", type="string", length=191)
      */
     #[Gedmo\Translatable]
@@ -55,6 +56,7 @@ class MappedSupperClass
      * @var \DateTime|null
      *
      * @ORM\Column(name="created_at", type="datetime")
+     *
      * @Gedmo\Timestampable(on="create")
      */
     #[ORM\Column(name: 'created_at', type: Types::DATETIME_MUTABLE)]

--- a/tests/Gedmo/Timestampable/Fixture/SupperClassExtension.php
+++ b/tests/Gedmo/Timestampable/Fixture/SupperClassExtension.php
@@ -22,6 +22,7 @@ class SupperClassExtension extends MappedSupperClass
 {
     /**
      * @ORM\Column(length=128)
+     *
      * @Gedmo\Translatable
      */
     #[ORM\Column(length: 128)]

--- a/tests/Gedmo/Timestampable/Fixture/TitledArticle.php
+++ b/tests/Gedmo/Timestampable/Fixture/TitledArticle.php
@@ -52,6 +52,7 @@ class TitledArticle implements Timestampable
 
     /**
      * @ORM\Column(name="chtext", type="datetime", nullable=true)
+     *
      * @Gedmo\Timestampable(on="change", field="text")
      */
     #[ORM\Column(name: 'chtext', type: Types::DATETIME_MUTABLE, nullable: true)]
@@ -60,6 +61,7 @@ class TitledArticle implements Timestampable
 
     /**
      * @ORM\Column(name="chtitle", type="datetime", nullable=true)
+     *
      * @Gedmo\Timestampable(on="change", field="title")
      */
     #[ORM\Column(name: 'chtitle', type: Types::DATETIME_MUTABLE, nullable: true)]
@@ -68,6 +70,7 @@ class TitledArticle implements Timestampable
 
     /**
      * @ORM\Column(name="closed", type="datetime", nullable=true)
+     *
      * @Gedmo\Timestampable(on="change", field="state", value={"Published", "Closed"})
      */
     #[ORM\Column(name: 'closed', type: Types::DATETIME_MUTABLE, nullable: true)]

--- a/tests/Gedmo/Timestampable/Fixture/WithoutInterface.php
+++ b/tests/Gedmo/Timestampable/Fixture/WithoutInterface.php
@@ -43,6 +43,7 @@ class WithoutInterface
      * @var \DateTime|null
      *
      * @Gedmo\Timestampable(on="create")
+     *
      * @ORM\Column(type="date")
      */
     #[Gedmo\Timestampable(on: 'create')]
@@ -53,6 +54,7 @@ class WithoutInterface
      * @var \DateTime|null
      *
      * @ORM\Column(type="datetime")
+     *
      * @Gedmo\Timestampable(on="update")
      */
     #[ORM\Column(type: Types::DATETIME_MUTABLE)]

--- a/tests/Gedmo/Translatable/Fixture/Article.php
+++ b/tests/Gedmo/Translatable/Fixture/Article.php
@@ -38,6 +38,7 @@ class Article implements Translatable
 
     /**
      * @Gedmo\Translatable
+     *
      * @ORM\Column(name="title", type="string", length=128)
      */
     #[Gedmo\Translatable]
@@ -46,6 +47,7 @@ class Article implements Translatable
 
     /**
      * @Gedmo\Translatable
+     *
      * @ORM\Column(name="content", type="text", nullable=true)
      */
     #[Gedmo\Translatable]
@@ -54,6 +56,7 @@ class Article implements Translatable
 
     /**
      * @Gedmo\Translatable(fallback=false)
+     *
      * @ORM\Column(name="views", type="integer", nullable=true)
      */
     #[Gedmo\Translatable(fallback: false)]
@@ -62,6 +65,7 @@ class Article implements Translatable
 
     /**
      * @Gedmo\Translatable(fallback=true)
+     *
      * @ORM\Column(name="author", type="string", nullable=true)
      */
     #[Gedmo\Translatable(fallback: true)]

--- a/tests/Gedmo/Translatable/Fixture/Comment.php
+++ b/tests/Gedmo/Translatable/Fixture/Comment.php
@@ -35,6 +35,7 @@ class Comment
 
     /**
      * @Gedmo\Translatable
+     *
      * @ORM\Column(name="subject", type="string", length=128)
      */
     #[Gedmo\Translatable]
@@ -43,6 +44,7 @@ class Comment
 
     /**
      * @Gedmo\Translatable
+     *
      * @ORM\Column(name="message", type="text")
      */
     #[Gedmo\Translatable]

--- a/tests/Gedmo/Translatable/Fixture/Company.php
+++ b/tests/Gedmo/Translatable/Fixture/Company.php
@@ -36,6 +36,7 @@ class Company implements Translatable
 
     /**
      * @ORM\Column(name="title", type="string", length=128)
+     *
      * @Gedmo\Translatable
      */
     #[Gedmo\Translatable]

--- a/tests/Gedmo/Translatable/Fixture/CompanyEmbedLink.php
+++ b/tests/Gedmo/Translatable/Fixture/CompanyEmbedLink.php
@@ -25,6 +25,7 @@ class CompanyEmbedLink
      * @var string
      *
      * @ORM\Column(name="website", type="string", length=191, nullable=true)
+     *
      * @Gedmo\Translatable
      */
     #[Gedmo\Translatable]
@@ -35,6 +36,7 @@ class CompanyEmbedLink
      * @var string
      *
      * @ORM\Column(name="facebook", type="string", length=191, nullable=true)
+     *
      * @Gedmo\Translatable
      */
     #[Gedmo\Translatable]

--- a/tests/Gedmo/Translatable/Fixture/Document/Article.php
+++ b/tests/Gedmo/Translatable/Fixture/Document/Article.php
@@ -31,6 +31,7 @@ class Article
 
     /**
      * @Gedmo\Translatable
+     *
      * @MongoODM\Field(type="string")
      */
     #[Gedmo\Translatable]
@@ -39,6 +40,7 @@ class Article
 
     /**
      * @Gedmo\Translatable
+     *
      * @MongoODM\Field(type="string")
      */
     #[Gedmo\Translatable]
@@ -50,6 +52,7 @@ class Article
      *
      * @Gedmo\Slug(fields={"title", "code"})
      * @Gedmo\Translatable
+     *
      * @MongoODM\Field(type="string")
      */
     #[Gedmo\Translatable]

--- a/tests/Gedmo/Translatable/Fixture/Document/Personal/Article.php
+++ b/tests/Gedmo/Translatable/Fixture/Document/Personal/Article.php
@@ -19,6 +19,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @Gedmo\TranslationEntity(class="Gedmo\Tests\Translatable\Fixture\Document\Personal\ArticleTranslation")
+ *
  * @MongoODM\Document(collection="articles")
  */
 #[Gedmo\TranslationEntity(class: ArticleTranslation::class)]
@@ -35,6 +36,7 @@ class Article
 
     /**
      * @Gedmo\Translatable
+     *
      * @MongoODM\Field(type="string")
      */
     #[Gedmo\Translatable]

--- a/tests/Gedmo/Translatable/Fixture/Document/SimpleArticle.php
+++ b/tests/Gedmo/Translatable/Fixture/Document/SimpleArticle.php
@@ -31,6 +31,7 @@ class SimpleArticle
 
     /**
      * @Gedmo\Translatable
+     *
      * @MongoODM\Field(type="string")
      */
     #[Gedmo\Translatable]
@@ -39,6 +40,7 @@ class SimpleArticle
 
     /**
      * @Gedmo\Translatable
+     *
      * @MongoODM\Field(type="string")
      */
     #[Gedmo\Translatable]

--- a/tests/Gedmo/Translatable/Fixture/File.php
+++ b/tests/Gedmo/Translatable/Fixture/File.php
@@ -41,6 +41,7 @@ class File
 
     /**
      * @Gedmo\Translatable
+     *
      * @ORM\Column(length=128)
      */
     #[Gedmo\Translatable]

--- a/tests/Gedmo/Translatable/Fixture/Image.php
+++ b/tests/Gedmo/Translatable/Fixture/Image.php
@@ -22,6 +22,7 @@ class Image extends File
 {
     /**
      * @Gedmo\Translatable
+     *
      * @ORM\Column(length=128)
      */
     #[Gedmo\Translatable]

--- a/tests/Gedmo/Translatable/Fixture/Issue1123/ChildEntity.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue1123/ChildEntity.php
@@ -26,6 +26,7 @@ class ChildEntity extends BaseEntity implements Translatable
 {
     /**
      * @Gedmo\Translatable
+     *
      * @ORM\Column(name="childTitle", type="string", length=128, nullable=true)
      */
     #[ORM\Column(name: 'childTitle', type: Types::STRING, length: 128, nullable: true)]

--- a/tests/Gedmo/Translatable/Fixture/Issue114/Article.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue114/Article.php
@@ -35,6 +35,7 @@ class Article
 
     /**
      * @Gedmo\Translatable
+     *
      * @ORM\Column(name="title", type="string", length=128)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]

--- a/tests/Gedmo/Translatable/Fixture/Issue114/Category.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue114/Category.php
@@ -37,6 +37,7 @@ class Category
 
     /**
      * @Gedmo\Translatable
+     *
      * @ORM\Column(name="title", type="string", length=128)
      */
     #[Gedmo\Translatable]

--- a/tests/Gedmo/Translatable/Fixture/Issue138/Article.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue138/Article.php
@@ -35,6 +35,7 @@ class Article
 
     /**
      * @Gedmo\Translatable
+     *
      * @ORM\Column(length=128)
      */
     #[Gedmo\Translatable]
@@ -43,6 +44,7 @@ class Article
 
     /**
      * @Gedmo\Translatable
+     *
      * @ORM\Column(length=128)
      */
     #[Gedmo\Translatable]

--- a/tests/Gedmo/Translatable/Fixture/Issue165/SimpleArticle.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue165/SimpleArticle.php
@@ -31,6 +31,7 @@ class SimpleArticle
 
     /**
      * @Gedmo\Translatable
+     *
      * @MongoODM\Field(type="string")
      */
     #[Gedmo\Translatable]
@@ -39,6 +40,7 @@ class SimpleArticle
 
     /**
      * @Gedmo\Translatable
+     *
      * @MongoODM\Field(type="string")
      */
     #[Gedmo\Translatable]

--- a/tests/Gedmo/Translatable/Fixture/Issue173/Article.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue173/Article.php
@@ -35,6 +35,7 @@ class Article
 
     /**
      * @Gedmo\Translatable
+     *
      * @ORM\Column(name="title", type="string", length=128)
      */
     #[Gedmo\Translatable]

--- a/tests/Gedmo/Translatable/Fixture/Issue173/Category.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue173/Category.php
@@ -37,6 +37,7 @@ class Category
 
     /**
      * @Gedmo\Translatable
+     *
      * @ORM\Column(name="title", type="string", length=128)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]

--- a/tests/Gedmo/Translatable/Fixture/Issue173/Product.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue173/Product.php
@@ -35,6 +35,7 @@ class Product
 
     /**
      * @Gedmo\Translatable
+     *
      * @ORM\Column(name="title", type="string", length=128)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]

--- a/tests/Gedmo/Translatable/Fixture/Issue2152/EntityWithTranslatableBoolean.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue2152/EntityWithTranslatableBoolean.php
@@ -37,6 +37,7 @@ class EntityWithTranslatableBoolean
 
     /**
      * @Gedmo\Translatable
+     *
      * @ORM\Column(type="string", nullable=true)
      */
     #[ORM\Column(type: Types::STRING, nullable: true)]
@@ -45,6 +46,7 @@ class EntityWithTranslatableBoolean
 
     /**
      * @Gedmo\Translatable
+     *
      * @ORM\Column(type="string", nullable=true)
      */
     #[ORM\Column(type: Types::STRING, nullable: true)]

--- a/tests/Gedmo/Translatable/Fixture/Issue2167/Article.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue2167/Article.php
@@ -35,6 +35,7 @@ class Article
 
     /**
      * @Gedmo\Translatable
+     *
      * @ORM\Column(name="title", type="string", length=128)
      */
     #[Gedmo\Translatable]

--- a/tests/Gedmo/Translatable/Fixture/Issue75/Article.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue75/Article.php
@@ -37,6 +37,7 @@ class Article
 
     /**
      * @Gedmo\Translatable
+     *
      * @ORM\Column(name="title", type="string", length=128)
      */
     #[Gedmo\Translatable]

--- a/tests/Gedmo/Translatable/Fixture/Issue75/File.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue75/File.php
@@ -35,6 +35,7 @@ class File
 
     /**
      * @Gedmo\Translatable
+     *
      * @ORM\Column(name="title", type="string", length=128)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]

--- a/tests/Gedmo/Translatable/Fixture/Issue75/Image.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue75/Image.php
@@ -37,6 +37,7 @@ class Image
 
     /**
      * @Gedmo\Translatable
+     *
      * @ORM\Column(name="title", type="string", length=128)
      */
     #[Gedmo\Translatable]

--- a/tests/Gedmo/Translatable/Fixture/Issue922/Post.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue922/Post.php
@@ -35,6 +35,7 @@ class Post
 
     /**
      * @Gedmo\Translatable
+     *
      * @ORM\Column(type="datetime", nullable=true)
      */
     #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
@@ -43,6 +44,7 @@ class Post
 
     /**
      * @Gedmo\Translatable
+     *
      * @ORM\Column(type="time")
      */
     #[ORM\Column(type: Types::TIME_MUTABLE)]
@@ -51,6 +53,7 @@ class Post
 
     /**
      * @Gedmo\Translatable
+     *
      * @ORM\Column(type="date")
      */
     #[ORM\Column(type: Types::DATE_MUTABLE)]
@@ -59,6 +62,7 @@ class Post
 
     /**
      * @Gedmo\Translatable
+     *
      * @ORM\Column(type="boolean")
      */
     #[ORM\Column(type: Types::BOOLEAN)]

--- a/tests/Gedmo/Translatable/Fixture/MixedValue.php
+++ b/tests/Gedmo/Translatable/Fixture/MixedValue.php
@@ -35,6 +35,7 @@ class MixedValue
 
     /**
      * @Gedmo\Translatable
+     *
      * @ORM\Column(type="datetime")
      */
     #[Gedmo\Translatable]
@@ -45,6 +46,7 @@ class MixedValue
      * @var mixed
      *
      * @Gedmo\Translatable
+     *
      * @ORM\Column(type="custom")
      */
     #[Gedmo\Translatable]

--- a/tests/Gedmo/Translatable/Fixture/Person.php
+++ b/tests/Gedmo/Translatable/Fixture/Person.php
@@ -17,6 +17,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
+ *
  * @Gedmo\TranslationEntity(class="PersonTranslation")
  */
 #[ORM\Entity]
@@ -37,6 +38,7 @@ class Person
 
     /**
      * @Gedmo\Translatable
+     *
      * @ORM\Column(name="name", type="string", length=128)
      */
     #[Gedmo\Translatable]

--- a/tests/Gedmo/Translatable/Fixture/Personal/Article.php
+++ b/tests/Gedmo/Translatable/Fixture/Personal/Article.php
@@ -19,6 +19,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @Gedmo\TranslationEntity(class="Gedmo\Tests\Translatable\Fixture\Personal\PersonalArticleTranslation")
+ *
  * @ORM\Entity
  */
 #[ORM\Entity]
@@ -39,6 +40,7 @@ class Article
 
     /**
      * @Gedmo\Translatable
+     *
      * @ORM\Column(length=128)
      */
     #[ORM\Column(length: 128)]

--- a/tests/Gedmo/Translatable/Fixture/Sport.php
+++ b/tests/Gedmo/Translatable/Fixture/Sport.php
@@ -35,6 +35,7 @@ class Sport
 
     /**
      * @Gedmo\Translatable
+     *
      * @ORM\Column(length=128)
      */
     #[Gedmo\Translatable]

--- a/tests/Gedmo/Translatable/Fixture/StringIdentifier.php
+++ b/tests/Gedmo/Translatable/Fixture/StringIdentifier.php
@@ -31,6 +31,7 @@ class StringIdentifier
 
     /**
      * @Gedmo\Translatable
+     *
      * @ORM\Column(name="title", type="string", length=128)
      */
     #[Gedmo\Translatable]

--- a/tests/Gedmo/Translatable/Fixture/Template/ArticleTemplate.php
+++ b/tests/Gedmo/Translatable/Fixture/Template/ArticleTemplate.php
@@ -32,6 +32,7 @@ class ArticleTemplate
     protected $locale;
     /**
      * @Gedmo\Translatable
+     *
      * @ORM\Column(name="title", type="string", length=128)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
@@ -40,6 +41,7 @@ class ArticleTemplate
 
     /**
      * @Gedmo\Translatable
+     *
      * @ORM\Column(name="content", type="text")
      */
     #[ORM\Column(name: 'content', type: Types::TEXT)]

--- a/tests/Gedmo/Translatable/Fixture/TemplatedArticle.php
+++ b/tests/Gedmo/Translatable/Fixture/TemplatedArticle.php
@@ -36,6 +36,7 @@ class TemplatedArticle extends ArticleTemplate
 
     /**
      * @Gedmo\Translatable
+     *
      * @ORM\Column(type="string", length=128)
      */
     #[Gedmo\Translatable]

--- a/tests/Gedmo/Tree/Fixture/ANode.php
+++ b/tests/Gedmo/Tree/Fixture/ANode.php
@@ -37,6 +37,7 @@ class ANode
      * @var int|null
      *
      * @Gedmo\TreeLeft
+     *
      * @ORM\Column(type="integer", nullable=true)
      */
     #[ORM\Column(type: Types::INTEGER, nullable: true)]
@@ -47,6 +48,7 @@ class ANode
      * @var int|null
      *
      * @Gedmo\TreeRight
+     *
      * @ORM\Column(type="integer", nullable=true)
      */
     #[ORM\Column(type: Types::INTEGER, nullable: true)]
@@ -55,6 +57,7 @@ class ANode
 
     /**
      * @Gedmo\TreeParent
+     *
      * @ORM\ManyToOne(targetEntity="BaseNode", inversedBy="children")
      * @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
      */

--- a/tests/Gedmo/Tree/Fixture/BaseNode.php
+++ b/tests/Gedmo/Tree/Fixture/BaseNode.php
@@ -23,6 +23,7 @@ use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
  * @ORM\InheritanceType("SINGLE_TABLE")
  * @ORM\DiscriminatorColumn(name="discriminator", type="string")
  * @ORM\DiscriminatorMap({"base": "BaseNode", "node": "Node"})
+ *
  * @Gedmo\Tree(type="nested")
  */
 #[ORM\Entity(repositoryClass: NestedTreeRepository::class)]
@@ -44,6 +45,7 @@ class BaseNode extends ANode
      * @var \DateTime|null
      *
      * @Gedmo\Timestampable(on="create")
+     *
      * @ORM\Column(type="datetime")
      */
     #[ORM\Column(type: Types::DATETIME_MUTABLE)]
@@ -60,6 +62,7 @@ class BaseNode extends ANode
      * @var \DateTime|null
      *
      * @ORM\Column(type="datetime")
+     *
      * @Gedmo\Timestampable
      */
     #[ORM\Column(type: Types::DATETIME_MUTABLE)]

--- a/tests/Gedmo/Tree/Fixture/BehavioralCategory.php
+++ b/tests/Gedmo/Tree/Fixture/BehavioralCategory.php
@@ -20,6 +20,7 @@ use Gedmo\Tests\Tree\Fixture\Repository\BehavioralCategoryRepository;
 
 /**
  * @ORM\Entity(repositoryClass="Gedmo\Tests\Tree\Fixture\Repository\BehavioralCategoryRepository")
+ *
  * @Gedmo\Tree(type="nested")
  */
 #[ORM\Entity(repositoryClass: BehavioralCategoryRepository::class)]
@@ -40,6 +41,7 @@ class BehavioralCategory
 
     /**
      * @Gedmo\Translatable
+     *
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
@@ -50,6 +52,7 @@ class BehavioralCategory
      * @var int|null
      *
      * @Gedmo\TreeLeft
+     *
      * @ORM\Column(name="lft", type="integer", nullable=true)
      */
     #[ORM\Column(name: 'lft', type: Types::INTEGER, nullable: true)]
@@ -60,6 +63,7 @@ class BehavioralCategory
      * @var int|null
      *
      * @Gedmo\TreeRight
+     *
      * @ORM\Column(name="rgt", type="integer", nullable=true)
      */
     #[ORM\Column(name: 'rgt', type: Types::INTEGER, nullable: true)]
@@ -68,6 +72,7 @@ class BehavioralCategory
 
     /**
      * @Gedmo\TreeParent
+     *
      * @ORM\ManyToOne(targetEntity="BehavioralCategory", inversedBy="children")
      * @ORM\JoinColumns({
      *     @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
@@ -91,6 +96,7 @@ class BehavioralCategory
      *
      * @Gedmo\Translatable
      * @Gedmo\Slug(fields={"title"})
+     *
      * @ORM\Column(name="slug", type="string", length=128, unique=true)
      */
     #[ORM\Column(name: 'slug', type: Types::STRING, length: 128, unique: true)]

--- a/tests/Gedmo/Tree/Fixture/Category.php
+++ b/tests/Gedmo/Tree/Fixture/Category.php
@@ -21,6 +21,7 @@ use Gedmo\Tree\Node as NodeInterface;
 
 /**
  * @ORM\Entity(repositoryClass="Gedmo\Tree\Entity\Repository\NestedTreeRepository")
+ *
  * @Gedmo\Tree(type="nested")
  */
 #[ORM\Entity(repositoryClass: NestedTreeRepository::class)]
@@ -49,6 +50,7 @@ class Category implements NodeInterface
      * @var int|null
      *
      * @Gedmo\TreeLeft
+     *
      * @ORM\Column(name="lft", type="integer")
      */
     #[ORM\Column(name: 'lft', type: Types::INTEGER)]
@@ -59,6 +61,7 @@ class Category implements NodeInterface
      * @var int|null
      *
      * @Gedmo\TreeRight
+     *
      * @ORM\Column(name="rgt", type="integer")
      */
     #[ORM\Column(name: 'rgt', type: Types::INTEGER)]
@@ -67,6 +70,7 @@ class Category implements NodeInterface
 
     /**
      * @Gedmo\TreeParent
+     *
      * @ORM\ManyToOne(targetEntity="Category", inversedBy="children")
      * @ORM\JoinColumns({
      *     @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
@@ -81,6 +85,7 @@ class Category implements NodeInterface
      * @var int|null
      *
      * @Gedmo\TreeLevel
+     *
      * @ORM\Column(name="lvl", type="integer")
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER)]

--- a/tests/Gedmo/Tree/Fixture/CategoryUuid.php
+++ b/tests/Gedmo/Tree/Fixture/CategoryUuid.php
@@ -21,7 +21,9 @@ use Gedmo\Tree\Node as NodeInterface;
 
 /**
  * @ORM\Entity(repositoryClass="Gedmo\Tree\Entity\Repository\NestedTreeRepository")
+ *
  * @Gedmo\Tree(type="nested")
+ *
  * @ORM\HasLifecycleCallbacks
  */
 #[ORM\Entity(repositoryClass: NestedTreeRepository::class)]
@@ -49,6 +51,7 @@ class CategoryUuid implements NodeInterface
      * @var int|null
      *
      * @Gedmo\TreeLeft
+     *
      * @ORM\Column(name="lft", type="integer")
      */
     #[ORM\Column(name: 'lft', type: Types::INTEGER)]
@@ -59,6 +62,7 @@ class CategoryUuid implements NodeInterface
      * @var int|null
      *
      * @Gedmo\TreeRight
+     *
      * @ORM\Column(name="rgt", type="integer")
      */
     #[ORM\Column(name: 'rgt', type: Types::INTEGER)]
@@ -67,6 +71,7 @@ class CategoryUuid implements NodeInterface
 
     /**
      * @Gedmo\TreeParent
+     *
      * @ORM\ManyToOne(targetEntity="CategoryUuid", inversedBy="children")
      * @ORM\JoinColumns({
      *     @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
@@ -81,6 +86,7 @@ class CategoryUuid implements NodeInterface
      * @var int|null
      *
      * @Gedmo\TreeLevel
+     *
      * @ORM\Column(name="lvl", type="integer")
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER)]
@@ -91,6 +97,7 @@ class CategoryUuid implements NodeInterface
      * @var string|null
      *
      * @Gedmo\TreeRoot
+     *
      * @ORM\Column(name="root", type="string")
      */
     #[ORM\Column(name: 'root', type: Types::STRING)]

--- a/tests/Gedmo/Tree/Fixture/Closure/Category.php
+++ b/tests/Gedmo/Tree/Fixture/Closure/Category.php
@@ -21,6 +21,7 @@ use Gedmo\Tree\Entity\Repository\ClosureTreeRepository;
 /**
  * @Gedmo\Tree(type="closure")
  * @Gedmo\TreeClosure(class="CategoryClosure")
+ *
  * @ORM\Entity(repositoryClass="Gedmo\Tree\Entity\Repository\ClosureTreeRepository")
  */
 #[ORM\Entity(repositoryClass: ClosureTreeRepository::class)]
@@ -48,6 +49,7 @@ class Category
 
     /**
      * @ORM\Column(name="level", type="integer", nullable=true)
+     *
      * @Gedmo\TreeLevel
      */
     #[ORM\Column(name: 'level', type: Types::INTEGER, nullable: true)]
@@ -56,6 +58,7 @@ class Category
 
     /**
      * @Gedmo\TreeParent
+     *
      * @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
      * @ORM\ManyToOne(targetEntity="Category", inversedBy="children")
      */

--- a/tests/Gedmo/Tree/Fixture/Closure/CategoryWithoutLevel.php
+++ b/tests/Gedmo/Tree/Fixture/Closure/CategoryWithoutLevel.php
@@ -21,6 +21,7 @@ use Gedmo\Tree\Entity\Repository\ClosureTreeRepository;
 /**
  * @Gedmo\Tree(type="closure")
  * @Gedmo\TreeClosure(class="Gedmo\Tests\Tree\Fixture\Closure\CategoryWithoutLevelClosure")
+ *
  * @ORM\Entity(repositoryClass="Gedmo\Tree\Entity\Repository\ClosureTreeRepository")
  */
 #[ORM\Entity(repositoryClass: ClosureTreeRepository::class)]
@@ -48,6 +49,7 @@ class CategoryWithoutLevel
 
     /**
      * @Gedmo\TreeParent
+     *
      * @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
      * @ORM\ManyToOne(targetEntity="CategoryWithoutLevel", inversedBy="children")
      */

--- a/tests/Gedmo/Tree/Fixture/Closure/Person.php
+++ b/tests/Gedmo/Tree/Fixture/Closure/Person.php
@@ -19,6 +19,7 @@ use Gedmo\Tree\Entity\Repository\ClosureTreeRepository;
 /**
  * @Gedmo\Tree(type="closure")
  * @Gedmo\TreeClosure(class="Gedmo\Tests\Tree\Fixture\Closure\PersonClosure")
+ *
  * @ORM\Entity(repositoryClass="Gedmo\Tree\Entity\Repository\ClosureTreeRepository")
  * @ORM\InheritanceType("JOINED")
  * @ORM\DiscriminatorColumn(name="discriminator", type="string")
@@ -54,6 +55,7 @@ abstract class Person
 
     /**
      * @Gedmo\TreeParent
+     *
      * @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
      * @ORM\ManyToOne(targetEntity="Person", inversedBy="children", cascade={"persist"})
      */
@@ -64,6 +66,7 @@ abstract class Person
 
     /**
      * @ORM\Column(name="level", type="integer")
+     *
      * @Gedmo\TreeLevel
      */
     #[ORM\Column(name: 'level', type: Types::INTEGER)]

--- a/tests/Gedmo/Tree/Fixture/Document/Article.php
+++ b/tests/Gedmo/Tree/Fixture/Document/Article.php
@@ -18,6 +18,7 @@ use Gedmo\Tree\Document\MongoDB\Repository\MaterializedPathRepository;
 
 /**
  * @Mongo\Document(repositoryClass="Gedmo\Tree\Document\MongoDB\Repository\MaterializedPathRepository")
+ *
  * @Gedmo\Tree(type="materializedPath", activateLocking=true)
  */
 #[Mongo\Document(repositoryClass: MaterializedPathRepository::class)]
@@ -34,6 +35,7 @@ class Article
 
     /**
      * @Mongo\Field(type="string")
+     *
      * @Gedmo\TreePathSource
      */
     #[Mongo\Field(type: Type::STRING)]
@@ -44,6 +46,7 @@ class Article
      * @var string|null
      *
      * @Mongo\Field(type="string")
+     *
      * @Gedmo\TreePath(separator="|")
      */
     #[Mongo\Field(type: Type::STRING)]
@@ -52,6 +55,7 @@ class Article
 
     /**
      * @Gedmo\TreeParent
+     *
      * @Mongo\ReferenceOne(targetDocument="Article")
      */
     #[Mongo\ReferenceOne(targetDocument: self::class)]
@@ -62,6 +66,7 @@ class Article
      * @var int|null
      *
      * @Gedmo\TreeLevel
+     *
      * @Mongo\Field(type="int")
      */
     #[Mongo\Field(type: Type::INT)]
@@ -72,6 +77,7 @@ class Article
      * @var \DateTime|null
      *
      * @Gedmo\TreeLockTime
+     *
      * @Mongo\Field(type="date")
      */
     #[Mongo\Field(type: Type::DATE)]

--- a/tests/Gedmo/Tree/Fixture/Document/Category.php
+++ b/tests/Gedmo/Tree/Fixture/Document/Category.php
@@ -18,6 +18,7 @@ use Gedmo\Tree\Document\MongoDB\Repository\MaterializedPathRepository;
 
 /**
  * @Mongo\Document(repositoryClass="Gedmo\Tree\Document\MongoDB\Repository\MaterializedPathRepository")
+ *
  * @Gedmo\Tree(type="materializedPath")
  */
 #[Mongo\Document(repositoryClass: MaterializedPathRepository::class)]
@@ -34,6 +35,7 @@ class Category
 
     /**
      * @Mongo\Field(type="string")
+     *
      * @Gedmo\TreePathSource
      */
     #[Mongo\Field(type: Type::STRING)]
@@ -44,6 +46,7 @@ class Category
      * @var string|null
      *
      * @Mongo\Field(type="string")
+     *
      * @Gedmo\TreePath(separator="|")
      */
     #[Mongo\Field(type: Type::STRING)]
@@ -52,6 +55,7 @@ class Category
 
     /**
      * @Gedmo\TreeParent
+     *
      * @Mongo\ReferenceOne(targetDocument="Gedmo\Tests\Tree\Fixture\Document\Category")
      */
     #[Mongo\ReferenceOne(targetDocument: self::class)]
@@ -62,6 +66,7 @@ class Category
      * @var int|null
      *
      * @Gedmo\TreeLevel
+     *
      * @Mongo\Field(type="int")
      */
     #[Mongo\Field(type: Type::INT)]

--- a/tests/Gedmo/Tree/Fixture/ForeignRootCategory.php
+++ b/tests/Gedmo/Tree/Fixture/ForeignRootCategory.php
@@ -20,6 +20,7 @@ use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
 
 /**
  * @ORM\Entity(repositoryClass="Gedmo\Tree\Entity\Repository\NestedTreeRepository")
+ *
  * @Gedmo\Tree(type="nested")
  */
 #[ORM\Entity(repositoryClass: NestedTreeRepository::class)]
@@ -48,6 +49,7 @@ class ForeignRootCategory
      * @var int|null
      *
      * @Gedmo\TreeLeft
+     *
      * @ORM\Column(name="lft", type="integer")
      */
     #[ORM\Column(name: 'lft', type: Types::INTEGER)]
@@ -58,6 +60,7 @@ class ForeignRootCategory
      * @var int|null
      *
      * @Gedmo\TreeRight
+     *
      * @ORM\Column(name="rgt", type="integer")
      */
     #[ORM\Column(name: 'rgt', type: Types::INTEGER)]
@@ -66,6 +69,7 @@ class ForeignRootCategory
 
     /**
      * @Gedmo\TreeParent
+     *
      * @ORM\ManyToOne(targetEntity="ForeignRootCategory", inversedBy="children")
      * @ORM\JoinColumns({
      *     @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
@@ -80,6 +84,7 @@ class ForeignRootCategory
      * @var int|null
      *
      * @Gedmo\TreeRoot(identifierMethod="getRoot")
+     *
      * @ORM\Column(type="integer")
      */
     #[ORM\Column(type: Types::INTEGER)]
@@ -90,6 +95,7 @@ class ForeignRootCategory
      * @var int|null
      *
      * @Gedmo\TreeLevel
+     *
      * @ORM\Column(name="lvl", type="integer")
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER)]

--- a/tests/Gedmo/Tree/Fixture/Genealogy/Person.php
+++ b/tests/Gedmo/Tree/Fixture/Genealogy/Person.php
@@ -24,6 +24,7 @@ use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
  * @ORM\InheritanceType("SINGLE_TABLE")
  * @ORM\DiscriminatorColumn(name="discr", type="string")
  * @ORM\DiscriminatorMap({"man": "Man", "woman": "Woman"})
+ *
  * @Gedmo\Tree(type="nested")
  */
 #[ORM\Entity(repositoryClass: NestedTreeRepository::class)]
@@ -56,6 +57,7 @@ abstract class Person
 
     /**
      * @Gedmo\TreeParent
+     *
      * @ORM\ManyToOne(targetEntity="Person", inversedBy="children")
      */
     #[ORM\ManyToOne(targetEntity: self::class, inversedBy: 'children')]
@@ -66,6 +68,7 @@ abstract class Person
      * @var int|null
      *
      * @Gedmo\TreeLeft
+     *
      * @ORM\Column(name="lft", type="integer")
      */
     #[ORM\Column(name: 'lft', type: Types::INTEGER)]
@@ -76,6 +79,7 @@ abstract class Person
      * @var int|null
      *
      * @Gedmo\TreeRight
+     *
      * @ORM\Column(name="rgt", type="integer")
      */
     #[ORM\Column(name: 'rgt', type: Types::INTEGER)]
@@ -86,6 +90,7 @@ abstract class Person
      * @var int|null
      *
      * @Gedmo\TreeLevel
+     *
      * @ORM\Column(name="lvl", type="integer")
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER)]

--- a/tests/Gedmo/Tree/Fixture/Issue2408/Category.php
+++ b/tests/Gedmo/Tree/Fixture/Issue2408/Category.php
@@ -20,6 +20,7 @@ use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
 
 /**
  * @Gedmo\Tree(type="nested")
+ *
  * @ORM\Table(name="categories")
  * @ORM\Entity(repositoryClass="Gedmo\Tree\Entity\Repository\NestedTreeRepository")
  */
@@ -50,6 +51,7 @@ class Category
      * @var int|null
      *
      * @Gedmo\TreeLeft
+     *
      * @ORM\Column(name="lft", type="integer")
      */
     #[ORM\Column(name: 'lft', type: Types::INTEGER)]
@@ -60,6 +62,7 @@ class Category
      * @var int|null
      *
      * @Gedmo\TreeRight
+     *
      * @ORM\Column(name="rgt", type="integer")
      */
     #[ORM\Column(name: 'rgt', type: Types::INTEGER)]
@@ -70,6 +73,7 @@ class Category
      * @var int|null
      *
      * @Gedmo\TreeLevel
+     *
      * @ORM\Column(name="lvl", type="integer")
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER)]
@@ -80,6 +84,7 @@ class Category
      * @var self|null
      *
      * @Gedmo\TreeRoot
+     *
      * @ORM\ManyToOne(targetEntity="Category")
      * @ORM\JoinColumn(name="tree_root", referencedColumnName="id", onDelete="CASCADE")
      */
@@ -90,6 +95,7 @@ class Category
 
     /**
      * @Gedmo\TreeParent
+     *
      * @ORM\ManyToOne(targetEntity="Category", inversedBy="children")
      * @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
      */

--- a/tests/Gedmo/Tree/Fixture/Issue2517/Category.php
+++ b/tests/Gedmo/Tree/Fixture/Issue2517/Category.php
@@ -20,6 +20,7 @@ use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
 
 /**
  * @Gedmo\Tree(type="nested")
+ *
  * @ORM\Table(name="categories")
  * @ORM\Entity(repositoryClass="Gedmo\Tree\Entity\Repository\NestedTreeRepository")
  */
@@ -50,6 +51,7 @@ class Category
      * @var int|null
      *
      * @Gedmo\TreeLeft
+     *
      * @ORM\Column(name="lft", type="integer")
      */
     #[ORM\Column(name: 'lft', type: Types::INTEGER)]
@@ -60,6 +62,7 @@ class Category
      * @var int|null
      *
      * @Gedmo\TreeRight
+     *
      * @ORM\Column(name="rgt", type="integer")
      */
     #[ORM\Column(name: 'rgt', type: Types::INTEGER)]
@@ -70,6 +73,7 @@ class Category
      * @var int|null
      *
      * @Gedmo\TreeLevel
+     *
      * @ORM\Column(name="lvl", type="integer")
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER)]
@@ -80,6 +84,7 @@ class Category
      * @var self|null
      *
      * @Gedmo\TreeRoot
+     *
      * @ORM\ManyToOne(targetEntity="Category")
      * @ORM\JoinColumn(name="tree_root", referencedColumnName="id", onDelete="CASCADE")
      */
@@ -90,6 +95,7 @@ class Category
 
     /**
      * @Gedmo\TreeParent
+     *
      * @ORM\ManyToOne(targetEntity="Category", inversedBy="children")
      * @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
      */

--- a/tests/Gedmo/Tree/Fixture/MPCategory.php
+++ b/tests/Gedmo/Tree/Fixture/MPCategory.php
@@ -20,6 +20,7 @@ use Gedmo\Tree\Entity\Repository\MaterializedPathRepository;
 
 /**
  * @ORM\Entity(repositoryClass="Gedmo\Tree\Entity\Repository\MaterializedPathRepository")
+ *
  * @Gedmo\Tree(type="materializedPath")
  */
 #[ORM\Entity(repositoryClass: MaterializedPathRepository::class)]
@@ -40,6 +41,7 @@ class MPCategory
 
     /**
      * @Gedmo\TreePath
+     *
      * @ORM\Column(name="path", type="string", length=3000, nullable=true)
      */
     #[ORM\Column(name: 'path', type: Types::STRING, length: 3000, nullable: true)]
@@ -48,6 +50,7 @@ class MPCategory
 
     /**
      * @Gedmo\TreePathSource
+     *
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
@@ -56,6 +59,7 @@ class MPCategory
 
     /**
      * @Gedmo\TreeParent
+     *
      * @ORM\ManyToOne(targetEntity="MPCategory", inversedBy="children")
      * @ORM\JoinColumns({
      *     @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
@@ -70,6 +74,7 @@ class MPCategory
      * @var int|null
      *
      * @Gedmo\TreeLevel
+     *
      * @ORM\Column(name="lvl", type="integer", nullable=true)
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER, nullable: true)]
@@ -80,6 +85,7 @@ class MPCategory
      * @var string|null
      *
      * @Gedmo\TreeRoot
+     *
      * @ORM\Column(name="tree_root_value", type="string", nullable=true)
      */
     #[ORM\Column(name: 'tree_root_value', type: Types::STRING, nullable: true)]

--- a/tests/Gedmo/Tree/Fixture/MPCategoryWithRootAssociation.php
+++ b/tests/Gedmo/Tree/Fixture/MPCategoryWithRootAssociation.php
@@ -20,6 +20,7 @@ use Gedmo\Tree\Entity\Repository\MaterializedPathRepository;
 
 /**
  * @ORM\Entity(repositoryClass="Gedmo\Tree\Entity\Repository\MaterializedPathRepository")
+ *
  * @Gedmo\Tree(type="materializedPath")
  */
 #[ORM\Entity(repositoryClass: MaterializedPathRepository::class)]
@@ -30,6 +31,7 @@ class MPCategoryWithRootAssociation
      * @var int|null
      *
      * @Gedmo\TreePathSource
+     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -42,6 +44,7 @@ class MPCategoryWithRootAssociation
 
     /**
      * @Gedmo\TreePath
+     *
      * @ORM\Column(name="path", type="string", length=3000, nullable=true)
      */
     #[ORM\Column(name: 'path', type: Types::STRING, length: 3000, nullable: true)]
@@ -56,6 +59,7 @@ class MPCategoryWithRootAssociation
 
     /**
      * @Gedmo\TreeParent
+     *
      * @ORM\ManyToOne(targetEntity="MPCategoryWithRootAssociation", inversedBy="children")
      * @ORM\JoinColumns({
      *     @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
@@ -70,6 +74,7 @@ class MPCategoryWithRootAssociation
      * @var int|null
      *
      * @Gedmo\TreeLevel
+     *
      * @ORM\Column(name="lvl", type="integer", nullable=true)
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER, nullable: true)]
@@ -80,6 +85,7 @@ class MPCategoryWithRootAssociation
      * @var self|null
      *
      * @Gedmo\TreeRoot
+     *
      * @ORM\ManyToOne(targetEntity="MPCategoryWithRootAssociation")
      * @ORM\JoinColumns({
      *     @ORM\JoinColumn(name="tree_root_entity", referencedColumnName="id", onDelete="CASCADE")

--- a/tests/Gedmo/Tree/Fixture/MPCategoryWithTrimmedSeparator.php
+++ b/tests/Gedmo/Tree/Fixture/MPCategoryWithTrimmedSeparator.php
@@ -20,6 +20,7 @@ use Gedmo\Tree\Entity\Repository\MaterializedPathRepository;
 
 /**
  * @ORM\Entity(repositoryClass="Gedmo\Tree\Entity\Repository\MaterializedPathRepository")
+ *
  * @Gedmo\Tree(type="materializedPath")
  */
 #[ORM\Entity(repositoryClass: MaterializedPathRepository::class)]
@@ -40,6 +41,7 @@ class MPCategoryWithTrimmedSeparator
 
     /**
      * @Gedmo\TreePath(appendId=false, startsWithSeparator=false, endsWithSeparator=false)
+     *
      * @ORM\Column(name="path", type="string", length=3000, nullable=true)
      */
     #[ORM\Column(name: 'path', type: Types::STRING, length: 3000, nullable: true)]
@@ -48,6 +50,7 @@ class MPCategoryWithTrimmedSeparator
 
     /**
      * @Gedmo\TreePathSource
+     *
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
@@ -56,6 +59,7 @@ class MPCategoryWithTrimmedSeparator
 
     /**
      * @Gedmo\TreeParent
+     *
      * @ORM\ManyToOne(targetEntity="MPCategoryWithTrimmedSeparator", inversedBy="children")
      * @ORM\JoinColumns({
      *     @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
@@ -70,6 +74,7 @@ class MPCategoryWithTrimmedSeparator
      * @var int|null
      *
      * @Gedmo\TreeLevel
+     *
      * @ORM\Column(name="lvl", type="integer", nullable=true)
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER, nullable: true)]

--- a/tests/Gedmo/Tree/Fixture/MPFeaturesCategory.php
+++ b/tests/Gedmo/Tree/Fixture/MPFeaturesCategory.php
@@ -20,6 +20,7 @@ use Gedmo\Tree\Entity\Repository\MaterializedPathRepository;
 
 /**
  * @ORM\Entity(repositoryClass="Gedmo\Tree\Entity\Repository\MaterializedPathRepository")
+ *
  * @Gedmo\Tree(type="materializedPath")
  */
 #[ORM\Entity(repositoryClass: MaterializedPathRepository::class)]
@@ -40,6 +41,7 @@ class MPFeaturesCategory
 
     /**
      * @Gedmo\TreePath(appendId=false, startsWithSeparator=true, endsWithSeparator=false)
+     *
      * @ORM\Column(name="path", type="string", length=3000, nullable=true)
      */
     #[ORM\Column(name: 'path', type: Types::STRING, length: 3000, nullable: true)]
@@ -50,6 +52,7 @@ class MPFeaturesCategory
      * @var string|null
      *
      * @Gedmo\TreePathHash
+     *
      * @ORM\Column(name="pathhash", type="string", length=32, nullable=true)
      */
     #[ORM\Column(name: 'pathhash', type: Types::STRING, length: 32, nullable: true)]
@@ -58,6 +61,7 @@ class MPFeaturesCategory
 
     /**
      * @Gedmo\TreePathSource
+     *
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
@@ -66,6 +70,7 @@ class MPFeaturesCategory
 
     /**
      * @Gedmo\TreeParent
+     *
      * @ORM\ManyToOne(targetEntity="MPFeaturesCategory", inversedBy="children")
      * @ORM\JoinColumns({
      *     @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
@@ -80,6 +85,7 @@ class MPFeaturesCategory
      * @var int|null
      *
      * @Gedmo\TreeLevel
+     *
      * @ORM\Column(name="lvl", type="integer", nullable=true)
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER, nullable: true)]
@@ -90,6 +96,7 @@ class MPFeaturesCategory
      * @var string|null
      *
      * @Gedmo\TreeRoot
+     *
      * @ORM\Column(name="tree_root_value", type="string", nullable=true)
      */
     #[ORM\Column(name: 'tree_root_value', type: Types::STRING, nullable: true)]

--- a/tests/Gedmo/Tree/Fixture/Node.php
+++ b/tests/Gedmo/Tree/Fixture/Node.php
@@ -24,6 +24,7 @@ class Node extends BaseNode
 {
     /**
      * @Gedmo\Translatable
+     *
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
@@ -35,6 +36,7 @@ class Node extends BaseNode
      *
      * @Gedmo\Translatable
      * @Gedmo\Slug(fields={"title"})
+     *
      * @ORM\Column(name="slug", type="string", length=128)
      */
     #[ORM\Column(name: 'slug', type: Types::STRING, length: 128)]

--- a/tests/Gedmo/Tree/Fixture/Role.php
+++ b/tests/Gedmo/Tree/Fixture/Role.php
@@ -24,6 +24,7 @@ use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
  * @ORM\InheritanceType("JOINED")
  * @ORM\DiscriminatorColumn(name="discr", type="string")
  * @ORM\DiscriminatorMap({"user": "User", "usergroup": "UserGroup", "userldap": "UserLDAP"})
+ *
  * @Gedmo\Tree(type="nested")
  */
 #[ORM\Entity(repositoryClass: NestedTreeRepository::class)]
@@ -56,6 +57,7 @@ abstract class Role
 
     /**
      * @Gedmo\TreeParent
+     *
      * @ORM\ManyToOne(targetEntity="UserGroup", inversedBy="children")
      */
     #[ORM\ManyToOne(targetEntity: UserGroup::class, inversedBy: 'children')]
@@ -66,6 +68,7 @@ abstract class Role
      * @var int|null
      *
      * @Gedmo\TreeLeft
+     *
      * @ORM\Column(name="lft", type="integer")
      */
     #[ORM\Column(name: 'lft', type: Types::INTEGER)]
@@ -76,6 +79,7 @@ abstract class Role
      * @var int|null
      *
      * @Gedmo\TreeRight
+     *
      * @ORM\Column(name="rgt", type="integer")
      */
     #[ORM\Column(name: 'rgt', type: Types::INTEGER)]
@@ -86,6 +90,7 @@ abstract class Role
      * @var int|null
      *
      * @Gedmo\TreeLevel
+     *
      * @ORM\Column(name="lvl", type="integer")
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER)]

--- a/tests/Gedmo/Tree/Fixture/RootAssociationCategory.php
+++ b/tests/Gedmo/Tree/Fixture/RootAssociationCategory.php
@@ -20,6 +20,7 @@ use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
 
 /**
  * @ORM\Entity(repositoryClass="Gedmo\Tree\Entity\Repository\NestedTreeRepository")
+ *
  * @Gedmo\Tree(type="nested")
  */
 #[ORM\Entity(repositoryClass: NestedTreeRepository::class)]
@@ -55,6 +56,7 @@ class RootAssociationCategory
      * @var int|null
      *
      * @Gedmo\TreeLeft
+     *
      * @ORM\Column(name="lft", type="integer")
      */
     #[ORM\Column(name: 'lft', type: Types::INTEGER)]
@@ -65,6 +67,7 @@ class RootAssociationCategory
      * @var int|null
      *
      * @Gedmo\TreeRight
+     *
      * @ORM\Column(name="rgt", type="integer")
      */
     #[ORM\Column(name: 'rgt', type: Types::INTEGER)]
@@ -73,6 +76,7 @@ class RootAssociationCategory
 
     /**
      * @Gedmo\TreeParent
+     *
      * @ORM\ManyToOne(targetEntity="RootAssociationCategory", inversedBy="children")
      * @ORM\JoinColumns({
      *     @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
@@ -87,6 +91,7 @@ class RootAssociationCategory
      * @var self|null
      *
      * @Gedmo\TreeRoot
+     *
      * @ORM\ManyToOne(targetEntity="RootAssociationCategory")
      * @ORM\JoinColumns({
      *     @ORM\JoinColumn(name="tree_root", referencedColumnName="id", onDelete="CASCADE")
@@ -101,6 +106,7 @@ class RootAssociationCategory
      * @var int|null
      *
      * @Gedmo\TreeLevel
+     *
      * @ORM\Column(name="lvl", type="integer")
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER)]

--- a/tests/Gedmo/Tree/Fixture/RootCategory.php
+++ b/tests/Gedmo/Tree/Fixture/RootCategory.php
@@ -21,6 +21,7 @@ use Gedmo\Tree\Node;
 
 /**
  * @ORM\Entity(repositoryClass="Gedmo\Tree\Entity\Repository\NestedTreeRepository")
+ *
  * @Gedmo\Tree(type="nested")
  */
 #[ORM\Entity(repositoryClass: NestedTreeRepository::class)]
@@ -56,6 +57,7 @@ class RootCategory implements Node
      * @var int|null
      *
      * @Gedmo\TreeLeft
+     *
      * @ORM\Column(name="lft", type="integer")
      */
     #[ORM\Column(name: 'lft', type: Types::INTEGER)]
@@ -66,6 +68,7 @@ class RootCategory implements Node
      * @var int|null
      *
      * @Gedmo\TreeRight
+     *
      * @ORM\Column(name="rgt", type="integer")
      */
     #[ORM\Column(name: 'rgt', type: Types::INTEGER)]
@@ -74,6 +77,7 @@ class RootCategory implements Node
 
     /**
      * @Gedmo\TreeParent
+     *
      * @ORM\ManyToOne(targetEntity="RootCategory", inversedBy="children")
      * @ORM\JoinColumns({
      *     @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
@@ -88,6 +92,7 @@ class RootCategory implements Node
      * @var int|null
      *
      * @Gedmo\TreeRoot
+     *
      * @ORM\Column(type="integer")
      */
     #[ORM\Column(type: Types::INTEGER)]
@@ -98,6 +103,7 @@ class RootCategory implements Node
      * @var int|null
      *
      * @Gedmo\TreeLevel(base=1)
+     *
      * @ORM\Column(name="lvl", type="integer")
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER)]

--- a/tests/Gedmo/Tree/Fixture/Transport/Car.php
+++ b/tests/Gedmo/Tree/Fixture/Transport/Car.php
@@ -20,6 +20,7 @@ use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
 
 /**
  * @Gedmo\Tree(type="nested")
+ *
  * @ORM\Entity(repositoryClass="Gedmo\Tree\Entity\Repository\NestedTreeRepository")
  */
 #[ORM\Entity(repositoryClass: NestedTreeRepository::class)]
@@ -36,6 +37,7 @@ class Car extends Vehicle
 
     /**
      * @Gedmo\TreeParent
+     *
      * @ORM\ManyToOne(targetEntity="Car", inversedBy="children")
      * @ORM\JoinColumns({
      *     @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
@@ -50,6 +52,7 @@ class Car extends Vehicle
      * @var int|null
      *
      * @Gedmo\TreeLeft
+     *
      * @ORM\Column(type="integer", nullable=true)
      */
     #[ORM\Column(type: Types::INTEGER, nullable: true)]
@@ -60,6 +63,7 @@ class Car extends Vehicle
      * @var int|null
      *
      * @Gedmo\TreeRight
+     *
      * @ORM\Column(type="integer", nullable=true)
      */
     #[ORM\Column(type: Types::INTEGER, nullable: true)]
@@ -70,6 +74,7 @@ class Car extends Vehicle
      * @var int|null
      *
      * @Gedmo\TreeRoot
+     *
      * @ORM\Column(type="integer", nullable=true)
      */
     #[ORM\Column(type: Types::INTEGER, nullable: true)]
@@ -80,6 +85,7 @@ class Car extends Vehicle
      * @var int|null
      *
      * @Gedmo\TreeLevel
+     *
      * @ORM\Column(name="lvl", type="integer", nullable=true)
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER, nullable: true)]

--- a/tests/Gedmo/Uploadable/Fixture/Entity/File.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/File.php
@@ -17,6 +17,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
+ *
  * @Gedmo\Uploadable(allowOverwrite=true, pathMethod="getPath", callback="callbackMethod")
  */
 #[ORM\Entity]
@@ -48,6 +49,7 @@ class File
 
     /**
      * @ORM\Column(name="path", type="string")
+     *
      * @Gedmo\UploadableFilePath
      */
     #[ORM\Column(name: 'path', type: Types::STRING)]

--- a/tests/Gedmo/Uploadable/Fixture/Entity/FileAppendNumber.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/FileAppendNumber.php
@@ -17,6 +17,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
+ *
  * @Gedmo\Uploadable(appendNumber=true, pathMethod="getPath")
  */
 #[ORM\Entity]
@@ -43,6 +44,7 @@ class FileAppendNumber
 
     /**
      * @ORM\Column(name="path", type="string")
+     *
      * @Gedmo\UploadableFilePath
      */
     #[ORM\Column(name: 'path', type: Types::STRING)]

--- a/tests/Gedmo/Uploadable/Fixture/Entity/FileAppendNumberRelative.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/FileAppendNumberRelative.php
@@ -18,6 +18,7 @@ use Gedmo\Uploadable\Mapping\Validator;
 
 /**
  * @ORM\Entity
+ *
  * @Gedmo\Uploadable(appendNumber=true, path="./", filenameGenerator="ALPHANUMERIC")
  */
 #[ORM\Entity]
@@ -44,6 +45,7 @@ class FileAppendNumberRelative
 
     /**
      * @ORM\Column(name="path", type="string")
+     *
      * @Gedmo\UploadableFilePath
      */
     #[ORM\Column(name: 'path', type: Types::STRING)]

--- a/tests/Gedmo/Uploadable/Fixture/Entity/FileWithAllowedTypes.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/FileWithAllowedTypes.php
@@ -17,6 +17,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
+ *
  * @Gedmo\Uploadable(allowedTypes="text/plain,text/html")
  */
 #[ORM\Entity]
@@ -43,6 +44,7 @@ class FileWithAllowedTypes
 
     /**
      * @ORM\Column(name="path", type="string", nullable=true)
+     *
      * @Gedmo\UploadableFilePath
      */
     #[ORM\Column(name: 'path', type: Types::STRING, nullable: true)]
@@ -51,6 +53,7 @@ class FileWithAllowedTypes
 
     /**
      * @ORM\Column(name="size", type="decimal", nullable=true)
+     *
      * @Gedmo\UploadableFileSize
      */
     #[ORM\Column(name: 'size', type: Types::DECIMAL, nullable: true)]

--- a/tests/Gedmo/Uploadable/Fixture/Entity/FileWithAlphanumericName.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/FileWithAlphanumericName.php
@@ -18,6 +18,7 @@ use Gedmo\Uploadable\Mapping\Validator;
 
 /**
  * @ORM\Entity
+ *
  * @Gedmo\Uploadable(pathMethod="getPath", filenameGenerator="ALPHANUMERIC", appendNumber=true)
  */
 #[ORM\Entity]
@@ -38,6 +39,7 @@ class FileWithAlphanumericName
 
     /**
      * @ORM\Column(name="path", type="string", nullable=true)
+     *
      * @Gedmo\UploadableFilePath
      */
     #[ORM\Column(name: 'path', type: Types::STRING, nullable: true)]

--- a/tests/Gedmo/Uploadable/Fixture/Entity/FileWithCustomFilenameGenerator.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/FileWithCustomFilenameGenerator.php
@@ -18,6 +18,7 @@ use Gedmo\Tests\Uploadable\FakeFilenameGenerator;
 
 /**
  * @ORM\Entity
+ *
  * @Gedmo\Uploadable(pathMethod="getPath", filenameGenerator="Gedmo\Tests\Uploadable\FakeFilenameGenerator")
  */
 #[ORM\Entity]
@@ -38,6 +39,7 @@ class FileWithCustomFilenameGenerator
 
     /**
      * @ORM\Column(name="path", type="string", nullable=true)
+     *
      * @Gedmo\UploadableFilePath
      */
     #[ORM\Column(name: 'path', type: Types::STRING, nullable: true)]

--- a/tests/Gedmo/Uploadable/Fixture/Entity/FileWithDisallowedTypes.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/FileWithDisallowedTypes.php
@@ -17,6 +17,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
+ *
  * @Gedmo\Uploadable(disallowedTypes="text/css, text/html")
  */
 #[ORM\Entity]
@@ -43,6 +44,7 @@ class FileWithDisallowedTypes
 
     /**
      * @ORM\Column(name="path", type="string", nullable=true)
+     *
      * @Gedmo\UploadableFilePath
      */
     #[ORM\Column(name: 'path', type: Types::STRING, nullable: true)]
@@ -51,6 +53,7 @@ class FileWithDisallowedTypes
 
     /**
      * @ORM\Column(name="size", type="decimal", nullable=true)
+     *
      * @Gedmo\UploadableFileSize
      */
     #[ORM\Column(name: 'size', type: Types::DECIMAL, nullable: true)]

--- a/tests/Gedmo/Uploadable/Fixture/Entity/FileWithMaxSize.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/FileWithMaxSize.php
@@ -17,6 +17,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
+ *
  * @Gedmo\Uploadable(allowOverwrite=true, pathMethod="getPath", callback="callbackMethod", maxSize="2")
  */
 #[ORM\Entity]
@@ -48,6 +49,7 @@ class FileWithMaxSize
 
     /**
      * @ORM\Column(name="path", type="string")
+     *
      * @Gedmo\UploadableFilePath
      */
     #[ORM\Column(name: 'path', type: Types::STRING)]
@@ -56,6 +58,7 @@ class FileWithMaxSize
 
     /**
      * @ORM\Column(name="size", type="decimal")
+     *
      * @Gedmo\UploadableFileSize
      */
     #[ORM\Column(name: 'size', type: Types::DECIMAL)]

--- a/tests/Gedmo/Uploadable/Fixture/Entity/FileWithSha1Name.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/FileWithSha1Name.php
@@ -18,6 +18,7 @@ use Gedmo\Uploadable\Mapping\Validator;
 
 /**
  * @ORM\Entity
+ *
  * @Gedmo\Uploadable(pathMethod="getPath", filenameGenerator="SHA1")
  */
 #[ORM\Entity]
@@ -38,6 +39,7 @@ class FileWithSha1Name
 
     /**
      * @ORM\Column(name="path", type="string", nullable=true)
+     *
      * @Gedmo\UploadableFilePath
      */
     #[ORM\Column(name: 'path', type: Types::STRING, nullable: true)]

--- a/tests/Gedmo/Uploadable/Fixture/Entity/FileWithoutPath.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/FileWithoutPath.php
@@ -17,6 +17,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
+ *
  * @Gedmo\Uploadable
  */
 #[ORM\Entity]
@@ -37,6 +38,7 @@ class FileWithoutPath
 
     /**
      * @ORM\Column(name="path", type="string", nullable=true)
+     *
      * @Gedmo\UploadableFilePath
      */
     #[ORM\Column(name: 'path', type: Types::STRING, nullable: true)]

--- a/tests/Gedmo/Uploadable/Fixture/Entity/Image.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/Image.php
@@ -17,6 +17,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
+ *
  * @Gedmo\Uploadable(pathMethod="getPath")
  */
 #[ORM\Entity]
@@ -43,6 +44,7 @@ class Image
 
     /**
      * @ORM\Column(name="path", type="string", nullable=true)
+     *
      * @Gedmo\UploadableFilePath
      */
     #[ORM\Column(name: 'path', type: Types::STRING, nullable: true)]
@@ -51,6 +53,7 @@ class Image
 
     /**
      * @ORM\Column(name="size", type="decimal", nullable=true)
+     *
      * @Gedmo\UploadableFileSize
      */
     #[ORM\Column(name: 'size', type: Types::DECIMAL, nullable: true)]
@@ -59,6 +62,7 @@ class Image
 
     /**
      * @ORM\Column(name="mime_type", type="string", nullable=true)
+     *
      * @Gedmo\UploadableFileMimeType
      */
     #[ORM\Column(name: 'mime_type', type: Types::STRING, nullable: true)]

--- a/tests/Gedmo/Uploadable/Fixture/Entity/ImageWithTypedProperties.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/ImageWithTypedProperties.php
@@ -17,6 +17,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
+ *
  * @Gedmo\Uploadable(pathMethod="getPath")
  */
 #[ORM\Entity]
@@ -41,6 +42,7 @@ class ImageWithTypedProperties
 
     /**
      * @ORM\Column(name="path", type="string", nullable=true)
+     *
      * @Gedmo\UploadableFilePath
      */
     #[ORM\Column(name: 'path', type: Types::STRING, nullable: true)]
@@ -49,6 +51,7 @@ class ImageWithTypedProperties
 
     /**
      * @ORM\Column(name="size", type="decimal", nullable=true)
+     *
      * @Gedmo\UploadableFileSize
      */
     #[ORM\Column(name: 'size', type: Types::DECIMAL, nullable: true)]
@@ -57,6 +60,7 @@ class ImageWithTypedProperties
 
     /**
      * @ORM\Column(name="mime_type", type="string", nullable=true)
+     *
      * @Gedmo\UploadableFileMimeType
      */
     #[ORM\Column(name: 'mime_type', type: Types::STRING, nullable: true)]


### PR DESCRIPTION
bump "rector/rector" to 0.17

is the upper constraint for friendsofphp/php-cs-fixer still in need?

On local development, this blocks doctrine/annotations v2.
The CI removes it before running the tests.
https://github.com/doctrine-extensions/DoctrineExtensions/blob/main/.github/workflows/continuous-integration.yml#L65