### PR TITLE
Allow UUIDs for Blameable fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ a release.
 - Dropped support for PHP < 7.4
 - Dropped support for Symfony < 5.4
 - Dropped support for doctrine/dbal < 3.2
+- Blameable: Added UUID in allowed types list for Blameable fields in Annotation
 
 ### Deprecated
 - Calling `Gedmo\Mapping\Event\Adapter\ORM::getObjectManager()` and `getObject()` on EventArgs that do not implement `getObjectManager()` and `getObject()` (such as old EventArgs implementing `getEntityManager()` and `getEntity()`) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ a release.
 ---
 
 ## [Unreleased]
+- Blameable: Added UUID in allowed types list for Blameable fields in Annotation
 
 ## [3.15.0]
 ### Added
@@ -49,7 +50,6 @@ a release.
 - Dropped support for PHP < 7.4
 - Dropped support for Symfony < 5.4
 - Dropped support for doctrine/dbal < 3.2
-- Blameable: Added UUID in allowed types list for Blameable fields in Annotation
 
 ### Deprecated
 - Calling `Gedmo\Mapping\Event\Adapter\ORM::getObjectManager()` and `getObject()` on EventArgs that do not implement `getObjectManager()` and `getObject()` (such as old EventArgs implementing `getEntityManager()` and `getEntity()`) 

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
         "rector/rector": "^0.19",
         "symfony/console": "^5.4 || ^6.0 || ^7.0",
         "symfony/phpunit-bridge": "^6.0 || ^7.0",
-        "symfony/uid": "^7.0",
+        "symfony/uid": "^5.4 || ^6.0 || ^7.0",
         "symfony/yaml": "^5.4 || ^6.0 || ^7.0"
     },
     "conflict": {

--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,7 @@
         "rector/rector": "^0.19",
         "symfony/console": "^5.4 || ^6.0 || ^7.0",
         "symfony/phpunit-bridge": "^6.0 || ^7.0",
+        "symfony/uid": "^7.0",
         "symfony/yaml": "^5.4 || ^6.0 || ^7.0"
     },
     "conflict": {

--- a/src/Blameable/Mapping/Driver/Annotation.php
+++ b/src/Blameable/Mapping/Driver/Annotation.php
@@ -39,6 +39,7 @@ class Annotation extends AbstractAnnotationDriver
         'one',
         'string',
         'int',
+        'uuid',
     ];
 
     public function readExtendedMetadata($meta, array &$config)

--- a/src/Blameable/Mapping/Driver/Annotation.php
+++ b/src/Blameable/Mapping/Driver/Annotation.php
@@ -39,6 +39,7 @@ class Annotation extends AbstractAnnotationDriver
         'one',
         'string',
         'int',
+        'ulid',
         'uuid',
     ];
 

--- a/src/Blameable/Mapping/Driver/Xml.php
+++ b/src/Blameable/Mapping/Driver/Xml.php
@@ -34,6 +34,7 @@ class Xml extends BaseXml
         'one',
         'string',
         'int',
+        'uuid',
     ];
 
     public function readExtendedMetadata($meta, array &$config)

--- a/src/Blameable/Mapping/Driver/Xml.php
+++ b/src/Blameable/Mapping/Driver/Xml.php
@@ -34,6 +34,7 @@ class Xml extends BaseXml
         'one',
         'string',
         'int',
+        'ulid',
         'uuid',
     ];
 

--- a/src/Blameable/Mapping/Driver/Yaml.php
+++ b/src/Blameable/Mapping/Driver/Yaml.php
@@ -37,6 +37,7 @@ class Yaml extends File implements Driver
         'one',
         'string',
         'int',
+        'uuid',
     ];
 
     /**

--- a/src/Blameable/Mapping/Driver/Yaml.php
+++ b/src/Blameable/Mapping/Driver/Yaml.php
@@ -37,6 +37,7 @@ class Yaml extends File implements Driver
         'one',
         'string',
         'int',
+        'ulid',
         'uuid',
     ];
 

--- a/tests/Gedmo/Blameable/BlameableUuidTest.php
+++ b/tests/Gedmo/Blameable/BlameableUuidTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Blameable;
+
+use Doctrine\Common\EventManager;
+use Gedmo\Blameable\Blameable;
+use Gedmo\Blameable\BlameableListener;
+use Gedmo\Tests\Blameable\Fixture\Entity\Company;
+use Gedmo\Tests\Tool\BaseTestCaseORM;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Uid\UuidV6;
+
+final class BlameableUuidTest extends BaseTestCaseORM
+{
+    private const COMPANY = Company::class;
+
+    private UuidV6 $uuid;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->uuid = Uuid::v6();
+
+        $listener = new BlameableListener();
+        $listener->setUserValue($this->uuid);
+
+        $evm = new EventManager();
+        $evm->addEventSubscriber($listener);
+
+        $this->getDefaultMockSqliteEntityManager($evm);
+    }
+
+    public function testBlameableUuid(): void
+    {
+        $company = new Company();
+        $company->setName('ACME');
+
+        self::assertInstanceOf(Blameable::class, $company);
+
+        $this->em->persist($company);
+        $this->em->flush();
+        $this->em->clear();
+
+        /**
+         * @var Company $foundCompany
+         */
+        $foundCompany = $this->em->getRepository(self::COMPANY)->findOneBy(['name' => 'ACME']);
+        $created = $foundCompany->getCreated();
+        $createdUuid = $created instanceof Uuid ? $created->toRfc4122() : null;
+
+        self::assertSame($this->uuid->toRfc4122(), $createdUuid);
+    }
+
+    protected function getUsedEntityFixtures(): array
+    {
+        return [
+            self::COMPANY,
+        ];
+    }
+}

--- a/tests/Gedmo/Blameable/Fixture/Entity/Company.php
+++ b/tests/Gedmo/Blameable/Fixture/Entity/Company.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Blameable\Fixture\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Blameable\Blameable;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Uid\UuidV6;
+
+/**
+ * @ORM\Entity
+ */
+#[ORM\Entity]
+class Company implements Blameable
+{
+    /**
+     * @var int|null
+     *
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    private $id;
+
+    /**
+     * @var string|null
+     *
+     * @ORM\Column(name="name", type="string", length=128)
+     */
+    #[ORM\Column(name: 'name', type: Types::STRING, length: 128)]
+    private $name;
+
+    /**
+     * @var UuidV6|null
+     *
+     * @Gedmo\Blameable(on="create")
+     * @ORM\Column(name="created", type="uuid")
+     */
+    #[ORM\Column(name: 'created', type: 'uuid')]
+    #[Gedmo\Blameable(on: 'create')]
+    private $created;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setName(?string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function getCreated(): ?Uuid
+    {
+        return $this->created;
+    }
+
+    public function setCreated(?UuidV6 $created): void
+    {
+        $this->created = $created;
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,7 +11,9 @@ declare(strict_types=1);
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\PsrCachedReader;
+use Doctrine\DBAL\Types\Type;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Bridge\Doctrine\Types\UuidType;
 
 /*
  * This is bootstrap for phpUnit unit tests,
@@ -30,3 +32,5 @@ require dirname(__DIR__).'/vendor/autoload.php';
 $reader = new AnnotationReader();
 $reader = new PsrCachedReader($reader, new ArrayAdapter());
 $_ENV['annotation_reader'] = $reader;
+
+Type::addType('uuid', UuidType::class);


### PR DESCRIPTION
**Feature request:** #2641

I'm using UUID as primary key fields and I would like to store the users' UUID in the createdBy/updatedBy fields using the Blameable annotation/attribute.

To allow UUIDs, I've extended the `validTypes` array in the annotation/XML/YAML driver with 'uuid'.

**Moved to separate PR:** #2645
In order to convert the given value to whatever type is required, in my case UuidV6 from the Symfony UID component, I've amended the functionality of `src/AbstractTrackingListener.php`. I'm checking for a setter method to use that one instead of setting the property value directly.