### PR TITLE
Simplify and improve consistency in methods that provide current dates

### DIFF
--- a/src/SoftDeleteable/Mapping/Event/Adapter/ODM.php
+++ b/src/SoftDeleteable/Mapping/Event/Adapter/ODM.php
@@ -26,15 +26,18 @@ final class ODM extends BaseAdapterODM implements SoftDeleteableAdapter
      */
     public function getDateValue($meta, $field)
     {
+        $datetime = new \DateTime();
         $mapping = $meta->getFieldMapping($field);
-        if (isset($mapping['type']) && 'timestamp' === $mapping['type']) {
-            return time();
-        }
-        if (isset($mapping['type']) && in_array($mapping['type'], ['date_immutable', 'time_immutable', 'datetime_immutable', 'datetimetz_immutable'], true)) {
-            return new \DateTimeImmutable();
+        $type = $mapping['type'] ?? null;
+
+        if ('timestamp' === $type) {
+            return (int) $datetime->format('U');
         }
 
-        return \DateTime::createFromFormat('U.u', number_format(microtime(true), 6, '.', ''))
-            ->setTimeZone(new \DateTimeZone(date_default_timezone_get()));
+        if (in_array($type, ['date_immutable', 'time_immutable', 'datetime_immutable', 'datetimetz_immutable'], true)) {
+            return \DateTimeImmutable::createFromMutable($datetime);
+        }
+
+        return $datetime;
     }
 }

--- a/src/SoftDeleteable/Mapping/Event/Adapter/ORM.php
+++ b/src/SoftDeleteable/Mapping/Event/Adapter/ORM.php
@@ -44,15 +44,17 @@ final class ORM extends BaseAdapterORM implements SoftDeleteableAdapter
      */
     private function getRawDateValue(array $mapping)
     {
-        if (isset($mapping['type']) && 'integer' === $mapping['type']) {
-            return time();
+        $datetime = new \DateTime();
+        $type = $mapping['type'] ?? null;
+
+        if ('integer' === $type) {
+            return (int) $datetime->format('U');
         }
 
-        if (isset($mapping['type']) && in_array($mapping['type'], ['date_immutable', 'time_immutable', 'datetime_immutable', 'datetimetz_immutable'], true)) {
-            return new \DateTimeImmutable();
+        if (in_array($type, ['date_immutable', 'time_immutable', 'datetime_immutable', 'datetimetz_immutable'], true)) {
+            return \DateTimeImmutable::createFromMutable($datetime);
         }
 
-        return \DateTime::createFromFormat('U.u', number_format(microtime(true), 6, '.', ''))
-            ->setTimeZone(new \DateTimeZone(date_default_timezone_get()));
+        return $datetime;
     }
 }

--- a/src/Timestampable/Mapping/Event/Adapter/ODM.php
+++ b/src/Timestampable/Mapping/Event/Adapter/ODM.php
@@ -26,15 +26,18 @@ final class ODM extends BaseAdapterODM implements TimestampableAdapter
      */
     public function getDateValue($meta, $field)
     {
+        $datetime = new \DateTime();
         $mapping = $meta->getFieldMapping($field);
-        if (isset($mapping['type']) && 'timestamp' === $mapping['type']) {
-            return time();
-        }
-        if (isset($mapping['type']) && in_array($mapping['type'], ['date_immutable', 'time_immutable', 'datetime_immutable', 'datetimetz_immutable'], true)) {
-            return new \DateTimeImmutable();
+        $type = $mapping['type'] ?? null;
+
+        if ('timestamp' === $type) {
+            return (int) $datetime->format('U');
         }
 
-        return \DateTime::createFromFormat('U.u', number_format(microtime(true), 6, '.', ''))
-            ->setTimeZone(new \DateTimeZone(date_default_timezone_get()));
+        if (in_array($type, ['date_immutable', 'time_immutable', 'datetime_immutable', 'datetimetz_immutable'], true)) {
+            return \DateTimeImmutable::createFromMutable($datetime);
+        }
+
+        return $datetime;
     }
 }

--- a/src/Timestampable/Mapping/Event/Adapter/ORM.php
+++ b/src/Timestampable/Mapping/Event/Adapter/ORM.php
@@ -44,15 +44,17 @@ final class ORM extends BaseAdapterORM implements TimestampableAdapter
      */
     private function getRawDateValue(array $mapping)
     {
-        if (isset($mapping['type']) && 'integer' === $mapping['type']) {
-            return time();
+        $datetime = new \DateTime();
+        $type = $mapping['type'] ?? null;
+
+        if ('integer' === $type) {
+            return (int) $datetime->format('U');
         }
 
-        if (isset($mapping['type']) && in_array($mapping['type'], ['date_immutable', 'time_immutable', 'datetime_immutable', 'datetimetz_immutable'], true)) {
-            return new \DateTimeImmutable();
+        if (in_array($type, ['date_immutable', 'time_immutable', 'datetime_immutable', 'datetimetz_immutable'], true)) {
+            return \DateTimeImmutable::createFromMutable($datetime);
         }
 
-        return \DateTime::createFromFormat('U.u', number_format(microtime(true), 6, '.', ''))
-            ->setTimeZone(new \DateTimeZone(date_default_timezone_get()));
+        return $datetime;
     }
 }


### PR DESCRIPTION
With this change, the returned timestamps are using the very same timestamp as base, regardless the mapping type.
Previously, the timestamps were being created in 3 different moments, so the produced results were slightly different depending on the configured type.