### PR TITLE
Feature/drop support for php 7.3

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,8 +23,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.2"
-          - "7.3"
           - "7.4"
           - "8.0"
           - "8.1"
@@ -35,7 +33,7 @@ jobs:
           - ""
         include:
           - deps: "lowest"
-            php-version: "7.2"
+            php-version: "7.4"
           - deps: "highest"
             php-version: "8.2"
             dbal-version: "^2.13.1"

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -10,11 +10,11 @@ declare(strict_types=1);
  */
 
 $header = <<<'HEADER'
-This file is part of the Doctrine Behavioral Extensions package.
-(c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
-For the full copyright and license information, please view the LICENSE
-file that was distributed with this source code.
-HEADER;
+    This file is part of the Doctrine Behavioral Extensions package.
+    (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+    For the full copyright and license information, please view the LICENSE
+    file that was distributed with this source code.
+    HEADER;
 
 $finder = PhpCsFixer\Finder::create()
     ->in([
@@ -32,6 +32,8 @@ return (new PhpCsFixer\Config())
         '@DoctrineAnnotation' => true,
         '@PHP71Migration' => true,
         '@PHP71Migration:risky' => true,
+        '@PHP74Migration' => true,
+        '@PHP74Migration:risky' => true,
         '@PHPUnit84Migration:risky' => true,
         '@PSR2' => true,
         '@Symfony' => true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ a release.
 ---
 
 ## [Unreleased]
+### Changed
+- Dropped support for PHP < 7.4
 
 ## [3.13.0]
 ### Fixed
@@ -35,7 +37,6 @@ a release.
   namespace
 - Removed conflict against "doctrine/cache" < 1.11, as this library is not used
 - Return type from `TranslationProxy::__set()` (from `TranslationProxy` to `void`)
-- Dropped support for PHP < 7.4
 
 ### Fixed
 - Tree: Creation of dynamic `Node::$sibling` property, which is deprecated as of PHP >= 8.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ a release.
   namespace
 - Removed conflict against "doctrine/cache" < 1.11, as this library is not used
 - Return type from `TranslationProxy::__set()` (from `TranslationProxy` to `void`)
+- Dropped support for PHP < 7.4
 
 ### Fixed
 - Tree: Creation of dynamic `Node::$sibling` property, which is deprecated as of PHP >= 8.2

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
         "phpstan/phpstan": "^1.10.2",
         "phpstan/phpstan-doctrine": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",
-        "phpunit/phpunit": "^8.5 || ^9.5",
+        "phpunit/phpunit": "^9.6",
         "rector/rector": "^0.15.20",
         "symfony/console": "^4.4 || ^5.3 || ^6.0",
         "symfony/phpunit-bridge": "^6.0",

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "wiki": "https://github.com/Atlantic18/DoctrineExtensions/tree/main/doc"
     },
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "behat/transliterator": "^1.2",
         "doctrine/annotations": "^1.13 || ^2.0",
         "doctrine/collections": "^1.2 || ^2.0",

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
         "phpstan/phpstan-doctrine": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",
         "phpunit/phpunit": "^9.6",
-        "rector/rector": "^0.15.20",
+        "rector/rector": "^0.18",
         "symfony/console": "^4.4 || ^5.3 || ^6.0",
         "symfony/phpunit-bridge": "^6.0",
         "symfony/yaml": "^4.4 || ^5.3 || ^6.0"

--- a/example/app/Command/PrintCategoryTranslationTreeCommand.php
+++ b/example/app/Command/PrintCategoryTranslationTreeCommand.php
@@ -95,9 +95,7 @@ final class PrintCategoryTranslationTreeCommand extends Command
             'rootClose' => '',
             'childOpen' => '',
             'childClose' => '',
-            'nodeDecorator' => static function ($node): string {
-                return str_repeat('-', $node['level']).$node['title'].PHP_EOL;
-            },
+            'nodeDecorator' => static fn ($node): string => str_repeat('-', $node['level']).$node['title'].PHP_EOL,
         ];
 
         // Build the tree in English

--- a/example/app/Entity/Category.php
+++ b/example/app/Entity/Category.php
@@ -89,7 +89,7 @@ class Category
     /**
      * @ORM\OneToMany(targetEntity="Category", mappedBy="parent")
      */
-    private $children;
+    private Collection $children;
 
     /**
      * @Gedmo\Timestampable(on="create")

--- a/rector.php
+++ b/rector.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\Php71\Rector\FuncCall\CountOnNullRector;
 use Rector\Set\ValueObject\LevelSetList;
+use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->paths([
@@ -21,7 +22,13 @@ return static function (RectorConfig $rectorConfig): void {
     ]);
 
     $rectorConfig->sets([
-        LevelSetList::UP_TO_PHP_72,
+        LevelSetList::UP_TO_PHP_74,
+    ]);
+
+    $rectorConfig->skip([
+        TypedPropertyFromAssignsRector::class => [
+            __DIR__.'/tests/Gedmo/Wrapper/Fixture/Entity/CompositeRelation.php', // @todo: remove this when https://github.com/doctrine/orm/issues/8255 is solved
+        ],
     ]);
 
     $rectorConfig->importNames();

--- a/src/Loggable/Document/Repository/LogEntryRepository.php
+++ b/src/Loggable/Document/Repository/LogEntryRepository.php
@@ -33,9 +33,9 @@ class LogEntryRepository extends DocumentRepository
     /**
      * Currently used loggable listener
      *
-     * @var LoggableListener<T>
+     * @var LoggableListener<T>|null
      */
-    private $listener;
+    private ?LoggableListener $listener = null;
 
     /**
      * Loads all log entries for the

--- a/src/Loggable/Entity/Repository/LogEntryRepository.php
+++ b/src/Loggable/Entity/Repository/LogEntryRepository.php
@@ -34,11 +34,9 @@ class LogEntryRepository extends EntityRepository
     /**
      * Currently used loggable listener
      *
-     * @var LoggableListener
-     *
-     * @phpstan-var LoggableListener<T>
+     * @phpstan-var LoggableListener<T>|null
      */
-    private $listener;
+    private ?LoggableListener $listener = null;
 
     /**
      * Loads all log entries for the given entity

--- a/src/Mapping/Annotation/Blameable.php
+++ b/src/Mapping/Annotation/Blameable.php
@@ -26,8 +26,7 @@ final class Blameable implements GedmoAnnotation
 {
     use ForwardCompatibilityTrait;
 
-    /** @var string */
-    public $on = 'update';
+    public string $on = 'update';
     /** @var string|string[] */
     public $field;
     /** @var mixed */

--- a/src/Mapping/Annotation/Slug.php
+++ b/src/Mapping/Annotation/Slug.php
@@ -32,24 +32,17 @@ final class Slug implements GedmoAnnotation
      * @Required
      */
     public $fields = [];
-    /** @var bool */
-    public $updatable = true;
-    /** @var string */
-    public $style = 'default'; // or "camel"
-    /** @var bool */
-    public $unique = true;
+    public bool $updatable = true;
+    public string $style = 'default'; // or "camel"
+    public bool $unique = true;
     /** @var string|null */
     public $unique_base;
-    /** @var string */
-    public $separator = '-';
-    /** @var string */
-    public $prefix = '';
-    /** @var string */
-    public $suffix = '';
+    public string $separator = '-';
+    public string $prefix = '';
+    public string $suffix = '';
     /** @var SlugHandler[] */
     public $handlers = [];
-    /** @var string */
-    public $dateFormat = 'Y-m-d-H:i';
+    public string $dateFormat = 'Y-m-d-H:i';
 
     /**
      * @param array<string, mixed> $data

--- a/src/Mapping/Annotation/SlugHandler.php
+++ b/src/Mapping/Annotation/SlugHandler.php
@@ -27,15 +27,14 @@ final class SlugHandler implements GedmoAnnotation
     use ForwardCompatibilityTrait;
 
     /**
-     * @var string
      * @phpstan-var string|class-string<SlugHandlerInterface>
      */
-    public $class = '';
+    public string $class = '';
 
     /**
      * @var array<SlugHandlerOption>|array<string, mixed>
      */
-    public $options = [];
+    public array $options = [];
 
     /**
      * @param array<string, mixed> $data

--- a/src/Mapping/Annotation/SlugHandlerOption.php
+++ b/src/Mapping/Annotation/SlugHandlerOption.php
@@ -24,10 +24,7 @@ final class SlugHandlerOption implements GedmoAnnotation
 {
     use ForwardCompatibilityTrait;
 
-    /**
-     * @var string
-     */
-    public $name;
+    public string $name;
 
     /**
      * @var mixed

--- a/src/Mapping/Annotation/SoftDeleteable.php
+++ b/src/Mapping/Annotation/SoftDeleteable.php
@@ -26,14 +26,11 @@ final class SoftDeleteable implements GedmoAnnotation
 {
     use ForwardCompatibilityTrait;
 
-    /** @var string */
-    public $fieldName = 'deletedAt';
+    public string $fieldName = 'deletedAt';
 
-    /** @var bool */
-    public $timeAware = false;
+    public bool $timeAware = false;
 
-    /** @var bool */
-    public $hardDelete = true;
+    public bool $hardDelete = true;
 
     /**
      * @param array<string, mixed> $data

--- a/src/Mapping/Annotation/Timestampable.php
+++ b/src/Mapping/Annotation/Timestampable.php
@@ -26,8 +26,7 @@ final class Timestampable implements GedmoAnnotation
 {
     use ForwardCompatibilityTrait;
 
-    /** @var string */
-    public $on = 'update';
+    public string $on = 'update';
     /** @var string|string[] */
     public $field;
     /** @var mixed */

--- a/src/Mapping/Annotation/TranslationEntity.php
+++ b/src/Mapping/Annotation/TranslationEntity.php
@@ -26,12 +26,8 @@ final class TranslationEntity implements GedmoAnnotation
 {
     use ForwardCompatibilityTrait;
 
-    /**
-     * @var string
-     *
-     * @Required
-     */
-    public $class;
+    /** @Required */
+    public string $class;
 
     /**
      * @param array<string, mixed> $data

--- a/src/Mapping/Annotation/Tree.php
+++ b/src/Mapping/Annotation/Tree.php
@@ -27,19 +27,16 @@ final class Tree implements GedmoAnnotation
     use ForwardCompatibilityTrait;
 
     /**
-     * @var string
      * @phpstan-var 'closure'|'materializedPath'|'nested'
      */
-    public $type = 'nested';
+    public string $type = 'nested';
 
-    /** @var bool */
-    public $activateLocking = false;
+    public bool $activateLocking = false;
 
     /**
-     * @var int
      * @phpstan-var positive-int
      */
-    public $lockingTimeout = 3;
+    public int $lockingTimeout = 3;
 
     /**
      * @var string|null

--- a/src/Mapping/Annotation/TreeClosure.php
+++ b/src/Mapping/Annotation/TreeClosure.php
@@ -28,10 +28,9 @@ final class TreeClosure implements GedmoAnnotation
     use ForwardCompatibilityTrait;
 
     /**
-     * @var string
      * @phpstan-var string|class-string<AbstractClosure>
      */
-    public $class;
+    public string $class;
 
     /**
      * @param array<string, mixed> $data

--- a/src/Mapping/Annotation/TreeLevel.php
+++ b/src/Mapping/Annotation/TreeLevel.php
@@ -28,10 +28,8 @@ final class TreeLevel implements GedmoAnnotation
 
     /**
      * The level which root nodes will have
-     *
-     * @var int
      */
-    public $base = 0;
+    public int $base = 0;
 
     /**
      * @param array<string, mixed> $data

--- a/src/Mapping/Annotation/TreePath.php
+++ b/src/Mapping/Annotation/TreePath.php
@@ -28,17 +28,14 @@ final class TreePath implements GedmoAnnotation
 {
     use ForwardCompatibilityTrait;
 
-    /** @var string */
-    public $separator = ',';
+    public string $separator = ',';
 
     /** @var bool|null */
     public $appendId;
 
-    /** @var bool */
-    public $startsWithSeparator = false;
+    public bool $startsWithSeparator = false;
 
-    /** @var bool */
-    public $endsWithSeparator = true;
+    public bool $endsWithSeparator = true;
 
     /**
      * @param array<string, mixed> $data

--- a/src/Mapping/Annotation/Uploadable.php
+++ b/src/Mapping/Annotation/Uploadable.php
@@ -29,52 +29,32 @@ final class Uploadable implements GedmoAnnotation
 {
     use ForwardCompatibilityTrait;
 
-    /**
-     * @var bool
-     */
-    public $allowOverwrite = false;
+    public bool $allowOverwrite = false;
+
+    public bool $appendNumber = false;
+
+    public string $path = '';
+
+    public string $pathMethod = '';
+
+    public string $callback = '';
 
     /**
-     * @var bool
-     */
-    public $appendNumber = false;
-
-    /**
-     * @var string
-     */
-    public $path = '';
-
-    /**
-     * @var string
-     */
-    public $pathMethod = '';
-
-    /**
-     * @var string
-     */
-    public $callback = '';
-
-    /**
-     * @var string
-     *
      * @phpstan-var Validator::FILENAME_GENERATOR_*|class-string<FilenameGeneratorInterface>
      */
-    public $filenameGenerator = Validator::FILENAME_GENERATOR_NONE;
+    public string $filenameGenerator = Validator::FILENAME_GENERATOR_NONE;
 
-    /**
-     * @var string
-     */
-    public $maxSize = '0';
+    public string $maxSize = '0';
 
     /**
      * @var string A list of comma separate values of allowed types, like "text/plain,text/css"
      */
-    public $allowedTypes = '';
+    public string $allowedTypes = '';
 
     /**
      * @var string A list of comma separate values of disallowed types, like "video/jpeg,text/html"
      */
-    public $disallowedTypes = '';
+    public string $disallowedTypes = '';
 
     /**
      * @param array<string, mixed> $data

--- a/src/Mapping/Driver/AttributeAnnotationReader.php
+++ b/src/Mapping/Driver/AttributeAnnotationReader.php
@@ -20,15 +20,9 @@ use Gedmo\Mapping\Annotation\Annotation;
  */
 final class AttributeAnnotationReader implements Reader
 {
-    /**
-     * @var Reader
-     */
-    private $annotationReader;
+    private Reader $annotationReader;
 
-    /**
-     * @var AttributeReader
-     */
-    private $attributeReader;
+    private AttributeReader $attributeReader;
 
     public function __construct(AttributeReader $attributeReader, Reader $annotationReader)
     {
@@ -66,11 +60,7 @@ final class AttributeAnnotationReader implements Reader
     {
         $annotation = $this->attributeReader->getClassAnnotation($class, $annotationName);
 
-        if (null !== $annotation) {
-            return $annotation;
-        }
-
-        return $this->annotationReader->getClassAnnotation($class, $annotationName);
+        return $annotation ?? $this->annotationReader->getClassAnnotation($class, $annotationName);
     }
 
     /**
@@ -98,11 +88,7 @@ final class AttributeAnnotationReader implements Reader
     {
         $annotation = $this->attributeReader->getPropertyAnnotation($property, $annotationName);
 
-        if (null !== $annotation) {
-            return $annotation;
-        }
-
-        return $this->annotationReader->getPropertyAnnotation($property, $annotationName);
+        return $annotation ?? $this->annotationReader->getPropertyAnnotation($property, $annotationName);
     }
 
     public function getMethodAnnotations(\ReflectionMethod $method): array

--- a/src/Mapping/Driver/AttributeReader.php
+++ b/src/Mapping/Driver/AttributeReader.php
@@ -19,7 +19,7 @@ use Gedmo\Mapping\Annotation\Annotation;
 final class AttributeReader
 {
     /** @var array<string,bool> */
-    private $isRepeatableAttribute = [];
+    private array $isRepeatableAttribute = [];
 
     /**
      * @phpstan-param \ReflectionClass<object> $class

--- a/src/Mapping/Driver/Chain.php
+++ b/src/Mapping/Driver/Chain.php
@@ -23,17 +23,15 @@ class Chain implements Driver
 {
     /**
      * The default driver
-     *
-     * @var Driver|null
      */
-    private $defaultDriver;
+    private ?Driver $defaultDriver = null;
 
     /**
      * List of drivers nested
      *
-     * @var Driver[]
+     * @var array<string, Driver>
      */
-    private $_drivers = [];
+    private array $_drivers = [];
 
     /**
      * Add a nested driver.
@@ -50,7 +48,7 @@ class Chain implements Driver
     /**
      * Get the array of nested drivers.
      *
-     * @return Driver[] $drivers
+     * @return array<string, Driver>
      */
     public function getDrivers()
     {

--- a/src/Mapping/Event/Adapter/ODM.php
+++ b/src/Mapping/Event/Adapter/ODM.php
@@ -24,15 +24,9 @@ use Gedmo\Mapping\Event\AdapterInterface;
  */
 class ODM implements AdapterInterface
 {
-    /**
-     * @var EventArgs
-     */
-    private $args;
+    private ?EventArgs $args = null;
 
-    /**
-     * @var DocumentManager
-     */
-    private $dm;
+    private ?DocumentManager $dm = null;
 
     public function __call($method, $args)
     {

--- a/src/Mapping/Event/Adapter/ORM.php
+++ b/src/Mapping/Event/Adapter/ORM.php
@@ -24,15 +24,9 @@ use Gedmo\Mapping\Event\AdapterInterface;
  */
 class ORM implements AdapterInterface
 {
-    /**
-     * @var EventArgs
-     */
-    private $args;
+    private ?EventArgs $args = null;
 
-    /**
-     * @var EntityManagerInterface
-     */
-    private $em;
+    private ?EntityManagerInterface $em = null;
 
     public function __call($method, $args)
     {

--- a/src/Mapping/ExtensionMetadataFactory.php
+++ b/src/Mapping/ExtensionMetadataFactory.php
@@ -66,10 +66,7 @@ class ExtensionMetadataFactory
      */
     protected $annotationReader;
 
-    /**
-     * @var CacheItemPoolInterface|null
-     */
-    private $cacheItemPool;
+    private ?CacheItemPoolInterface $cacheItemPool = null;
 
     /**
      * @param Reader|AttributeReader|object $annotationReader

--- a/src/Mapping/MappedEventSubscriber.php
+++ b/src/Mapping/MappedEventSubscriber.php
@@ -67,14 +67,14 @@ abstract class MappedEventSubscriber implements EventSubscriber
      *
      * @var array<int, ExtensionMetadataFactory>
      */
-    private $extensionMetadataFactory = [];
+    private array $extensionMetadataFactory = [];
 
     /**
      * List of event adapters used for this listener
      *
      * @var array<string, AdapterInterface>
      */
-    private $adapters = [];
+    private array $adapters = [];
 
     /**
      * Custom annotation reader
@@ -83,10 +83,7 @@ abstract class MappedEventSubscriber implements EventSubscriber
      */
     private $annotationReader;
 
-    /**
-     * @var PsrCachedReader|null
-     */
-    private static $defaultAnnotationReader;
+    private static ?PsrCachedReader $defaultAnnotationReader = null;
 
     /**
      * @var CacheItemPoolInterface|null
@@ -328,9 +325,7 @@ abstract class MappedEventSubscriber implements EventSubscriber
 
         if ($objectManager instanceof EntityManagerInterface || $objectManager instanceof DocumentManager) {
             $metadataFactory = $objectManager->getMetadataFactory();
-            $getCache = \Closure::bind(static function (AbstractClassMetadataFactory $metadataFactory): ?CacheItemPoolInterface {
-                return $metadataFactory->getCache();
-            }, null, \get_class($metadataFactory));
+            $getCache = \Closure::bind(static fn (AbstractClassMetadataFactory $metadataFactory): ?CacheItemPoolInterface => $metadataFactory->getCache(), null, \get_class($metadataFactory));
 
             $metadataCache = $getCache($metadataFactory);
 

--- a/src/References/Mapping/Driver/Xml.php
+++ b/src/References/Mapping/Driver/Xml.php
@@ -35,7 +35,7 @@ class Xml extends BaseXml
     /**
      * @var string[]
      */
-    private $validReferences = [
+    private array $validReferences = [
         'referenceOne',
         'referenceMany',
         'referenceManyEmbed',

--- a/src/References/Mapping/Driver/Yaml.php
+++ b/src/References/Mapping/Driver/Yaml.php
@@ -32,7 +32,7 @@ class Yaml extends File implements Driver
     /**
      * @var array<string, array<string, array<string, mixed>>>
      */
-    private $validReferences = [
+    private array $validReferences = [
         'referenceOne' => [],
         'referenceMany' => [],
         'referenceManyEmbed' => [],

--- a/src/References/ReferencesListener.php
+++ b/src/References/ReferencesListener.php
@@ -48,7 +48,7 @@ class ReferencesListener extends MappedEventSubscriber
     /**
      * @var array<string, ObjectManager>
      */
-    private $managers;
+    private array $managers;
 
     /**
      * @param array<string, ObjectManager> $managers

--- a/src/Sluggable/SluggableListener.php
+++ b/src/Sluggable/SluggableListener.php
@@ -101,7 +101,7 @@ class SluggableListener extends MappedEventSubscriber
      *
      * @phpstan-var array<class-string, array<int, object>>
      */
-    private $persisted = [];
+    private array $persisted = [];
 
     /**
      * List of initialized slug handlers
@@ -110,14 +110,14 @@ class SluggableListener extends MappedEventSubscriber
      *
      * @phpstan-var array<class-string<SlugHandlerInterface>, SlugHandlerInterface>
      */
-    private $handlers = [];
+    private array $handlers = [];
 
     /**
      * List of filters which are manipulated when slugs are generated
      *
      * @var array<string, array<string, mixed>>
      */
-    private $managedFilters = [];
+    private array $managedFilters = [];
 
     /**
      * Specifies the list of events to listen
@@ -401,9 +401,7 @@ class SluggableListener extends MappedEventSubscriber
                 switch ($options['style']) {
                     case 'camel':
                         $quotedSeparator = preg_quote($options['separator']);
-                        $slug = preg_replace_callback('/^[a-z]|'.$quotedSeparator.'[a-z]/smi', static function ($m) {
-                            return strtoupper($m[0]);
-                        }, $slug);
+                        $slug = preg_replace_callback('/^[a-z]|'.$quotedSeparator.'[a-z]/smi', static fn ($m) => strtoupper($m[0]), $slug);
 
                         break;
 
@@ -504,7 +502,7 @@ class SluggableListener extends MappedEventSubscriber
         }
 
         // load similar slugs
-        $result = array_merge($ea->getSimilarSlugs($object, $meta, $config, $preferredSlug), $similarPersisted);
+        $result = [...$ea->getSimilarSlugs($object, $meta, $config, $preferredSlug), ...$similarPersisted];
 
         // leave only right slugs
 

--- a/src/SoftDeleteable/Filter/SoftDeleteableFilter.php
+++ b/src/SoftDeleteable/Filter/SoftDeleteableFilter.php
@@ -142,9 +142,7 @@ class SoftDeleteableFilter extends SQLFilter
     protected function getEntityManager()
     {
         if (null === $this->entityManager) {
-            $getEntityManager = \Closure::bind(function (): EntityManagerInterface {
-                return $this->em;
-            }, $this, parent::class);
+            $getEntityManager = \Closure::bind(fn (): EntityManagerInterface => $this->em, $this, parent::class);
 
             $this->entityManager = $getEntityManager();
         }

--- a/src/Sortable/SortableListener.php
+++ b/src/Sortable/SortableListener.php
@@ -57,13 +57,12 @@ class SortableListener extends MappedEventSubscriber
      * @var array<string, array<string, mixed>>
      * @phpstan-var array<string, SortableRelocation>
      */
-    private $relocations = [];
+    private array $relocations = [];
 
-    /** @var bool */
-    private $persistenceNeeded = false;
+    private bool $persistenceNeeded = false;
 
     /** @var array<string, int> */
-    private $maxPositions = [];
+    private array $maxPositions = [];
 
     /**
      * Specifies the list of events to listen

--- a/src/Tool/Logging/DBAL/QueryAnalyzer.php
+++ b/src/Tool/Logging/DBAL/QueryAnalyzer.php
@@ -38,10 +38,8 @@ class QueryAnalyzer implements SQLLogger
 
     /**
      * Total execution time of all queries
-     *
-     * @var float
      */
-    private $totalExecutionTime = 0;
+    private int $totalExecutionTime = 0;
 
     /**
      * List of queries executed
@@ -82,7 +80,7 @@ class QueryAnalyzer implements SQLLogger
      */
     public function stopQuery()
     {
-        $ms = round(microtime(true) - $this->queryStartTime, 4) * 1000;
+        $ms = (int) (round(microtime(true) - $this->queryStartTime, 4) * 1000);
         $this->queryExecutionTimes[] = $ms;
         $this->totalExecutionTime += $ms;
     }

--- a/src/Tool/Wrapper/EntityWrapper.php
+++ b/src/Tool/Wrapper/EntityWrapper.php
@@ -36,10 +36,8 @@ class EntityWrapper extends AbstractWrapper
 
     /**
      * True if entity or proxy is loaded
-     *
-     * @var bool
      */
-    private $initialized = false;
+    private bool $initialized = false;
 
     /**
      * Wrap entity

--- a/src/Tool/Wrapper/MongoDocumentWrapper.php
+++ b/src/Tool/Wrapper/MongoDocumentWrapper.php
@@ -27,17 +27,13 @@ class MongoDocumentWrapper extends AbstractWrapper
 {
     /**
      * Document identifier
-     *
-     * @var string|null
      */
-    private $identifier;
+    private ?string $identifier = null;
 
     /**
      * True if document or proxy is loaded
-     *
-     * @var bool
      */
-    private $initialized = false;
+    private bool $initialized = false;
 
     /**
      * Wrap document
@@ -123,9 +119,7 @@ class MongoDocumentWrapper extends AbstractWrapper
                         $identifier = $this->getIdentifier();
                     } else {
                         // this may not happen but in case
-                        $getIdentifier = \Closure::bind(function () {
-                            return $this->identifier;
-                        }, $this->object, get_class($this->object));
+                        $getIdentifier = \Closure::bind(fn () => $this->identifier, $this->object, get_class($this->object));
 
                         $identifier = $getIdentifier();
                     }

--- a/src/Translatable/Document/Repository/TranslationRepository.php
+++ b/src/Translatable/Document/Repository/TranslationRepository.php
@@ -35,10 +35,8 @@ class TranslationRepository extends DocumentRepository
     /**
      * Current TranslatableListener instance used
      * in EntityManager
-     *
-     * @var TranslatableListener|null
      */
-    private $listener;
+    private ?TranslatableListener $listener = null;
 
     public function __construct(DocumentManager $dm, UnitOfWork $uow, ClassMetadata $class)
     {

--- a/src/Translatable/Entity/Repository/TranslationRepository.php
+++ b/src/Translatable/Entity/Repository/TranslationRepository.php
@@ -35,10 +35,8 @@ class TranslationRepository extends EntityRepository
     /**
      * Current TranslatableListener instance used
      * in EntityManager
-     *
-     * @var TranslatableListener|null
      */
-    private $listener;
+    private ?TranslatableListener $listener = null;
 
     public function __construct(EntityManagerInterface $em, ClassMetadata $class)
     {

--- a/src/Translatable/Query/TreeWalker/TranslationWalker.php
+++ b/src/Translatable/Query/TreeWalker/TranslationWalker.php
@@ -74,7 +74,7 @@ class TranslationWalker extends SqlWalker
      *
      * @phpstan-var array<string, array{metadata: ClassMetadata}>
      */
-    private $translatedComponents = [];
+    private array $translatedComponents = [];
 
     /**
      * DBAL database platform
@@ -96,19 +96,16 @@ class TranslationWalker extends SqlWalker
      *
      * @var array<string, string>
      */
-    private $replacements = [];
+    private array $replacements = [];
 
     /**
      * List of joins for translated components in query
      *
      * @var array<string, string>
      */
-    private $components = [];
+    private array $components = [];
 
-    /**
-     * @var TranslatableListener
-     */
-    private $listener;
+    private TranslatableListener $listener;
 
     public function __construct($query, $parserResult, array $queryComponents)
     {
@@ -440,9 +437,7 @@ class TranslationWalker extends SqlWalker
     private function replace(array $repl, string $str): string
     {
         foreach ($repl as $target => $result) {
-            $str = preg_replace_callback('/(\s|\()('.$target.')(,?)(\s|\)|$)/smi', static function (array $m) use ($result): string {
-                return $m[1].$result.$m[3].$m[4];
-            }, $str);
+            $str = preg_replace_callback('/(\s|\()('.$target.')(,?)(\s|\)|$)/smi', static fn (array $m): string => $m[1].$result.$m[3].$m[4], $str);
         }
 
         return $str;

--- a/src/Translatable/TranslatableListener.php
+++ b/src/Translatable/TranslatableListener.php
@@ -82,19 +82,15 @@ class TranslatableListener extends MappedEventSubscriber
      * which is used for updating is not default. This
      * will load the default translation in other locales
      * if record is not translated yet
-     *
-     * @var string
      */
-    private $defaultLocale = 'en_US';
+    private string $defaultLocale = 'en_US';
 
     /**
      * If this is set to false, when if entity does
      * not have a translation for requested locale
      * it will show a blank value
-     *
-     * @var bool
      */
-    private $translationFallback = false;
+    private bool $translationFallback = false;
 
     /**
      * List of translations which do not have the foreign
@@ -103,45 +99,39 @@ class TranslatableListener extends MappedEventSubscriber
      *
      * @var array<int, array<int, object|Translatable>>
      */
-    private $pendingTranslationInserts = [];
+    private array $pendingTranslationInserts = [];
 
     /**
      * Currently in case if there is TranslationQueryWalker
      * in charge. We need to skip issuing additional queries
      * on load
-     *
-     * @var bool
      */
-    private $skipOnLoad = false;
+    private bool $skipOnLoad = false;
 
     /**
      * Tracks locale the objects currently translated in
      *
      * @var array<int, string>
      */
-    private $translatedInLocale = [];
+    private array $translatedInLocale = [];
 
     /**
      * Whether or not, to persist default locale
      * translation or keep it in original record
-     *
-     * @var bool
      */
-    private $persistDefaultLocaleTranslation = false;
+    private bool $persistDefaultLocaleTranslation = false;
 
     /**
      * Tracks translation object for default locale
      *
      * @var array<int, array<string, object|Translatable>>
      */
-    private $translationInDefaultLocale = [];
+    private array $translationInDefaultLocale = [];
 
     /**
      * Default translation value upon missing translation
-     *
-     * @var string|null
      */
-    private $defaultTranslationValue;
+    private ?string $defaultTranslationValue = null;
 
     /**
      * Specifies the list of events to listen

--- a/src/Tree/Entity/Repository/ClosureTreeRepository.php
+++ b/src/Tree/Entity/Repository/ClosureTreeRepository.php
@@ -102,9 +102,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
      */
     public function getPath($node)
     {
-        return array_map(static function (AbstractClosure $closure) {
-            return $closure->getAncestor();
-        }, $this->getPathQuery($node)->getResult());
+        return array_map(static fn (AbstractClosure $closure) => $closure->getAncestor(), $this->getPathQuery($node)->getResult());
     }
 
     /**
@@ -215,9 +213,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
     {
         $result = $this->childrenQuery($node, $direct, $sortByField, $direction, $includeNode)->getResult();
         if ($node) {
-            $result = array_map(static function (AbstractClosure $closure) {
-                return $closure->getDescendant();
-            }, $result);
+            $result = array_map(static fn (AbstractClosure $closure) => $closure->getDescendant(), $result);
         }
 
         return $result;
@@ -574,9 +570,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
         $q = $this->getEntityManager()->createQuery($dql)->setMaxResults($batchSize)->setCacheable(false);
 
         while (($ids = $q->getScalarResult()) && [] !== $ids) {
-            $ids = array_map(static function (array $el) {
-                return $el['id'];
-            }, $ids);
+            $ids = array_map(static fn (array $el) => $el['id'], $ids);
             $query = "DELETE FROM {$closureTableName} WHERE id IN (".implode(', ', $ids).')';
             if (0 === $conn->executeStatement($query)) {
                 throw new \RuntimeException('Failed to remove incorrect closures');

--- a/src/Tree/Entity/Repository/MaterializedPathRepository.php
+++ b/src/Tree/Entity/Repository/MaterializedPathRepository.php
@@ -250,9 +250,7 @@ class MaterializedPathRepository extends AbstractTreeRepository
         $nodes = $this->getNodesHierarchyQuery($node, $direct, $options, $includeNode)->getArrayResult();
         usort(
             $nodes,
-            static function (array $a, array $b) use ($path): int {
-                return strcmp($a[$path], $b[$path]);
-            }
+            static fn (array $a, array $b): int => strcmp($a[$path], $b[$path])
         );
 
         return $nodes;

--- a/src/Tree/Mapping/Driver/Xml.php
+++ b/src/Tree/Mapping/Driver/Xml.php
@@ -32,7 +32,7 @@ class Xml extends BaseXml
      *
      * @var string[]
      */
-    private $strategies = [
+    private array $strategies = [
         'nested',
         'closure',
         'materializedPath',

--- a/src/Tree/Mapping/Driver/Yaml.php
+++ b/src/Tree/Mapping/Driver/Yaml.php
@@ -40,7 +40,7 @@ class Yaml extends File implements Driver
      *
      * @var string[]
      */
-    private $strategies = [
+    private array $strategies = [
         'nested',
         'closure',
         'materializedPath',

--- a/src/Tree/Mapping/Validator.php
+++ b/src/Tree/Mapping/Validator.php
@@ -42,7 +42,7 @@ class Validator
      *
      * @var string[]
      */
-    private $validPathTypes = [
+    private array $validPathTypes = [
         'string',
         'text',
     ];
@@ -52,7 +52,7 @@ class Validator
      *
      * @var string[]
      */
-    private $validPathSourceTypes = [
+    private array $validPathSourceTypes = [
         'id',
         'integer',
         'smallint',
@@ -67,7 +67,7 @@ class Validator
      *
      * @var string[]
      */
-    private $validPathHashTypes = [
+    private array $validPathHashTypes = [
         'string',
     ];
 
@@ -76,7 +76,7 @@ class Validator
      *
      * @var string[]
      */
-    private $validRootTypes = [
+    private array $validRootTypes = [
         'integer',
         'smallint',
         'bigint',

--- a/src/Tree/Strategy/ORM/Closure.php
+++ b/src/Tree/Strategy/ORM/Closure.php
@@ -51,7 +51,7 @@ class Closure implements Strategy
      *
      * @var array<int, array<int, object|Node>>
      */
-    private $pendingChildNodeInserts = [];
+    private array $pendingChildNodeInserts = [];
 
     /**
      * List of nodes which has their parents updated, but using
@@ -72,7 +72,7 @@ class Closure implements Strategy
      *
      * @phpstan-var array<array-key, object|Node>
      */
-    private $pendingNodesLevelProcess = [];
+    private array $pendingNodesLevelProcess = [];
 
     public function __construct(TreeListener $listener)
     {
@@ -206,9 +206,7 @@ class Closure implements Strategy
 
         if (!$hasTheUserExplicitlyDefinedMapping) {
             $metadataFactory = $em->getMetadataFactory();
-            $getCache = \Closure::bind(static function (AbstractClassMetadataFactory $metadataFactory): ?CacheItemPoolInterface {
-                return $metadataFactory->getCache();
-            }, null, \get_class($metadataFactory));
+            $getCache = \Closure::bind(static fn (AbstractClassMetadataFactory $metadataFactory): ?CacheItemPoolInterface => $metadataFactory->getCache(), null, \get_class($metadataFactory));
 
             $metadataCache = $getCache($metadataFactory);
 

--- a/src/Tree/Strategy/ORM/Nested.php
+++ b/src/Tree/Strategy/ORM/Nested.php
@@ -84,7 +84,7 @@ class Nested implements Strategy
      *
      * @phpstan-var array<int, value-of<self::ALLOWED_NODE_POSITIONS>>
      */
-    private $nodePositions = [];
+    private array $nodePositions = [];
 
     /**
      * Stores a list of delayed nodes for correct order of updates
@@ -93,7 +93,7 @@ class Nested implements Strategy
      *
      * @phpstan-var array<int, array<int, array{node: Node|object, position: value-of<self::ALLOWED_NODE_POSITIONS>}>>
      */
-    private $delayedNodes = [];
+    private array $delayedNodes = [];
 
     public function __construct(TreeListener $listener)
     {
@@ -673,7 +673,7 @@ class Nested implements Strategy
                 \TypeError::class
             ), E_USER_DEPRECATED);
         }
-        $levelDelta = $levelDelta ?? 0;
+        $levelDelta ??= 0;
 
         $meta = $em->getClassMetadata($class);
         $config = $this->listener->getConfiguration($em, $class);

--- a/src/Tree/Traits/MaterializedPath.php
+++ b/src/Tree/Traits/MaterializedPath.php
@@ -125,6 +125,6 @@ trait MaterializedPath
      */
     public function getChildren()
     {
-        return $this->children = $this->children ?? new ArrayCollection();
+        return $this->children ??= new ArrayCollection();
     }
 }

--- a/src/Tree/TreeListener.php
+++ b/src/Tree/TreeListener.php
@@ -63,7 +63,7 @@ class TreeListener extends MappedEventSubscriber
      *
      * @phpstan-var array<class-string, string>
      */
-    private $strategies = [];
+    private array $strategies = [];
 
     /**
      * List of strategy instances
@@ -72,7 +72,7 @@ class TreeListener extends MappedEventSubscriber
      *
      * @phpstan-var array<value-of<self::strategies>, Strategy>
      */
-    private $strategyInstances = [];
+    private array $strategyInstances = [];
 
     /**
      * List of used classes on flush
@@ -81,7 +81,7 @@ class TreeListener extends MappedEventSubscriber
      *
      * @phpstan-var array<class-string, null>
      */
-    private $usedClassesOnFlush = [];
+    private array $usedClassesOnFlush = [];
 
     /**
      * Specifies the list of events to listen

--- a/src/Uploadable/Event/UploadableBaseEventArgs.php
+++ b/src/Uploadable/Event/UploadableBaseEventArgs.php
@@ -24,22 +24,15 @@ abstract class UploadableBaseEventArgs extends EventArgs
 {
     /**
      * The instance of the Uploadable listener that fired this event
-     *
-     * @var UploadableListener
      */
-    private $uploadableListener;
+    private UploadableListener $uploadableListener;
 
-    /**
-     * @var EntityManagerInterface
-     */
-    private $em;
+    private EntityManagerInterface $em;
 
     /**
      * @todo Check if this property must be removed, as it is not used.
-     *
-     * @var array
      */
-    private $config = [];
+    private array $config = [];
 
     /**
      * The Uploadable entity
@@ -57,10 +50,7 @@ abstract class UploadableBaseEventArgs extends EventArgs
      */
     private $extensionConfiguration;
 
-    /**
-     * @var FileInfoInterface
-     */
-    private $fileInfo;
+    private FileInfoInterface $fileInfo;
 
     /**
      * Is the file being created, updated or removed?

--- a/src/Uploadable/UploadableListener.php
+++ b/src/Uploadable/UploadableListener.php
@@ -60,19 +60,15 @@ class UploadableListener extends MappedEventSubscriber
 
     /**
      * Mime type guesser
-     *
-     * @var MimeTypeGuesserInterface
      */
-    private $mimeTypeGuesser;
+    private MimeTypeGuesserInterface $mimeTypeGuesser;
 
     /**
      * Default FileInfoInterface class
      *
-     * @var string
-     *
      * @phpstan-var class-string<FileInfoInterface>
      */
-    private $defaultFileInfoClass = FileInfoArray::class;
+    private string $defaultFileInfoClass = FileInfoArray::class;
 
     /**
      * Array of files to remove on postFlush
@@ -659,9 +655,7 @@ class UploadableListener extends MappedEventSubscriber
         if ('' === $path) {
             $defaultPath = $this->getDefaultPath();
             if ('' !== $config['pathMethod']) {
-                $getPathMethod = \Closure::bind(function (string $pathMethod, ?string $defaultPath): string {
-                    return $this->{$pathMethod}($defaultPath);
-                }, $object, $meta->getReflectionClass()->getName());
+                $getPathMethod = \Closure::bind(fn (string $pathMethod, ?string $defaultPath): string => $this->{$pathMethod}($defaultPath), $object, $meta->getReflectionClass()->getName());
 
                 $path = $getPathMethod($config['pathMethod'], $defaultPath);
             } elseif (null !== $defaultPath) {
@@ -720,9 +714,7 @@ class UploadableListener extends MappedEventSubscriber
      */
     protected function getPropertyValueFromObject(ClassMetadata $meta, $propertyName, $object)
     {
-        $getFilePath = \Closure::bind(function (string $propertyName) {
-            return $this->{$propertyName};
-        }, $object, $meta->getReflectionClass()->getName());
+        $getFilePath = \Closure::bind(fn (string $propertyName) => $this->{$propertyName}, $object, $meta->getReflectionClass()->getName());
 
         return $getFilePath($propertyName);
     }

--- a/tests/Gedmo/Blameable/ChangeTest.php
+++ b/tests/Gedmo/Blameable/ChangeTest.php
@@ -25,10 +25,7 @@ final class ChangeTest extends BaseTestCaseORM
 {
     private const FIXTURE = TitledArticle::class;
 
-    /**
-     * @var BlameableListener
-     */
-    private $listener;
+    private BlameableListener $listener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Blameable/Fixture/Document/Article.php
+++ b/tests/Gedmo/Blameable/Fixture/Document/Article.php
@@ -31,59 +31,47 @@ class Article
 
     /**
      * @ODM\Field(type="string")
-     *
-     * @var string|null
      */
     #[ODM\Field(type: MongoDBType::STRING)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @ODM\ReferenceOne(targetDocument="Type")
-     *
-     * @var Type|null
      */
     #[Odm\ReferenceOne(targetDocument: Type::class)]
-    private $type;
+    private ?\Gedmo\Tests\Blameable\Fixture\Document\Type $type = null;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      * @Gedmo\Blameable(on="create")
      */
     #[ODM\Field(type: MongoDBType::STRING)]
     #[Gedmo\Blameable(on: 'create')]
-    private $created;
+    private ?string $created = null;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      * @Gedmo\Blameable
      */
     #[ODM\Field(type: MongoDBType::STRING)]
     #[Gedmo\Blameable]
-    private $updated;
+    private ?string $updated = null;
 
     /**
      * @ODM\ReferenceOne(targetDocument="User")
      * @Gedmo\Blameable(on="create")
-     *
-     * @var User|null
      */
     #[ODM\ReferenceOne(targetDocument: User::class)]
     #[Gedmo\Blameable(on: 'create')]
-    private $creator;
+    private ?User $creator = null;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      * @Gedmo\Blameable(on="change", field="type.title", value="Published")
      */
     #[Gedmo\Blameable(on: 'change', field: 'type.title', value: 'Published')]
     #[ODM\Field(type: MongoDBType::STRING)]
-    private $published;
+    private ?string $published = null;
 
     public function getId(): ?string
     {

--- a/tests/Gedmo/Blameable/Fixture/Document/Type.php
+++ b/tests/Gedmo/Blameable/Fixture/Document/Type.php
@@ -30,19 +30,15 @@ class Type
 
     /**
      * @ODM\Field(type="string")
-     *
-     * @var string|null
      */
     #[ODM\Field(type: MongoDBType::STRING)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @ODM\Field(type="string")
-     *
-     * @var string|null
      */
     #[ODM\Field(type: MongoDBType::STRING)]
-    private $identifier;
+    private ?string $identifier = null;
 
     public function getId(): ?string
     {

--- a/tests/Gedmo/Blameable/Fixture/Document/User.php
+++ b/tests/Gedmo/Blameable/Fixture/Document/User.php
@@ -30,11 +30,9 @@ class User
 
     /**
      * @ODM\Field(type="string")
-     *
-     * @var string|null
      */
     #[ODM\Field(type: MongoDBType::STRING)]
-    private $username;
+    private ?string $username = null;
 
     public function getId(): ?string
     {

--- a/tests/Gedmo/Blameable/Fixture/Entity/Article.php
+++ b/tests/Gedmo/Blameable/Fixture/Entity/Article.php
@@ -37,12 +37,10 @@ class Article implements Blameable
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=128)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var Collection<int, Comment>
@@ -53,42 +51,34 @@ class Article implements Blameable
     private $comments;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Blameable(on="create")
      * @ORM\Column(name="created", type="string")
      */
     #[ORM\Column(name: 'created', type: Types::STRING)]
     #[Gedmo\Blameable(on: 'create')]
-    private $created;
+    private ?string $created = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="updated", type="string")
      * @Gedmo\Blameable
      */
     #[Gedmo\Blameable]
     #[ORM\Column(name: 'updated', type: Types::STRING)]
-    private $updated;
+    private ?string $updated = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="published", type="string", nullable=true)
      * @Gedmo\Blameable(on="change", field="type.title", value="Published")
      */
     #[ORM\Column(name: 'published', type: Types::STRING, nullable: true)]
     #[Gedmo\Blameable(on: 'change', field: 'type.title', value: 'Published')]
-    private $published;
+    private ?string $published = null;
 
     /**
-     * @var Type|null
-     *
      * @ORM\ManyToOne(targetEntity="Type", inversedBy="articles")
      */
     #[ORM\ManyToOne(targetEntity: Type::class, inversedBy: 'articles')]
-    private $type;
+    private ?Type $type = null;
 
     public function __construct()
     {

--- a/tests/Gedmo/Blameable/Fixture/Entity/Comment.php
+++ b/tests/Gedmo/Blameable/Fixture/Entity/Comment.php
@@ -35,28 +35,22 @@ class Comment implements Blameable
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="message", type="text")
      */
     #[ORM\Column(name: 'message', type: Types::TEXT)]
-    private $message;
+    private ?string $message = null;
 
     /**
-     * @var Article|null
-     *
      * @ORM\ManyToOne(targetEntity="Gedmo\Tests\Blameable\Fixture\Entity\Article", inversedBy="comments")
      */
     #[ORM\ManyToOne(targetEntity: Article::class, inversedBy: 'comments')]
-    private $article;
+    private ?Article $article = null;
 
     /**
-     * @var int|null
-     *
      * @ORM\Column(type="integer")
      */
     #[ORM\Column(type: Types::INTEGER)]
-    private $status;
+    private ?int $status = null;
 
     /**
      * @var string|null

--- a/tests/Gedmo/Blameable/Fixture/Entity/SupperClassExtension.php
+++ b/tests/Gedmo/Blameable/Fixture/Entity/SupperClassExtension.php
@@ -21,14 +21,12 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class SupperClassExtension extends MappedSupperClass
 {
     /**
-     * @var string|null
-     *
      * @ORM\Column(length=128)
      * @Gedmo\Translatable
      */
     #[ORM\Column(length: 128)]
     #[Gedmo\Translatable]
-    private $title;
+    private ?string $title = null;
 
     public function setTitle(?string $title): void
     {

--- a/tests/Gedmo/Blameable/Fixture/Entity/TitledArticle.php
+++ b/tests/Gedmo/Blameable/Fixture/Entity/TitledArticle.php
@@ -23,8 +23,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class TitledArticle implements Blameable
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -32,43 +30,35 @@ class TitledArticle implements Blameable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=128)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="text", type="string", length=128)
      */
     #[ORM\Column(name: 'text', type: Types::STRING, length: 128)]
-    private $text;
+    private ?string $text = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="chtext", type="string", nullable=true)
      * @Gedmo\Blameable(on="change", field="text")
      */
     #[ORM\Column(name: 'chtext', type: Types::STRING, nullable: true)]
     #[Gedmo\Blameable(on: 'change', field: 'text')]
-    private $chtext;
+    private ?string $chtext = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="chtitle", type="string", nullable=true)
      * @Gedmo\Blameable(on="change", field="title")
      */
     #[ORM\Column(name: 'chtitle', type: Types::STRING, nullable: true)]
     #[Gedmo\Blameable(on: 'change', field: 'title')]
-    private $chtitle;
+    private ?string $chtitle = null;
 
     public function setChtext(?string $chtext): void
     {

--- a/tests/Gedmo/Blameable/Fixture/Entity/Type.php
+++ b/tests/Gedmo/Blameable/Fixture/Entity/Type.php
@@ -35,12 +35,10 @@ class Type
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=128)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var Collection<int, Article>
@@ -48,7 +46,7 @@ class Type
      * @ORM\OneToMany(targetEntity="Article", mappedBy="type")
      */
     #[ORM\OneToMany(targetEntity: Article::class, mappedBy: 'type')]
-    private $articles;
+    private Collection $articles;
 
     public function __construct()
     {

--- a/tests/Gedmo/Blameable/Fixture/Entity/UsingTrait.php
+++ b/tests/Gedmo/Blameable/Fixture/Entity/UsingTrait.php
@@ -40,12 +40,10 @@ class UsingTrait
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(length=128)
      */
     #[ORM\Column(length: 128)]
-    private $title;
+    private ?string $title = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Blameable/Fixture/Entity/WithoutInterface.php
+++ b/tests/Gedmo/Blameable/Fixture/Entity/WithoutInterface.php
@@ -34,12 +34,10 @@ class WithoutInterface
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(type="string", length=128)
      */
     #[ORM\Column(type: Types::STRING, length: 128)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var string|null

--- a/tests/Gedmo/IpTraceable/Fixture/Article.php
+++ b/tests/Gedmo/IpTraceable/Fixture/Article.php
@@ -37,12 +37,10 @@ class Article implements IpTraceable
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=128)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var Collection<int, Comment>
@@ -53,52 +51,42 @@ class Article implements IpTraceable
     private $comments;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\IpTraceable(on="create")
      * @ORM\Column(name="created", type="string", length=45)
      */
     #[ORM\Column(name: 'created', type: Types::STRING, length: 45)]
     #[Gedmo\IpTraceable(on: 'create')]
-    private $created;
+    private ?string $created = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="updated", type="string", length=45)
      * @Gedmo\IpTraceable
      */
     #[ORM\Column(name: 'updated', type: Types::STRING, length: 45)]
     #[Gedmo\IpTraceable]
-    private $updated;
+    private ?string $updated = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="published", type="string", length=45, nullable=true)
      * @Gedmo\IpTraceable(on="change", field="type.title", value="Published")
      */
     #[ORM\Column(name: 'published', type: Types::STRING, length: 45, nullable: true)]
     #[Gedmo\IpTraceable(on: 'change', field: 'type.title', value: 'Published')]
-    private $published;
+    private ?string $published = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="content_changed", type="string", length=45, nullable=true)
      * @Gedmo\IpTraceable(on="change", field={"title", "body"})
      */
     #[ORM\Column(name: 'content_changed', type: Types::STRING, length: 45, nullable: true)]
     #[Gedmo\IpTraceable(on: 'change', field: ['title', 'body'])]
-    private $contentChanged;
+    private ?string $contentChanged = null;
 
     /**
-     * @var Type|null
-     *
      * @ORM\ManyToOne(targetEntity="Type", inversedBy="articles")
      */
     #[ORM\ManyToOne(targetEntity: Type::class, inversedBy: 'articles')]
-    private $type;
+    private ?Type $type = null;
 
     public function __construct()
     {

--- a/tests/Gedmo/IpTraceable/Fixture/Comment.php
+++ b/tests/Gedmo/IpTraceable/Fixture/Comment.php
@@ -35,28 +35,22 @@ class Comment implements IpTraceable
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="message", type="text")
      */
     #[ORM\Column(name: 'message', type: Types::TEXT)]
-    private $message;
+    private ?string $message = null;
 
     /**
-     * @var Article|null
-     *
      * @ORM\ManyToOne(targetEntity="Gedmo\Tests\IpTraceable\Fixture\Article", inversedBy="comments")
      */
     #[ORM\ManyToOne(targetEntity: Article::class, inversedBy: 'comments')]
-    private $article;
+    private ?Article $article = null;
 
     /**
-     * @var int|null
-     *
      * @ORM\Column(type="integer")
      */
     #[ORM\Column(type: Types::INTEGER)]
-    private $status;
+    private ?int $status = null;
 
     /**
      * @var string|null

--- a/tests/Gedmo/IpTraceable/Fixture/Document/Article.php
+++ b/tests/Gedmo/IpTraceable/Fixture/Document/Article.php
@@ -29,66 +29,54 @@ class Article
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: MongoDBType::STRING)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var Type|null
-     *
      * @ODM\ReferenceOne(targetDocument="Gedmo\Tests\IpTraceable\Fixture\Document\Type")
      */
     #[ODM\ReferenceOne(targetDocument: Type::class)]
-    private $type;
+    private ?\Gedmo\Tests\IpTraceable\Fixture\Document\Type $type = null;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      * @Gedmo\IpTraceable(on="create")
      */
     #[ODM\Field(type: MongoDBType::STRING)]
     #[Gedmo\IpTraceable(on: 'create')]
-    private $created;
+    private ?string $created = null;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      * @Gedmo\IpTraceable
      */
     #[ODM\Field(type: MongoDBType::STRING)]
     #[Gedmo\IpTraceable]
-    private $updated;
+    private ?string $updated = null;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      * @Gedmo\IpTraceable(on="change", field="type.title", value="Published")
      */
     #[ODM\Field(type: MongoDBType::STRING)]
     #[Gedmo\IpTraceable(on: 'change', field: 'type.title', value: 'Published')]
-    private $published;
+    private ?string $published = null;
 
     /**
-     * @var string|null
      * @ODM\Field(type="string")
      * @Gedmo\IpTraceable(on="change", field="isReady", value=true)
      */
     #[ODM\Field(type: MongoDBType::STRING)]
     #[Gedmo\IpTraceable(on: 'change', field: 'isReady', value: true)]
-    private $ready;
+    private ?string $ready = null;
 
     /**
-     * @var bool
      * @ODM\Field(type="bool")
      */
     #[ODM\Field(type: MongoDBType::BOOL)]
-    private $isReady = false;
+    private bool $isReady = false;
 
     public function getId(): ?string
     {

--- a/tests/Gedmo/IpTraceable/Fixture/Document/Type.php
+++ b/tests/Gedmo/IpTraceable/Fixture/Document/Type.php
@@ -29,20 +29,16 @@ class Type
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: MongoDBType::STRING)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: MongoDBType::STRING)]
-    private $identifier;
+    private ?string $identifier = null;
 
     public function getId(): ?string
     {

--- a/tests/Gedmo/IpTraceable/Fixture/SupperClassExtension.php
+++ b/tests/Gedmo/IpTraceable/Fixture/SupperClassExtension.php
@@ -21,14 +21,12 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class SupperClassExtension extends MappedSupperClass
 {
     /**
-     * @var string|null
-     *
      * @ORM\Column(length=128)
      * @Gedmo\Translatable
      */
     #[ORM\Column(length: 128)]
     #[Gedmo\Translatable]
-    private $title;
+    private ?string $title = null;
 
     public function setTitle(?string $title): void
     {

--- a/tests/Gedmo/IpTraceable/Fixture/TitledArticle.php
+++ b/tests/Gedmo/IpTraceable/Fixture/TitledArticle.php
@@ -23,8 +23,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class TitledArticle implements IpTraceable
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -32,43 +30,35 @@ class TitledArticle implements IpTraceable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=128)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="text", type="string", length=128)
      */
     #[ORM\Column(name: 'text', type: Types::STRING, length: 128)]
-    private $text;
+    private ?string $text = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="chtext", type="string", length=45, nullable=true)
      * @Gedmo\IpTraceable(on="change", field="text")
      */
     #[ORM\Column(name: 'chtext', type: Types::STRING, length: 45, nullable: true)]
     #[Gedmo\IpTraceable(on: 'change', field: 'text')]
-    private $chtext;
+    private ?string $chtext = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="chtitle", type="string", length=45, nullable=true)
      * @Gedmo\IpTraceable(on="change", field="title")
      */
     #[ORM\Column(name: 'chtitle', type: Types::STRING, length: 45, nullable: true)]
     #[Gedmo\IpTraceable(on: 'change', field: 'title')]
-    private $chtitle;
+    private ?string $chtitle = null;
 
     public function setChtext(?string $chtext): void
     {

--- a/tests/Gedmo/IpTraceable/Fixture/Type.php
+++ b/tests/Gedmo/IpTraceable/Fixture/Type.php
@@ -35,12 +35,10 @@ class Type
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=128)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var Collection<int, Article>
@@ -48,7 +46,7 @@ class Type
      * @ORM\OneToMany(targetEntity="Article", mappedBy="type")
      */
     #[ORM\OneToMany(targetEntity: Article::class, mappedBy: 'type')]
-    private $articles;
+    private Collection $articles;
 
     public function __construct()
     {

--- a/tests/Gedmo/IpTraceable/Fixture/UsingTrait.php
+++ b/tests/Gedmo/IpTraceable/Fixture/UsingTrait.php
@@ -40,12 +40,10 @@ class UsingTrait
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(length=128)
      */
     #[ORM\Column(length: 128)]
-    private $title;
+    private ?string $title = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/IpTraceable/Fixture/WithoutInterface.php
+++ b/tests/Gedmo/IpTraceable/Fixture/WithoutInterface.php
@@ -34,12 +34,10 @@ class WithoutInterface
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(type="string", length=128)
      */
     #[ORM\Column(type: Types::STRING, length: 128)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var string|null

--- a/tests/Gedmo/Loggable/Fixture/Document/Article.php
+++ b/tests/Gedmo/Loggable/Fixture/Document/Article.php
@@ -32,22 +32,20 @@ class Article implements Loggable
     private $id;
 
     /**
-     * @var string|null
      * @Gedmo\Versioned
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: Type::STRING)]
     #[Gedmo\Versioned]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var Author|null
      * @ODM\EmbedOne(targetDocument="Gedmo\Tests\Loggable\Fixture\Document\Author")
      * @Gedmo\Versioned
      */
     #[ODM\EmbedOne(targetDocument: Author::class)]
     #[Gedmo\Versioned]
-    private $author;
+    private ?Author $author = null;
 
     public function __toString()
     {

--- a/tests/Gedmo/Loggable/Fixture/Document/Author.php
+++ b/tests/Gedmo/Loggable/Fixture/Document/Author.php
@@ -25,22 +25,20 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Author implements Loggable
 {
     /**
-     * @var string|null
      * @Gedmo\Versioned
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: Type::STRING)]
     #[Gedmo\Versioned]
-    private $name;
+    private ?string $name = null;
 
     /**
-     * @var string|null
      * @Gedmo\Versioned
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: Type::STRING)]
     #[Gedmo\Versioned]
-    private $email;
+    private ?string $email = null;
 
     public function __toString()
     {

--- a/tests/Gedmo/Loggable/Fixture/Document/Comment.php
+++ b/tests/Gedmo/Loggable/Fixture/Document/Comment.php
@@ -33,40 +33,36 @@ class Comment implements Loggable
     private $id;
 
     /**
-     * @var string|null
      * @Gedmo\Versioned
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: Type::STRING)]
     #[Gedmo\Versioned]
-    private $subject;
+    private ?string $subject = null;
 
     /**
-     * @var string|null
      * @Gedmo\Versioned
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: Type::STRING)]
     #[Gedmo\Versioned]
-    private $message;
+    private ?string $message = null;
 
     /**
-     * @var RelatedArticle|null
      * @Gedmo\Versioned
      * @ODM\ReferenceOne(targetDocument="Gedmo\Tests\Loggable\Fixture\Document\RelatedArticle", inversedBy="comments")
      */
     #[ODM\ReferenceOne(targetDocument: RelatedArticle::class, inversedBy: 'comments')]
     #[Gedmo\Versioned]
-    private $article;
+    private ?RelatedArticle $article = null;
 
     /**
-     * @var Author|null
      * @ODM\EmbedOne(targetDocument="Gedmo\Tests\Loggable\Fixture\Document\Author")
      * @Gedmo\Versioned
      */
     #[ODM\EmbedOne(targetDocument: Author::class)]
     #[Gedmo\Versioned]
-    private $author;
+    private ?Author $author = null;
 
     public function setArticle(?RelatedArticle $article): void
     {

--- a/tests/Gedmo/Loggable/Fixture/Document/RelatedArticle.php
+++ b/tests/Gedmo/Loggable/Fixture/Document/RelatedArticle.php
@@ -34,22 +34,20 @@ class RelatedArticle implements Loggable
     private $id;
 
     /**
-     * @var string|null
      * @Gedmo\Versioned
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: Type::STRING)]
     #[Gedmo\Versioned]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
      * @Gedmo\Versioned
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: Type::STRING)]
     #[Gedmo\Versioned]
-    private $content;
+    private ?string $content = null;
 
     /**
      * @var Collection<int, Comment>

--- a/tests/Gedmo/Loggable/Fixture/Entity/Article.php
+++ b/tests/Gedmo/Loggable/Fixture/Entity/Article.php
@@ -37,13 +37,12 @@ class Article implements Loggable
     private $id;
 
     /**
-     * @var string|null
      * @Gedmo\Versioned
      * @ORM\Column(name="title", type="string", length=8)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 8)]
     #[Gedmo\Versioned]
-    private $title;
+    private ?string $title = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Loggable/Fixture/Entity/Comment.php
+++ b/tests/Gedmo/Loggable/Fixture/Entity/Comment.php
@@ -37,31 +37,28 @@ class Comment implements Loggable
     private $id;
 
     /**
-     * @var string|null
      * @Gedmo\Versioned
      * @ORM\Column(length=128)
      */
     #[ORM\Column(length: 128)]
     #[Gedmo\Versioned]
-    private $subject;
+    private ?string $subject = null;
 
     /**
-     * @var string|null
      * @Gedmo\Versioned
      * @ORM\Column(type="text")
      */
     #[ORM\Column(type: Types::TEXT)]
     #[Gedmo\Versioned]
-    private $message;
+    private ?string $message = null;
 
     /**
-     * @var RelatedArticle|null
      * @Gedmo\Versioned
      * @ORM\ManyToOne(targetEntity="RelatedArticle", inversedBy="comments")
      */
     #[ORM\ManyToOne(targetEntity: RelatedArticle::class, inversedBy: 'comments')]
     #[Gedmo\Versioned]
-    private $article;
+    private ?RelatedArticle $article = null;
 
     public function setArticle(?RelatedArticle $article): void
     {

--- a/tests/Gedmo/Loggable/Fixture/Entity/Composite.php
+++ b/tests/Gedmo/Loggable/Fixture/Entity/Composite.php
@@ -22,34 +22,28 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Composite
 {
     /**
-     * @var int
-     *
      * @ORM\Id
      * @ORM\Column(type="integer")
      */
     #[ORM\Id]
     #[ORM\Column(name: 'one', type: Types::INTEGER)]
-    private $one;
+    private int $one;
 
     /**
-     * @var int
-     *
      * @ORM\Id
      * @ORM\Column(type="integer")
      */
     #[ORM\Id]
     #[ORM\Column(name: 'two', type: Types::INTEGER)]
-    private $two;
+    private int $two;
 
     /**
-     * @var string
-     *
      * @ORM\Column(length=8)
      * @Gedmo\Versioned
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 8)]
     #[Gedmo\Versioned]
-    private $title;
+    private ?string $title = null;
 
     public function __construct(int $one, int $two)
     {

--- a/tests/Gedmo/Loggable/Fixture/Entity/CompositeRelation.php
+++ b/tests/Gedmo/Loggable/Fixture/Entity/CompositeRelation.php
@@ -22,34 +22,28 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class CompositeRelation
 {
     /**
-     * @var Article
-     *
      * @ORM\Id
      * @ORM\ManyToOne(targetEntity="Article")
      */
     #[ORM\Id]
     #[ORM\ManyToOne(targetEntity: Article::class)]
-    private $articleOne;
+    private Article $articleOne;
 
     /**
-     * @var Article
-     *
      * @ORM\Id
      * @ORM\ManyToOne(targetEntity="Article")
      */
     #[ORM\Id]
     #[ORM\ManyToOne(targetEntity: Article::class)]
-    private $articleTwo;
+    private Article $articleTwo;
 
     /**
-     * @var string
-     *
      * @ORM\Column(length=8)
      * @Gedmo\Versioned
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 8)]
     #[Gedmo\Versioned]
-    private $title;
+    private ?string $title = null;
 
     public function __construct(Article $articleOne, Article $articleTwo)
     {

--- a/tests/Gedmo/Loggable/Fixture/Entity/RelatedArticle.php
+++ b/tests/Gedmo/Loggable/Fixture/Entity/RelatedArticle.php
@@ -38,22 +38,20 @@ class RelatedArticle implements Loggable
     private $id;
 
     /**
-     * @var string|null
      * @Gedmo\Versioned
      * @ORM\Column(length=128)
      */
     #[ORM\Column(length: 128)]
     #[Gedmo\Versioned]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
      * @Gedmo\Versioned
      * @ORM\Column(type="text")
      */
     #[ORM\Column(Types::TEXT)]
     #[Gedmo\Versioned]
-    private $content;
+    private ?string $content = null;
 
     /**
      * @var Collection<int, Comment>

--- a/tests/Gedmo/Mapping/ExtensionODMTest.php
+++ b/tests/Gedmo/Mapping/ExtensionODMTest.php
@@ -23,10 +23,7 @@ final class ExtensionODMTest extends BaseTestCaseMongoODM
 {
     private const USER = User::class;
 
-    /**
-     * @var EncoderListener
-     */
-    private $encoderListener;
+    private EncoderListener $encoderListener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Mapping/ExtensionORMTest.php
+++ b/tests/Gedmo/Mapping/ExtensionORMTest.php
@@ -23,10 +23,7 @@ final class ExtensionORMTest extends BaseTestCaseORM
 {
     private const USER = User::class;
 
-    /**
-     * @var EncoderListener
-     */
-    private $encoderListener;
+    private EncoderListener $encoderListener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Mapping/Fixture/Attribute/TranslatableModel.php
+++ b/tests/Gedmo/Mapping/Fixture/Attribute/TranslatableModel.php
@@ -16,7 +16,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class TranslatableModel
 {
     #[Gedmo\Translatable]
-    private ?string $title;
+    private ?string $title = null;
 
     /**
      * @var string|null

--- a/tests/Gedmo/Mapping/Fixture/Document/User.php
+++ b/tests/Gedmo/Mapping/Fixture/Document/User.php
@@ -27,20 +27,16 @@ class User
     private $id;
 
     /**
-     * @var string|null
-     *
      * @Ext\Encode(type="sha1", secret="xxx")
      * @ODM\Field(type="string")
      */
-    private $name;
+    private ?string $name = null;
 
     /**
-     * @var string|null
-     *
      * @Ext\Encode(type="md5")
      * @ODM\Field(type="string")
      */
-    private $password;
+    private ?string $password = null;
 
     public function setName(?string $name): void
     {

--- a/tests/Gedmo/Mapping/Fixture/Loggable.php
+++ b/tests/Gedmo/Mapping/Fixture/Loggable.php
@@ -28,12 +28,10 @@ class Loggable
     private $id;
 
     /**
-     * @var string
-     *
      * @ORM\Column(name="title", type="string", length=64)
      * @Gedmo\Versioned
      */
-    private $title;
+    private ?string $title = null;
 
     public function getId(): int
     {

--- a/tests/Gedmo/Mapping/Fixture/LoggableComposite.php
+++ b/tests/Gedmo/Mapping/Fixture/LoggableComposite.php
@@ -35,12 +35,10 @@ class LoggableComposite
     private $two;
 
     /**
-     * @var string
-     *
      * @ORM\Column(name="title", type="string", length=64)
      * @Gedmo\Versioned
      */
-    private $title;
+    private ?string $title = null;
 
     public function getOne(): int
     {

--- a/tests/Gedmo/Mapping/Fixture/LoggableCompositeRelation.php
+++ b/tests/Gedmo/Mapping/Fixture/LoggableCompositeRelation.php
@@ -35,12 +35,10 @@ class LoggableCompositeRelation
     private $two;
 
     /**
-     * @var string
-     *
      * @ORM\Column(name="title", type="string", length=64)
      * @Gedmo\Versioned
      */
-    private $title;
+    private ?string $title = null;
 
     public function getOne(): Loggable
     {

--- a/tests/Gedmo/Mapping/Fixture/MappedSuperClass.php
+++ b/tests/Gedmo/Mapping/Fixture/MappedSuperClass.php
@@ -34,13 +34,11 @@ class MappedSuperClass
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(length=32)
      * @Ext\Encode(type="md5")
      */
     #[ORM\Column(length: 32)]
-    private $content;
+    private ?string $content = null;
 
     public function setContent(?string $content): void
     {

--- a/tests/Gedmo/Mapping/Fixture/Sluggable.php
+++ b/tests/Gedmo/Mapping/Fixture/Sluggable.php
@@ -36,20 +36,16 @@ class Sluggable
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="code", type="string", length=16)
      */
     #[ORM\Column(name: 'code', type: Types::STRING, length: 64, nullable: true)]
-    private $code;
+    private ?string $code = null;
 
     /**
      * @var string|null

--- a/tests/Gedmo/Mapping/Fixture/SoftDeleteable.php
+++ b/tests/Gedmo/Mapping/Fixture/SoftDeleteable.php
@@ -29,15 +29,9 @@ class SoftDeleteable
      */
     private $id;
 
-    /**
-     * @var string|null
-     */
-    private $title;
+    private ?string $title = null;
 
-    /**
-     * @var string|null
-     */
-    private $code;
+    private ?string $code = null;
 
     /**
      * @var string|null

--- a/tests/Gedmo/Mapping/Fixture/SuperClassExtension.php
+++ b/tests/Gedmo/Mapping/Fixture/SuperClassExtension.php
@@ -20,12 +20,10 @@ use Doctrine\ORM\Mapping as ORM;
 class SuperClassExtension extends MappedSuperClass
 {
     /**
-     * @var string|null
-     *
      * @ORM\Column(length=128)
      */
     #[ORM\Column(length: 128)]
-    private $title;
+    private ?string $title = null;
 
     public function setTitle(?string $title): void
     {

--- a/tests/Gedmo/Mapping/Fixture/User.php
+++ b/tests/Gedmo/Mapping/Fixture/User.php
@@ -36,22 +36,18 @@ class User
     private $id;
 
     /**
-     * @var string|null
-     *
      * @Ext\Encode(type="sha1", secret="xxx")
      * @ORM\Column(length=64)
      */
     #[ORM\Column(length: 64)]
-    private $name;
+    private ?string $name = null;
 
     /**
-     * @var string|null
-     *
      * @Ext\Encode(type="md5")
      * @ORM\Column(length=32)
      */
     #[ORM\Column(length: 32)]
-    private $password;
+    private ?string $password = null;
 
     public function setName(?string $name): void
     {

--- a/tests/Gedmo/Mapping/Fixture/Yaml/BaseCategory.php
+++ b/tests/Gedmo/Mapping/Fixture/Yaml/BaseCategory.php
@@ -13,35 +13,17 @@ namespace Gedmo\Tests\Mapping\Fixture\Yaml;
 
 class BaseCategory
 {
-    /**
-     * @var int
-     */
-    private $left;
+    private ?int $left = null;
 
-    /**
-     * @var int
-     */
-    private $right;
+    private ?int $right = null;
 
-    /**
-     * @var int
-     */
-    private $level;
+    private ?int $level = null;
 
-    /**
-     * @var int
-     */
-    private $rooted;
+    private ?int $rooted = null;
 
-    /**
-     * @var \DateTime|null
-     */
-    private $created;
+    private ?\DateTime $created = null;
 
-    /**
-     * @var \DateTime|null
-     */
-    private $updated;
+    private ?\DateTime $updated = null;
 
     public function setCreated(\DateTime $created): void
     {

--- a/tests/Gedmo/Mapping/Fixture/Yaml/Category.php
+++ b/tests/Gedmo/Mapping/Fixture/Yaml/Category.php
@@ -21,25 +21,16 @@ class Category extends BaseCategory
      */
     private $id;
 
-    /**
-     * @var string
-     */
-    private $title;
+    private ?string $title = null;
 
-    /**
-     * @var string
-     */
-    private $slug;
+    private ?string $slug = null;
 
     /**
      * @var Collection<int, self>
      */
     private $children;
 
-    /**
-     * @var self
-     */
-    private $parent;
+    private ?\Gedmo\Tests\Mapping\Fixture\Yaml\Category $parent = null;
 
     /**
      * @var \DateTime

--- a/tests/Gedmo/Mapping/Fixture/Yaml/ClosureCategory.php
+++ b/tests/Gedmo/Mapping/Fixture/Yaml/ClosureCategory.php
@@ -21,25 +21,16 @@ class ClosureCategory
      */
     private $id;
 
-    /**
-     * @var string
-     */
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var Collection<int, ClosureCategory>
      */
     private $children;
 
-    /**
-     * @var ClosureCategory
-     */
-    private $parent;
+    private ?\Gedmo\Tests\Mapping\Fixture\Yaml\ClosureCategory $parent = null;
 
-    /**
-     * @var int
-     */
-    private $level;
+    private ?int $level = null;
 
     public function __construct()
     {

--- a/tests/Gedmo/Mapping/Fixture/Yaml/MaterializedPathCategory.php
+++ b/tests/Gedmo/Mapping/Fixture/Yaml/MaterializedPathCategory.php
@@ -21,35 +21,20 @@ class MaterializedPathCategory
      */
     private $id;
 
-    /**
-     * @var string
-     */
-    private $title;
+    private ?string $title = null;
 
-    /**
-     * @var string
-     */
-    private $path;
+    private ?string $path = null;
 
-    /**
-     * @var int
-     */
-    private $level;
+    private ?int $level = null;
 
     /**
      * @var Collection<int, Category>
      */
     private $children;
 
-    /**
-     * @var MaterializedPathCategory
-     */
-    private $parent;
+    private ?\Gedmo\Tests\Mapping\Fixture\Yaml\MaterializedPathCategory $parent = null;
 
-    /**
-     * @var \DateTime|null
-     */
-    private $lockTime;
+    private ?\DateTime $lockTime = null;
 
     public function __construct()
     {

--- a/tests/Gedmo/Mapping/Fixture/Yaml/User.php
+++ b/tests/Gedmo/Mapping/Fixture/Yaml/User.php
@@ -18,20 +18,11 @@ class User
      */
     private $id;
 
-    /**
-     * @var string
-     */
-    private $password;
+    private ?string $password = null;
 
-    /**
-     * @var string
-     */
-    private $username;
+    private ?string $username = null;
 
-    /**
-     * @var string
-     */
-    private $company;
+    private ?string $company = null;
 
     /**
      * @var string

--- a/tests/Gedmo/Mapping/LoggableORMMappingTest.php
+++ b/tests/Gedmo/Mapping/LoggableORMMappingTest.php
@@ -37,10 +37,7 @@ final class LoggableORMMappingTest extends ORMMappingTestCase
     private const COMPOSITE = LoggableComposite::class;
     private const COMPOSITE_RELATION = LoggableCompositeRelation::class;
 
-    /**
-     * @var EntityManager
-     */
-    private $em;
+    private EntityManager $em;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Mapping/MappingEventSubscriberTest.php
+++ b/tests/Gedmo/Mapping/MappingEventSubscriberTest.php
@@ -28,10 +28,7 @@ use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 final class MappingEventSubscriberTest extends ORMMappingTestCase
 {
-    /**
-     * @var EntityManager
-     */
-    private $em;
+    private EntityManager $em;
 
     protected function setUp(): void
     {
@@ -56,9 +53,7 @@ final class MappingEventSubscriberTest extends ORMMappingTestCase
     public function testGetMetadataFactoryCacheFromDoctrineForSluggable(): void
     {
         $metadataFactory = $this->em->getMetadataFactory();
-        $getCache = \Closure::bind(static function (AbstractClassMetadataFactory $metadataFactory): ?CacheItemPoolInterface {
-            return $metadataFactory->getCache();
-        }, null, \get_class($metadataFactory));
+        $getCache = \Closure::bind(static fn (AbstractClassMetadataFactory $metadataFactory): ?CacheItemPoolInterface => $metadataFactory->getCache(), null, \get_class($metadataFactory));
 
         $cache = $getCache($metadataFactory);
 
@@ -76,9 +71,7 @@ final class MappingEventSubscriberTest extends ORMMappingTestCase
     public function testGetMetadataFactoryCacheFromDoctrineForSuperClassExtension(): void
     {
         $metadataFactory = $this->em->getMetadataFactory();
-        $getCache = \Closure::bind(static function (AbstractClassMetadataFactory $metadataFactory): ?CacheItemPoolInterface {
-            return $metadataFactory->getCache();
-        }, null, \get_class($metadataFactory));
+        $getCache = \Closure::bind(static fn (AbstractClassMetadataFactory $metadataFactory): ?CacheItemPoolInterface => $metadataFactory->getCache(), null, \get_class($metadataFactory));
 
         /** @var CacheItemPoolInterface $cache */
         $cache = $getCache($metadataFactory);

--- a/tests/Gedmo/Mapping/MappingTest.php
+++ b/tests/Gedmo/Mapping/MappingTest.php
@@ -36,15 +36,9 @@ final class MappingTest extends TestCase
     private const TEST_ENTITY_CATEGORY = BehavioralCategory::class;
     private const TEST_ENTITY_TRANSLATION = Translation::class;
 
-    /**
-     * @var EntityManager
-     */
-    private $em;
+    private EntityManager $em;
 
-    /**
-     * @var TimestampableListener
-     */
-    private $timestampable;
+    private TimestampableListener $timestampable;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Mapping/MetadataFactory/CustomDriverTest.php
+++ b/tests/Gedmo/Mapping/MetadataFactory/CustomDriverTest.php
@@ -30,15 +30,9 @@ use PHPUnit\Framework\TestCase;
  */
 final class CustomDriverTest extends TestCase
 {
-    /**
-     * @var TimestampableListener
-     */
-    private $timestampable;
+    private TimestampableListener $timestampable;
 
-    /**
-     * @var EntityManagerInterface
-     */
-    private $em;
+    private EntityManagerInterface $em;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Mapping/MetadataFactory/ForcedMetadataTest.php
+++ b/tests/Gedmo/Mapping/MetadataFactory/ForcedMetadataTest.php
@@ -34,15 +34,9 @@ use PHPUnit\Framework\TestCase;
  */
 final class ForcedMetadataTest extends TestCase
 {
-    /**
-     * @var TimestampableListener
-     */
-    private $timestampable;
+    private TimestampableListener $timestampable;
 
-    /**
-     * @var EntityManagerInterface
-     */
-    private $em;
+    private EntityManagerInterface $em;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Mapping/MultiManagerMappingTest.php
+++ b/tests/Gedmo/Mapping/MultiManagerMappingTest.php
@@ -29,20 +29,11 @@ use Gedmo\Tests\Translatable\Fixture\PersonTranslation;
  */
 final class MultiManagerMappingTest extends BaseTestCaseOM
 {
-    /**
-     * @var EntityManager
-     */
-    private $em1;
+    private EntityManager $em1;
 
-    /**
-     * @var EntityManager
-     */
-    private $em2;
+    private EntityManager $em2;
 
-    /**
-     * @var DocumentManager
-     */
-    private $dm1;
+    private DocumentManager $dm1;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Mapping/ReferenceIntegrityMappingTest.php
+++ b/tests/Gedmo/Mapping/ReferenceIntegrityMappingTest.php
@@ -27,15 +27,9 @@ use Gedmo\Tests\Tool\BaseTestCaseOM;
  */
 final class ReferenceIntegrityMappingTest extends BaseTestCaseOM
 {
-    /**
-     * @var DocumentManager
-     */
-    private $dm;
+    private DocumentManager $dm;
 
-    /**
-     * @var ReferenceIntegrityListener
-     */
-    private $referenceIntegrity;
+    private ReferenceIntegrityListener $referenceIntegrity;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Mapping/SluggableMappingTest.php
+++ b/tests/Gedmo/Mapping/SluggableMappingTest.php
@@ -36,10 +36,7 @@ final class SluggableMappingTest extends ORMMappingTestCase
     private const TEST_YAML_ENTITY_CLASS = Category::class;
     private const SLUGGABLE = Sluggable::class;
 
-    /**
-     * @var EntityManager
-     */
-    private $em;
+    private EntityManager $em;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Mapping/SoftDeleteableMappingTest.php
+++ b/tests/Gedmo/Mapping/SoftDeleteableMappingTest.php
@@ -29,15 +29,9 @@ use Gedmo\Tests\Tool\BaseTestCaseOM;
  */
 final class SoftDeleteableMappingTest extends BaseTestCaseOM
 {
-    /**
-     * @var EntityManager
-     */
-    private $em;
+    private EntityManager $em;
 
-    /**
-     * @var SoftDeleteableListener
-     */
-    private $softDeleteable;
+    private SoftDeleteableListener $softDeleteable;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Mapping/SortableMappingTest.php
+++ b/tests/Gedmo/Mapping/SortableMappingTest.php
@@ -29,15 +29,9 @@ use Gedmo\Tests\Tool\BaseTestCaseOM;
  */
 final class SortableMappingTest extends BaseTestCaseOM
 {
-    /**
-     * @var EntityManager
-     */
-    private $em;
+    private EntityManager $em;
 
-    /**
-     * @var SortableListener
-     */
-    private $sortable;
+    private SortableListener $sortable;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Mapping/TimestampableMappingTest.php
+++ b/tests/Gedmo/Mapping/TimestampableMappingTest.php
@@ -29,10 +29,7 @@ final class TimestampableMappingTest extends ORMMappingTestCase
 {
     private const TEST_YAML_ENTITY_CLASS = Category::class;
 
-    /**
-     * @var EntityManager
-     */
-    private $em;
+    private EntityManager $em;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Mapping/TranslatableMappingTest.php
+++ b/tests/Gedmo/Mapping/TranslatableMappingTest.php
@@ -31,15 +31,9 @@ final class TranslatableMappingTest extends ORMMappingTestCase
 {
     private const TEST_YAML_ENTITY_CLASS = User::class;
 
-    /**
-     * @var TranslatableListener
-     */
-    private $translatableListener;
+    private TranslatableListener $translatableListener;
 
-    /**
-     * @var EntityManagerInterface
-     */
-    private $em;
+    private EntityManagerInterface $em;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Mapping/TreeMappingTest.php
+++ b/tests/Gedmo/Mapping/TreeMappingTest.php
@@ -37,15 +37,9 @@ final class TreeMappingTest extends ORMMappingTestCase
     private const YAML_CLOSURE_CATEGORY = ClosureCategory::class;
     private const YAML_MATERIALIZED_PATH_CATEGORY = MaterializedPathCategory::class;
 
-    /**
-     * @var EntityManager
-     */
-    private $em;
+    private EntityManager $em;
 
-    /**
-     * @var TreeListener
-     */
-    private $listener;
+    private TreeListener $listener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Mapping/UploadableMappingTest.php
+++ b/tests/Gedmo/Mapping/UploadableMappingTest.php
@@ -30,15 +30,9 @@ use Gedmo\Uploadable\UploadableListener;
  */
 final class UploadableMappingTest extends BaseTestCaseOM
 {
-    /**
-     * @var EntityManager
-     */
-    private $em;
+    private EntityManager $em;
 
-    /**
-     * @var UploadableListener
-     */
-    private $listener;
+    private UploadableListener $listener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Mapping/Xml/ClosureTreeMappingTest.php
+++ b/tests/Gedmo/Mapping/Xml/ClosureTreeMappingTest.php
@@ -29,15 +29,9 @@ use Gedmo\Tree\TreeListener;
  */
 final class ClosureTreeMappingTest extends BaseTestCaseOM
 {
-    /**
-     * @var EntityManager
-     */
-    private $em;
+    private EntityManager $em;
 
-    /**
-     * @var TreeListener
-     */
-    private $tree;
+    private TreeListener $tree;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Mapping/Xml/LoggableMappingTest.php
+++ b/tests/Gedmo/Mapping/Xml/LoggableMappingTest.php
@@ -34,17 +34,12 @@ use Gedmo\Tests\Tool\BaseTestCaseOM;
  */
 final class LoggableMappingTest extends BaseTestCaseOM
 {
-    /**
-     * @var EntityManager
-     */
-    private $em;
+    private EntityManager $em;
 
     /**
-     * @var LoggableListener
-     *
      * @phpstan-var LoggableListener<Loggable>
      */
-    private $loggable;
+    private LoggableListener $loggable;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Mapping/Xml/MaterializedPathTreeMappingTest.php
+++ b/tests/Gedmo/Mapping/Xml/MaterializedPathTreeMappingTest.php
@@ -29,15 +29,9 @@ use Gedmo\Tree\TreeListener;
  */
 final class MaterializedPathTreeMappingTest extends BaseTestCaseOM
 {
-    /**
-     * @var EntityManager
-     */
-    private $em;
+    private EntityManager $em;
 
-    /**
-     * @var TreeListener
-     */
-    private $tree;
+    private TreeListener $tree;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Mapping/Xml/NestedTreeMappingTest.php
+++ b/tests/Gedmo/Mapping/Xml/NestedTreeMappingTest.php
@@ -26,15 +26,9 @@ use Gedmo\Tree\TreeListener;
  */
 final class NestedTreeMappingTest extends BaseTestCaseOM
 {
-    /**
-     * @var EntityManager
-     */
-    private $em;
+    private EntityManager $em;
 
-    /**
-     * @var TreeListener
-     */
-    private $tree;
+    private TreeListener $tree;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Mapping/Xml/ReferencesMappingTest.php
+++ b/tests/Gedmo/Mapping/Xml/ReferencesMappingTest.php
@@ -26,15 +26,9 @@ use Gedmo\Tests\Tool\BaseTestCaseOM;
  */
 final class ReferencesMappingTest extends BaseTestCaseOM
 {
-    /**
-     * @var EntityManager
-     */
-    private $em;
+    private EntityManager $em;
 
-    /**
-     * @var ReferencesListener
-     */
-    private $referencesListener;
+    private ReferencesListener $referencesListener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Mapping/Xml/Simplified/TimestampableMappingTest.php
+++ b/tests/Gedmo/Mapping/Xml/Simplified/TimestampableMappingTest.php
@@ -27,10 +27,7 @@ use Gedmo\Timestampable\TimestampableListener;
  */
 final class TimestampableMappingTest extends BaseTestCaseORM
 {
-    /**
-     * @var TimestampableListener
-     */
-    private $timestampable;
+    private TimestampableListener $timestampable;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Mapping/Xml/SluggableMappingTest.php
+++ b/tests/Gedmo/Mapping/Xml/SluggableMappingTest.php
@@ -28,10 +28,7 @@ use Gedmo\Tests\Tool\BaseTestCaseORM;
  */
 final class SluggableMappingTest extends BaseTestCaseORM
 {
-    /**
-     * @var SluggableListener
-     */
-    private $sluggable;
+    private SluggableListener $sluggable;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Mapping/Xml/SoftDeleteableMappingTest.php
+++ b/tests/Gedmo/Mapping/Xml/SoftDeleteableMappingTest.php
@@ -29,15 +29,9 @@ use Gedmo\Tests\Tool\BaseTestCaseOM;
  */
 final class SoftDeleteableMappingTest extends BaseTestCaseOM
 {
-    /**
-     * @var EntityManager
-     */
-    private $em;
+    private EntityManager $em;
 
-    /**
-     * @var SoftDeleteableListener
-     */
-    private $softDeleteable;
+    private SoftDeleteableListener $softDeleteable;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Mapping/Xml/SortableMappingTest.php
+++ b/tests/Gedmo/Mapping/Xml/SortableMappingTest.php
@@ -29,15 +29,9 @@ use Gedmo\Tests\Tool\BaseTestCaseOM;
  */
 final class SortableMappingTest extends BaseTestCaseOM
 {
-    /**
-     * @var EntityManager
-     */
-    private $em;
+    private EntityManager $em;
 
-    /**
-     * @var SortableListener
-     */
-    private $sortable;
+    private SortableListener $sortable;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Mapping/Xml/TimestampableMappingTest.php
+++ b/tests/Gedmo/Mapping/Xml/TimestampableMappingTest.php
@@ -27,15 +27,9 @@ use Gedmo\Timestampable\TimestampableListener;
  */
 final class TimestampableMappingTest extends BaseTestCaseOM
 {
-    /**
-     * @var EntityManager
-     */
-    private $em;
+    private EntityManager $em;
 
-    /**
-     * @var TimestampableListener
-     */
-    private $timestampable;
+    private TimestampableListener $timestampable;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Mapping/Xml/TranslatableMappingTest.php
+++ b/tests/Gedmo/Mapping/Xml/TranslatableMappingTest.php
@@ -30,15 +30,9 @@ use Gedmo\Translatable\TranslatableListener;
  */
 final class TranslatableMappingTest extends BaseTestCaseOM
 {
-    /**
-     * @var EntityManager
-     */
-    private $em;
+    private EntityManager $em;
 
-    /**
-     * @var TranslatableListener
-     */
-    private $translatable;
+    private TranslatableListener $translatable;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Mapping/Xml/UploadableMappingTest.php
+++ b/tests/Gedmo/Mapping/Xml/UploadableMappingTest.php
@@ -30,15 +30,9 @@ use Gedmo\Uploadable\UploadableListener;
  */
 final class UploadableMappingTest extends BaseTestCaseOM
 {
-    /**
-     * @var EntityManager
-     */
-    private $em;
+    private EntityManager $em;
 
-    /**
-     * @var UploadableListener
-     */
-    private $listener;
+    private UploadableListener $listener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Mapping/Yaml/LoggableMappingTest.php
+++ b/tests/Gedmo/Mapping/Yaml/LoggableMappingTest.php
@@ -32,17 +32,12 @@ use Gedmo\Tests\Tool\BaseTestCaseOM;
  */
 final class LoggableMappingTest extends BaseTestCaseOM
 {
-    /**
-     * @var EntityManager
-     */
-    private $em;
+    private EntityManager $em;
 
     /**
-     * @var LoggableListener
-     *
      * @phpstan-var LoggableListener<LoggableWithEmbedded>
      */
-    private $loggable;
+    private LoggableListener $loggable;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyNullify/Article.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyNullify/Article.php
@@ -29,20 +29,16 @@ class Article
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: MongoDBType::STRING)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var Type|null
-     *
      * @ODM\ReferenceOne(targetDocument="Gedmo\Tests\ReferenceIntegrity\Fixture\Document\ManyNullify\Type", inversedBy="articles")
      */
     #[ODM\ReferenceOne(targetDocument: Type::class, inversedBy: 'articles')]
-    private $type;
+    private ?\Gedmo\Tests\ReferenceIntegrity\Fixture\Document\ManyNullify\Type $type = null;
 
     public function getId(): ?string
     {

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyNullify/Type.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyNullify/Type.php
@@ -42,20 +42,16 @@ class Type
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: MongoDBType::STRING)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: MongoDBType::STRING)]
-    private $identifier;
+    private ?string $identifier = null;
 
     public function __construct()
     {

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyPull/Article.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyPull/Article.php
@@ -31,12 +31,10 @@ class Article
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: MongoDBType::STRING)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var Collection<int, Type>

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyPull/Type.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyPull/Type.php
@@ -42,20 +42,16 @@ class Type
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: MongoDBType::STRING)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: MongoDBType::STRING)]
-    private $identifier;
+    private ?string $identifier = null;
 
     public function __construct()
     {

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyRestrict/Article.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyRestrict/Article.php
@@ -29,20 +29,16 @@ class Article
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: MongoDBType::STRING)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var Type|null
-     *
      * @ODM\ReferenceOne(targetDocument="Gedmo\Tests\ReferenceIntegrity\Fixture\Document\ManyRestrict\Type", inversedBy="articles")
      */
     #[ODM\ReferenceOne(targetDocument: Type::class, inversedBy: 'articles')]
-    private $type;
+    private ?\Gedmo\Tests\ReferenceIntegrity\Fixture\Document\ManyRestrict\Type $type = null;
 
     public function getId(): ?string
     {

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyRestrict/Type.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyRestrict/Type.php
@@ -42,20 +42,16 @@ class Type
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: MongoDBType::STRING)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: MongoDBType::STRING)]
-    private $identifier;
+    private ?string $identifier = null;
 
     public function __construct()
     {

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OneNullify/Article.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OneNullify/Article.php
@@ -29,20 +29,16 @@ class Article
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: MongoDBType::STRING)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var Type|null
-     *
      * @ODM\ReferenceOne(targetDocument="Gedmo\Tests\ReferenceIntegrity\Fixture\Document\OneNullify\Type", inversedBy="articles")
      */
     #[ODM\ReferenceOne(targetDocument: Type::class, inversedBy: 'articles')]
-    private $type;
+    private ?\Gedmo\Tests\ReferenceIntegrity\Fixture\Document\OneNullify\Type $type = null;
 
     public function getId(): ?string
     {

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OneNullify/Type.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OneNullify/Type.php
@@ -40,20 +40,16 @@ class Type
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: MongoDBType::STRING)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: MongoDBType::STRING)]
-    private $identifier;
+    private ?string $identifier = null;
 
     public function getId(): ?string
     {

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OnePull/Article.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OnePull/Article.php
@@ -31,12 +31,10 @@ class Article
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: MongoDBType::STRING)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var Collection<int, Type>

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OnePull/Type.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OnePull/Type.php
@@ -40,20 +40,16 @@ class Type
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: MongoDBType::STRING)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: MongoDBType::STRING)]
-    private $identifier;
+    private ?string $identifier = null;
 
     public function getId(): ?string
     {

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OneRestrict/Article.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OneRestrict/Article.php
@@ -29,20 +29,16 @@ class Article
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: MongoDBType::STRING)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var Type|null
-     *
      * @ODM\ReferenceOne(targetDocument="Gedmo\Tests\ReferenceIntegrity\Fixture\Document\OneRestrict\Type", inversedBy="articles")
      */
     #[ODM\ReferenceOne(targetDocument: Type::class, inversedBy: 'articles')]
-    private $type;
+    private ?\Gedmo\Tests\ReferenceIntegrity\Fixture\Document\OneRestrict\Type $type = null;
 
     public function getId(): ?string
     {

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OneRestrict/Type.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OneRestrict/Type.php
@@ -40,20 +40,16 @@ class Type
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: MongoDBType::STRING)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: MongoDBType::STRING)]
-    private $identifier;
+    private ?string $identifier = null;
 
     public function getId(): ?string
     {

--- a/tests/Gedmo/References/Fixture/ODM/MongoDB/Metadata.php
+++ b/tests/Gedmo/References/Fixture/ODM/MongoDB/Metadata.php
@@ -32,20 +32,16 @@ class Metadata
     private $name;
 
     /**
-     * @var Category|null
-     *
      * @Gedmo\ReferenceOne(type="entity", class="Gedmo\Tests\References\Fixture\ORM\Category", identifier="categoryId")
      */
     #[Gedmo\ReferenceOne(type: 'entity', class: Category::class, identifier: 'categoryId')]
-    private $category;
+    private Category $category;
 
     /**
-     * @var int|null
-     *
      * @ODM\Field(type="int")
      */
     #[ODM\Field(type: Type::INT)]
-    private $categoryId;
+    private ?int $categoryId = null;
 
     public function __construct(Category $category)
     {
@@ -68,7 +64,7 @@ class Metadata
         $this->categoryId = $category->getId();
     }
 
-    public function getCategory(): ?Category
+    public function getCategory(): Category
     {
         return $this->category;
     }

--- a/tests/Gedmo/References/Fixture/ODM/MongoDB/Product.php
+++ b/tests/Gedmo/References/Fixture/ODM/MongoDB/Product.php
@@ -25,20 +25,16 @@ use Gedmo\Tests\References\Fixture\ORM\StockItem;
 class Product
 {
     /**
-     * @var string|null
-     *
      * @ODM\Id
      */
     #[ODM\Id]
-    private $id;
+    private ?string $id = null;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: Type::STRING)]
-    private $name;
+    private ?string $name = null;
 
     /**
      * @var Collection<int, StockItem>

--- a/tests/Gedmo/References/Fixture/ORM/Category.php
+++ b/tests/Gedmo/References/Fixture/ORM/Category.php
@@ -37,12 +37,10 @@ class Category
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="name", type="string", length=128)
      */
     #[ORM\Column(name: 'name', type: Types::STRING, length: 128)]
-    private $name;
+    private ?string $name = null;
 
     /**
      * @var Collection<int, Product>
@@ -50,7 +48,7 @@ class Category
      * @Gedmo\ReferenceManyEmbed(class="Gedmo\Tests\References\Fixture\ODM\MongoDB\Product", identifier="metadatas.categoryId")
      */
     #[Gedmo\ReferenceManyEmbed(class: Product::class, identifier: 'metadatas.categoryId')]
-    private $products;
+    private Collection $products;
 
     public function __construct()
     {

--- a/tests/Gedmo/References/Fixture/ORM/StockItem.php
+++ b/tests/Gedmo/References/Fixture/ORM/StockItem.php
@@ -35,44 +35,34 @@ class StockItem
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column
      */
     #[ORM\Column]
-    private $name;
+    private ?string $name = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column
      */
     #[ORM\Column]
-    private $sku;
+    private ?string $sku = null;
 
     /**
-     * @var int|null
-     *
      * @ORM\Column(type="integer")
      */
     #[ORM\Column(type: Types::INTEGER)]
-    private $quantity;
+    private ?int $quantity = null;
 
     /**
-     * @var Product|null
-     *
      * @Gedmo\ReferenceOne(type="document", class="Gedmo\Tests\References\Fixture\ODM\MongoDB\Product", inversedBy="stockItems", identifier="productId")
      */
     #[Gedmo\ReferenceOne(type: 'document', class: Product::class, inversedBy: 'stockItems', identifier: 'productId')]
-    private $product;
+    private ?Product $product = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(type="string")
      */
     #[ORM\Column(type: Types::STRING)]
-    private $productId;
+    private ?string $productId = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/References/LazyCollectionTest.php
+++ b/tests/Gedmo/References/LazyCollectionTest.php
@@ -19,9 +19,7 @@ final class LazyCollectionTest extends TestCase
 {
     public function testCallback(): void
     {
-        $collection = new LazyCollection(static function (): Collection {
-            return new ArrayCollection(['1', '2']);
-        });
+        $collection = new LazyCollection(static fn (): Collection => new ArrayCollection(['1', '2']));
 
         static::assertCount(2, $collection);
     }

--- a/tests/Gedmo/References/ReferencesListenerTest.php
+++ b/tests/Gedmo/References/ReferencesListenerTest.php
@@ -23,15 +23,9 @@ use Gedmo\Tests\Tool\BaseTestCaseOM;
 
 final class ReferencesListenerTest extends BaseTestCaseOM
 {
-    /**
-     * @var EntityManager
-     */
-    private $em;
+    private EntityManager $em;
 
-    /**
-     * @var DocumentManager
-     */
-    private $dm;
+    private DocumentManager $dm;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Sluggable/Fixture/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Article.php
@@ -35,30 +35,24 @@ class Article implements Sluggable
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="code", type="string", length=16)
      */
     #[ORM\Column(name: 'code', type: Types::STRING, length: 16)]
-    private $code;
+    private ?string $code = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Slug(separator="-", updatable=true, fields={"title", "code"})
      * @ORM\Column(name="slug", type="string", length=64, unique=true)
      */
     #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title', 'code'])]
     #[ORM\Column(name: 'slug', type: Types::STRING, length: 64, unique: true)]
-    private $slug;
+    private ?string $slug = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Sluggable/Fixture/ArticleWithoutFields.php
+++ b/tests/Gedmo/Sluggable/Fixture/ArticleWithoutFields.php
@@ -35,14 +35,12 @@ class ArticleWithoutFields implements Sluggable
     private $id;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Slug(separator="-", updatable=true)
      * @ORM\Column(name="slug", type="string", length=64, unique=true)
      */
     #[Gedmo\Slug(separator: '-', updatable: true)]
     #[ORM\Column(name: 'slug', type: Types::STRING, length: 64, unique: true)]
-    private $slug;
+    private ?string $slug = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Sluggable/Fixture/Comment.php
+++ b/tests/Gedmo/Sluggable/Fixture/Comment.php
@@ -33,20 +33,16 @@ class Comment
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(type="text")
      */
     #[ORM\Column(type: Types::TEXT)]
-    private $message;
+    private ?string $message = null;
 
     /**
-     * @var TranslatableArticle|null
-     *
      * @ORM\ManyToOne(targetEntity="TranslatableArticle", inversedBy="comments")
      */
     #[ORM\ManyToOne(targetEntity: TranslatableArticle::class, inversedBy: 'comments')]
-    private $article;
+    private ?TranslatableArticle $article = null;
 
     public function setArticle(TranslatableArticle $article): void
     {

--- a/tests/Gedmo/Sluggable/Fixture/ConfigurationArticle.php
+++ b/tests/Gedmo/Sluggable/Fixture/ConfigurationArticle.php
@@ -35,30 +35,24 @@ class ConfigurationArticle implements Sluggable
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="code", type="string", length=16)
      */
     #[ORM\Column(name: 'code', type: Types::STRING, length: 16)]
-    private $code;
+    private ?string $code = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Slug(updatable=false, unique=false, unique_base=null, fields={"title", "code"})
      * @ORM\Column(name="slug", type="string", length=32)
      */
     #[Gedmo\Slug(updatable: false, unique: false, unique_base: null, fields: ['title', 'code'])]
     #[ORM\Column(name: 'slug', type: Types::STRING, length: 32)]
-    private $slug;
+    private ?string $slug = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDate.php
+++ b/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDate.php
@@ -35,30 +35,24 @@ class ArticleDate implements Sluggable
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var \DateTime|null
-     *
      * @ORM\Column(name="created_at", type="date")
      */
     #[ORM\Column(name: 'created_at', type: Types::DATE_MUTABLE)]
-    private $createdAt;
+    private ?\DateTime $createdAt = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Slug(separator="-", updatable=true, fields={"title", "createdAt"}, dateFormat="Y-m-d")
      * @ORM\Column(name="slug", type="string", length=64, unique=true)
      */
     #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title', 'createdAt'], dateFormat: 'Y-m-d')]
     #[ORM\Column(name: 'slug', type: Types::STRING, length: 64, unique: true)]
-    private $slug;
+    private ?string $slug = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateImmutable.php
+++ b/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateImmutable.php
@@ -35,30 +35,24 @@ class ArticleDateImmutable implements Sluggable
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var \DateTimeImmutable|null
-     *
      * @ORM\Column(name="created_at", type="date_immutable")
      */
     #[ORM\Column(name: 'created_at', type: Types::DATE_IMMUTABLE)]
-    private $createdAt;
+    private ?\DateTimeImmutable $createdAt = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Slug(separator="-", updatable=true, fields={"title", "createdAt"}, dateFormat="Y-m-d")
      * @ORM\Column(name="slug", type="string", length=64, unique=true)
      */
     #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title', 'createdAt'], dateFormat: 'Y-m-d')]
     #[ORM\Column(name: 'slug', type: Types::STRING, length: 64, unique: true)]
-    private $slug;
+    private ?string $slug = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateTime.php
+++ b/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateTime.php
@@ -35,30 +35,24 @@ class ArticleDateTime implements Sluggable
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var \DateTime|null
-     *
      * @ORM\Column(name="created_at", type="datetime")
      */
     #[ORM\Column(name: 'created_at', type: Types::DATETIME_MUTABLE)]
-    private $createdAt;
+    private ?\DateTime $createdAt = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Slug(separator="-", updatable=true, fields={"title", "createdAt"}, dateFormat="Y-m-d")
      * @ORM\Column(name="slug", type="string", length=64, unique=true)
      */
     #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title', 'createdAt'], dateFormat: 'Y-m-d')]
     #[ORM\Column(name: 'slug', type: Types::STRING, length: 64, unique: true)]
-    private $slug;
+    private ?string $slug = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateTimeImmutable.php
+++ b/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateTimeImmutable.php
@@ -35,30 +35,24 @@ class ArticleDateTimeImmutable implements Sluggable
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var \DateTimeImmutable|null
-     *
      * @ORM\Column(name="created_at", type="datetime_immutable")
      */
     #[ORM\Column(name: 'created_at', type: Types::DATETIME_IMMUTABLE)]
-    private $createdAt;
+    private ?\DateTimeImmutable $createdAt = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Slug(separator="-", updatable=true, fields={"title", "createdAt"}, dateFormat="Y-m-d")
      * @ORM\Column(name="slug", type="string", length=64, unique=true)
      */
     #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title', 'createdAt'], dateFormat: 'Y-m-d')]
     #[ORM\Column(name: 'slug', type: Types::STRING, length: 64, unique: true)]
-    private $slug;
+    private ?string $slug = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateTimeTz.php
+++ b/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateTimeTz.php
@@ -35,30 +35,24 @@ class ArticleDateTimeTz implements Sluggable
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var \DateTime|null
-     *
      * @ORM\Column(name="created_at", type="datetimetz")
      */
     #[ORM\Column(name: 'created_at', type: Types::DATETIMETZ_MUTABLE)]
-    private $createdAt;
+    private ?\DateTime $createdAt = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Slug(separator="-", updatable=true, fields={"title", "createdAt"}, dateFormat="Y-m-d")
      * @ORM\Column(name="slug", type="string", length=64, unique=true)
      */
     #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title', 'createdAt'], dateFormat: 'Y-m-d')]
     #[ORM\Column(name: 'slug', type: Types::STRING, length: 64, unique: true)]
-    private $slug;
+    private ?string $slug = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateTimeTzImmutable.php
+++ b/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateTimeTzImmutable.php
@@ -35,30 +35,24 @@ class ArticleDateTimeTzImmutable implements Sluggable
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var \DateTimeImmutable|null
-     *
      * @ORM\Column(name="created_at", type="datetimetz_immutable")
      */
     #[ORM\Column(name: 'created_at', type: Types::DATETIMETZ_IMMUTABLE)]
-    private $createdAt;
+    private ?\DateTimeImmutable $createdAt = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Slug(separator="-", updatable=true, fields={"title", "createdAt"}, dateFormat="Y-m-d")
      * @ORM\Column(name="slug", type="string", length=64, unique=true)
      */
     #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title', 'createdAt'], dateFormat: 'Y-m-d')]
     #[ORM\Column(name: 'slug', type: Types::STRING, length: 64, unique: true)]
-    private $slug;
+    private ?string $slug = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Sluggable/Fixture/Document/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Document/Article.php
@@ -30,20 +30,16 @@ class Article
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: Type::STRING)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: Type::STRING)]
-    private $code;
+    private ?string $code = null;
 
     /**
      * @var string|null

--- a/tests/Gedmo/Sluggable/Fixture/Document/Handler/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Document/Handler/Article.php
@@ -31,20 +31,16 @@ class Article
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: Type::STRING)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: Type::STRING)]
-    private $code;
+    private ?string $code = null;
 
     /**
      * @var string|null

--- a/tests/Gedmo/Sluggable/Fixture/Document/Handler/RelativeSlug.php
+++ b/tests/Gedmo/Sluggable/Fixture/Document/Handler/RelativeSlug.php
@@ -31,12 +31,10 @@ class RelativeSlug
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: Type::STRING)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var string|null
@@ -56,12 +54,10 @@ class RelativeSlug
     private $alias;
 
     /**
-     * @var Article|null
-     *
      * @ODM\ReferenceOne(targetDocument="Gedmo\Tests\Sluggable\Fixture\Document\Handler\Article")
      */
     #[ODM\ReferenceOne(targetDocument: Article::class)]
-    private $article;
+    private ?Article $article = null;
 
     public function setArticle(?Article $article = null): void
     {

--- a/tests/Gedmo/Sluggable/Fixture/Document/Handler/TreeSlug.php
+++ b/tests/Gedmo/Sluggable/Fixture/Document/Handler/TreeSlug.php
@@ -31,12 +31,10 @@ class TreeSlug
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: Type::STRING)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var string|null
@@ -55,12 +53,10 @@ class TreeSlug
     private $alias;
 
     /**
-     * @var TreeSlug|null
-     *
      * @ODM\ReferenceOne(targetDocument="TreeSlug")
      */
     #[ODM\ReferenceOne(targetDocument: self::class)]
-    private $parent;
+    private ?\Gedmo\Tests\Sluggable\Fixture\Document\Handler\TreeSlug $parent = null;
 
     public function setParent(?self $parent = null): void
     {

--- a/tests/Gedmo/Sluggable/Fixture/Handler/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Handler/Article.php
@@ -36,20 +36,16 @@ class Article implements Sluggable
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="code", type="string", length=16)
      */
     #[ORM\Column(name: 'code', type: Types::STRING, length: 16)]
-    private $code;
+    private ?string $code = null;
 
     /**
      * @var string|null

--- a/tests/Gedmo/Sluggable/Fixture/Handler/ArticleRelativeSlug.php
+++ b/tests/Gedmo/Sluggable/Fixture/Handler/ArticleRelativeSlug.php
@@ -35,12 +35,10 @@ class ArticleRelativeSlug
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(length=64)
      */
     #[ORM\Column(length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var string|null
@@ -60,12 +58,10 @@ class ArticleRelativeSlug
     private $slug;
 
     /**
-     * @var Article|null
-     *
      * @ORM\ManyToOne(targetEntity="Article")
      */
     #[ORM\ManyToOne(targetEntity: Article::class)]
-    private $article;
+    private ?Article $article = null;
 
     public function setArticle(?Article $article = null): void
     {

--- a/tests/Gedmo/Sluggable/Fixture/Handler/Company.php
+++ b/tests/Gedmo/Sluggable/Fixture/Handler/Company.php
@@ -35,12 +35,10 @@ class Company
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(length=64)
      */
     #[ORM\Column(length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var string|null

--- a/tests/Gedmo/Sluggable/Fixture/Handler/People/Occupation.php
+++ b/tests/Gedmo/Sluggable/Fixture/Handler/People/Occupation.php
@@ -41,12 +41,10 @@ class Occupation
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(length=64)
      */
     #[ORM\Column(length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var string|null
@@ -71,8 +69,6 @@ class Occupation
     private $slug;
 
     /**
-     * @var Occupation|null
-     *
      * @Gedmo\TreeParent
      * @ORM\ManyToOne(targetEntity="Occupation")
      * @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
@@ -80,12 +76,12 @@ class Occupation
     #[ORM\ManyToOne(targetEntity: self::class)]
     #[ORM\JoinColumn(name: 'parent_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
     #[Gedmo\TreeParent]
-    private $parent;
+    private ?\Gedmo\Tests\Sluggable\Fixture\Handler\People\Occupation $parent = null;
 
     /**
      * @var Collection<int, self>
      */
-    private $children;
+    private Collection $children;
 
     /**
      * @var int|null

--- a/tests/Gedmo/Sluggable/Fixture/Handler/People/Person.php
+++ b/tests/Gedmo/Sluggable/Fixture/Handler/People/Person.php
@@ -35,12 +35,10 @@ class Person
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(length=64)
      */
     #[ORM\Column(length: 64)]
-    private $name;
+    private ?string $name = null;
 
     /**
      * @var string|null
@@ -60,12 +58,10 @@ class Person
     private $slug;
 
     /**
-     * @var Occupation|null
-     *
      * @ORM\ManyToOne(targetEntity="Occupation")
      */
     #[ORM\ManyToOne(targetEntity: Occupation::class)]
-    private $occupation;
+    private ?Occupation $occupation = null;
 
     public function setOccupation(?Occupation $occupation = null): void
     {

--- a/tests/Gedmo/Sluggable/Fixture/Handler/TreeSlug.php
+++ b/tests/Gedmo/Sluggable/Fixture/Handler/TreeSlug.php
@@ -41,12 +41,10 @@ class TreeSlug implements Node
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var string|null
@@ -65,8 +63,6 @@ class TreeSlug implements Node
     private $slug;
 
     /**
-     * @var self|null
-     *
      * @Gedmo\TreeParent
      * @ORM\ManyToOne(targetEntity="TreeSlug")
      * @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
@@ -74,12 +70,12 @@ class TreeSlug implements Node
     #[ORM\ManyToOne(targetEntity: self::class)]
     #[ORM\JoinColumn(name: 'parent_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
     #[Gedmo\TreeParent]
-    private $parent;
+    private ?\Gedmo\Tests\Sluggable\Fixture\Handler\TreeSlug $parent = null;
 
     /**
      * @var Collection<int, self>
      */
-    private $children;
+    private Collection $children;
 
     /**
      * @var int|null
@@ -121,10 +117,7 @@ class TreeSlug implements Node
     #[Gedmo\TreeLevel]
     private $level;
 
-    /**
-     * @var Node|null
-     */
-    private $sibling;
+    private ?Node $sibling = null;
 
     public function __construct()
     {

--- a/tests/Gedmo/Sluggable/Fixture/Handler/TreeSlugPrefixSuffix.php
+++ b/tests/Gedmo/Sluggable/Fixture/Handler/TreeSlugPrefixSuffix.php
@@ -40,12 +40,10 @@ class TreeSlugPrefixSuffix
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var string|null
@@ -66,8 +64,6 @@ class TreeSlugPrefixSuffix
     private $slug;
 
     /**
-     * @var self|null
-     *
      * @Gedmo\TreeParent
      * @ORM\ManyToOne(targetEntity="TreeSlugPrefixSuffix")
      * @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
@@ -75,12 +71,12 @@ class TreeSlugPrefixSuffix
     #[ORM\ManyToOne(targetEntity: self::class)]
     #[ORM\JoinColumn(name: 'parent_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
     #[Gedmo\TreeParent]
-    private $parent;
+    private ?\Gedmo\Tests\Sluggable\Fixture\Handler\TreeSlugPrefixSuffix $parent = null;
 
     /**
      * @var Collection<int, self>
      */
-    private $children;
+    private Collection $children;
 
     /**
      * @var int|null

--- a/tests/Gedmo/Sluggable/Fixture/Handler/User.php
+++ b/tests/Gedmo/Sluggable/Fixture/Handler/User.php
@@ -35,12 +35,10 @@ class User
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(length=64)
      */
     #[ORM\Column(length: 64)]
-    private $username;
+    private ?string $username = null;
 
     /**
      * @var string|null
@@ -60,12 +58,10 @@ class User
     private $slug;
 
     /**
-     * @var Company|null
-     *
      * @ORM\ManyToOne(targetEntity="Company")
      */
     #[ORM\ManyToOne(targetEntity: Company::class)]
-    private $company;
+    private ?Company $company = null;
 
     public function setCompany(?Company $company = null): void
     {

--- a/tests/Gedmo/Sluggable/Fixture/Identifier.php
+++ b/tests/Gedmo/Sluggable/Fixture/Identifier.php
@@ -33,12 +33,10 @@ class Identifier
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(length=32)
      */
     #[ORM\Column(length: 32)]
-    private $title;
+    private ?string $title = null;
 
     public function getId(): ?string
     {

--- a/tests/Gedmo/Sluggable/Fixture/Inheritance/Car.php
+++ b/tests/Gedmo/Sluggable/Fixture/Inheritance/Car.php
@@ -20,12 +20,10 @@ use Doctrine\ORM\Mapping as ORM;
 class Car extends Vehicle
 {
     /**
-     * @var string|null
-     *
      * @ORM\Column(length=128)
      */
     #[ORM\Column(length: 128)]
-    private $description;
+    private ?string $description = null;
 
     public function setDescription(?string $description): void
     {

--- a/tests/Gedmo/Sluggable/Fixture/Inheritance/Vehicle.php
+++ b/tests/Gedmo/Sluggable/Fixture/Inheritance/Vehicle.php
@@ -43,12 +43,10 @@ class Vehicle
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(length=128)
      */
     #[ORM\Column(length: 128)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var string|null

--- a/tests/Gedmo/Sluggable/Fixture/Inheritance2/Car.php
+++ b/tests/Gedmo/Sluggable/Fixture/Inheritance2/Car.php
@@ -29,12 +29,10 @@ class Car extends Vehicle
     protected $title;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(length=128)
      */
     #[ORM\Column(length: 128)]
-    private $description;
+    private ?string $description = null;
 
     /**
      * @var string|null

--- a/tests/Gedmo/Sluggable/Fixture/Issue104/Bus.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue104/Bus.php
@@ -33,12 +33,10 @@ class Bus
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(length=128)
      */
     #[ORM\Column(length: 128)]
-    private $title;
+    private ?string $title = null;
 
     public function setTitle(?string $title): void
     {

--- a/tests/Gedmo/Sluggable/Fixture/Issue104/Car.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue104/Car.php
@@ -28,12 +28,10 @@ class Car extends Vehicle
     protected $title;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(length=128)
      */
     #[ORM\Column(length: 128)]
-    private $description;
+    private ?string $description = null;
 
     public function setDescription(?string $description): void
     {

--- a/tests/Gedmo/Sluggable/Fixture/Issue104/Icarus.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue104/Icarus.php
@@ -21,12 +21,10 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Icarus extends Bus
 {
     /**
-     * @var string|null
-     *
      * @ORM\Column(length=128)
      */
     #[ORM\Column(length: 128)]
-    private $description;
+    private ?string $description = null;
 
     /**
      * @var string|null

--- a/tests/Gedmo/Sluggable/Fixture/Issue1058/Page.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue1058/Page.php
@@ -34,32 +34,26 @@ class Page
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var User|null
-     *
      * @ORM\ManyToOne(targetEntity="Gedmo\Tests\Sluggable\Fixture\Issue1058\User")
      * @ORM\JoinColumn(nullable=false)
      */
     #[ORM\ManyToOne(targetEntity: User::class)]
     #[ORM\JoinColumn(nullable: false)]
-    private $user;
+    private ?User $user = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Slug(separator="-", fields={"title"}, unique=true, unique_base="user")
      * @ORM\Column(name="slug", type="string", length=64)
      */
     #[Gedmo\Slug(separator: '-', unique: true, unique_base: 'user', fields: ['title'])]
     #[ORM\Column(name: 'slug', type: Types::STRING, length: 64)]
-    private $slug;
+    private ?string $slug = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Sluggable/Fixture/Issue1151/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue1151/Article.php
@@ -22,30 +22,24 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Article
 {
     /**
-     * @var string|null
-     *
      * @ODM\Id(strategy="NONE")
      */
     #[ODM\Id(strategy: 'NONE')]
-    private $id;
+    private ?string $id = null;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: Type::STRING)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Slug(separator="-", updatable=true, fields={"title"})
      * @ODM\Field(type="string")
      */
     #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title'])]
     #[ODM\Field(type: Type::STRING)]
-    private $slug;
+    private ?string $slug = null;
 
     public function setId(?string $id): self
     {

--- a/tests/Gedmo/Sluggable/Fixture/Issue116/Country.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue116/Country.php
@@ -23,10 +23,7 @@ class Country
      */
     private $languageCode;
 
-    /**
-     * @var string|null
-     */
-    private $originalName;
+    private ?string $originalName = null;
 
     /**
      * @var string|null

--- a/tests/Gedmo/Sluggable/Fixture/Issue1177/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue1177/Article.php
@@ -35,22 +35,18 @@ class Article implements Sluggable
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Slug(separator="-", updatable=true, fields={"title"})
      * @ORM\Column(name="slug", type="string", length=64, unique=true)
      */
     #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title'])]
     #[ORM\Column(name: 'slug', type: Types::STRING, length: 64, unique: true)]
-    private $slug;
+    private ?string $slug = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Sluggable/Fixture/Issue1240/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue1240/Article.php
@@ -35,32 +35,26 @@ class Article implements Sluggable
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Slug(separator="+", updatable=true, fields={"title"})
      * @ORM\Column(name="slug", type="string", length=64, unique=true)
      */
     #[Gedmo\Slug(separator: '+', updatable: true, fields: ['title'])]
     #[ORM\Column(name: 'slug', type: Types::STRING, length: 64, unique: true)]
-    private $slug;
+    private ?string $slug = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Slug(separator="+", updatable=true, fields={"title"}, style="camel")
      * @ORM\Column(name="camel_slug", type="string", length=64, unique=true)
      */
     #[ORM\Column(name: 'camel_slug', type: Types::STRING, length: 64, unique: true)]
     #[Gedmo\Slug(separator: '+', updatable: true, fields: ['title'], style: 'camel')]
-    private $camelSlug;
+    private ?string $camelSlug = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Sluggable/Fixture/Issue131/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue131/Article.php
@@ -34,12 +34,10 @@ class Article
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(length=64)
      */
     #[ORM\Column(length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var string|null

--- a/tests/Gedmo/Sluggable/Fixture/Issue449/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue449/Article.php
@@ -37,38 +37,30 @@ class Article implements Sluggable
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="code", type="string", length=16)
      */
     #[ORM\Column(name: 'code', type: Types::STRING, length: 16)]
-    private $code;
+    private ?string $code = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Slug(separator="-", updatable=true, fields={"title", "code"})
      * @ORM\Column(name="slug", type="string", length=64, unique=true)
      */
     #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title', 'code'])]
     #[ORM\Column(name: 'slug', type: Types::STRING, length: 64, unique: true)]
-    private $slug;
+    private ?string $slug = null;
 
     /**
-     * @var \DateTime|null
-     *
      * @ORM\Column(name="deletedAt", type="datetime", nullable=true)
      */
     #[ORM\Column(name: 'deletedAt', type: Types::DATETIME_MUTABLE, nullable: true)]
-    private $deletedAt;
+    private ?\DateTime $deletedAt = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Sluggable/Fixture/Issue633/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue633/Article.php
@@ -34,20 +34,16 @@ class Article
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="code", type="string", length=16)
      */
     #[ORM\Column(name: 'code', type: Types::STRING, length: 16)]
-    private $code;
+    private ?string $code = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", length=64)
      */
     #[ORM\Column(name: 'title', length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var string|null

--- a/tests/Gedmo/Sluggable/Fixture/Issue827/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue827/Article.php
@@ -34,22 +34,18 @@ class Article
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", length=64)
      */
     #[ORM\Column(name: 'title', length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var Category|null
-     *
      * @ORM\ManyToOne(targetEntity="Category", inversedBy="articles")
      * @ORM\JoinColumn(name="category_id", referencedColumnName="id", nullable=false)
      */
     #[ORM\ManyToOne(targetEntity: Category::class, inversedBy: 'articles')]
     #[ORM\JoinColumn(name: 'category_id', referencedColumnName: 'id', nullable: false)]
-    private $category;
+    private ?Category $category = null;
 
     /**
      * @var string|null

--- a/tests/Gedmo/Sluggable/Fixture/Issue827/Category.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue827/Category.php
@@ -36,12 +36,10 @@ class Category
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", length=64)
      */
     #[ORM\Column(name: 'title', length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var string|null
@@ -59,7 +57,7 @@ class Category
      * @ORM\OneToMany(targetEntity="Article", mappedBy="category")
      */
     #[ORM\OneToMany(targetEntity: Article::class, mappedBy: 'category')]
-    private $articles;
+    private Collection $articles;
 
     public function __construct()
     {

--- a/tests/Gedmo/Sluggable/Fixture/Issue827/Comment.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue827/Comment.php
@@ -34,16 +34,12 @@ class Comment
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", length=64)
      */
     #[ORM\Column(name: 'title', length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var Post|null
-     *
      * @ORM\ManyToOne(targetEntity="Post", inversedBy="comments")
      * @ORM\JoinColumns({
      *     @ORM\JoinColumn(name="post_title", referencedColumnName="title", nullable=false),
@@ -53,7 +49,7 @@ class Comment
     #[ORM\ManyToOne(targetEntity: Post::class, inversedBy: 'comments')]
     #[ORM\JoinColumn(name: 'post_title', referencedColumnName: 'title', nullable: false)]
     #[ORM\JoinColumn(name: 'post_slug', referencedColumnName: 'slug', nullable: false)]
-    private $post;
+    private ?Post $post = null;
 
     /**
      * @var string|null

--- a/tests/Gedmo/Sluggable/Fixture/Issue827/Post.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue827/Post.php
@@ -23,14 +23,12 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Post
 {
     /**
-     * @var string|null
-     *
      * @ORM\Id
      * @ORM\Column(name="title", unique=true, length=64)
      */
     #[ORM\Id]
     #[ORM\Column(name: 'title', unique: true, length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var string|null
@@ -50,7 +48,7 @@ class Post
      * @ORM\OneToMany(targetEntity="Comment", mappedBy="post")
      */
     #[ORM\OneToMany(targetEntity: Comment::class, mappedBy: 'post')]
-    private $comments;
+    private Collection $comments;
 
     public function __construct()
     {

--- a/tests/Gedmo/Sluggable/Fixture/Issue939/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue939/Article.php
@@ -34,22 +34,18 @@ class Article
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", length=64)
      */
     #[ORM\Column(name: 'title', length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var Category|null
-     *
      * @ORM\ManyToOne(targetEntity="Category", inversedBy="articles")
      * @ORM\JoinColumn(name="category_id", referencedColumnName="id", nullable=false)
      */
     #[ORM\ManyToOne(targetEntity: Category::class, inversedBy: 'articles')]
     #[ORM\JoinColumn(name: 'category_id', referencedColumnName: 'id', nullable: false)]
-    private $category;
+    private ?Category $category = null;
 
     /**
      * @var string|null

--- a/tests/Gedmo/Sluggable/Fixture/Issue939/Category.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue939/Category.php
@@ -36,12 +36,10 @@ class Category
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", length=64)
      */
     #[ORM\Column(name: 'title', length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var string|null
@@ -59,7 +57,7 @@ class Category
      * @ORM\OneToMany(targetEntity="Article", mappedBy="category")
      */
     #[ORM\OneToMany(targetEntity: Article::class, mappedBy: 'category')]
-    private $articles;
+    private Collection $articles;
 
     public function __construct()
     {

--- a/tests/Gedmo/Sluggable/Fixture/MappedSuperclass/Car.php
+++ b/tests/Gedmo/Sluggable/Fixture/MappedSuperclass/Car.php
@@ -33,12 +33,10 @@ class Car extends Vehicle
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(length=128)
      */
     #[ORM\Column(length: 128)]
-    private $description;
+    private ?string $description = null;
 
     public function setDescription(?string $description): void
     {

--- a/tests/Gedmo/Sluggable/Fixture/MappedSuperclass/Vehicle.php
+++ b/tests/Gedmo/Sluggable/Fixture/MappedSuperclass/Vehicle.php
@@ -26,12 +26,10 @@ class Vehicle
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(length=128)
      */
     #[ORM\Column(length: 128)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var string|null

--- a/tests/Gedmo/Sluggable/Fixture/Page.php
+++ b/tests/Gedmo/Sluggable/Fixture/Page.php
@@ -36,12 +36,10 @@ class Page
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(type="string", length=191)
      */
     #[ORM\Column(type: Types::STRING, length: 191)]
-    private $content;
+    private ?string $content = null;
 
     /**
      * @var string|null

--- a/tests/Gedmo/Sluggable/Fixture/Prefix.php
+++ b/tests/Gedmo/Sluggable/Fixture/Prefix.php
@@ -37,22 +37,18 @@ class Prefix implements Sluggable
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Slug(separator="-", updatable=true, fields={"title"}, prefix="test-")
      * @ORM\Column(name="slug", type="string", length=64, unique=true)
      */
     #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title'], prefix: 'test-')]
     #[ORM\Column(name: 'slug', type: Types::STRING, length: 64, unique: true)]
-    private $slug;
+    private ?string $slug = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Sluggable/Fixture/PrefixWithTreeHandler.php
+++ b/tests/Gedmo/Sluggable/Fixture/PrefixWithTreeHandler.php
@@ -41,16 +41,12 @@ class PrefixWithTreeHandler implements Sluggable
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Slug(handlers={
      *     @Gedmo\SlugHandler(class="Gedmo\Sluggable\Handler\TreeSlugHandler", options={
      *         @Gedmo\SlugHandlerOption(name="parentRelationField", value="parent"),
@@ -62,11 +58,9 @@ class PrefixWithTreeHandler implements Sluggable
     #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title'], prefix: 'test.')]
     #[Gedmo\SlugHandler(class: TreeSlugHandler::class, options: ['parentRelationField' => 'parent', 'separator' => '/'])]
     #[ORM\Column(name: 'slug', type: Types::STRING, length: 64, unique: true)]
-    private $slug;
+    private ?string $slug = null;
 
     /**
-     * @var PrefixWithTreeHandler|null
-     *
      * @Gedmo\TreeParent
      * @ORM\ManyToOne(targetEntity="PrefixWithTreeHandler")
      * @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
@@ -74,47 +68,39 @@ class PrefixWithTreeHandler implements Sluggable
     #[ORM\ManyToOne(targetEntity: self::class)]
     #[ORM\JoinColumn(name: 'parent_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
     #[Gedmo\TreeParent]
-    private $parent;
+    private ?\Gedmo\Tests\Sluggable\Fixture\PrefixWithTreeHandler $parent = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeLeft
      * @ORM\Column(name="lft", type="integer")
      */
     #[ORM\Column(name: 'lft', type: Types::INTEGER)]
     #[Gedmo\TreeLeft]
-    private $lft;
+    private ?int $lft = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeLevel
      * @ORM\Column(name="lvl", type="integer")
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER)]
     #[Gedmo\TreeLevel]
-    private $lvl;
+    private ?int $lvl = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeRight
      * @ORM\Column(name="rgt", type="integer")
      */
     #[ORM\Column(name: 'rgt', type: Types::INTEGER)]
     #[Gedmo\TreeRight]
-    private $rgt;
+    private ?int $rgt = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeRoot
      * @ORM\Column(name="root", type="integer", nullable=true)
      */
     #[ORM\Column(name: 'root', type: Types::INTEGER, nullable: true)]
     #[Gedmo\TreeRoot]
-    private $root;
+    private ?int $root = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Sluggable/Fixture/Suffix.php
+++ b/tests/Gedmo/Sluggable/Fixture/Suffix.php
@@ -37,22 +37,18 @@ class Suffix implements Sluggable
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Slug(separator="-", updatable=true, fields={"title"}, suffix=".test")
      * @ORM\Column(name="slug", type="string", length=64, unique=true)
      */
     #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title'], suffix: '.test')]
     #[ORM\Column(name: 'slug', type: Types::STRING, length: 64, unique: true)]
-    private $slug;
+    private ?string $slug = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Sluggable/Fixture/SuffixWithTreeHandler.php
+++ b/tests/Gedmo/Sluggable/Fixture/SuffixWithTreeHandler.php
@@ -41,16 +41,12 @@ class SuffixWithTreeHandler implements Sluggable
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Slug(handlers={
      *     @Gedmo\SlugHandler(class="Gedmo\Sluggable\Handler\TreeSlugHandler", options={
      *         @Gedmo\SlugHandlerOption(name="parentRelationField", value="parent"),
@@ -62,11 +58,9 @@ class SuffixWithTreeHandler implements Sluggable
     #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title'], suffix: '.test')]
     #[Gedmo\SlugHandler(class: TreeSlugHandler::class, options: ['parentRelationField' => 'parent', 'separator' => '/'])]
     #[ORM\Column(name: 'slug', type: Types::STRING, length: 64, unique: true)]
-    private $slug;
+    private ?string $slug = null;
 
     /**
-     * @var SuffixWithTreeHandler|null
-     *
      * @Gedmo\TreeParent
      * @ORM\ManyToOne(targetEntity="SuffixWithTreeHandler")
      * @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
@@ -74,47 +68,39 @@ class SuffixWithTreeHandler implements Sluggable
     #[ORM\ManyToOne(targetEntity: self::class)]
     #[ORM\JoinColumn(name: 'parent_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
     #[Gedmo\TreeParent]
-    private $parent;
+    private ?\Gedmo\Tests\Sluggable\Fixture\SuffixWithTreeHandler $parent = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeLeft
      * @ORM\Column(name="lft", type="integer")
      */
     #[ORM\Column(name: 'lft', type: Types::INTEGER)]
     #[Gedmo\TreeLeft]
-    private $lft;
+    private ?int $lft = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeLevel
      * @ORM\Column(name="lvl", type="integer")
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER)]
     #[Gedmo\TreeLevel]
-    private $lvl;
+    private ?int $lvl = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeRight
      * @ORM\Column(name="rgt", type="integer")
      */
     #[ORM\Column(name: 'rgt', type: Types::INTEGER)]
     #[Gedmo\TreeRight]
-    private $rgt;
+    private ?int $rgt = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeRoot
      * @ORM\Column(name="root", type="integer", nullable=true)
      */
     #[ORM\Column(name: 'root', type: Types::INTEGER, nullable: true)]
     #[Gedmo\TreeRoot]
-    private $root;
+    private ?int $root = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Sluggable/Fixture/TransArticleManySlug.php
+++ b/tests/Gedmo/Sluggable/Fixture/TransArticleManySlug.php
@@ -35,28 +35,21 @@ class TransArticleManySlug implements Sluggable, Translatable
     #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
-    /**
-     * @var int|null
-     */
-    private $page;
+    private ?int $page = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @ORM\Column(type="string", length=64)
      */
     #[ORM\Column(type: Types::STRING, length: 64)]
     #[Gedmo\Translatable]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(type="string", length=64)
      */
     #[ORM\Column(type: Types::STRING, length: 64)]
-    private $uniqueTitle;
+    private ?string $uniqueTitle = null;
 
     /**
      * @var string|null
@@ -69,14 +62,12 @@ class TransArticleManySlug implements Sluggable, Translatable
     private $uniqueSlug;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @ORM\Column(type="string", length=16)
      */
     #[ORM\Column(type: Types::STRING, length: 16)]
     #[Gedmo\Translatable]
-    private $code;
+    private ?string $code = null;
 
     /**
      * @var string|null
@@ -91,13 +82,11 @@ class TransArticleManySlug implements Sluggable, Translatable
     private $slug;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Locale
      * Used locale to override Translation listener`s locale
      */
     #[Gedmo\Locale]
-    private $locale;
+    private ?string $locale = null;
 
     public function setPage(?int $page): void
     {

--- a/tests/Gedmo/Sluggable/Fixture/TranslatableArticle.php
+++ b/tests/Gedmo/Sluggable/Fixture/TranslatableArticle.php
@@ -38,24 +38,20 @@ class TranslatableArticle implements Sluggable, Translatable
     private $id;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @ORM\Column(type="string", length=64)
      */
     #[ORM\Column(type: Types::STRING, length: 64)]
     #[Gedmo\Translatable]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @ORM\Column(type="string", length=16)
      */
     #[ORM\Column(type: Types::STRING, length: 16)]
     #[Gedmo\Translatable]
-    private $code;
+    private ?string $code = null;
 
     /**
      * @var string|null
@@ -78,21 +74,17 @@ class TranslatableArticle implements Sluggable, Translatable
     private $comments;
 
     /**
-     * @var Page|null
-     *
      * @ORM\ManyToOne(targetEntity="Page", inversedBy="articles")
      */
     #[ORM\ManyToOne(targetEntity: Page::class, inversedBy: 'articles')]
-    private $page;
+    private ?Page $page = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Locale
      * Used locale to override Translation listener`s locale
      */
     #[Gedmo\Language]
-    private $locale;
+    private ?string $locale = null;
 
     public function __construct()
     {

--- a/tests/Gedmo/Sluggable/Issue/Issue449Test.php
+++ b/tests/Gedmo/Sluggable/Issue/Issue449Test.php
@@ -30,10 +30,7 @@ final class Issue449Test extends BaseTestCaseORM
     private const TARGET = Article::class;
     private const SOFT_DELETEABLE_FILTER_NAME = 'soft-deleteable';
 
-    /**
-     * @var SoftDeleteableListener
-     */
-    private $softDeleteableListener;
+    private SoftDeleteableListener $softDeleteableListener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Sluggable/SluggableConfigurationTest.php
+++ b/tests/Gedmo/Sluggable/SluggableConfigurationTest.php
@@ -26,10 +26,7 @@ final class SluggableConfigurationTest extends BaseTestCaseORM
 {
     private const ARTICLE = ConfigurationArticle::class;
 
-    /**
-     * @var int|null
-     */
-    private $articleId;
+    private ?int $articleId = null;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Sluggable/SluggableTest.php
+++ b/tests/Gedmo/Sluggable/SluggableTest.php
@@ -27,10 +27,7 @@ use Gedmo\Tests\Tool\BaseTestCaseORM;
  */
 final class SluggableTest extends BaseTestCaseORM
 {
-    /**
-     * @var int|null
-     */
-    private $articleId;
+    private ?int $articleId = null;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Sluggable/TranslatableManySlugTest.php
+++ b/tests/Gedmo/Sluggable/TranslatableManySlugTest.php
@@ -30,15 +30,9 @@ final class TranslatableManySlugTest extends BaseTestCaseORM
     private const ARTICLE = TransArticleManySlug::class;
     private const TRANSLATION = Translation::class;
 
-    /**
-     * @var int|null
-     */
-    private $articleId;
+    private ?int $articleId = null;
 
-    /**
-     * @var TranslatableListener
-     */
-    private $translatableListener;
+    private TranslatableListener $translatableListener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Sluggable/TranslatableSlugTest.php
+++ b/tests/Gedmo/Sluggable/TranslatableSlugTest.php
@@ -34,15 +34,9 @@ final class TranslatableSlugTest extends BaseTestCaseORM
     private const PAGE = Page::class;
     private const TRANSLATION = Translation::class;
 
-    /**
-     * @var int|null
-     */
-    private $articleId;
+    private ?int $articleId = null;
 
-    /**
-     * @var TranslatableListener
-     */
-    private $translatableListener;
+    private TranslatableListener $translatableListener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/SoftDeleteable/CarbonTest.php
+++ b/tests/Gedmo/SoftDeleteable/CarbonTest.php
@@ -26,10 +26,7 @@ final class CarbonTest extends BaseTestCaseORM
     private const COMMENT_CLASS = Comment::class;
     private const SOFT_DELETEABLE_FILTER_NAME = 'soft-deleteable';
 
-    /**
-     * @var SoftDeleteableListener
-     */
-    private $softDeleteableListener;
+    private SoftDeleteableListener $softDeleteableListener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/SoftDeleteable/Fixture/Document/User.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Document/User.php
@@ -39,12 +39,10 @@ class User
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: Type::STRING)]
-    private $username;
+    private ?string $username = null;
 
     public function setDeletedAt(\DateTime $deletedAt): self
     {

--- a/tests/Gedmo/SoftDeleteable/Fixture/Document/UserTimeAware.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Document/UserTimeAware.php
@@ -39,12 +39,10 @@ class UserTimeAware
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: Type::STRING)]
-    private $username;
+    private ?string $username = null;
 
     public function setDeletedAt(\DateTime $deletedAt): self
     {

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/Address.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/Address.php
@@ -36,28 +36,22 @@ class Address
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(length=128)
      */
     #[ORM\Column(length: 128)]
-    private $street;
+    private ?string $street = null;
 
     /**
-     * @var \DateTime|null
-     *
      * @ORM\Column(type="datetime", nullable=true)
      */
     #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
-    private $deletedAt;
+    private ?\DateTime $deletedAt = null;
 
     /**
-     * @var Person|null
-     *
      * @ORM\OneToOne(targetEntity="Person", mappedBy="address", cascade={"remove"})
      */
     #[ORM\OneToOne(targetEntity: Person::class, mappedBy: 'address', cascade: ['remove'])]
-    private $owner;
+    private ?Person $owner = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/Article.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/Article.php
@@ -38,20 +38,16 @@ class Article
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string")
      */
     #[ORM\Column(name: 'title', type: Types::STRING)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var \DateTime|null
-     *
      * @ORM\Column(name="deletedAt", type="datetime", nullable=true)
      */
     #[ORM\Column(name: 'deletedAt', type: Types::DATETIME_MUTABLE, nullable: true)]
-    private $deletedAt;
+    private ?\DateTime $deletedAt = null;
 
     /**
      * @var Collection<int, Comment>

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/Child.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/Child.php
@@ -21,12 +21,10 @@ use Doctrine\ORM\Mapping as ORM;
 class Child extends MappedSuperclass
 {
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string")
      */
     #[ORM\Column(name: 'title', type: Types::STRING)]
-    private $title;
+    private ?string $title = null;
 
     public function setTitle(?string $title): void
     {

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/Comment.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/Comment.php
@@ -36,20 +36,16 @@ class Comment
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="comment", type="string")
      */
     #[ORM\Column(name: 'comment', type: Types::STRING)]
-    private $comment;
+    private ?string $comment = null;
 
     /**
-     * @var \DateTime|null
-     *
      * @ORM\Column(name="deletedAt", type="datetime", nullable=true)
      */
     #[ORM\Column(name: 'deletedAt', type: Types::DATETIME_MUTABLE, nullable: true)]
-    private $deletedAt;
+    private ?\DateTime $deletedAt = null;
 
     /**
      * @var Article|null

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/MappedSuperclass.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/MappedSuperclass.php
@@ -36,12 +36,10 @@ class MappedSuperclass
     private $id;
 
     /**
-     * @var \DateTime|null
-     *
      * @ORM\Column(name="deletedAt", type="datetime", nullable=true)
      */
     #[ORM\Column(name: 'deletedAt', type: Types::DATETIME_MUTABLE, nullable: true)]
-    private $deletedAt;
+    private ?\DateTime $deletedAt = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/Module.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/Module.php
@@ -36,28 +36,22 @@ class Module
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string")
      */
     #[ORM\Column(name: 'title', type: Types::STRING)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var \DateTime|null
-     *
      * @ORM\Column(name="deletedAt", type="datetime", nullable=true)
      */
     #[ORM\Column(name: 'deletedAt', type: Types::DATETIME_MUTABLE, nullable: true)]
-    private $deletedAt;
+    private ?\DateTime $deletedAt = null;
 
     /**
-     * @var Page|null
-     *
      * @ORM\ManyToOne(targetEntity="Page", inversedBy="modules")
      */
     #[ORM\ManyToOne(targetEntity: Page::class, inversedBy: 'modules')]
-    private $page;
+    private ?Page $page = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/OtherArticle.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/OtherArticle.php
@@ -38,20 +38,16 @@ class OtherArticle
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string")
      */
     #[ORM\Column(name: 'title', type: Types::STRING)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var \DateTime|null
-     *
      * @ORM\Column(name="deletedAt", type="datetime", nullable=true)
      */
     #[ORM\Column(name: 'deletedAt', type: Types::DATETIME_MUTABLE, nullable: true)]
-    private $deletedAt;
+    private ?\DateTime $deletedAt = null;
 
     /**
      * @var Collection<int, OtherComment>

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/OtherComment.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/OtherComment.php
@@ -33,25 +33,18 @@ class OtherComment
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="comment", type="string")
      */
     #[ORM\Column(name: 'comment', type: Types::STRING)]
-    private $comment;
+    private ?string $comment = null;
 
     /**
-     * @var OtherArticle|null
-     *
      * @ORM\ManyToOne(targetEntity="OtherArticle", inversedBy="comments")
      */
     #[ORM\ManyToOne(targetEntity: OtherArticle::class, inversedBy: 'comments')]
-    private $article;
+    private ?OtherArticle $article = null;
 
-    /**
-     * @var \DateTimeInterface|null
-     */
-    private $deletedAt;
+    private ?\DateTimeInterface $deletedAt = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/Page.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/Page.php
@@ -44,20 +44,16 @@ class Page
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string")
      */
     #[ORM\Column(name: 'title', type: Types::STRING)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var \DateTime|null
-     *
      * @ORM\Column(name="deletedAt", type="datetime", nullable=true)
      */
     #[ORM\Column(name: 'deletedAt', type: Types::DATETIME_MUTABLE, nullable: true)]
-    private $deletedAt;
+    private ?\DateTime $deletedAt = null;
 
     /**
      * @var Collection<int, Module>

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/Person.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/Person.php
@@ -36,28 +36,22 @@ class Person
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(length=32)
      */
     #[ORM\Column(length: 32)]
-    private $name;
+    private ?string $name = null;
 
     /**
-     * @var \DateTime|null
-     *
      * @ORM\Column(name="deletedAt", type="datetime", nullable=true)
      */
     #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
-    private $deletedAt;
+    private ?\DateTime $deletedAt = null;
 
     /**
-     * @var Address|null
-     *
      * @ORM\OneToOne(targetEntity="Address", inversedBy="owner", cascade={"remove"})
      */
     #[ORM\OneToOne(targetEntity: Address::class, inversedBy: 'owner', cascade: ['remove'])]
-    private $address;
+    private ?Address $address = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/User.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/User.php
@@ -36,20 +36,16 @@ class User
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string")
      */
     #[ORM\Column(name: 'title', type: Types::STRING)]
-    private $username;
+    private ?string $username = null;
 
     /**
-     * @var \DateTime|null
-     *
      * @ORM\Column(name="deleted_time", type="datetime", nullable=true)
      */
     #[ORM\Column(name: 'deleted_time', type: Types::DATETIME_MUTABLE, nullable: true)]
-    private $deletedAt;
+    private ?\DateTime $deletedAt = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/UserNoHardDelete.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/UserNoHardDelete.php
@@ -36,20 +36,16 @@ class UserNoHardDelete
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string")
      */
     #[ORM\Column(name: 'title', type: Types::STRING)]
-    private $username;
+    private ?string $username = null;
 
     /**
-     * @var \DateTime|null
-     *
      * @ORM\Column(name="deleted_time", type="datetime", nullable=true)
      */
     #[ORM\Column(name: 'deleted_time', type: Types::DATETIME_MUTABLE, nullable: true)]
-    private $deletedAt;
+    private ?\DateTime $deletedAt = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/SoftDeleteable/SoftDeleteableDocumentTest.php
+++ b/tests/Gedmo/SoftDeleteable/SoftDeleteableDocumentTest.php
@@ -32,10 +32,7 @@ final class SoftDeleteableDocumentTest extends BaseTestCaseMongoODM
     private const USER__TIME_AWARE_CLASS = UserTimeAware::class;
     private const SOFT_DELETEABLE_FILTER_NAME = 'soft-deleteable';
 
-    /**
-     * @var SoftDeleteableListener
-     */
-    private $softDeleteableListener;
+    private SoftDeleteableListener $softDeleteableListener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/SoftDeleteable/SoftDeleteableEntityTest.php
+++ b/tests/Gedmo/SoftDeleteable/SoftDeleteableEntityTest.php
@@ -51,10 +51,7 @@ final class SoftDeleteableEntityTest extends BaseTestCaseORM
     private const SOFT_DELETEABLE_FILTER_NAME = 'soft-deleteable';
     private const USER_NO_HARD_DELETE_CLASS = UserNoHardDelete::class;
 
-    /**
-     * @var SoftDeleteableListener
-     */
-    private $softDeleteableListener;
+    private SoftDeleteableListener $softDeleteableListener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Sortable/Fixture/Author.php
+++ b/tests/Gedmo/Sortable/Fixture/Author.php
@@ -35,32 +35,26 @@ class Author
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="name", type="string")
      */
     #[ORM\Column(name: 'name', type: Types::STRING)]
-    private $name;
+    private ?string $name = null;
 
     /**
-     * @var Paper|null
-     *
      * @Gedmo\SortableGroup
      * @ORM\ManyToOne(targetEntity="Paper", inversedBy="authors")
      */
     #[Gedmo\SortableGroup]
     #[ORM\ManyToOne(targetEntity: Paper::class, inversedBy: 'authors')]
-    private $paper;
+    private ?Paper $paper = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\SortablePosition
      * @ORM\Column(name="position", type="integer")
      */
     #[Gedmo\SortablePosition]
     #[ORM\Column(name: 'position', type: Types::INTEGER)]
-    private $position;
+    private ?int $position = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Sortable/Fixture/Category.php
+++ b/tests/Gedmo/Sortable/Fixture/Category.php
@@ -35,12 +35,10 @@ class Category
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(type="string", length=191)
      */
     #[ORM\Column(type: Types::STRING, length: 191)]
-    private $name;
+    private ?string $name = null;
 
     /**
      * @var Collection<int, Item>
@@ -48,7 +46,7 @@ class Category
      * @ORM\OneToMany(targetEntity="Item", mappedBy="category")
      */
     #[ORM\OneToMany(mappedBy: 'category', targetEntity: Item::class)]
-    private $items;
+    private Collection $items;
 
     public function __construct()
     {

--- a/tests/Gedmo/Sortable/Fixture/Customer.php
+++ b/tests/Gedmo/Sortable/Fixture/Customer.php
@@ -33,20 +33,16 @@ class Customer
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="name", type="string")
      */
     #[ORM\Column(name: 'name', type: Types::STRING)]
-    private $name;
+    private ?string $name = null;
 
     /**
-     * @var CustomerType|null
-     *
      * @ORM\ManyToOne(targetEntity="CustomerType", inversedBy="customers")
      */
     #[ORM\ManyToOne(targetEntity: CustomerType::class, inversedBy: 'customers')]
-    private $type;
+    private ?CustomerType $type = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Sortable/Fixture/CustomerType.php
+++ b/tests/Gedmo/Sortable/Fixture/CustomerType.php
@@ -42,22 +42,18 @@ class CustomerType
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="name", type="string")
      */
     #[ORM\Column(name: 'name', type: Types::STRING)]
-    private $name;
+    private ?string $name = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\SortablePosition
      * @ORM\Column(name="position", type="integer")
      */
     #[Gedmo\SortablePosition]
     #[ORM\Column(name: 'position', type: Types::INTEGER)]
-    private $position;
+    private ?int $position = null;
 
     /**
      * @var Collection<int, Customer>
@@ -65,7 +61,7 @@ class CustomerType
      * @ORM\OneToMany(targetEntity="Customer", mappedBy="type")
      */
     #[ORM\OneToMany(mappedBy: 'type', targetEntity: Customer::class)]
-    private $customers;
+    private Collection $customers;
 
     public function __construct()
     {

--- a/tests/Gedmo/Sortable/Fixture/Document/Article.php
+++ b/tests/Gedmo/Sortable/Fixture/Document/Article.php
@@ -40,12 +40,10 @@ class Article
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: MongoDBType::STRING)]
-    private $title;
+    private ?string $title = null;
 
     public function getId(): ?string
     {

--- a/tests/Gedmo/Sortable/Fixture/Document/Category.php
+++ b/tests/Gedmo/Sortable/Fixture/Document/Category.php
@@ -29,12 +29,10 @@ class Category
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: MongoDBType::STRING)]
-    private $name;
+    private ?string $name = null;
 
     public function getId(): ?string
     {

--- a/tests/Gedmo/Sortable/Fixture/Document/Kid.php
+++ b/tests/Gedmo/Sortable/Fixture/Document/Kid.php
@@ -50,12 +50,10 @@ class Kid
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: MongoDBType::STRING)]
-    private $lastname;
+    private ?string $lastname = null;
 
     public function getId(): ?string
     {

--- a/tests/Gedmo/Sortable/Fixture/Document/Post.php
+++ b/tests/Gedmo/Sortable/Fixture/Document/Post.php
@@ -50,12 +50,10 @@ class Post
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: MongoDBType::STRING)]
-    private $title;
+    private ?string $title = null;
 
     public function getId(): ?string
     {

--- a/tests/Gedmo/Sortable/Fixture/Event.php
+++ b/tests/Gedmo/Sortable/Fixture/Event.php
@@ -35,32 +35,26 @@ class Event
     private $id;
 
     /**
-     * @var \DateTime
-     *
      * @Gedmo\SortableGroup
      * @ORM\Column(type="datetime")
      */
     #[Gedmo\SortableGroup]
     #[ORM\Column(type: Types::DATETIME_MUTABLE)]
-    private $dateTime;
+    private ?\DateTime $dateTime = null;
 
     /**
-     * @var string
-     *
      * @ORM\Column(type="string", length=191)
      */
     #[ORM\Column(type: Types::STRING, length: 191)]
-    private $name;
+    private ?string $name = null;
 
     /**
-     * @var int
-     *
      * @Gedmo\SortablePosition
      * @ORM\Column(type="integer")
      */
     #[Gedmo\SortablePosition]
     #[ORM\Column(type: Types::INTEGER)]
-    private $position;
+    private ?int $position = null;
 
     public function getId(): int
     {

--- a/tests/Gedmo/Sortable/Fixture/Item.php
+++ b/tests/Gedmo/Sortable/Fixture/Item.php
@@ -35,32 +35,26 @@ class Item
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(type="string", length=191)
      */
     #[ORM\Column(type: Types::STRING, length: 191)]
-    private $name;
+    private ?string $name = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\SortablePosition
      * @ORM\Column(type="integer")
      */
     #[Gedmo\SortablePosition]
     #[ORM\Column(type: Types::INTEGER)]
-    private $position;
+    private ?int $position = null;
 
     /**
-     * @var Category|null
-     *
      * @Gedmo\SortableGroup
      * @ORM\ManyToOne(targetEntity="Category", inversedBy="items")
      */
     #[Gedmo\SortableGroup]
     #[ORM\ManyToOne(targetEntity: Category::class, inversedBy: 'items')]
-    private $category;
+    private ?Category $category = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Sortable/Fixture/ItemWithDateColumn.php
+++ b/tests/Gedmo/Sortable/Fixture/ItemWithDateColumn.php
@@ -21,8 +21,6 @@ use Gedmo\Sortable\Entity\Repository\SortableRepository;
 class ItemWithDateColumn
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -30,27 +28,23 @@ class ItemWithDateColumn
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
-     * @var int
-     *
      * @Gedmo\SortablePosition
      * @ORM\Column(type="integer")
      */
     #[Gedmo\SortablePosition]
     #[ORM\Column(type: Types::INTEGER)]
-    private $position = 0;
+    private int $position = 0;
 
     /**
-     * @var \DateTime|null
-     *
      * @Gedmo\SortableGroup
      * @ORM\Column(type="date")
      */
     #[Gedmo\SortableGroup]
     #[ORM\Column(type: Types::DATE_MUTABLE)]
-    private $date;
+    private ?\DateTime $date = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Sortable/Fixture/Paper.php
+++ b/tests/Gedmo/Sortable/Fixture/Paper.php
@@ -35,12 +35,10 @@ class Paper
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="name", type="string")
      */
     #[ORM\Column(name: 'name', type: Types::STRING)]
-    private $name;
+    private ?string $name = null;
 
     /**
      * @var Collection<int, Author>
@@ -48,7 +46,7 @@ class Paper
      * @ORM\OneToMany(targetEntity="Author", mappedBy="paper", cascade={"persist", "remove"})
      */
     #[ORM\OneToMany(mappedBy: 'paper', targetEntity: Author::class, cascade: ['persist', 'remove'])]
-    private $authors;
+    private Collection $authors;
 
     public function __construct()
     {

--- a/tests/Gedmo/Sortable/Fixture/SimpleListItem.php
+++ b/tests/Gedmo/Sortable/Fixture/SimpleListItem.php
@@ -35,22 +35,18 @@ class SimpleListItem
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(type="string", length=191)
      */
     #[ORM\Column(type: Types::STRING, length: 191)]
-    private $name;
+    private ?string $name = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\SortablePosition
      * @ORM\Column(type="integer")
      */
     #[Gedmo\SortablePosition]
     #[ORM\Column(type: Types::INTEGER)]
-    private $position;
+    private ?int $position = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Sortable/Fixture/Transport/Car.php
+++ b/tests/Gedmo/Sortable/Fixture/Transport/Car.php
@@ -22,14 +22,12 @@ use Doctrine\ORM\Mapping as ORM;
 class Car extends Vehicle
 {
     /**
-     * @var self|null
-     *
      * @ORM\ManyToOne(targetEntity="Car", inversedBy="children")
      * @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
      */
     #[ORM\ManyToOne(targetEntity: self::class, inversedBy: 'children')]
     #[ORM\JoinColumn(name: 'parent_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
-    private $parent;
+    private ?\Gedmo\Tests\Sortable\Fixture\Transport\Car $parent = null;
 
     /**
      * @var Collection<int, self>
@@ -37,7 +35,7 @@ class Car extends Vehicle
      * @ORM\OneToMany(targetEntity="Car", mappedBy="parent")
      */
     #[ORM\OneToMany(mappedBy: 'parent', targetEntity: self::class)]
-    private $children;
+    private Collection $children;
 
     public function __construct()
     {

--- a/tests/Gedmo/Sortable/Fixture/Transport/Engine.php
+++ b/tests/Gedmo/Sortable/Fixture/Transport/Engine.php
@@ -33,20 +33,16 @@ class Engine
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(length=32)
      */
     #[ORM\Column(length: 32)]
-    private $type;
+    private ?string $type = null;
 
     /**
-     * @var int|null
-     *
      * @ORM\Column(type="integer")
      */
     #[ORM\Column(type: Types::INTEGER)]
-    private $valves;
+    private ?int $valves = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Sortable/Fixture/Transport/Reservation.php
+++ b/tests/Gedmo/Sortable/Fixture/Transport/Reservation.php
@@ -34,52 +34,42 @@ class Reservation
     private $id;
 
     /**
-     * @var Bus|null
-     *
      * @ORM\ManyToOne(targetEntity="Bus")
      */
     #[ORM\ManyToOne(targetEntity: Bus::class)]
-    private $bus;
+    private ?Bus $bus = null;
 
     /**
      * Bus destination
-     *
-     * @var string|null
      *
      * @Gedmo\SortableGroup
      * @ORM\Column(length=191)
      */
     #[Gedmo\SortableGroup]
     #[ORM\Column(length: 191)]
-    private $destination;
+    private ?string $destination = null;
 
     /**
-     * @var \DateTime|null
-     *
      * @Gedmo\SortableGroup
      * @ORM\Column(type="datetime")
      */
     #[Gedmo\SortableGroup]
     #[ORM\Column(type: Types::DATETIME_MUTABLE)]
-    private $travelDate;
+    private ?\DateTime $travelDate = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\SortablePosition
      * @ORM\Column(type="integer")
      */
     #[Gedmo\SortablePosition]
     #[ORM\Column(type: Types::INTEGER)]
-    private $seat;
+    private ?int $seat = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(length=191)
      */
     #[ORM\Column(length: 191)]
-    private $name;
+    private ?string $name = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Sortable/Fixture/Transport/Vehicle.php
+++ b/tests/Gedmo/Sortable/Fixture/Transport/Vehicle.php
@@ -44,32 +44,26 @@ class Vehicle
     private $id;
 
     /**
-     * @var Engine|null
-     *
      * @Gedmo\SortableGroup
      * @ORM\ManyToOne(targetEntity="Engine")
      */
     #[Gedmo\SortableGroup]
     #[ORM\ManyToOne(targetEntity: Engine::class)]
-    private $engine;
+    private ?Engine $engine = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(length=128)
      */
     #[ORM\Column(length: 128)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\SortablePosition
      * @ORM\Column(type="integer")
      */
     #[Gedmo\SortablePosition]
     #[ORM\Column(type: Types::INTEGER)]
-    private $sortByEngine;
+    private ?int $sortByEngine = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Sortable/SortableGroupTest.php
+++ b/tests/Gedmo/Sortable/SortableGroupTest.php
@@ -159,7 +159,7 @@ final class SortableGroupTest extends BaseTestCaseORM
         static::assertCount(self::SEATS - 1, $bratislavaToday);
         // Test seat numbers
         // Should be [ 0, 1 ]
-        $seats = array_map(static function ($r) { return $r->getSeat(); }, $bratislavaToday);
+        $seats = array_map(static fn ($r) => $r->getSeat(), $bratislavaToday);
         static::assertSame(range(0, self::SEATS - 2), $seats, 'Should be seats [ 0, 1 ] to Bratislava Today');
 
         // Bratislava Tomorrow should have 4 seats
@@ -170,7 +170,7 @@ final class SortableGroupTest extends BaseTestCaseORM
         static::assertCount(self::SEATS + 1, $bratislavaTomorrow);
         // Test seat numbers
         // Should be [ 0, 1, 2, 3 ]
-        $seats = array_map(static function ($r) { return $r->getSeat(); }, $bratislavaTomorrow);
+        $seats = array_map(static fn ($r) => $r->getSeat(), $bratislavaTomorrow);
         static::assertSame(range(0, self::SEATS), $seats, 'Should be seats [ 0, 1, 2, 3 ] to Bratislava Tomorrow');
 
         // Prague Today should have 3 seats
@@ -180,7 +180,7 @@ final class SortableGroupTest extends BaseTestCaseORM
         ], ['seat' => 'asc']);
         static::assertCount(self::SEATS, $pragueToday);
         // Test seat numbers
-        $seats = array_map(static function ($r) { return $r->getSeat(); }, $pragueToday);
+        $seats = array_map(static fn ($r) => $r->getSeat(), $pragueToday);
         static::assertSame(range(0, self::SEATS - 1), $seats, 'Should be seats [ 0, 1, 2 ] to Prague Today');
     }
 

--- a/tests/Gedmo/Sortable/SortableTest.php
+++ b/tests/Gedmo/Sortable/SortableTest.php
@@ -44,10 +44,7 @@ final class SortableTest extends BaseTestCaseORM
     private const CUSTOMER = Customer::class;
     private const CUSTOMER_TYPE = CustomerType::class;
 
-    /**
-     * @var int|null
-     */
-    private $nodeId;
+    private ?int $nodeId = null;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Timestampable/ChangeTest.php
+++ b/tests/Gedmo/Timestampable/ChangeTest.php
@@ -117,10 +117,7 @@ final class ChangeTest extends BaseTestCaseORM
 
 final class EventAdapterORMStub extends BaseAdapterORM implements TimestampableAdapter
 {
-    /**
-     * @var \DateTime|null
-     */
-    private $dateTime;
+    private ?\DateTime $dateTime = null;
 
     public function setDateValue(\DateTime $dateTime): void
     {

--- a/tests/Gedmo/Timestampable/Fixture/Article.php
+++ b/tests/Gedmo/Timestampable/Fixture/Article.php
@@ -37,20 +37,16 @@ class Article implements Timestampable
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=128)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="body", type="string")
      */
     #[ORM\Column(name: 'body', type: Types::STRING)]
-    private $body;
+    private ?string $body = null;
 
     /**
      * @var Collection<int, Comment>
@@ -61,52 +57,42 @@ class Article implements Timestampable
     private $comments;
 
     /**
-     * @var Author|null
-     *
      * @ORM\Embedded(class="Gedmo\Tests\Timestampable\Fixture\Author")
      */
     #[ORM\Embedded(class: Author::class)]
-    private $author;
+    private ?Author $author = null;
 
     /**
-     * @var \DateTime|null
-     *
      * @Gedmo\Timestampable(on="create")
      * @ORM\Column(name="created", type="date")
      */
     #[Gedmo\Timestampable(on: 'create')]
     #[ORM\Column(name: 'created', type: Types::DATE_MUTABLE)]
-    private $created;
+    private ?\DateTime $created = null;
 
     /**
-     * @var \DateTime|null
-     *
      * @ORM\Column(name="updated", type="datetime")
      * @Gedmo\Timestampable
      */
     #[ORM\Column(name: 'updated', type: Types::DATETIME_MUTABLE)]
     #[Gedmo\Timestampable]
-    private $updated;
+    private ?\DateTime $updated = null;
 
     /**
-     * @var \DateTime|null
-     *
      * @ORM\Column(name="published", type="datetime", nullable=true)
      * @Gedmo\Timestampable(on="change", field="type.title", value="Published")
      */
     #[ORM\Column(name: 'published', type: Types::DATETIME_MUTABLE, nullable: true)]
     #[Gedmo\Timestampable(on: 'change', field: 'type.title', value: 'Published')]
-    private $published;
+    private ?\DateTime $published = null;
 
     /**
-     * @var \DateTime|null
-     *
      * @ORM\Column(name="content_changed", type="datetime", nullable=true)
      * @Gedmo\Timestampable(on="change", field={"title", "body"})
      */
     #[ORM\Column(name: 'content_changed', type: Types::DATETIME_MUTABLE, nullable: true)]
     #[Gedmo\Timestampable(on: 'change', field: ['title', 'body'])]
-    private $contentChanged;
+    private ?\DateTime $contentChanged = null;
     /**
      * @var \DateTime|null
      *
@@ -118,20 +104,16 @@ class Article implements Timestampable
     private $authorChanged;
 
     /**
-     * @var Type|null
-     *
      * @ORM\ManyToOne(targetEntity="Type", inversedBy="articles")
      */
     #[ORM\ManyToOne(targetEntity: Type::class, inversedBy: 'articles')]
-    private $type;
+    private ?Type $type = null;
 
     /**
-     * @var int|null
-     *
      * @ORM\Column(name="level", type="integer")
      */
     #[ORM\Column(name: 'level', type: Types::INTEGER)]
-    private $level = 0;
+    private int $level = 0;
 
     /**
      * We use the value "10" as string here in order to check the behavior of `AbstractTrackingListener`

--- a/tests/Gedmo/Timestampable/Fixture/ArticleCarbon.php
+++ b/tests/Gedmo/Timestampable/Fixture/ArticleCarbon.php
@@ -39,20 +39,16 @@ class ArticleCarbon implements Timestampable
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=128)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="body", type="string")
      */
     #[ORM\Column(name: 'body', type: Types::STRING)]
-    private $body;
+    private ?string $body = null;
 
     /**
      * @var Collection<int, Comment>
@@ -63,12 +59,10 @@ class ArticleCarbon implements Timestampable
     private $comments;
 
     /**
-     * @var Author|null
-     *
      * @ORM\Embedded(class="Gedmo\Tests\Timestampable\Fixture\Author")
      */
     #[ORM\Embedded(class: Author::class)]
-    private $author;
+    private ?Author $author = null;
 
     /**
      * @var \DateTime|Carbon|null
@@ -121,20 +115,16 @@ class ArticleCarbon implements Timestampable
     private $authorChanged;
 
     /**
-     * @var Type|null
-     *
      * @ORM\ManyToOne(targetEntity="Type", inversedBy="articles")
      */
     #[ORM\ManyToOne(targetEntity: Type::class, inversedBy: 'articles')]
-    private $type;
+    private ?Type $type = null;
 
     /**
-     * @var int|null
-     *
      * @ORM\Column(name="level", type="integer")
      */
     #[ORM\Column(name: 'level', type: Types::INTEGER)]
-    private $level = 0;
+    private int $level = 0;
 
     /**
      * We use the value "10" as string here in order to check the behavior of `AbstractTrackingListener`
@@ -212,7 +202,8 @@ class ArticleCarbon implements Timestampable
         return $this->created;
     }
 
-    public function setCreated(\DateTime $created): void
+    /** @param CarbonImmutable|\DateTime $created */
+    public function setCreated($created): void
     {
         $this->created = $created;
     }
@@ -222,7 +213,8 @@ class ArticleCarbon implements Timestampable
         return $this->published;
     }
 
-    public function setPublished(\DateTime $published): void
+    /** @param CarbonImmutable|\DateTime $published */
+    public function setPublished($published): void
     {
         $this->published = $published;
     }
@@ -232,12 +224,14 @@ class ArticleCarbon implements Timestampable
         return $this->updated;
     }
 
-    public function setUpdated(\DateTime $updated): void
+    /** @param CarbonImmutable|\DateTime $updated */
+    public function setUpdated($updated): void
     {
         $this->updated = $updated;
     }
 
-    public function setContentChanged(\DateTime $contentChanged): void
+    /** @param CarbonImmutable|\DateTime $contentChanged */
+    public function setContentChanged($contentChanged): void
     {
         $this->contentChanged = $contentChanged;
     }

--- a/tests/Gedmo/Timestampable/Fixture/Attribute/TitledArticle.php
+++ b/tests/Gedmo/Timestampable/Fixture/Attribute/TitledArticle.php
@@ -22,28 +22,28 @@ class TitledArticle implements Timestampable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private ?int $id;
+    private ?int $id = null;
 
     #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
-    private ?string $title;
+    private ?string $title = null;
 
     #[ORM\Column(name: 'text', type: Types::STRING, length: 128)]
-    private ?string $text;
+    private ?string $text = null;
 
     #[ORM\Column(name: 'state', type: Types::STRING, length: 128)]
-    private ?string $state;
+    private ?string $state = null;
 
     #[ORM\Column(name: 'chtext', type: Types::DATETIME_MUTABLE, nullable: true)]
     #[Gedmo\Timestampable(on: 'change', field: 'text')]
-    private ?\DateTime $chText;
+    private ?\DateTime $chText = null;
 
     #[ORM\Column(name: 'chtitle', type: Types::DATETIME_MUTABLE, nullable: true)]
     #[Gedmo\Timestampable(on: 'change', field: 'title')]
-    private ?\DateTime $chTitle;
+    private ?\DateTime $chTitle = null;
 
     #[ORM\Column(name: 'closed', type: Types::DATETIME_MUTABLE, nullable: true)]
     #[Gedmo\Timestampable(on: 'change', field: 'state', value: ['Published', 'Closed'])]
-    private ?\DateTime $closed;
+    private ?\DateTime $closed = null;
 
     public function setChText(\DateTime $chText): void
     {

--- a/tests/Gedmo/Timestampable/Fixture/Author.php
+++ b/tests/Gedmo/Timestampable/Fixture/Author.php
@@ -21,20 +21,16 @@ use Doctrine\ORM\Mapping as ORM;
 class Author
 {
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="author_name", type="string", length=128, nullable=true)
      */
     #[ORM\Column(name: 'author_name', type: Types::STRING, length: 128, nullable: true)]
-    private $name;
+    private ?string $name = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="author_email", type="string", length=50, nullable=true)
      */
     #[ORM\Column(name: 'author_email', type: Types::STRING, length: 50, nullable: true)]
-    private $email;
+    private ?string $email = null;
 
     public function getName(): ?string
     {

--- a/tests/Gedmo/Timestampable/Fixture/Comment.php
+++ b/tests/Gedmo/Timestampable/Fixture/Comment.php
@@ -35,12 +35,10 @@ class Comment implements Timestampable
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="message", type="text")
      */
     #[ORM\Column(name: 'message', type: Types::TEXT)]
-    private $message;
+    private ?string $message = null;
 
     /**
      * @var Article|null
@@ -51,12 +49,10 @@ class Comment implements Timestampable
     private $article;
 
     /**
-     * @var int|null
-     *
      * @ORM\Column(type="integer")
      */
     #[ORM\Column(type: Types::INTEGER)]
-    private $status;
+    private ?int $status = null;
 
     /**
      * @var \DateTime|null

--- a/tests/Gedmo/Timestampable/Fixture/CommentCarbon.php
+++ b/tests/Gedmo/Timestampable/Fixture/CommentCarbon.php
@@ -36,28 +36,22 @@ class CommentCarbon implements Timestampable
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="message", type="text")
      */
     #[ORM\Column(name: 'message', type: Types::TEXT)]
-    private $message;
+    private ?string $message = null;
 
     /**
-     * @var ArticleCarbon|null
-     *
      * @ORM\ManyToOne(targetEntity="Gedmo\Tests\Timestampable\Fixture\ArticleCarbon", inversedBy="comments")
      */
     #[ORM\ManyToOne(targetEntity: ArticleCarbon::class, inversedBy: 'comments')]
-    private $article;
+    private ?ArticleCarbon $article = null;
 
     /**
-     * @var int|null
-     *
      * @ORM\Column(type="integer")
      */
     #[ORM\Column(type: Types::INTEGER)]
-    private $status;
+    private ?int $status = null;
 
     /**
      * @var CarbonImmutable|null

--- a/tests/Gedmo/Timestampable/Fixture/Document/Article.php
+++ b/tests/Gedmo/Timestampable/Fixture/Document/Article.php
@@ -31,20 +31,16 @@ class Article
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: MongoDBType::STRING)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var Type|null
-     *
      * @ODM\ReferenceOne(targetDocument="Gedmo\Tests\Timestampable\Fixture\Document\Type")
      */
     #[ODM\ReferenceOne(targetDocument: Type::class)]
-    private $type;
+    private ?\Gedmo\Tests\Timestampable\Fixture\Document\Type $type = null;
 
     /**
      * @var int|Timestamp|null
@@ -57,42 +53,34 @@ class Article
     private $created;
 
     /**
-     * @var \DateTime|null
-     *
      * @ODM\Field(type="date")
      * @Gedmo\Timestampable
      */
     #[Gedmo\Timestampable]
     #[ODM\Field(type: MongoDBType::DATE)]
-    private $updated;
+    private ?\DateTime $updated = null;
 
     /**
-     * @var \DateTime|null
-     *
      * @ODM\Field(type="date")
      * @Gedmo\Timestampable(on="change", field="type.title", value="Published")
      */
     #[Gedmo\Timestampable(on: 'change', field: 'type.title', value: 'Published')]
     #[ODM\Field(type: MongoDBType::DATE)]
-    private $published;
+    private ?\DateTime $published = null;
 
     /**
-     * @var \DateTime|null
-     *
      * @ODM\Field(type="date")
      * @Gedmo\Timestampable(on="change", field="isReady", value=true)
      */
     #[Gedmo\Timestampable(on: 'change', field: 'isReady', value: true)]
     #[ODM\Field(type: MongoDBType::DATE)]
-    private $ready;
+    private ?\DateTime $ready = null;
 
     /**
-     * @var bool
-     *
      * @ODM\Field(type="bool")
      */
     #[ODM\Field(type: MongoDBType::BOOL)]
-    private $isReady = false;
+    private bool $isReady = false;
 
     public function getId(): ?string
     {
@@ -137,7 +125,8 @@ class Article
         return $this->type;
     }
 
-    public function setCreated(?int $created): void
+    /** @param int|Timestamp|null $created */
+    public function setCreated($created): void
     {
         $this->created = $created;
     }

--- a/tests/Gedmo/Timestampable/Fixture/Document/Type.php
+++ b/tests/Gedmo/Timestampable/Fixture/Document/Type.php
@@ -29,20 +29,16 @@ class Type
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: MongoDBType::STRING)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: MongoDBType::STRING)]
-    private $identifier;
+    private ?string $identifier = null;
 
     public function getId(): ?string
     {

--- a/tests/Gedmo/Timestampable/Fixture/SupperClassExtension.php
+++ b/tests/Gedmo/Timestampable/Fixture/SupperClassExtension.php
@@ -21,14 +21,12 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class SupperClassExtension extends MappedSupperClass
 {
     /**
-     * @var string|null
-     *
      * @ORM\Column(length=128)
      * @Gedmo\Translatable
      */
     #[ORM\Column(length: 128)]
     #[Gedmo\Translatable]
-    private $title;
+    private ?string $title = null;
 
     public function setTitle(?string $title): void
     {

--- a/tests/Gedmo/Timestampable/Fixture/TitledArticle.php
+++ b/tests/Gedmo/Timestampable/Fixture/TitledArticle.php
@@ -23,8 +23,6 @@ use Gedmo\Timestampable\Timestampable;
 class TitledArticle implements Timestampable
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -32,61 +30,49 @@ class TitledArticle implements Timestampable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=128)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="text", type="string", length=128)
      */
     #[ORM\Column(name: 'text', type: Types::STRING, length: 128)]
-    private $text;
+    private ?string $text = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="state", type="string", length=128)
      */
     #[ORM\Column(name: 'state', type: Types::STRING, length: 128)]
-    private $state;
+    private ?string $state = null;
 
     /**
-     * @var \DateTime
-     *
      * @ORM\Column(name="chtext", type="datetime", nullable=true)
      * @Gedmo\Timestampable(on="change", field="text")
      */
     #[ORM\Column(name: 'chtext', type: Types::DATETIME_MUTABLE, nullable: true)]
     #[Gedmo\Timestampable(on: 'change', field: 'text')]
-    private $chText;
+    private ?\DateTime $chText = null;
 
     /**
-     * @var \DateTime
-     *
      * @ORM\Column(name="chtitle", type="datetime", nullable=true)
      * @Gedmo\Timestampable(on="change", field="title")
      */
     #[ORM\Column(name: 'chtitle', type: Types::DATETIME_MUTABLE, nullable: true)]
     #[Gedmo\Timestampable(on: 'change', field: 'title')]
-    private $chTitle;
+    private ?\DateTime $chTitle = null;
 
     /**
-     * @var \DateTime
-     *
      * @ORM\Column(name="closed", type="datetime", nullable=true)
      * @Gedmo\Timestampable(on="change", field="state", value={"Published", "Closed"})
      */
     #[ORM\Column(name: 'closed', type: Types::DATETIME_MUTABLE, nullable: true)]
     #[Gedmo\Timestampable(on: 'change', field: 'state', value: ['Published', 'Closed'])]
-    private $closed;
+    private ?\DateTime $closed = null;
 
     public function setChText(\DateTime $chText): void
     {

--- a/tests/Gedmo/Timestampable/Fixture/Type.php
+++ b/tests/Gedmo/Timestampable/Fixture/Type.php
@@ -35,12 +35,10 @@ class Type
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=128)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var Collection<int, Article>
@@ -48,7 +46,7 @@ class Type
      * @ORM\OneToMany(targetEntity="Article", mappedBy="type")
      */
     #[ORM\OneToMany(targetEntity: Article::class, mappedBy: 'type')]
-    private $articles;
+    private Collection $articles;
 
     public function __construct()
     {

--- a/tests/Gedmo/Timestampable/Fixture/UsingTrait.php
+++ b/tests/Gedmo/Timestampable/Fixture/UsingTrait.php
@@ -40,12 +40,10 @@ class UsingTrait
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(length=128)
      */
     #[ORM\Column(length: 128)]
-    private $title;
+    private ?string $title = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Timestampable/Fixture/WithoutInterface.php
+++ b/tests/Gedmo/Timestampable/Fixture/WithoutInterface.php
@@ -34,12 +34,10 @@ class WithoutInterface
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(type="string", length=128)
      */
     #[ORM\Column(type: Types::STRING, length: 128)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var \DateTime|null

--- a/tests/Gedmo/Tool/BaseTestCaseMongoODM.php
+++ b/tests/Gedmo/Tool/BaseTestCaseMongoODM.php
@@ -68,8 +68,8 @@ abstract class BaseTestCaseMongoODM extends TestCase
     {
         $client = new Client($_ENV['MONGODB_SERVER'], [], ['typeMap' => DocumentManager::CLIENT_TYPEMAP]);
 
-        $config = $config ?? $this->getMockAnnotatedConfig();
-        $evm = $evm ?? $this->getEventManager();
+        $config ??= $this->getMockAnnotatedConfig();
+        $evm ??= $this->getEventManager();
 
         return $this->dm = DocumentManager::create($client, $config, $evm);
     }
@@ -87,7 +87,7 @@ abstract class BaseTestCaseMongoODM extends TestCase
     {
         $conn = $this->createStub(Client::class);
 
-        $config = $config ?? $this->getMockAnnotatedConfig();
+        $config ??= $this->getMockAnnotatedConfig();
 
         $this->dm = DocumentManager::create($conn, $config, $evm ?? $this->getEventManager());
 

--- a/tests/Gedmo/Tool/BaseTestCaseOM.php
+++ b/tests/Gedmo/Tool/BaseTestCaseOM.php
@@ -57,7 +57,7 @@ abstract class BaseTestCaseOM extends TestCase
      *
      * @var DocumentManager[]
      */
-    private $dms = [];
+    private array $dms = [];
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Tool/BaseTestCaseORM.php
+++ b/tests/Gedmo/Tool/BaseTestCaseORM.php
@@ -73,13 +73,11 @@ abstract class BaseTestCaseORM extends TestCase
             'memory' => true,
         ];
 
-        $config = $config ?? $this->getDefaultConfiguration();
+        $config ??= $this->getDefaultConfiguration();
         $connection = DriverManager::getConnection($conn, $config);
         $em = new EntityManager($connection, $config, $evm ?? $this->getEventManager());
 
-        $schema = array_map(static function (string $class) use ($em): ClassMetadata {
-            return $em->getClassMetadata($class);
-        }, $this->getUsedEntityFixtures());
+        $schema = array_map(static fn (string $class): ClassMetadata => $em->getClassMetadata($class), $this->getUsedEntityFixtures());
 
         $schemaTool = new SchemaTool($em);
         $schemaTool->dropSchema([]);

--- a/tests/Gedmo/Tool/QueryAnalyzer.php
+++ b/tests/Gedmo/Tool/QueryAnalyzer.php
@@ -22,10 +22,8 @@ final class QueryAnalyzer implements SQLLogger
 {
     /**
      * Used database platform
-     *
-     * @var AbstractPlatform
      */
-    private $platform;
+    private AbstractPlatform $platform;
 
     /**
      * List of queries executed

--- a/tests/Gedmo/Translatable/AttributeEntityTranslationTableTest.php
+++ b/tests/Gedmo/Translatable/AttributeEntityTranslationTableTest.php
@@ -32,10 +32,7 @@ final class AttributeEntityTranslationTableTest extends BaseTestCaseORM
     private const TRANSLATION = PersonTranslation::class;
     private const FILE = File::class;
 
-    /**
-     * @var TranslatableListener
-     */
-    private $translatableListener;
+    private TranslatableListener $translatableListener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Translatable/EntityTranslationTableTest.php
+++ b/tests/Gedmo/Translatable/EntityTranslationTableTest.php
@@ -28,10 +28,7 @@ final class EntityTranslationTableTest extends BaseTestCaseORM
     private const PERSON = Person::class;
     private const TRANSLATION = PersonTranslation::class;
 
-    /**
-     * @var TranslatableListener
-     */
-    private $translatableListener;
+    private TranslatableListener $translatableListener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Translatable/Fixture/Article.php
+++ b/tests/Gedmo/Translatable/Fixture/Article.php
@@ -37,44 +37,36 @@ class Article implements Translatable
     private $id;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @ORM\Column(name="title", type="string", length=128)
      */
     #[Gedmo\Translatable]
     #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @ORM\Column(name="content", type="text", nullable=true)
      */
     #[Gedmo\Translatable]
     #[ORM\Column(name: 'content', type: Types::TEXT, nullable: true)]
-    private $content;
+    private ?string $content = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\Translatable(fallback=false)
      * @ORM\Column(name="views", type="integer", nullable=true)
      */
     #[Gedmo\Translatable(fallback: false)]
     #[ORM\Column(name: 'views', type: Types::INTEGER, nullable: true)]
-    private $views;
+    private ?int $views = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable(fallback=true)
      * @ORM\Column(name="author", type="string", nullable=true)
      */
     #[Gedmo\Translatable(fallback: true)]
     #[ORM\Column(name: 'author', type: Types::STRING, nullable: true)]
-    private $author;
+    private ?string $author = null;
 
     /**
      * @var string|null
@@ -84,7 +76,7 @@ class Article implements Translatable
      * @Gedmo\Locale
      */
     #[Gedmo\Locale]
-    private $locale;
+    private ?string $locale = null;
 
     /**
      * @var Collection<int, Comment>

--- a/tests/Gedmo/Translatable/Fixture/Attribute/File.php
+++ b/tests/Gedmo/Translatable/Fixture/Attribute/File.php
@@ -32,12 +32,9 @@ class File
     #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
-    /**
-     * @var string|null
-     */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
     #[Gedmo\Translatable]
-    private $title;
+    private ?string $title = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Translatable/Fixture/Attribute/Person.php
+++ b/tests/Gedmo/Translatable/Fixture/Attribute/Person.php
@@ -22,11 +22,11 @@ class Person
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private ?int $id;
+    private ?int $id = null;
 
     #[Gedmo\Translatable]
     #[ORM\Column(name: 'name', type: Types::STRING, length: 128)]
-    private ?string $name;
+    private ?string $name = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Translatable/Fixture/Comment.php
+++ b/tests/Gedmo/Translatable/Fixture/Comment.php
@@ -34,32 +34,26 @@ class Comment
     private $id;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @ORM\Column(name="subject", type="string", length=128)
      */
     #[Gedmo\Translatable]
     #[ORM\Column(name: 'subject', type: Types::STRING, length: 128)]
-    private $subject;
+    private ?string $subject = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @ORM\Column(name="message", type="text")
      */
     #[Gedmo\Translatable]
     #[ORM\Column(name: 'message', type: Types::TEXT)]
-    private $message;
+    private ?string $message = null;
 
     /**
-     * @var Article|null
-     *
      * @ORM\ManyToOne(targetEntity="Article", inversedBy="comments")
      */
     #[ORM\ManyToOne(targetEntity: Article::class, inversedBy: 'comments')]
-    private $article;
+    private ?Article $article = null;
 
     /**
      * @var string|null
@@ -69,7 +63,7 @@ class Comment
      * @Gedmo\Language
      */
     #[Gedmo\Language]
-    private $locale;
+    private ?string $locale = null;
 
     public function setArticle(Article $article): void
     {

--- a/tests/Gedmo/Translatable/Fixture/Company.php
+++ b/tests/Gedmo/Translatable/Fixture/Company.php
@@ -35,21 +35,18 @@ class Company implements Translatable
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=128)
      * @Gedmo\Translatable
      */
     #[Gedmo\Translatable]
     #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var CompanyEmbedLink
      * @ORM\Embedded(class="Gedmo\Tests\Translatable\Fixture\CompanyEmbedLink")
      */
     #[ORM\Embedded(class: CompanyEmbedLink::class)]
-    private $link;
+    private CompanyEmbedLink $link;
 
     /**
      * @var string|null
@@ -59,7 +56,7 @@ class Company implements Translatable
      * @Gedmo\Locale
      */
     #[Gedmo\Locale]
-    private $locale;
+    private ?string $locale = null;
 
     public function __construct()
     {

--- a/tests/Gedmo/Translatable/Fixture/Document/Article.php
+++ b/tests/Gedmo/Translatable/Fixture/Document/Article.php
@@ -30,24 +30,20 @@ class Article
     private $id;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @MongoODM\Field(type="string")
      */
     #[Gedmo\Translatable]
     #[MongoODM\Field(type: Type::STRING)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @MongoODM\Field(type="string")
      */
     #[Gedmo\Translatable]
     #[MongoODM\Field(type: Type::STRING)]
-    private $code;
+    private ?string $code = null;
 
     /**
      * @var string|null

--- a/tests/Gedmo/Translatable/Fixture/Document/Personal/Article.php
+++ b/tests/Gedmo/Translatable/Fixture/Document/Personal/Article.php
@@ -34,14 +34,12 @@ class Article
     private $id;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @MongoODM\Field(type="string")
      */
     #[Gedmo\Translatable]
     #[MongoODM\Field(type: Type::STRING)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var Collection<int, ArticleTranslation>
@@ -51,10 +49,7 @@ class Article
     #[MongoODM\ReferenceMany(targetDocument: ArticleTranslation::class, mappedBy: 'object')]
     private $translations;
 
-    /**
-     * @var string|null
-     */
-    private $code;
+    private ?string $code = null;
 
     /**
      * @var string

--- a/tests/Gedmo/Translatable/Fixture/Document/SimpleArticle.php
+++ b/tests/Gedmo/Translatable/Fixture/Document/SimpleArticle.php
@@ -30,24 +30,20 @@ class SimpleArticle
     private $id;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @MongoODM\Field(type="string")
      */
     #[Gedmo\Translatable]
     #[MongoODM\Field(type: Type::STRING)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @MongoODM\Field(type="string")
      */
     #[Gedmo\Translatable]
     #[MongoODM\Field(type: Type::STRING)]
-    private $content;
+    private ?string $content = null;
 
     public function getId(): ?string
     {

--- a/tests/Gedmo/Translatable/Fixture/File.php
+++ b/tests/Gedmo/Translatable/Fixture/File.php
@@ -40,22 +40,18 @@ class File
     private $id;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @ORM\Column(length=128)
      */
     #[Gedmo\Translatable]
     #[ORM\Column(length: 128)]
-    private $name;
+    private ?string $name = null;
 
     /**
-     * @var int|null
-     *
      * @ORM\Column(type="integer")
      */
     #[ORM\Column(type: Types::INTEGER)]
-    private $size;
+    private ?int $size = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Translatable/Fixture/Image.php
+++ b/tests/Gedmo/Translatable/Fixture/Image.php
@@ -21,14 +21,12 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Image extends File
 {
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @ORM\Column(length=128)
      */
     #[Gedmo\Translatable]
     #[ORM\Column(length: 128)]
-    private $mime;
+    private ?string $mime = null;
 
     public function setMime(?string $mime): void
     {

--- a/tests/Gedmo/Translatable/Fixture/Issue1123/ChildEntity.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue1123/ChildEntity.php
@@ -25,24 +25,20 @@ use Gedmo\Translatable\Translatable;
 class ChildEntity extends BaseEntity implements Translatable
 {
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @ORM\Column(name="childTitle", type="string", length=128, nullable=true)
      */
     #[ORM\Column(name: 'childTitle', type: Types::STRING, length: 128, nullable: true)]
     #[Gedmo\Translatable]
-    private $childTitle;
+    private ?string $childTitle = null;
 
     /**
-     * @var string
-     *
      * @Gedmo\Locale
      * Used locale to override Translation listener`s locale
      * this is not a mapped field of entity metadata, just a simple property
      */
     #[Gedmo\Locale]
-    private $locale = 'en';
+    private string $locale = 'en';
 
     public function getChildTitle(): ?string
     {

--- a/tests/Gedmo/Translatable/Fixture/Issue114/Article.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue114/Article.php
@@ -34,22 +34,18 @@ class Article
     private $id;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @ORM\Column(name="title", type="string", length=128)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
     #[Gedmo\Translatable]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var Category|null
-     *
      * @ORM\ManyToOne(targetEntity="Category", inversedBy="articles")
      */
     #[ORM\ManyToOne(targetEntity: Category::class, inversedBy: 'articles')]
-    private $category;
+    private ?Category $category = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Translatable/Fixture/Issue114/Category.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue114/Category.php
@@ -36,14 +36,12 @@ class Category
     private $id;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @ORM\Column(name="title", type="string", length=128)
      */
     #[Gedmo\Translatable]
     #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var Collection<int, Article>

--- a/tests/Gedmo/Translatable/Fixture/Issue138/Article.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue138/Article.php
@@ -34,24 +34,20 @@ class Article
     private $id;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @ORM\Column(length=128)
      */
     #[Gedmo\Translatable]
     #[ORM\Column(length: 128)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @ORM\Column(length=128)
      */
     #[Gedmo\Translatable]
     #[ORM\Column(length: 128)]
-    private $titleTest;
+    private ?string $titleTest = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Translatable/Fixture/Issue165/SimpleArticle.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue165/SimpleArticle.php
@@ -30,32 +30,26 @@ class SimpleArticle
     private $id;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @MongoODM\Field(type="string")
      */
     #[Gedmo\Translatable]
     #[MongoODM\Field(type: Type::STRING)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @MongoODM\Field(type="string")
      */
     #[Gedmo\Translatable]
     #[MongoODM\Field(type: Type::STRING)]
-    private $content;
+    private ?string $content = null;
 
     /**
-     * @var string|null
-     *
      * @MongoODM\Field(type="string")
      */
     #[MongoODM\Field(type: Type::STRING)]
-    private $untranslated;
+    private ?string $untranslated = null;
 
     public function getId(): ?string
     {

--- a/tests/Gedmo/Translatable/Fixture/Issue173/Article.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue173/Article.php
@@ -34,22 +34,18 @@ class Article
     private $id;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @ORM\Column(name="title", type="string", length=128)
      */
     #[Gedmo\Translatable]
     #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var Category|null
-     *
      * @ORM\ManyToOne(targetEntity="Category", inversedBy="articles")
      */
     #[ORM\ManyToOne(targetEntity: Category::class, inversedBy: 'articles')]
-    private $category;
+    private ?Category $category = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Translatable/Fixture/Issue173/Category.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue173/Category.php
@@ -36,14 +36,12 @@ class Category
     private $id;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @ORM\Column(name="title", type="string", length=128)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
     #[Gedmo\Translatable]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var Collection<int, Article>

--- a/tests/Gedmo/Translatable/Fixture/Issue173/Product.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue173/Product.php
@@ -34,22 +34,18 @@ class Product
     private $id;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @ORM\Column(name="title", type="string", length=128)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
     #[Gedmo\Translatable]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var Category|null
-     *
      * @ORM\ManyToOne(targetEntity="Category", inversedBy="products")
      */
     #[ORM\ManyToOne(targetEntity: Category::class, inversedBy: 'products')]
-    private $category;
+    private ?Category $category = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Translatable/Fixture/Issue2152/EntityWithTranslatableBoolean.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue2152/EntityWithTranslatableBoolean.php
@@ -38,30 +38,24 @@ class EntityWithTranslatableBoolean
     /**
      * @Gedmo\Translatable
      * @ORM\Column(type="string", nullable=true)
-     *
-     * @var string|null
      */
     #[ORM\Column(type: Types::STRING, nullable: true)]
     #[Gedmo\Translatable]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @Gedmo\Translatable
      * @ORM\Column(type="string", nullable=true)
-     *
-     * @var string|null
      */
     #[ORM\Column(type: Types::STRING, nullable: true)]
     #[Gedmo\Translatable]
-    private $isOperating;
+    private ?string $isOperating = null;
 
     /**
-     * @var string
-     *
      * @Gedmo\Locale
      */
     #[Gedmo\Locale]
-    private $locale;
+    private ?string $locale = null;
 
     public function __construct(string $title, string $isOperating = '0')
     {
@@ -90,7 +84,7 @@ class EntityWithTranslatableBoolean
         return $this->isOperating;
     }
 
-    public function getLocale(): string
+    public function getLocale(): ?string
     {
         return $this->locale;
     }

--- a/tests/Gedmo/Translatable/Fixture/Issue2167/Article.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue2167/Article.php
@@ -34,22 +34,18 @@ class Article
     private $id;
 
     /**
-     * @var string
-     *
      * @Gedmo\Translatable
      * @ORM\Column(name="title", type="string", length=128)
      */
     #[Gedmo\Translatable]
     #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string
-     *
      * @Gedmo\Locale
      */
     #[Gedmo\Locale]
-    private $locale;
+    private ?string $locale = null;
 
     public function getId(): int
     {

--- a/tests/Gedmo/Translatable/Fixture/Issue75/Article.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue75/Article.php
@@ -36,14 +36,12 @@ class Article
     private $id;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @ORM\Column(name="title", type="string", length=128)
      */
     #[Gedmo\Translatable]
     #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var Collection<int, Image>

--- a/tests/Gedmo/Translatable/Fixture/Issue75/File.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue75/File.php
@@ -34,14 +34,12 @@ class File
     private $id;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @ORM\Column(name="title", type="string", length=128)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
     #[Gedmo\Translatable]
-    private $title;
+    private ?string $title = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Translatable/Fixture/Issue75/Image.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue75/Image.php
@@ -36,14 +36,12 @@ class Image
     private $id;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @ORM\Column(name="title", type="string", length=128)
      */
     #[Gedmo\Translatable]
     #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var Collection<int, Article>

--- a/tests/Gedmo/Translatable/Fixture/Issue922/Post.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue922/Post.php
@@ -34,44 +34,36 @@ class Post
     private $id;
 
     /**
-     * @var \DateTime|null
-     *
      * @Gedmo\Translatable
      * @ORM\Column(type="datetime", nullable=true)
      */
     #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
     #[Gedmo\Translatable]
-    private $publishedAt;
+    private ?\DateTime $publishedAt = null;
 
     /**
-     * @var \DateTime|null
-     *
      * @Gedmo\Translatable
      * @ORM\Column(type="time")
      */
     #[ORM\Column(type: Types::TIME_MUTABLE)]
     #[Gedmo\Translatable]
-    private $timestampAt;
+    private ?\DateTime $timestampAt = null;
 
     /**
-     * @var \DateTime|null
-     *
      * @Gedmo\Translatable
      * @ORM\Column(type="date")
      */
     #[ORM\Column(type: Types::DATE_MUTABLE)]
     #[Gedmo\Translatable]
-    private $dateAt;
+    private ?\DateTime $dateAt = null;
 
     /**
-     * @var bool|null
-     *
      * @Gedmo\Translatable
      * @ORM\Column(type="boolean")
      */
     #[ORM\Column(type: Types::BOOLEAN)]
     #[Gedmo\Translatable]
-    private $boolean;
+    private ?bool $boolean = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Translatable/Fixture/MixedValue.php
+++ b/tests/Gedmo/Translatable/Fixture/MixedValue.php
@@ -34,14 +34,12 @@ class MixedValue
     private $id;
 
     /**
-     * @var \DateTime|null
-     *
      * @Gedmo\Translatable
      * @ORM\Column(type="datetime")
      */
     #[Gedmo\Translatable]
     #[ORM\Column(type: Types::DATETIME_MUTABLE)]
-    private $date;
+    private ?\DateTime $date = null;
 
     /**
      * @var mixed

--- a/tests/Gedmo/Translatable/Fixture/Person.php
+++ b/tests/Gedmo/Translatable/Fixture/Person.php
@@ -36,14 +36,12 @@ class Person
     private $id;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @ORM\Column(name="name", type="string", length=128)
      */
     #[Gedmo\Translatable]
     #[ORM\Column(name: 'name', type: Types::STRING, length: 128)]
-    private $name;
+    private ?string $name = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Translatable/Fixture/Personal/Article.php
+++ b/tests/Gedmo/Translatable/Fixture/Personal/Article.php
@@ -38,14 +38,12 @@ class Article
     private $id;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @ORM\Column(length=128)
      */
     #[ORM\Column(length: 128)]
     #[Gedmo\Translatable]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var Collection<int, PersonalArticleTranslation>

--- a/tests/Gedmo/Translatable/Fixture/Sport.php
+++ b/tests/Gedmo/Translatable/Fixture/Sport.php
@@ -34,22 +34,18 @@ class Sport
     private $id;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @ORM\Column(length=128)
      */
     #[Gedmo\Translatable]
     #[ORM\Column(length: 128)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(type="text", nullable=true)
      */
     #[ORM\Column(type: Types::TEXT, nullable: true)]
-    private $description;
+    private ?string $description = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Translatable/Fixture/StringIdentifier.php
+++ b/tests/Gedmo/Translatable/Fixture/StringIdentifier.php
@@ -22,24 +22,20 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class StringIdentifier
 {
     /**
-     * @var string|null
-     *
      * @ORM\Id
      * @ORM\Column(name="uid", type="string", length=32)
      */
     #[ORM\Id]
     #[ORM\Column(name: 'uid', type: Types::STRING, length: 32)]
-    private $uid;
+    private ?string $uid = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @ORM\Column(name="title", type="string", length=128)
      */
     #[Gedmo\Translatable]
     #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var string|null
@@ -49,7 +45,7 @@ class StringIdentifier
      * @Gedmo\Locale
      */
     #[Gedmo\Locale]
-    private $locale;
+    private ?string $locale = null;
 
     public function getUid(): ?string
     {

--- a/tests/Gedmo/Translatable/Fixture/Template/ArticleTemplate.php
+++ b/tests/Gedmo/Translatable/Fixture/Template/ArticleTemplate.php
@@ -31,24 +31,20 @@ class ArticleTemplate
     #[Gedmo\Locale]
     protected $locale;
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @ORM\Column(name="title", type="string", length=128)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
     #[Gedmo\Translatable]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @ORM\Column(name="content", type="text")
      */
     #[ORM\Column(name: 'content', type: Types::TEXT)]
     #[Gedmo\Translatable]
-    private $content;
+    private ?string $content = null;
 
     public function setTitle(?string $title): void
     {

--- a/tests/Gedmo/Translatable/Fixture/TemplatedArticle.php
+++ b/tests/Gedmo/Translatable/Fixture/TemplatedArticle.php
@@ -35,14 +35,12 @@ class TemplatedArticle extends ArticleTemplate
     private $id;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @ORM\Column(type="string", length=128)
      */
     #[Gedmo\Translatable]
     #[ORM\Column(type: Types::STRING, length: 128)]
-    private $name;
+    private ?string $name = null;
 
     public function setName(?string $name): void
     {

--- a/tests/Gedmo/Translatable/InheritanceTest.php
+++ b/tests/Gedmo/Translatable/InheritanceTest.php
@@ -36,10 +36,7 @@ final class InheritanceTest extends BaseTestCaseORM
 
     private const TREE_WALKER_TRANSLATION = TranslationWalker::class;
 
-    /**
-     * @var TranslatableListener
-     */
-    private $translatableListener;
+    private TranslatableListener $translatableListener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Translatable/Issue/Issue109Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue109Test.php
@@ -34,10 +34,7 @@ final class Issue109Test extends BaseTestCaseORM
 
     private const TREE_WALKER_TRANSLATION = TranslationWalker::class;
 
-    /**
-     * @var TranslatableListener
-     */
-    private $translatableListener;
+    private TranslatableListener $translatableListener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Translatable/Issue/Issue1123Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue1123Test.php
@@ -26,10 +26,7 @@ final class Issue1123Test extends BaseTestCaseORM
     private const BASE_ENTITY = BaseEntity::class;
     private const CHILD_ENTITY = ChildEntity::class;
 
-    /**
-     * @var TranslatableListener
-     */
-    private $translatableListener;
+    private TranslatableListener $translatableListener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Translatable/Issue/Issue114Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue114Test.php
@@ -29,10 +29,7 @@ final class Issue114Test extends BaseTestCaseORM
     private const ARTICLE = Article::class;
     private const TRANSLATION = Translation::class;
 
-    /**
-     * @var TranslatableListener
-     */
-    private $translatableListener;
+    private TranslatableListener $translatableListener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Translatable/Issue/Issue135Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue135Test.php
@@ -33,10 +33,7 @@ final class Issue135Test extends BaseTestCaseORM
 
     private const TREE_WALKER_TRANSLATION = TranslationWalker::class;
 
-    /**
-     * @var TranslatableListener
-     */
-    private $translatableListener;
+    private TranslatableListener $translatableListener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Translatable/Issue/Issue138Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue138Test.php
@@ -30,10 +30,7 @@ final class Issue138Test extends BaseTestCaseORM
     private const TRANSLATION = Translation::class;
     private const TREE_WALKER_TRANSLATION = TranslationWalker::class;
 
-    /**
-     * @var TranslatableListener
-     */
-    private $translatableListener;
+    private TranslatableListener $translatableListener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Translatable/Issue/Issue165Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue165Test.php
@@ -23,10 +23,7 @@ use Gedmo\Translatable\TranslatableListener;
  */
 final class Issue165Test extends BaseTestCaseMongoODM
 {
-    /**
-     * @var TranslatableListener
-     */
-    private $translatableListener;
+    private TranslatableListener $translatableListener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Translatable/Issue/Issue173Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue173Test.php
@@ -35,10 +35,7 @@ final class Issue173Test extends BaseTestCaseORM
     private const PRODUCT = Product::class;
     private const TRANSLATION = Translation::class;
 
-    /**
-     * @var TranslatableListener
-     */
-    private $translatableListener;
+    private TranslatableListener $translatableListener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Translatable/Issue/Issue2152Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue2152Test.php
@@ -22,10 +22,7 @@ final class Issue2152Test extends BaseTestCaseORM
     private const TRANSLATION = Translation::class;
     private const ENTITY = EntityWithTranslatableBoolean::class;
 
-    /**
-     * @var TranslatableListener
-     */
-    private $translatableListener;
+    private TranslatableListener $translatableListener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Translatable/Issue/Issue2167Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue2167Test.php
@@ -22,10 +22,7 @@ class Issue2167Test extends BaseTestCaseORM
     private const TRANSLATION = Translation::class;
     private const ENTITY = Article::class;
 
-    /**
-     * @var TranslatableListener
-     */
-    private $translatableListener;
+    private TranslatableListener $translatableListener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Translatable/Issue/Issue84Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue84Test.php
@@ -28,10 +28,7 @@ final class Issue84Test extends BaseTestCaseORM
     private const ARTICLE = Article::class;
     private const TRANSLATION = Translation::class;
 
-    /**
-     * @var TranslatableListener
-     */
-    private $translatableListener;
+    private TranslatableListener $translatableListener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Translatable/Issue/Issue922Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue922Test.php
@@ -27,10 +27,7 @@ final class Issue922Test extends BaseTestCaseORM
 
     private const TREE_WALKER_TRANSLATION = TranslationWalker::class;
 
-    /**
-     * @var TranslatableListener
-     */
-    private $translatableListener;
+    private TranslatableListener $translatableListener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Translatable/MixedValueTranslationTest.php
+++ b/tests/Gedmo/Translatable/MixedValueTranslationTest.php
@@ -29,10 +29,7 @@ final class MixedValueTranslationTest extends BaseTestCaseORM
     private const MIXED = MixedValue::class;
     private const TRANSLATION = Translation::class;
 
-    /**
-     * @var TranslatableListener
-     */
-    private $translatableListener;
+    private TranslatableListener $translatableListener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Translatable/PersonalTranslationDocumentTest.php
+++ b/tests/Gedmo/Translatable/PersonalTranslationDocumentTest.php
@@ -26,15 +26,9 @@ final class PersonalTranslationDocumentTest extends BaseTestCaseMongoODM
 {
     private const ARTICLE = Article::class;
 
-    /**
-     * @var TranslatableListener
-     */
-    private $translatableListener;
+    private TranslatableListener $translatableListener;
 
-    /**
-     * @var string|null
-     */
-    private $id;
+    private ?string $id = null;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Translatable/PersonalTranslationTest.php
+++ b/tests/Gedmo/Translatable/PersonalTranslationTest.php
@@ -32,10 +32,7 @@ final class PersonalTranslationTest extends BaseTestCaseORM
     private const TRANSLATION = PersonalArticleTranslation::class;
     private const TREE_WALKER_TRANSLATION = TranslationWalker::class;
 
-    /**
-     * @var TranslatableListener
-     */
-    private $translatableListener;
+    private TranslatableListener $translatableListener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Translatable/TranslatableDocumentCollectionTest.php
+++ b/tests/Gedmo/Translatable/TranslatableDocumentCollectionTest.php
@@ -28,15 +28,9 @@ final class TranslatableDocumentCollectionTest extends BaseTestCaseMongoODM
     private const ARTICLE = Article::class;
     private const TRANSLATION = Translation::class;
 
-    /**
-     * @var TranslatableListener
-     */
-    private $translatableListener;
+    private TranslatableListener $translatableListener;
 
-    /**
-     * @var string|null
-     */
-    private $id;
+    private ?string $id = null;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Translatable/TranslatableDocumentTest.php
+++ b/tests/Gedmo/Translatable/TranslatableDocumentTest.php
@@ -29,15 +29,9 @@ final class TranslatableDocumentTest extends BaseTestCaseMongoODM
     private const ARTICLE = Article::class;
     private const TRANSLATION = Translation::class;
 
-    /**
-     * @var TranslatableListener
-     */
-    private $translatableListener;
+    private TranslatableListener $translatableListener;
 
-    /**
-     * @var string|null
-     */
-    private $articleId;
+    private ?string $articleId = null;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Translatable/TranslatableEntityCollectionTest.php
+++ b/tests/Gedmo/Translatable/TranslatableEntityCollectionTest.php
@@ -29,10 +29,7 @@ final class TranslatableEntityCollectionTest extends BaseTestCaseORM
     private const COMMENT = Comment::class;
     private const TRANSLATION = Translation::class;
 
-    /**
-     * @var TranslatableListener
-     */
-    private $translatableListener;
+    private TranslatableListener $translatableListener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Translatable/TranslatableEntityDefaultTranslationTest.php
+++ b/tests/Gedmo/Translatable/TranslatableEntityDefaultTranslationTest.php
@@ -28,10 +28,7 @@ final class TranslatableEntityDefaultTranslationTest extends BaseTestCaseORM
     private const ARTICLE = Article::class;
     private const TRANSLATION = Translation::class;
 
-    /**
-     * @var TranslatableListener
-     */
-    private $translatableListener;
+    private TranslatableListener $translatableListener;
 
     /**
      * @var TranslationRepository

--- a/tests/Gedmo/Translatable/TranslatableIdentifierTest.php
+++ b/tests/Gedmo/Translatable/TranslatableIdentifierTest.php
@@ -27,15 +27,9 @@ final class TranslatableIdentifierTest extends BaseTestCaseORM
     private const FIXTURE = StringIdentifier::class;
     private const TRANSLATION = Translation::class;
 
-    /**
-     * @var string|null
-     */
-    private $testObjectId;
+    private ?string $testObjectId = null;
 
-    /**
-     * @var TranslatableListener
-     */
-    private $translatableListener;
+    private TranslatableListener $translatableListener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Translatable/TranslatableTest.php
+++ b/tests/Gedmo/Translatable/TranslatableTest.php
@@ -33,15 +33,9 @@ final class TranslatableTest extends BaseTestCaseORM
     private const COMMENT = Comment::class;
     private const TRANSLATION = Translation::class;
 
-    /**
-     * @var int|null
-     */
-    private $articleId;
+    private ?int $articleId = null;
 
-    /**
-     * @var TranslatableListener
-     */
-    private $translatableListener;
+    private TranslatableListener $translatableListener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Translatable/TranslatableWithEmbeddedTest.php
+++ b/tests/Gedmo/Translatable/TranslatableWithEmbeddedTest.php
@@ -27,10 +27,7 @@ final class TranslatableWithEmbeddedTest extends BaseTestCaseORM
 
     private const TREE_WALKER_TRANSLATION = TranslationWalker::class;
 
-    /**
-     * @var TranslatableListener
-     */
-    private $translatableListener;
+    private TranslatableListener $translatableListener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Translatable/TranslationQueryWalkerTest.php
+++ b/tests/Gedmo/Translatable/TranslationQueryWalkerTest.php
@@ -37,10 +37,7 @@ final class TranslationQueryWalkerTest extends BaseTestCaseORM
 
     private const TREE_WALKER_TRANSLATION = TranslationWalker::class;
 
-    /**
-     * @var TranslatableListener
-     */
-    private $translatableListener;
+    private TranslatableListener $translatableListener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Translator/Fixture/Person.php
+++ b/tests/Gedmo/Translator/Fixture/Person.php
@@ -66,15 +66,13 @@ class Person
      * @ORM\OneToMany(targetEntity="PersonTranslation", mappedBy="translatable", cascade={"persist"})
      */
     #[ORM\OneToMany(targetEntity: PersonTranslation::class, mappedBy: 'translatable', cascade: ['persist'])]
-    private $translations;
+    private Collection $translations;
 
     /**
-     * @var Person|null
-     *
      * @ORM\ManyToOne(targetEntity="Person")
      */
     #[ORM\ManyToOne(targetEntity: self::class)]
-    private $parent;
+    private ?\Gedmo\Tests\Translator\Fixture\Person $parent = null;
 
     public function __construct()
     {

--- a/tests/Gedmo/Translator/Fixture/PersonCustom.php
+++ b/tests/Gedmo/Translator/Fixture/PersonCustom.php
@@ -36,20 +36,16 @@ class PersonCustom
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="name", type="string", length=128)
      */
     #[ORM\Column(name: 'name', type: Types::STRING, length: 128)]
-    private $name;
+    private ?string $name = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="desc", type="string", length=128)
      */
     #[ORM\Column(name: 'desc', type: Types::STRING, length: 128)]
-    private $description;
+    private ?string $description = null;
 
     /**
      * @var Collection<int, TranslationInterface>
@@ -57,7 +53,7 @@ class PersonCustom
      * @ORM\OneToMany(targetEntity="PersonCustomTranslation", mappedBy="translatable", cascade={"persist"})
      */
     #[ORM\OneToMany(targetEntity: PersonCustomTranslation::class, mappedBy: 'translatable', cascade: ['persist'])]
-    private $translations;
+    private Collection $translations;
 
     public function __construct()
     {

--- a/tests/Gedmo/Tree/ClosureTreeRepositoryTest.php
+++ b/tests/Gedmo/Tree/ClosureTreeRepositoryTest.php
@@ -474,14 +474,12 @@ final class ClosureTreeRepositoryTest extends BaseTestCaseORM
         static::assertSame('Milk', $tree[2]['title']);
 
         // Helper Closures
-        $getTree = static function ($includeNode) use ($repo, $roots, $sortOption) {
-            return $repo->childrenHierarchy(
-                $roots[0],
-                true,
-                array_merge($sortOption, ['decorate' => true]),
-                $includeNode
-            );
-        };
+        $getTree = static fn ($includeNode) => $repo->childrenHierarchy(
+            $roots[0],
+            true,
+            array_merge($sortOption, ['decorate' => true]),
+            $includeNode
+        );
         $getTreeHtml = static function ($includeNode) {
             $baseHtml = '<li>Boring Food<ul><li>Vegitables<ul><li>Cabbages</li><li>Carrots</li></ul></li></ul></li><li>Fruits<ul><li>Berries<ul><li>Strawberries</li></ul></li><li>Lemons</li><li>Oranges</li></ul></li><li>Milk<ul><li>Cheese<ul><li>Mould cheese</li></ul></li></ul></li></ul>';
 

--- a/tests/Gedmo/Tree/Fixture/ANode.php
+++ b/tests/Gedmo/Tree/Fixture/ANode.php
@@ -54,8 +54,6 @@ class ANode
     private $rgt;
 
     /**
-     * @var BaseNode|null
-     *
      * @Gedmo\TreeParent
      * @ORM\ManyToOne(targetEntity="BaseNode", inversedBy="children")
      * @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
@@ -63,7 +61,7 @@ class ANode
     #[ORM\ManyToOne(targetEntity: BaseNode::class, inversedBy: 'children')]
     #[ORM\JoinColumn(name: 'parent_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
     #[Gedmo\TreeParent]
-    private $parent;
+    private ?BaseNode $parent = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Tree/Fixture/Article.php
+++ b/tests/Gedmo/Tree/Fixture/Article.php
@@ -35,12 +35,10 @@ class Article
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=128)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 128)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var Collection<int, Comment>
@@ -51,12 +49,10 @@ class Article
     private $comments;
 
     /**
-     * @var Category|null
-     *
      * @ORM\ManyToOne(targetEntity="Category", inversedBy="articles")
      */
     #[ORM\ManyToOne(targetEntity: Category::class, inversedBy: 'articles')]
-    private $category;
+    private ?Category $category = null;
 
     public function __construct()
     {

--- a/tests/Gedmo/Tree/Fixture/BaseNode.php
+++ b/tests/Gedmo/Tree/Fixture/BaseNode.php
@@ -38,7 +38,7 @@ class BaseNode extends ANode
      * @ORM\OneToMany(targetEntity="BaseNode", mappedBy="parent")
      */
     #[ORM\OneToMany(targetEntity: self::class, mappedBy: 'parent')]
-    private $children;
+    private Collection $children;
 
     /**
      * @var \DateTime|null
@@ -51,12 +51,10 @@ class BaseNode extends ANode
     private $created;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(length=128, unique=true)
      */
     #[ORM\Column(length: 128, unique: true)]
-    private $identifier;
+    private ?string $identifier = null;
 
     /**
      * @var \DateTime|null

--- a/tests/Gedmo/Tree/Fixture/BehavioralCategory.php
+++ b/tests/Gedmo/Tree/Fixture/BehavioralCategory.php
@@ -39,14 +39,12 @@ class BehavioralCategory
     private $id;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
     #[Gedmo\Translatable]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var int|null
@@ -69,8 +67,6 @@ class BehavioralCategory
     private $rgt;
 
     /**
-     * @var self|null
-     *
      * @Gedmo\TreeParent
      * @ORM\ManyToOne(targetEntity="BehavioralCategory", inversedBy="children")
      * @ORM\JoinColumns({
@@ -80,7 +76,7 @@ class BehavioralCategory
     #[ORM\ManyToOne(targetEntity: self::class, inversedBy: 'children')]
     #[ORM\JoinColumn(name: 'parent_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
     #[Gedmo\TreeParent]
-    private $parent;
+    private ?\Gedmo\Tests\Tree\Fixture\BehavioralCategory $parent = null;
 
     /**
      * @var Collection<int, self>
@@ -88,7 +84,7 @@ class BehavioralCategory
      * @ORM\OneToMany(targetEntity="BehavioralCategory", mappedBy="parent")
      */
     #[ORM\OneToMany(targetEntity: self::class, mappedBy: 'parent')]
-    private $children;
+    private Collection $children;
 
     /**
      * @var string|null

--- a/tests/Gedmo/Tree/Fixture/Category.php
+++ b/tests/Gedmo/Tree/Fixture/Category.php
@@ -40,12 +40,10 @@ class Category implements NodeInterface
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var int|null
@@ -68,8 +66,6 @@ class Category implements NodeInterface
     private $rgt;
 
     /**
-     * @var self|null
-     *
      * @Gedmo\TreeParent
      * @ORM\ManyToOne(targetEntity="Category", inversedBy="children")
      * @ORM\JoinColumns({
@@ -79,7 +75,7 @@ class Category implements NodeInterface
     #[ORM\ManyToOne(targetEntity: self::class, inversedBy: 'children')]
     #[ORM\JoinColumn(name: 'parent_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
     #[Gedmo\TreeParent]
-    private $parentId;
+    private ?\Gedmo\Tests\Tree\Fixture\Category $parentId = null;
 
     /**
      * @var int|null
@@ -97,7 +93,7 @@ class Category implements NodeInterface
      * @ORM\OneToMany(targetEntity="Category", mappedBy="parent")
      */
     #[ORM\OneToMany(targetEntity: self::class, mappedBy: 'parent')]
-    private $children;
+    private Collection $children;
 
     /**
      * @var Collection<int, Article>
@@ -105,12 +101,9 @@ class Category implements NodeInterface
      * @ORM\OneToMany(targetEntity="Article", mappedBy="category")
      */
     #[ORM\OneToMany(targetEntity: Article::class, mappedBy: 'article')]
-    private $comments;
+    private Collection $comments;
 
-    /**
-     * @var NodeInterface|null
-     */
-    private $sibling;
+    private ?NodeInterface $sibling = null;
 
     public function __construct()
     {

--- a/tests/Gedmo/Tree/Fixture/CategoryUuid.php
+++ b/tests/Gedmo/Tree/Fixture/CategoryUuid.php
@@ -30,8 +30,6 @@ use Gedmo\Tree\Node as NodeInterface;
 class CategoryUuid implements NodeInterface
 {
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="id", type="string", nullable=false)
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="NONE")
@@ -39,15 +37,13 @@ class CategoryUuid implements NodeInterface
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'NONE')]
     #[ORM\Column(name: 'id', type: Types::STRING, nullable: false)]
-    private $id;
+    private ?string $id = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var int|null
@@ -70,8 +66,6 @@ class CategoryUuid implements NodeInterface
     private $rgt;
 
     /**
-     * @var self|null
-     *
      * @Gedmo\TreeParent
      * @ORM\ManyToOne(targetEntity="CategoryUuid", inversedBy="children")
      * @ORM\JoinColumns({
@@ -81,7 +75,7 @@ class CategoryUuid implements NodeInterface
     #[ORM\ManyToOne(targetEntity: self::class, inversedBy: 'children')]
     #[ORM\JoinColumn(name: 'parent_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
     #[Gedmo\TreeParent]
-    private $parentId;
+    private ?\Gedmo\Tests\Tree\Fixture\CategoryUuid $parentId = null;
 
     /**
      * @var int|null
@@ -109,7 +103,7 @@ class CategoryUuid implements NodeInterface
      * @ORM\OneToMany(targetEntity="CategoryUuid", mappedBy="parent")
      */
     #[ORM\OneToMany(targetEntity: self::class, mappedBy: 'parent')]
-    private $children;
+    private Collection $children;
 
     /**
      * @var Collection<int, Article>
@@ -117,12 +111,9 @@ class CategoryUuid implements NodeInterface
      * @ORM\OneToMany(targetEntity="Article", mappedBy="category")
      */
     #[ORM\OneToMany(targetEntity: Article::class, mappedBy: 'category')]
-    private $comments;
+    private Collection $comments;
 
-    /**
-     * @var NodeInterface|null
-     */
-    private $sibling;
+    private ?NodeInterface $sibling = null;
 
     public function __construct()
     {

--- a/tests/Gedmo/Tree/Fixture/Closure/Category.php
+++ b/tests/Gedmo/Tree/Fixture/Closure/Category.php
@@ -41,26 +41,20 @@ class Category
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var int|null
-     *
      * @ORM\Column(name="level", type="integer", nullable=true)
      * @Gedmo\TreeLevel
      */
     #[ORM\Column(name: 'level', type: Types::INTEGER, nullable: true)]
     #[Gedmo\TreeLevel]
-    private $level;
+    private ?int $level = null;
 
     /**
-     * @var self|null
-     *
      * @Gedmo\TreeParent
      * @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
      * @ORM\ManyToOne(targetEntity="Category", inversedBy="children")
@@ -68,7 +62,7 @@ class Category
     #[ORM\ManyToOne(targetEntity: self::class, inversedBy: 'children')]
     #[ORM\JoinColumn(name: 'category_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
     #[Gedmo\TreeParent]
-    private $parent;
+    private ?\Gedmo\Tests\Tree\Fixture\Closure\Category $parent = null;
 
     /**
      * @var Collection<int, CategoryClosure>

--- a/tests/Gedmo/Tree/Fixture/Closure/CategoryWithoutLevel.php
+++ b/tests/Gedmo/Tree/Fixture/Closure/CategoryWithoutLevel.php
@@ -41,16 +41,12 @@ class CategoryWithoutLevel
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var self|null
-     *
      * @Gedmo\TreeParent
      * @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
      * @ORM\ManyToOne(targetEntity="CategoryWithoutLevel", inversedBy="children")
@@ -58,7 +54,7 @@ class CategoryWithoutLevel
     #[ORM\ManyToOne(targetEntity: self::class, inversedBy: 'children')]
     #[ORM\JoinColumn(name: 'category_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
     #[Gedmo\TreeParent]
-    private $parent;
+    private ?\Gedmo\Tests\Tree\Fixture\Closure\CategoryWithoutLevel $parent = null;
 
     /**
      * @var Collection<int, CategoryWithoutLevelClosure>

--- a/tests/Gedmo/Tree/Fixture/Closure/News.php
+++ b/tests/Gedmo/Tree/Fixture/Closure/News.php
@@ -35,22 +35,18 @@ class News
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
-    private $title;
+    private string $title;
 
     /**
-     * @var Category|null
-     *
      * @ORM\OneToOne(targetEntity="Gedmo\Tests\Tree\Fixture\Closure\Category", cascade={"persist"})
      * @ORM\JoinColumn(name="category_id", referencedColumnName="id")
      */
     #[ORM\OneToOne(targetEntity: Category::class, cascade: ['persist'])]
     #[ORM\JoinColumn(name: 'category_id', referencedColumnName: 'id')]
-    private $category;
+    private Category $category;
 
     public function __construct(string $title, Category $category)
     {

--- a/tests/Gedmo/Tree/Fixture/Closure/Person.php
+++ b/tests/Gedmo/Tree/Fixture/Closure/Person.php
@@ -47,16 +47,12 @@ abstract class Person
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="full_name", type="string", length=64)
      */
     #[ORM\Column(name: 'full_name', type: Types::STRING, length: 64)]
-    private $fullName;
+    private ?string $fullName = null;
 
     /**
-     * @var self|null
-     *
      * @Gedmo\TreeParent
      * @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
      * @ORM\ManyToOne(targetEntity="Person", inversedBy="children", cascade={"persist"})
@@ -64,27 +60,22 @@ abstract class Person
     #[ORM\ManyToOne(targetEntity: self::class, inversedBy: 'children', cascade: ['persist'])]
     #[ORM\JoinColumn(name: 'parent_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
     #[Gedmo\TreeParent]
-    private $parent;
+    private ?\Gedmo\Tests\Tree\Fixture\Closure\Person $parent = null;
 
     /**
-     * @var int|null
-     *
      * @ORM\Column(name="level", type="integer")
      * @Gedmo\TreeLevel
      */
     #[ORM\Column(name: 'level', type: Types::INTEGER)]
     #[Gedmo\TreeLevel]
-    private $level;
+    private ?int $level = null;
 
-    /**
-     * @var string|null
-     */
-    private $name;
+    private ?string $name = null;
 
     /**
      * @var CategoryClosure[]
      */
-    private $closures = [];
+    private array $closures = [];
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Tree/Fixture/Closure/User.php
+++ b/tests/Gedmo/Tree/Fixture/Closure/User.php
@@ -21,12 +21,10 @@ use Doctrine\ORM\Mapping as ORM;
 class User extends Person
 {
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="username", type="string", length=64)
      */
     #[ORM\Column(name: 'username', type: Types::STRING, length: 64)]
-    private $username;
+    private ?string $username = null;
 
     public function setUsername(?string $username): void
     {

--- a/tests/Gedmo/Tree/Fixture/Comment.php
+++ b/tests/Gedmo/Tree/Fixture/Comment.php
@@ -33,20 +33,16 @@ class Comment
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="message", type="text")
      */
     #[ORM\Column(name: 'message', type: Types::TEXT)]
-    private $message;
+    private ?string $message = null;
 
     /**
-     * @var Article|null
-     *
      * @ORM\ManyToOne(targetEntity="Article", inversedBy="comments")
      */
     #[ORM\ManyToOne(targetEntity: Article::class, inversedBy: 'comments')]
-    private $article;
+    private ?Article $article = null;
 
     public function setArticle(?Article $article): void
     {

--- a/tests/Gedmo/Tree/Fixture/Document/Article.php
+++ b/tests/Gedmo/Tree/Fixture/Document/Article.php
@@ -33,14 +33,12 @@ class Article
     private $id;
 
     /**
-     * @var string|null
-     *
      * @Mongo\Field(type="string")
      * @Gedmo\TreePathSource
      */
     #[Mongo\Field(type: Type::STRING)]
     #[Gedmo\TreePathSource]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var string|null
@@ -53,14 +51,12 @@ class Article
     private $path;
 
     /**
-     * @var self|null
-     *
      * @Gedmo\TreeParent
      * @Mongo\ReferenceOne(targetDocument="Article")
      */
     #[Mongo\ReferenceOne(targetDocument: self::class)]
     #[Gedmo\TreeParent]
-    private $parent;
+    private ?\Gedmo\Tests\Tree\Fixture\Document\Article $parent = null;
 
     /**
      * @var int|null

--- a/tests/Gedmo/Tree/Fixture/Document/Category.php
+++ b/tests/Gedmo/Tree/Fixture/Document/Category.php
@@ -33,14 +33,12 @@ class Category
     private $id;
 
     /**
-     * @var string|null
-     *
      * @Mongo\Field(type="string")
      * @Gedmo\TreePathSource
      */
     #[Mongo\Field(type: Type::STRING)]
     #[Gedmo\TreePathSource]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var string|null
@@ -53,14 +51,12 @@ class Category
     private $path;
 
     /**
-     * @var self|null
-     *
      * @Gedmo\TreeParent
      * @Mongo\ReferenceOne(targetDocument="Gedmo\Tests\Tree\Fixture\Document\Category")
      */
     #[Mongo\ReferenceOne(targetDocument: self::class)]
     #[Gedmo\TreeParent]
-    private $parent;
+    private ?\Gedmo\Tests\Tree\Fixture\Document\Category $parent = null;
 
     /**
      * @var int|null

--- a/tests/Gedmo/Tree/Fixture/ForeignRootCategory.php
+++ b/tests/Gedmo/Tree/Fixture/ForeignRootCategory.php
@@ -39,12 +39,10 @@ class ForeignRootCategory
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var int|null
@@ -67,8 +65,6 @@ class ForeignRootCategory
     private $rgt;
 
     /**
-     * @var self|null
-     *
      * @Gedmo\TreeParent
      * @ORM\ManyToOne(targetEntity="ForeignRootCategory", inversedBy="children")
      * @ORM\JoinColumns({
@@ -78,7 +74,7 @@ class ForeignRootCategory
     #[ORM\ManyToOne(targetEntity: self::class, inversedBy: 'children')]
     #[ORM\JoinColumn(name: 'parent_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
     #[Gedmo\TreeParent]
-    private $parent;
+    private ?\Gedmo\Tests\Tree\Fixture\ForeignRootCategory $parent = null;
 
     /**
      * @var int|null

--- a/tests/Gedmo/Tree/Fixture/Genealogy/Person.php
+++ b/tests/Gedmo/Tree/Fixture/Genealogy/Person.php
@@ -55,14 +55,12 @@ abstract class Person
     private $id;
 
     /**
-     * @var self|null
-     *
      * @Gedmo\TreeParent
      * @ORM\ManyToOne(targetEntity="Person", inversedBy="children")
      */
     #[ORM\ManyToOne(targetEntity: self::class, inversedBy: 'children')]
     #[Gedmo\TreeParent]
-    private $parent;
+    private ?\Gedmo\Tests\Tree\Fixture\Genealogy\Person $parent = null;
 
     /**
      * @var int|null
@@ -95,12 +93,10 @@ abstract class Person
     private $lvl;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="name", type="string", length=191, nullable=false)
      */
     #[ORM\Column(name: 'name', type: Types::STRING, length: 191, nullable: false)]
-    private $name;
+    private string $name;
 
     public function __construct(string $name)
     {
@@ -115,7 +111,7 @@ abstract class Person
         return $this;
     }
 
-    public function getName(): ?string
+    public function getName(): string
     {
         return $this->name;
     }

--- a/tests/Gedmo/Tree/Fixture/Issue2408/Category.php
+++ b/tests/Gedmo/Tree/Fixture/Issue2408/Category.php
@@ -41,12 +41,10 @@ class Category
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var int|null
@@ -91,8 +89,6 @@ class Category
     private $root;
 
     /**
-     * @var self|null
-     *
      * @Gedmo\TreeParent
      * @ORM\ManyToOne(targetEntity="Category", inversedBy="children")
      * @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
@@ -100,7 +96,7 @@ class Category
     #[Gedmo\TreeParent]
     #[ORM\ManyToOne(targetEntity: self::class, inversedBy: 'children')]
     #[ORM\JoinColumn(name: 'parent_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
-    private $parent;
+    private ?\Gedmo\Tests\Tree\Fixture\Issue2408\Category $parent = null;
 
     /**
      * @var Collection<int, Category>
@@ -110,7 +106,7 @@ class Category
      */
     #[ORM\OneToMany(targetEntity: self::class, mappedBy: 'parent')]
     #[ORM\OrderBy(['lft' => 'ASC'])]
-    private $children;
+    private Collection $children;
 
     public function __construct()
     {

--- a/tests/Gedmo/Tree/Fixture/Issue2517/Category.php
+++ b/tests/Gedmo/Tree/Fixture/Issue2517/Category.php
@@ -41,12 +41,10 @@ class Category
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var int|null
@@ -91,8 +89,6 @@ class Category
     private $root;
 
     /**
-     * @var self|null
-     *
      * @Gedmo\TreeParent
      * @ORM\ManyToOne(targetEntity="Category", inversedBy="children")
      * @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
@@ -100,7 +96,7 @@ class Category
     #[Gedmo\TreeParent]
     #[ORM\ManyToOne(targetEntity: self::class, inversedBy: 'children')]
     #[ORM\JoinColumn(name: 'parent_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
-    private $parent;
+    private ?\Gedmo\Tests\Tree\Fixture\Issue2517\Category $parent = null;
 
     /**
      * @var Collection<int, Category>
@@ -110,7 +106,7 @@ class Category
      */
     #[ORM\OneToMany(targetEntity: self::class, mappedBy: 'parent')]
     #[ORM\OrderBy(['lft' => 'ASC'])]
-    private $children;
+    private Collection $children;
 
     public function __construct()
     {

--- a/tests/Gedmo/Tree/Fixture/MPCategory.php
+++ b/tests/Gedmo/Tree/Fixture/MPCategory.php
@@ -39,28 +39,22 @@ class MPCategory
     private $id;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\TreePath
      * @ORM\Column(name="path", type="string", length=3000, nullable=true)
      */
     #[ORM\Column(name: 'path', type: Types::STRING, length: 3000, nullable: true)]
     #[Gedmo\TreePath]
-    private $path;
+    private ?string $path = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\TreePathSource
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
     #[Gedmo\TreePathSource]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var self|null
-     *
      * @Gedmo\TreeParent
      * @ORM\ManyToOne(targetEntity="MPCategory", inversedBy="children")
      * @ORM\JoinColumns({
@@ -70,7 +64,7 @@ class MPCategory
     #[ORM\ManyToOne(targetEntity: self::class, inversedBy: 'children')]
     #[ORM\JoinColumn(name: 'parent_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
     #[Gedmo\TreeParent]
-    private $parentId;
+    private ?\Gedmo\Tests\Tree\Fixture\MPCategory $parentId = null;
 
     /**
      * @var int|null
@@ -98,7 +92,7 @@ class MPCategory
      * @ORM\OneToMany(targetEntity="MPCategory", mappedBy="parent")
      */
     #[ORM\OneToMany(targetEntity: self::class, mappedBy: 'parent')]
-    private $children;
+    private Collection $children;
 
     /**
      * @var Collection<int, Article>
@@ -106,7 +100,7 @@ class MPCategory
      * @ORM\OneToMany(targetEntity="Article", mappedBy="category")
      */
     #[ORM\OneToMany(targetEntity: Article::class, mappedBy: 'category')]
-    private $comments;
+    private Collection $comments;
 
     public function __construct()
     {

--- a/tests/Gedmo/Tree/Fixture/MPCategoryWithRootAssociation.php
+++ b/tests/Gedmo/Tree/Fixture/MPCategoryWithRootAssociation.php
@@ -41,26 +41,20 @@ class MPCategoryWithRootAssociation
     private $id;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\TreePath
      * @ORM\Column(name="path", type="string", length=3000, nullable=true)
      */
     #[ORM\Column(name: 'path', type: Types::STRING, length: 3000, nullable: true)]
     #[Gedmo\TreePath]
-    private $path;
+    private ?string $path = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var self|null
-     *
      * @Gedmo\TreeParent
      * @ORM\ManyToOne(targetEntity="MPCategoryWithRootAssociation", inversedBy="children")
      * @ORM\JoinColumns({
@@ -70,7 +64,7 @@ class MPCategoryWithRootAssociation
     #[ORM\ManyToOne(targetEntity: self::class, inversedBy: 'children')]
     #[ORM\JoinColumn(name: 'parent_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
     #[Gedmo\TreeParent]
-    private $parentId;
+    private ?\Gedmo\Tests\Tree\Fixture\MPCategoryWithRootAssociation $parentId = null;
 
     /**
      * @var int|null
@@ -102,7 +96,7 @@ class MPCategoryWithRootAssociation
      * @ORM\OneToMany(targetEntity="MPCategory", mappedBy="parent")
      */
     #[ORM\OneToMany(targetEntity: self::class, mappedBy: 'parent')]
-    private $children;
+    private Collection $children;
 
     /**
      * @var Collection<int, Article>
@@ -110,7 +104,7 @@ class MPCategoryWithRootAssociation
      * @ORM\OneToMany(targetEntity="Article", mappedBy="category")
      */
     #[ORM\OneToMany(targetEntity: Article::class, mappedBy: 'category')]
-    private $comments;
+    private Collection $comments;
 
     public function __construct()
     {

--- a/tests/Gedmo/Tree/Fixture/MPCategoryWithTrimmedSeparator.php
+++ b/tests/Gedmo/Tree/Fixture/MPCategoryWithTrimmedSeparator.php
@@ -39,28 +39,22 @@ class MPCategoryWithTrimmedSeparator
     private $id;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\TreePath(appendId=false, startsWithSeparator=false, endsWithSeparator=false)
      * @ORM\Column(name="path", type="string", length=3000, nullable=true)
      */
     #[ORM\Column(name: 'path', type: Types::STRING, length: 3000, nullable: true)]
     #[Gedmo\TreePath(appendId: false, startsWithSeparator: false, endsWithSeparator: false)]
-    private $path;
+    private ?string $path = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\TreePathSource
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
     #[Gedmo\TreePathSource]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var self|null
-     *
      * @Gedmo\TreeParent
      * @ORM\ManyToOne(targetEntity="MPCategoryWithTrimmedSeparator", inversedBy="children")
      * @ORM\JoinColumns({
@@ -70,7 +64,7 @@ class MPCategoryWithTrimmedSeparator
     #[ORM\ManyToOne(targetEntity: self::class, inversedBy: 'children')]
     #[ORM\JoinColumn(name: 'parent_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
     #[Gedmo\TreeParent]
-    private $parentId;
+    private ?\Gedmo\Tests\Tree\Fixture\MPCategoryWithTrimmedSeparator $parentId = null;
 
     /**
      * @var int|null
@@ -88,7 +82,7 @@ class MPCategoryWithTrimmedSeparator
      * @ORM\OneToMany(targetEntity="MPCategoryWithTrimmedSeparator", mappedBy="parent")
      */
     #[ORM\OneToMany(targetEntity: self::class, mappedBy: 'parent')]
-    private $children;
+    private Collection $children;
 
     public function __construct()
     {

--- a/tests/Gedmo/Tree/Fixture/MPFeaturesCategory.php
+++ b/tests/Gedmo/Tree/Fixture/MPFeaturesCategory.php
@@ -39,14 +39,12 @@ class MPFeaturesCategory
     private $id;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\TreePath(appendId=false, startsWithSeparator=true, endsWithSeparator=false)
      * @ORM\Column(name="path", type="string", length=3000, nullable=true)
      */
     #[ORM\Column(name: 'path', type: Types::STRING, length: 3000, nullable: true)]
     #[Gedmo\TreePath(appendId: false, startsWithSeparator: true, endsWithSeparator: false)]
-    private $path;
+    private ?string $path = null;
 
     /**
      * @var string|null
@@ -59,18 +57,14 @@ class MPFeaturesCategory
     private $pathHash;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\TreePathSource
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
     #[Gedmo\TreePathSource]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var self|null
-     *
      * @Gedmo\TreeParent
      * @ORM\ManyToOne(targetEntity="MPFeaturesCategory", inversedBy="children")
      * @ORM\JoinColumns({
@@ -80,7 +74,7 @@ class MPFeaturesCategory
     #[ORM\ManyToOne(targetEntity: self::class, inversedBy: 'children')]
     #[ORM\JoinColumn(name: 'parent_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
     #[Gedmo\TreeParent]
-    private $parentId;
+    private ?\Gedmo\Tests\Tree\Fixture\MPFeaturesCategory $parentId = null;
 
     /**
      * @var int|null
@@ -108,7 +102,7 @@ class MPFeaturesCategory
      * @ORM\OneToMany(targetEntity="MPFeaturesCategory", mappedBy="parent")
      */
     #[ORM\OneToMany(targetEntity: self::class, mappedBy: 'parent')]
-    private $children;
+    private Collection $children;
 
     /**
      * @var Collection<int, Article>
@@ -116,7 +110,7 @@ class MPFeaturesCategory
      * @ORM\OneToMany(targetEntity="Article", mappedBy="category")
      */
     #[ORM\OneToMany(targetEntity: Article::class, mappedBy: 'category')]
-    private $comments;
+    private Collection $comments;
 
     public function __construct()
     {

--- a/tests/Gedmo/Tree/Fixture/Node.php
+++ b/tests/Gedmo/Tree/Fixture/Node.php
@@ -23,14 +23,12 @@ use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
 class Node extends BaseNode
 {
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
     #[Gedmo\Translatable]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var string|null

--- a/tests/Gedmo/Tree/Fixture/Role.php
+++ b/tests/Gedmo/Tree/Fixture/Role.php
@@ -55,14 +55,12 @@ abstract class Role
     private $id;
 
     /**
-     * @var UserGroup
-     *
      * @Gedmo\TreeParent
      * @ORM\ManyToOne(targetEntity="UserGroup", inversedBy="children")
      */
     #[ORM\ManyToOne(targetEntity: UserGroup::class, inversedBy: 'children')]
     #[Gedmo\TreeParent]
-    private $parent;
+    private ?UserGroup $parent = null;
 
     /**
      * @var int|null
@@ -95,12 +93,10 @@ abstract class Role
     private $lvl;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="role", type="string", length=191, nullable=false)
      */
     #[ORM\Column(name: 'role', type: Types::STRING, length: 191, nullable: false)]
-    private $role;
+    private ?string $role = null;
 
     public function __construct()
     {

--- a/tests/Gedmo/Tree/Fixture/RootAssociationCategory.php
+++ b/tests/Gedmo/Tree/Fixture/RootAssociationCategory.php
@@ -46,12 +46,10 @@ class RootAssociationCategory
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var int|null
@@ -74,8 +72,6 @@ class RootAssociationCategory
     private $rgt;
 
     /**
-     * @var self|null
-     *
      * @Gedmo\TreeParent
      * @ORM\ManyToOne(targetEntity="RootAssociationCategory", inversedBy="children")
      * @ORM\JoinColumns({
@@ -85,7 +81,7 @@ class RootAssociationCategory
     #[ORM\ManyToOne(targetEntity: self::class, inversedBy: 'children')]
     #[ORM\JoinColumn(name: 'parent_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
     #[Gedmo\TreeParent]
-    private $parent;
+    private ?\Gedmo\Tests\Tree\Fixture\RootAssociationCategory $parent = null;
 
     /**
      * @var self|null

--- a/tests/Gedmo/Tree/Fixture/RootCategory.php
+++ b/tests/Gedmo/Tree/Fixture/RootCategory.php
@@ -47,12 +47,10 @@ class RootCategory implements Node
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", length=64)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var int|null
@@ -75,8 +73,6 @@ class RootCategory implements Node
     private $rgt;
 
     /**
-     * @var self|null
-     *
      * @Gedmo\TreeParent
      * @ORM\ManyToOne(targetEntity="RootCategory", inversedBy="children")
      * @ORM\JoinColumns({
@@ -86,7 +82,7 @@ class RootCategory implements Node
     #[ORM\ManyToOne(targetEntity: self::class, inversedBy: 'children')]
     #[ORM\JoinColumn(name: 'parent_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
     #[Gedmo\TreeParent]
-    private $parent;
+    private ?\Gedmo\Tests\Tree\Fixture\RootCategory $parent = null;
 
     /**
      * @var int|null
@@ -108,10 +104,7 @@ class RootCategory implements Node
     #[Gedmo\TreeLevel(base: 1)]
     private $level;
 
-    /**
-     * @var Node|null
-     */
-    private $sibling;
+    private ?Node $sibling = null;
 
     public function __construct()
     {

--- a/tests/Gedmo/Tree/Fixture/Transport/Car.php
+++ b/tests/Gedmo/Tree/Fixture/Transport/Car.php
@@ -35,8 +35,6 @@ class Car extends Vehicle
     protected $children;
 
     /**
-     * @var self|null
-     *
      * @Gedmo\TreeParent
      * @ORM\ManyToOne(targetEntity="Car", inversedBy="children")
      * @ORM\JoinColumns({
@@ -46,7 +44,7 @@ class Car extends Vehicle
     #[ORM\ManyToOne(targetEntity: self::class, inversedBy: 'children')]
     #[ORM\JoinColumn(name: 'parent_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
     #[Gedmo\TreeParent]
-    private $parent;
+    private ?\Gedmo\Tests\Tree\Fixture\Transport\Car $parent = null;
 
     /**
      * @var int|null

--- a/tests/Gedmo/Tree/Fixture/Transport/Engine.php
+++ b/tests/Gedmo/Tree/Fixture/Transport/Engine.php
@@ -33,20 +33,16 @@ class Engine
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(length=32)
      */
     #[ORM\Column(length: 32)]
-    private $type;
+    private ?string $type = null;
 
     /**
-     * @var int|null
-     *
      * @ORM\Column(type="integer")
      */
     #[ORM\Column(type: Types::INTEGER)]
-    private $valves;
+    private ?int $valves = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Tree/Fixture/Transport/Vehicle.php
+++ b/tests/Gedmo/Tree/Fixture/Transport/Vehicle.php
@@ -43,20 +43,16 @@ class Vehicle
     private $id;
 
     /**
-     * @var Engine|null
-     *
      * @ORM\OneToOne(targetEntity="Engine")
      */
     #[ORM\OneToOne(targetEntity: Engine::class)]
-    private $engine;
+    private ?Engine $engine = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(length=128)
      */
     #[ORM\Column(type: Types::STRING)]
-    private $title;
+    private ?string $title = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Tree/Fixture/User.php
+++ b/tests/Gedmo/Tree/Fixture/User.php
@@ -26,28 +26,22 @@ class User extends Role
     private const PASSWORD_SALT = 'dfJko$~346958rg!DFT]AEtzserf9giq)3/TAeg;aDFa43';
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="email", type="string", unique=true)
      */
     #[ORM\Column(name: 'email', type: Types::STRING, unique: true)]
-    private $email;
+    private ?string $email = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="password_hash", type="string", length=32)
      */
     #[ORM\Column(name: 'password_hash', type: Types::STRING, length: 32)]
-    private $passwordHash;
+    private string $passwordHash;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="activation_code", type="string", length=12)
      */
     #[ORM\Column(name: 'activation_code', type: Types::STRING, length: 12)]
-    private $activationCode;
+    private ?string $activationCode = null;
 
     public function __construct(string $email, string $password)
     {
@@ -102,7 +96,7 @@ class User extends Role
         return $this;
     }
 
-    public function getPasswordHash(): ?string
+    public function getPasswordHash(): string
     {
         return $this->passwordHash;
     }

--- a/tests/Gedmo/Tree/Fixture/UserGroup.php
+++ b/tests/Gedmo/Tree/Fixture/UserGroup.php
@@ -26,12 +26,10 @@ use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
 class UserGroup extends Role
 {
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="name", type="string", length=191)
      */
     #[ORM\Column(name: 'name', type: Types::STRING, length: 191)]
-    private $name;
+    private string $name;
 
     public function __construct(string $name)
     {
@@ -43,7 +41,7 @@ class UserGroup extends Role
         return $this->name;
     }
 
-    public function getName(): ?string
+    public function getName(): string
     {
         return $this->name;
     }

--- a/tests/Gedmo/Tree/Issue/Issue2408Test.php
+++ b/tests/Gedmo/Tree/Issue/Issue2408Test.php
@@ -18,10 +18,7 @@ use Gedmo\Tree\TreeListener;
 
 final class Issue2408Test extends BaseTestCaseORM
 {
-    /**
-     * @var TreeListener
-     */
-    private $listener;
+    private TreeListener $listener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Tree/Issue/Issue2517Test.php
+++ b/tests/Gedmo/Tree/Issue/Issue2517Test.php
@@ -18,10 +18,7 @@ use Gedmo\Tree\TreeListener;
 
 final class Issue2517Test extends BaseTestCaseORM
 {
-    /**
-     * @var TreeListener
-     */
-    private $listener;
+    private TreeListener $listener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Tree/MaterializedPathORMRepositoryTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathORMRepositoryTest.php
@@ -33,10 +33,7 @@ final class MaterializedPathORMRepositoryTest extends BaseTestCaseORM
     /** @var MaterializedPathRepository */
     protected $repo;
 
-    /**
-     * @var TreeListener
-     */
-    private $listener;
+    private TreeListener $listener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Tree/MaterializedPathORMRepositoryTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathORMRepositoryTest.php
@@ -345,12 +345,8 @@ final class MaterializedPathORMRepositoryTest extends BaseTestCaseORM
         $this->em->persist($newNode);
         $this->em->flush();
 
-        // @todo: Remove the condition and the `else` block when dropping support for "phpunit/phpunit" < 9.1.
-        if (method_exists($this, 'assertMatchesRegularExpression')) {
-            static::assertMatchesRegularExpression('/Food\-\d+,New\sNode\-\d+/', $newNode->getPath());
-        } else {
-            static::assertRegExp('/Food\-\d+,New\sNode\-\d+/', $newNode->getPath());
-        }
+        static::assertMatchesRegularExpression('/Food\-\d+,New\sNode\-\d+/', $newNode->getPath());
+
         static::assertSame(2, $newNode->getLevel());
     }
 

--- a/tests/Gedmo/Tree/MultInheritanceWithJoinedTableTest.php
+++ b/tests/Gedmo/Tree/MultInheritanceWithJoinedTableTest.php
@@ -33,10 +33,7 @@ final class MultInheritanceWithJoinedTableTest extends BaseTestCaseORM
     private const ROLE = Role::class;
     private const USERLDAP = UserLDAP::class;
 
-    /**
-     * @var TreeListener
-     */
-    private $tree;
+    private TreeListener $tree;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Tree/NestedTreeRootRepositoryTest.php
+++ b/tests/Gedmo/Tree/NestedTreeRootRepositoryTest.php
@@ -139,9 +139,7 @@ final class NestedTreeRootRepositoryTest extends BaseTestCaseORM
         );
 
         // custom title
-        $nodeDecorator = static function ($node) {
-            return '<span>'.$node['title'].'</span>';
-        };
+        $nodeDecorator = static fn ($node) => '<span>'.$node['title'].'</span>';
 
         $decoratedHtmlTree = $repo->childrenHierarchy(
             $food,
@@ -161,9 +159,7 @@ final class NestedTreeRootRepositoryTest extends BaseTestCaseORM
         $rootClose = '';
         $childOpen = '';
         $childClose = '';
-        $nodeDecorator = static function ($node) {
-            return str_repeat('-', $node['level'] - 1).$node['title']."\n";
-        };
+        $nodeDecorator = static fn ($node) => str_repeat('-', $node['level'] - 1).$node['title']."\n";
 
         $decoratedCliTree = $repo->childrenHierarchy(
             $food,
@@ -182,16 +178,12 @@ final class NestedTreeRootRepositoryTest extends BaseTestCaseORM
             $decoratedCliTree
         );
 
-        $rootOpen = static function () {return '<ul class="group">'; };
+        $rootOpen = static fn () => '<ul class="group">';
         // check support of the closures in rootClose
-        $rootClose = static function () {return '</ul><!--rootCloseClosure-->'; };
-        $childOpen = static function (&$node) {
-            return '<li class="depth'.($node['level'] - 1).'">';
-        };
+        $rootClose = static fn () => '</ul><!--rootCloseClosure-->';
+        $childOpen = static fn (&$node) => '<li class="depth'.($node['level'] - 1).'">';
         // check support of the closures in childClose
-        $childClose = static function (&$node) {
-            return '</li><!--childCloseClosure-->';
-        };
+        $childClose = static fn (&$node) => '</li><!--childCloseClosure-->';
         $decoratedHtmlTree = $repo->childrenHierarchy(
             $food,
             false,

--- a/tests/Gedmo/Tree/TranslatableSluggableTreeTest.php
+++ b/tests/Gedmo/Tree/TranslatableSluggableTreeTest.php
@@ -34,10 +34,7 @@ final class TranslatableSluggableTreeTest extends BaseTestCaseORM
     private const COMMENT = Comment::class;
     private const TRANSLATION = Translation::class;
 
-    /**
-     * @var TranslatableListener
-     */
-    private $translatableListener;
+    private TranslatableListener $translatableListener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Uploadable/Fixture/Entity/Article.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/Article.php
@@ -35,12 +35,10 @@ class Article
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string")
      */
     #[ORM\Column(name: 'title', type: Types::STRING)]
-    private $title;
+    private ?string $title = null;
 
     /**
      * @var Collection<int, File>
@@ -50,10 +48,7 @@ class Article
     #[ORM\OneToMany(targetEntity: File::class, mappedBy: 'article', cascade: ['persist', 'remove'])]
     private $files;
 
-    /**
-     * @var string|null
-     */
-    private $filePath;
+    private ?string $filePath = null;
 
     public function __construct()
     {

--- a/tests/Gedmo/Uploadable/Fixture/Entity/File.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/File.php
@@ -41,32 +41,26 @@ class File
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", nullable=true)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, nullable: true)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="path", type="string")
      * @Gedmo\UploadableFilePath
      */
     #[ORM\Column(name: 'path', type: Types::STRING)]
     #[Gedmo\UploadableFilePath]
-    private $filePath;
+    private ?string $filePath = null;
 
     /**
-     * @var Article|null
-     *
      * @ORM\ManyToOne(targetEntity="Article", inversedBy="files")
      * @ORM\JoinColumn(name="article_id", referencedColumnName="id")
      */
     #[ORM\ManyToOne(targetEntity: Article::class, inversedBy: 'files')]
     #[ORM\JoinColumn(name: 'article_id', referencedColumnName: 'id')]
-    private $article;
+    private ?Article $article = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Uploadable/Fixture/Entity/FileAppendNumber.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/FileAppendNumber.php
@@ -36,32 +36,26 @@ class FileAppendNumber
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", nullable=true)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, nullable: true)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="path", type="string")
      * @Gedmo\UploadableFilePath
      */
     #[ORM\Column(name: 'path', type: Types::STRING)]
     #[Gedmo\UploadableFilePath]
-    private $filePath;
+    private ?string $filePath = null;
 
     /**
-     * @var Article|null
-     *
      * @ORM\ManyToOne(targetEntity="Article", inversedBy="files")
      * @ORM\JoinColumn(name="article_id", referencedColumnName="id")
      */
     #[ORM\ManyToOne(targetEntity: Article::class, inversedBy: 'files')]
     #[ORM\JoinColumn(name: 'article_id', referencedColumnName: 'id')]
-    private $article;
+    private ?Article $article = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Uploadable/Fixture/Entity/FileAppendNumberRelative.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/FileAppendNumberRelative.php
@@ -37,32 +37,26 @@ class FileAppendNumberRelative
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", nullable=true)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, nullable: true)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="path", type="string")
      * @Gedmo\UploadableFilePath
      */
     #[ORM\Column(name: 'path', type: Types::STRING)]
     #[Gedmo\UploadableFilePath]
-    private $filePath;
+    private ?string $filePath = null;
 
     /**
-     * @var Article|null
-     *
      * @ORM\ManyToOne(targetEntity="Article", inversedBy="files")
      * @ORM\JoinColumn(name="article_id", referencedColumnName="id")
      */
     #[ORM\ManyToOne(targetEntity: Article::class, inversedBy: 'files')]
     #[ORM\JoinColumn(name: 'article_id', referencedColumnName: 'id')]
-    private $article;
+    private ?Article $article = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Uploadable/Fixture/Entity/FileWithAllowedTypes.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/FileWithAllowedTypes.php
@@ -36,42 +36,34 @@ class FileWithAllowedTypes
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", nullable=true)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, nullable: true)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="path", type="string", nullable=true)
      * @Gedmo\UploadableFilePath
      */
     #[ORM\Column(name: 'path', type: Types::STRING, nullable: true)]
     #[Gedmo\UploadableFilePath]
-    private $filePath;
+    private ?string $filePath = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="size", type="decimal", nullable=true)
      * @Gedmo\UploadableFileSize
      */
     #[ORM\Column(name: 'size', type: Types::DECIMAL, nullable: true)]
     #[Gedmo\UploadableFileSize]
-    private $fileSize;
+    private ?string $fileSize = null;
 
     /**
-     * @var Article|null
-     *
      * @ORM\ManyToOne(targetEntity="Article", inversedBy="files")
      * @ORM\JoinColumn(name="article_id", referencedColumnName="id")
      */
     #[ORM\ManyToOne(targetEntity: Article::class, inversedBy: 'files')]
     #[ORM\JoinColumn(name: 'article_id', referencedColumnName: 'id')]
-    private $article;
+    private ?Article $article = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Uploadable/Fixture/Entity/FileWithAlphanumericName.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/FileWithAlphanumericName.php
@@ -37,14 +37,12 @@ class FileWithAlphanumericName
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="path", type="string", nullable=true)
      * @Gedmo\UploadableFilePath
      */
     #[ORM\Column(name: 'path', type: Types::STRING, nullable: true)]
     #[Gedmo\UploadableFilePath]
-    private $filePath;
+    private ?string $filePath = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Uploadable/Fixture/Entity/FileWithCustomFilenameGenerator.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/FileWithCustomFilenameGenerator.php
@@ -37,14 +37,12 @@ class FileWithCustomFilenameGenerator
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="path", type="string", nullable=true)
      * @Gedmo\UploadableFilePath
      */
     #[ORM\Column(name: 'path', type: Types::STRING, nullable: true)]
     #[Gedmo\UploadableFilePath]
-    private $filePath;
+    private ?string $filePath = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Uploadable/Fixture/Entity/FileWithDisallowedTypes.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/FileWithDisallowedTypes.php
@@ -36,42 +36,34 @@ class FileWithDisallowedTypes
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", nullable=true)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, nullable: true)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="path", type="string", nullable=true)
      * @Gedmo\UploadableFilePath
      */
     #[ORM\Column(name: 'path', type: Types::STRING, nullable: true)]
     #[Gedmo\UploadableFilePath]
-    private $filePath;
+    private ?string $filePath = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="size", type="decimal", nullable=true)
      * @Gedmo\UploadableFileSize
      */
     #[ORM\Column(name: 'size', type: Types::DECIMAL, nullable: true)]
     #[Gedmo\UploadableFileSize]
-    private $fileSize;
+    private ?string $fileSize = null;
 
     /**
-     * @var Article|null
-     *
      * @ORM\ManyToOne(targetEntity="Article", inversedBy="files")
      * @ORM\JoinColumn(name="article_id", referencedColumnName="id")
      */
     #[ORM\ManyToOne(targetEntity: Article::class, inversedBy: 'files')]
     #[ORM\JoinColumn(name: 'article_id', referencedColumnName: 'id')]
-    private $article;
+    private ?Article $article = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Uploadable/Fixture/Entity/FileWithMaxSize.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/FileWithMaxSize.php
@@ -41,42 +41,34 @@ class FileWithMaxSize
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string", nullable=true)
      */
     #[ORM\Column(name: 'title', type: Types::STRING, nullable: true)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="path", type="string")
      * @Gedmo\UploadableFilePath
      */
     #[ORM\Column(name: 'path', type: Types::STRING)]
     #[Gedmo\UploadableFilePath]
-    private $filePath;
+    private ?string $filePath = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="size", type="decimal")
      * @Gedmo\UploadableFileSize
      */
     #[ORM\Column(name: 'size', type: Types::DECIMAL)]
     #[Gedmo\UploadableFileSize]
-    private $fileSize;
+    private ?string $fileSize = null;
 
     /**
-     * @var Article|null
-     *
      * @ORM\ManyToOne(targetEntity="Article", inversedBy="files")
      * @ORM\JoinColumn(name="article_id", referencedColumnName="id")
      */
     #[ORM\ManyToOne(targetEntity: Article::class, inversedBy: 'files')]
     #[ORM\JoinColumn(name: 'article_id', referencedColumnName: 'id')]
-    private $article;
+    private ?Article $article = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Uploadable/Fixture/Entity/FileWithSha1Name.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/FileWithSha1Name.php
@@ -37,14 +37,12 @@ class FileWithSha1Name
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="path", type="string", nullable=true)
      * @Gedmo\UploadableFilePath
      */
     #[ORM\Column(name: 'path', type: Types::STRING, nullable: true)]
     #[Gedmo\UploadableFilePath]
-    private $filePath;
+    private ?string $filePath = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Uploadable/Fixture/Entity/FileWithoutPath.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/FileWithoutPath.php
@@ -36,14 +36,12 @@ class FileWithoutPath
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="path", type="string", nullable=true)
      * @Gedmo\UploadableFilePath
      */
     #[ORM\Column(name: 'path', type: Types::STRING, nullable: true)]
     #[Gedmo\UploadableFilePath]
-    private $filePath;
+    private ?string $filePath = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Uploadable/Fixture/Entity/Image.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/Image.php
@@ -36,47 +36,36 @@ class Image
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="title", type="string")
      */
     #[ORM\Column(name: 'title', type: Types::STRING)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="path", type="string", nullable=true)
      * @Gedmo\UploadableFilePath
      */
     #[ORM\Column(name: 'path', type: Types::STRING, nullable: true)]
     #[Gedmo\UploadableFilePath]
-    private $filePath;
+    private ?string $filePath = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="size", type="decimal", nullable=true)
      * @Gedmo\UploadableFileSize
      */
     #[ORM\Column(name: 'size', type: Types::DECIMAL, nullable: true)]
     #[Gedmo\UploadableFileSize]
-    private $size;
+    private ?string $size = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="mime_type", type="string", nullable=true)
      * @Gedmo\UploadableFileMimeType
      */
     #[ORM\Column(name: 'mime_type', type: Types::STRING, nullable: true)]
     #[Gedmo\UploadableFileMimeType]
-    private $mime;
+    private ?string $mime = null;
 
-    /**
-     * @var bool
-     */
-    private $useBasePath = false;
+    private bool $useBasePath = false;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Uploadable/UploadableEntitySizeTypeTest.php
+++ b/tests/Gedmo/Uploadable/UploadableEntitySizeTypeTest.php
@@ -27,15 +27,9 @@ final class UploadableEntitySizeTypeTest extends BaseTestCaseORM
 {
     private const IMAGE_WITH_TYPED_PROPERTIES_CLASS = ImageWithTypedProperties::class;
 
-    /**
-     * @var UploadableListenerStub
-     */
-    private $listener;
+    private UploadableListenerStub $listener;
 
-    /**
-     * @var string
-     */
-    private $destinationTestDir;
+    private string $destinationTestDir;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Uploadable/UploadableEntityTest.php
+++ b/tests/Gedmo/Uploadable/UploadableEntityTest.php
@@ -68,10 +68,7 @@ final class UploadableEntityTest extends BaseTestCaseORM
     private const FILE_WITH_ALLOWED_TYPES_CLASS = FileWithAllowedTypes::class;
     private const FILE_WITH_DISALLOWED_TYPES_CLASS = FileWithDisallowedTypes::class;
 
-    /**
-     * @var UploadableListenerStub
-     */
-    private $listener;
+    private UploadableListenerStub $listener;
 
     /** @var string */
     private $testFile;
@@ -88,32 +85,23 @@ final class UploadableEntityTest extends BaseTestCaseORM
     /** @var string */
     private $testFileWithSpaces;
 
-    /** @var string */
-    private $destinationTestDir;
+    private string $destinationTestDir;
 
-    /** @var string */
-    private $destinationTestFile;
+    private string $destinationTestFile;
 
-    /** @var false|string */
-    private $testFilename;
+    private string $testFilename;
 
-    /** @var false|string */
-    private $testFilename2;
+    private string $testFilename2;
 
-    /** @var false|string */
-    private $testFilename3;
+    private string $testFilename3;
 
-    /** @var false|string */
-    private $testFilenameWithoutExt;
+    private string $testFilenameWithoutExt;
 
-    /** @var false|string */
-    private $testFilenameWithSpaces;
+    private string $testFilenameWithSpaces;
 
-    /** @var int */
-    private $testFileSize;
+    private int $testFileSize;
 
-    /** @var string */
-    private $testFileMimeType;
+    private string $testFileMimeType;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Uploadable/UploadableEntityTest.php
+++ b/tests/Gedmo/Uploadable/UploadableEntityTest.php
@@ -394,12 +394,7 @@ final class UploadableEntityTest extends BaseTestCaseORM
         $sha1String = substr($file->getFilePath(), strrpos($file->getFilePath(), '/') + 1);
         $sha1String = str_replace('.txt', '', $sha1String);
 
-        // @todo: Remove the condition and the `else` block when dropping support for "phpunit/phpunit" < 9.1.
-        if (method_exists($this, 'assertMatchesRegularExpression')) {
-            static::assertMatchesRegularExpression('/[a-z0-9]{40}/', $sha1String);
-        } else {
-            static::assertRegExp('/[a-z0-9]{40}/', $sha1String);
-        }
+        static::assertMatchesRegularExpression('/[a-z0-9]{40}/', $sha1String);
     }
 
     public function testFileWithFilenameAlphanumericGenerator(): void

--- a/tests/Gedmo/Wrapper/Fixture/Document/Article.php
+++ b/tests/Gedmo/Wrapper/Fixture/Document/Article.php
@@ -29,12 +29,10 @@ class Article
     private $id;
 
     /**
-     * @var string|null
-     *
      * @MongoODM\Field(type="string")
      */
     #[MongoODM\Field(type: Type::STRING)]
-    private $title;
+    private ?string $title = null;
 
     public function getId(): ?string
     {

--- a/tests/Gedmo/Wrapper/Fixture/Entity/Article.php
+++ b/tests/Gedmo/Wrapper/Fixture/Entity/Article.php
@@ -33,12 +33,10 @@ class Article
     private $id;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(length=128)
      */
     #[ORM\Column(length: 128)]
-    private $title;
+    private ?string $title = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Wrapper/Fixture/Entity/Composite.php
+++ b/tests/Gedmo/Wrapper/Fixture/Entity/Composite.php
@@ -19,32 +19,26 @@ use Doctrine\ORM\Mapping as ORM;
 class Composite
 {
     /**
-     * @var int
-     *
      * @ORM\Id
      * @ORM\Column(type="integer")
      */
     #[ORM\Id]
     #[ORM\Column(type: Types::INTEGER)]
-    private $one;
+    private int $one;
 
     /**
-     * @var int
-     *
      * @ORM\Id
      * @ORM\Column(type="integer")
      */
     #[ORM\Id]
     #[ORM\Column(type: Types::INTEGER)]
-    private $two;
+    private int $two;
 
     /**
-     * @var string
-     *
      * @ORM\Column(length=128)
      */
     #[ORM\Column(length: 128)]
-    private $title;
+    private ?string $title = null;
 
     public function __construct(int $one, int $two)
     {

--- a/tests/Gedmo/Wrapper/Fixture/Entity/CompositeRelation.php
+++ b/tests/Gedmo/Wrapper/Fixture/Entity/CompositeRelation.php
@@ -21,6 +21,8 @@ class CompositeRelation
     /**
      * @var Article
      *
+     * @todo: add type hint when https://github.com/doctrine/orm/issues/8255 is solved
+     *
      * @ORM\Id
      * @ORM\ManyToOne(targetEntity="Gedmo\Tests\Wrapper\Fixture\Entity\Article")
      */
@@ -29,22 +31,18 @@ class CompositeRelation
     private $article;
 
     /**
-     * @var int
-     *
      * @ORM\Id
      * @ORM\Column(type="integer")
      */
     #[ORM\Id]
     #[ORM\Column(type: Types::INTEGER)]
-    private $status;
+    private int $status;
 
     /**
-     * @var string
-     *
      * @ORM\Column(length=128)
      */
     #[ORM\Column(length: 128)]
-    private $title;
+    private ?string $title = null;
 
     public function __construct(Article $articleOne, int $status)
     {

--- a/tests/Gedmo/Wrapper/MongoDocumentWrapperTest.php
+++ b/tests/Gedmo/Wrapper/MongoDocumentWrapperTest.php
@@ -25,10 +25,7 @@ final class MongoDocumentWrapperTest extends BaseTestCaseMongoODM
 {
     private const ARTICLE = Article::class;
 
-    /**
-     * @var string|null
-     */
-    private $articleId;
+    private ?string $articleId = null;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
https://github.com/doctrine-extensions/DoctrineExtensions/issues/2635

- drop support for php < 7.3
- add property types for final classes
- Remove 2 function related to PHPunit < 9.1
- use null coalescing operator 2x

Needs a check for BC breaks.