### PR TITLE
chore: bump hadolint/hadolint-action 2 => 3

### DIFF
--- a/.github/workflows/qa-dockerfile.yml
+++ b/.github/workflows/qa-dockerfile.yml
@@ -17,6 +17,6 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Lint Dockerfile
-        uses: hadolint/hadolint-action@v2.1.0
+        uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: ".docker/php/Dockerfile"


### PR DESCRIPTION
https://github.com/hadolint/hadolint-action

Please see [Ahttps://github.com/doctrine-extensions/DoctrineExtensions/actions/runs/5177781653](https://github.com/doctrine-extensions/DoctrineExtensions/actions/runs/5177781653/jobs/9328454130#step:4:12)

Hadolint
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/


