### PR TITLE
Replaced deprecated LifecycleEventArgs method calls

### DIFF
--- a/doc/mapping.md
+++ b/doc/mapping.md
@@ -192,14 +192,14 @@ class EncoderListener extends MappedEventSubscriber
     {
         // this will check for our metadata
         $this->loadMetadataForObjectClass(
-            $args->getEntityManager(),
+            $args->getObjectManager(),
             $args->getClassMetadata()
         );
     }
 
     public function onFlush(EventArgs $args)
     {
-        $em = $args->getEntityManager();
+        $em = $args->getObjectManager();
         $uow = $em->getUnitOfWork();
 
         // check all pending updates

--- a/tests/Gedmo/Mapping/MappingEventAdapterTest.php
+++ b/tests/Gedmo/Mapping/MappingEventAdapterTest.php
@@ -53,10 +53,10 @@ final class MappingEventAdapterTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $eventArgsMock->expects(static::once())
-            ->method('getEntityManager');
+            ->method('getObjectManager');
 
         $eventArgsMock->expects(static::once())
-            ->method('getEntity')
+            ->method('getObject')
             ->willReturn(new \stdClass());
 
         $eventAdapter = new EventAdapterORM();


### PR DESCRIPTION
The class `Doctrine\ORM\Event\LifecycleEventArgs` has been deprecated with `doctrine/orm` v2.14 and will be removed with v3.0. See the changelog: [changelog](https://github.com/doctrine/orm/blob/2.14.x/UPGRADE.md#deprecated-doctrineormeventlifecycleeventargs-class)

I've just replaced the imports with the corresponding classes in the Persistence namespace.

This fixes the issue: #2560