### PR TITLE
Honor return type for `__set()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,11 @@ a release.
 - Named arguments have precedence over the values passed in the `$data` array in annotation classes at `Gedmo\Mapping\Annotation\`
   namespace
 - Removed conflict against "doctrine/cache" < 1.11, as this library is not used
+- Return type from `TranslationProxy::__set()` (from `TranslationProxy` to `void`)
 
 ### Fixed
 - Tree: Creation of dynamic `Node::$sibling` property, which is deprecated as of PHP >= 8.2
+- Return type from `TranslationProxy::__set()` in order to honor its original signature (`void`)
 
 ### Deprecated
 - Tree: Not implementing `Node` interface in classes that are used as nodes

--- a/src/Translator/TranslationProxy.php
+++ b/src/Translator/TranslationProxy.php
@@ -123,24 +123,22 @@ class TranslationProxy
     /**
      * @param string $property
      * @param mixed  $value
-     *
-     * @return self
      */
     public function __set($property, $value)
     {
         if (in_array($property, $this->properties, true)) {
             if (method_exists($this, $setter = 'set'.ucfirst($property))) {
-                return $this->$setter($value);
+                $this->$setter($value);
+
+                return;
             }
 
             $this->setTranslatedValue($property, $value);
 
-            return $this;
+            return;
         }
 
         $this->translatable->$property = $value;
-
-        return $this;
     }
 
     /**


### PR DESCRIPTION
Return type for `__set()` is defined as `void`: https://www.php.net/manual/en/language.oop5.overloading.php#object.set.
This change fixes the findings detected by PHPStan, those that are currently breaking the CI pipeline.
Although it can be technically considered a BC break, I think this is a minor change, as there is no way to get the return value when this method is called.