### PR TITLE
Add config options to allow fields to be updated using a setter method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,9 @@ a release.
 
 ## [3.12.0] - 2023-07-08
 ### Added
+- Blameable/IpTraceable/SoftDeletable/Timestampable: Added functionality to use setter method instead of setting property values directly (#2644)
+
+### Added
 - Tree: `setSibling()` and `getSibling()` methods in the `Node` interface through the BC `@method` annotation
 - Tree: Support array of fields and directions in the `$sortByField` and `$direction` parameters at `AbstractTreeRepository::recover()`
 - Loggable: Support for composite identifiers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ a release.
 - Sluggable: Allow ascii_string to validTypes
 - IpTraceable: Allow ascii_string to validTypes
 - Sluggable: Use `TranslationWalker` hint when looking for similar slugs (`getSimilarSlugs` method) for entities which implement `Translatable` interface and have `uniqueOverTranslations: true` Slug option (#100, #2530)
+- Blameable/IpTraceable/SoftDeletable/Timestampable: Added functionality to use setter method instead of setting property values directly (#2644)
 
 ## [3.15.0]
 ### Added
@@ -66,9 +67,6 @@ a release.
 - Fix bug collecting metadata for inherited mapped classes
 
 ## [3.12.0] - 2023-07-08
-### Added
-- Blameable/IpTraceable/SoftDeletable/Timestampable: Added functionality to use setter method instead of setting property values directly (#2644)
-
 ### Added
 - Tree: `setSibling()` and `getSibling()` methods in the `Node` interface through the BC `@method` annotation
 - Tree: Support array of fields and directions in the `$sortByField` and `$direction` parameters at `AbstractTreeRepository::recover()`

--- a/src/AbstractTrackingListener.php
+++ b/src/AbstractTrackingListener.php
@@ -20,6 +20,7 @@ use Doctrine\Persistence\Event\ManagerEventArgs;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\NotifyPropertyChanged;
 use Doctrine\Persistence\ObjectManager;
+use Gedmo\Exception\InvalidMappingException;
 use Gedmo\Exception\UnexpectedValueException;
 use Gedmo\Mapping\Event\AdapterInterface;
 use Gedmo\Mapping\MappedEventSubscriber;
@@ -89,7 +90,7 @@ abstract class AbstractTrackingListener extends MappedEventSubscriber
                     $new = array_key_exists($field, $changeSet) ? $changeSet[$field][1] : false;
                     if (null === $new) { // let manual values
                         $needChanges = true;
-                        $this->updateField($object, $ea, $meta, $field);
+                        $this->updateField($object, $ea, $meta, $field, $config);
                     }
                 }
             }
@@ -101,7 +102,7 @@ abstract class AbstractTrackingListener extends MappedEventSubscriber
                         && null === $changeSet[$field][1];
                     if (!isset($changeSet[$field]) || $isInsertAndNull) { // let manual values
                         $needChanges = true;
-                        $this->updateField($object, $ea, $meta, $field);
+                        $this->updateField($object, $ea, $meta, $field, $config);
                     }
                 }
             }
@@ -152,7 +153,7 @@ abstract class AbstractTrackingListener extends MappedEventSubscriber
 
                             if (null === $configuredValues || ($singleField && in_array($value, $configuredValues, true))) {
                                 $needChanges = true;
-                                $this->updateField($object, $ea, $meta, $options['field']);
+                                $this->updateField($object, $ea, $meta, $options['field'], $config);
                             }
                         }
                     }
@@ -184,14 +185,14 @@ abstract class AbstractTrackingListener extends MappedEventSubscriber
             if (isset($config['update'])) {
                 foreach ($config['update'] as $field) {
                     if (null === $meta->getReflectionProperty($field)->getValue($object)) { // let manual values
-                        $this->updateField($object, $ea, $meta, $field);
+                        $this->updateField($object, $ea, $meta, $field, $config);
                     }
                 }
             }
             if (isset($config['create'])) {
                 foreach ($config['create'] as $field) {
                     if (null === $meta->getReflectionProperty($field)->getValue($object)) { // let manual values
-                        $this->updateField($object, $ea, $meta, $field);
+                        $this->updateField($object, $ea, $meta, $field, $config);
                     }
                 }
             }
@@ -216,10 +217,11 @@ abstract class AbstractTrackingListener extends MappedEventSubscriber
      * @param AdapterInterface $eventAdapter
      * @param ClassMetadata    $meta
      * @param string           $field
+     * @param array            $config
      *
      * @return void
      */
-    protected function updateField($object, $eventAdapter, $meta, $field)
+    protected function updateField($object, $eventAdapter, $meta, $field, array $config = [])
     {
         $property = $meta->getReflectionProperty($field);
         $oldValue = $property->getValue($object);
@@ -235,7 +237,18 @@ abstract class AbstractTrackingListener extends MappedEventSubscriber
             }
         }
 
-        $property->setValue($object, $newValue);
+        if (!empty($config['setterMethod'][$field])) {
+            $reflectionClass = $meta->getReflectionClass();
+            $setterName = $config['setterMethod'][$field];
+
+            if (!$reflectionClass->hasMethod($setterName)) {
+                throw new InvalidMappingException("Setter method - [{$setterName}] does not exist in class - {$meta->getName()}");
+            }
+
+            $reflectionClass->getMethod($setterName)->invoke($object, $newValue);
+        } else {
+            $property->setValue($object, $newValue);
+        }
 
         if ($object instanceof NotifyPropertyChanged) {
             $uow = $eventAdapter->getObjectManager()->getUnitOfWork();

--- a/src/AbstractTrackingListener.php
+++ b/src/AbstractTrackingListener.php
@@ -237,14 +237,19 @@ abstract class AbstractTrackingListener extends MappedEventSubscriber
         }
 
         if (!empty($config['setterMethod'][$field])) {
-            $reflectionClass = $meta->getReflectionClass();
             $setterName = $config['setterMethod'][$field];
 
-            if (!$reflectionClass->hasMethod($setterName)) {
-                throw new InvalidMappingException("Setter method - [{$setterName}] does not exist in class - {$meta->getName()}");
+            if (!method_exists($object, $setterName)) {
+                throw new InvalidMappingException(
+                    sprintf(
+                        "Setter method [%s] does not exist in class %s",
+                        $setterName,
+                        $meta->getName(),
+                    ),
+                );
             }
 
-            $reflectionClass->getMethod($setterName)->invoke($object, $newValue);
+            $object->{$setterName}($newValue);
         } else {
             $property->setValue($object, $newValue);
         }

--- a/src/AbstractTrackingListener.php
+++ b/src/AbstractTrackingListener.php
@@ -217,7 +217,6 @@ abstract class AbstractTrackingListener extends MappedEventSubscriber
      * @param AdapterInterface $eventAdapter
      * @param ClassMetadata    $meta
      * @param string           $field
-     * @param array            $config
      *
      * @return void
      */

--- a/src/Blameable/Mapping/Driver/Annotation.php
+++ b/src/Blameable/Mapping/Driver/Annotation.php
@@ -91,7 +91,7 @@ class Annotation extends AbstractAnnotationDriver
                     ];
                 }
                 // add the setter method for the field
-                $this->setSetterMethod($field, $blameable->setterMethod, $config);
+                $this->setSetterMethod($property->getName(), $blameable->setterMethod, $config);
                 // properties are unique and mapper checks that, no risk here
                 $config[$blameable->on][] = $field;
             }

--- a/src/Blameable/Mapping/Driver/Annotation.php
+++ b/src/Blameable/Mapping/Driver/Annotation.php
@@ -49,16 +49,13 @@ class Annotation extends AbstractAnnotationDriver
         $class = $this->getMetaReflectionClass($meta);
         // property annotations
         foreach ($class->getProperties() as $property) {
-            if (
-                isset($meta->associationMappings[$property->name]['inherited'])
-                || ($meta->isMappedSuperclass && !$property->isPrivate())
+            if ($meta->isMappedSuperclass && !$property->isPrivate()
                 || $meta->isInheritedField($property->name)
+                || isset($meta->associationMappings[$property->name]['inherited'])
             ) {
                 continue;
             }
             if ($blameable = $this->reader->getPropertyAnnotation($property, self::BLAMEABLE)) {
-                assert($blameable instanceof Blameable);
-
                 $field = $property->getName();
 
                 if (!$meta->hasField($field) && !$meta->hasAssociation($field)) {

--- a/src/Blameable/Mapping/Driver/Xml.php
+++ b/src/Blameable/Mapping/Driver/Xml.php
@@ -65,7 +65,10 @@ class Xml extends BaseXml
                     if (!$this->_isAttributeSet($data, 'on') || !in_array($this->_getAttribute($data, 'on'), ['update', 'create', 'change'], true)) {
                         throw new InvalidMappingException("Field - [{$field}] trigger 'on' is not one of [update, create, change] in class - {$meta->getName()}");
                     }
-
+                    if ($this->_isAttributeSet($data, 'setterMethod')) {
+                        $setterMethod = $this->_getAttribute($data, 'setterMethod');
+                        $this->setSetterMethod($field, $setterMethod, $config);
+                    }
                     if ('change' === $this->_getAttribute($data, 'on')) {
                         if (!$this->_isAttributeSet($data, 'field')) {
                             throw new InvalidMappingException("Missing parameters on property - {$field}, field must be set on [change] trigger in class - {$meta->getName()}");

--- a/src/Blameable/Mapping/Driver/Yaml.php
+++ b/src/Blameable/Mapping/Driver/Yaml.php
@@ -63,6 +63,10 @@ class Yaml extends File implements Driver
                         throw new InvalidMappingException("Field - [{$field}] trigger 'on' is not one of [update, create, change] in class - {$meta->getName()}");
                     }
 
+                    if (isset($mappingProperty['setterMethod'])) {
+                        $this->setSetterMethod($field, $mappingProperty['setterMethod'], $config);
+                    }
+
                     if ('change' === $mappingProperty['on']) {
                         if (!isset($mappingProperty['field'])) {
                             throw new InvalidMappingException("Missing parameters on property - {$field}, field must be set on [change] trigger in class - {$meta->getName()}");

--- a/src/IpTraceable/Mapping/Driver/Annotation.php
+++ b/src/IpTraceable/Mapping/Driver/Annotation.php
@@ -45,13 +45,16 @@ class Annotation extends AbstractAnnotationDriver
         $class = $this->getMetaReflectionClass($meta);
         // property annotations
         foreach ($class->getProperties() as $property) {
-            if ($meta->isMappedSuperclass && !$property->isPrivate()
-                || $meta->isInheritedField($property->name)
-                || isset($meta->associationMappings[$property->name]['inherited'])
+            if (
+                isset($meta->associationMappings[$property->name]['inherited']) ||
+                ($meta->isMappedSuperclass && !$property->isPrivate()) ||
+                $meta->isInheritedField($property->name)
             ) {
                 continue;
             }
             if ($ipTraceable = $this->reader->getPropertyAnnotation($property, self::IP_TRACEABLE)) {
+                assert($ipTraceable instanceof IpTraceable);
+
                 $field = $property->getName();
 
                 if (!$meta->hasField($field)) {
@@ -76,6 +79,8 @@ class Annotation extends AbstractAnnotationDriver
                         'value' => $ipTraceable->value,
                     ];
                 }
+                // add the setter method for the field
+                $this->setSetterMethod($field, $ipTraceable->setterMethod, $config);
                 // properties are unique and mapper checks that, no risk here
                 $config[$ipTraceable->on][] = $field;
             }

--- a/src/IpTraceable/Mapping/Driver/Annotation.php
+++ b/src/IpTraceable/Mapping/Driver/Annotation.php
@@ -46,9 +46,9 @@ class Annotation extends AbstractAnnotationDriver
         // property annotations
         foreach ($class->getProperties() as $property) {
             if (
-                isset($meta->associationMappings[$property->name]['inherited']) ||
-                ($meta->isMappedSuperclass && !$property->isPrivate()) ||
-                $meta->isInheritedField($property->name)
+                isset($meta->associationMappings[$property->name]['inherited'])
+                || ($meta->isMappedSuperclass && !$property->isPrivate())
+                || $meta->isInheritedField($property->name)
             ) {
                 continue;
             }
@@ -80,7 +80,7 @@ class Annotation extends AbstractAnnotationDriver
                     ];
                 }
                 // add the setter method for the field
-                $this->setSetterMethod($field, $ipTraceable->setterMethod, $config);
+                $this->setSetterMethod($property->getName(), $ipTraceable->setterMethod, $config);
                 // properties are unique and mapper checks that, no risk here
                 $config[$ipTraceable->on][] = $field;
             }

--- a/src/IpTraceable/Mapping/Driver/Annotation.php
+++ b/src/IpTraceable/Mapping/Driver/Annotation.php
@@ -45,16 +45,13 @@ class Annotation extends AbstractAnnotationDriver
         $class = $this->getMetaReflectionClass($meta);
         // property annotations
         foreach ($class->getProperties() as $property) {
-            if (
-                isset($meta->associationMappings[$property->name]['inherited'])
-                || ($meta->isMappedSuperclass && !$property->isPrivate())
+            if ($meta->isMappedSuperclass && !$property->isPrivate()
                 || $meta->isInheritedField($property->name)
+                || isset($meta->associationMappings[$property->name]['inherited'])
             ) {
                 continue;
             }
             if ($ipTraceable = $this->reader->getPropertyAnnotation($property, self::IP_TRACEABLE)) {
-                assert($ipTraceable instanceof IpTraceable);
-
                 $field = $property->getName();
 
                 if (!$meta->hasField($field)) {

--- a/src/IpTraceable/Mapping/Driver/Xml.php
+++ b/src/IpTraceable/Mapping/Driver/Xml.php
@@ -63,7 +63,10 @@ class Xml extends BaseXml
                     if (!$this->_isAttributeSet($data, 'on') || !in_array($this->_getAttribute($data, 'on'), ['update', 'create', 'change'], true)) {
                         throw new InvalidMappingException("Field - [{$field}] trigger 'on' is not one of [update, create, change] in class - {$meta->getName()}");
                     }
-
+                    if ($this->_isAttributeSet($data, 'setterMethod')) {
+                        $setterMethod = $this->_getAttribute($data, 'setterMethod');
+                        $this->setSetterMethod($field, $setterMethod, $config);
+                    }
                     if ('change' === $this->_getAttribute($data, 'on')) {
                         if (!$this->_isAttributeSet($data, 'field')) {
                             throw new InvalidMappingException("Missing parameters on property - {$field}, field must be set on [change] trigger in class - {$meta->getName()}");

--- a/src/IpTraceable/Mapping/Driver/Yaml.php
+++ b/src/IpTraceable/Mapping/Driver/Yaml.php
@@ -58,6 +58,9 @@ class Yaml extends File implements Driver
                     if (!isset($mappingProperty['on']) || !in_array($mappingProperty['on'], ['update', 'create', 'change'], true)) {
                         throw new InvalidMappingException("Field - [{$field}] trigger 'on' is not one of [update, create, change] in class - {$meta->getName()}");
                     }
+                    if (isset($mappingProperty['setterMethod'])) {
+                        $this->setSetterMethod($field, $mappingProperty['setterMethod'], $config);
+                    }
 
                     if ('change' === $mappingProperty['on']) {
                         if (!isset($mappingProperty['field'])) {

--- a/src/Mapping/Annotation/Blameable.php
+++ b/src/Mapping/Annotation/Blameable.php
@@ -34,7 +34,7 @@ final class Blameable implements GedmoAnnotation
     public $field;
     /** @var mixed */
     public $value;
-    /** @var string|null */
+    /** @var string */
     public $setterMethod;
 
     /**
@@ -47,7 +47,7 @@ final class Blameable implements GedmoAnnotation
         string $on = 'update',
         $field = null,
         $value = null,
-        ?string $setterMethod = null
+        string $setterMethod = ''
     ) {
         if ([] !== $data) {
             Deprecation::trigger(

--- a/src/Mapping/Annotation/Blameable.php
+++ b/src/Mapping/Annotation/Blameable.php
@@ -47,7 +47,7 @@ final class Blameable implements GedmoAnnotation
         string $on = 'update',
         $field = null,
         $value = null,
-        string $setterMethod = null
+        ?string $setterMethod = null
     ) {
         if ([] !== $data) {
             Deprecation::trigger(

--- a/src/Mapping/Annotation/Blameable.php
+++ b/src/Mapping/Annotation/Blameable.php
@@ -34,14 +34,21 @@ final class Blameable implements GedmoAnnotation
     public $field;
     /** @var mixed */
     public $value;
+    /** @var string|null */
+    public $setterMethod;
 
     /**
      * @param array<string, mixed> $data
      * @param string|string[]|null $field
      * @param mixed                $value
      */
-    public function __construct(array $data = [], string $on = 'update', $field = null, $value = null)
-    {
+    public function __construct(
+        array $data = [],
+        string $on = 'update',
+        $field = null,
+        $value = null,
+        string $setterMethod = null
+    ) {
         if ([] !== $data) {
             Deprecation::trigger(
                 'gedmo/doctrine-extensions',
@@ -55,6 +62,7 @@ final class Blameable implements GedmoAnnotation
             $this->on = $this->getAttributeValue($data, 'on', $args, 1, $on);
             $this->field = $this->getAttributeValue($data, 'field', $args, 2, $field);
             $this->value = $this->getAttributeValue($data, 'value', $args, 3, $value);
+            $this->setterMethod = $this->getAttributeValue($data, 'setterMethod', $args, 4, $setterMethod);
 
             return;
         }
@@ -62,5 +70,6 @@ final class Blameable implements GedmoAnnotation
         $this->on = $on;
         $this->field = $field;
         $this->value = $value;
+        $this->setterMethod = $setterMethod;
     }
 }

--- a/src/Mapping/Annotation/IpTraceable.php
+++ b/src/Mapping/Annotation/IpTraceable.php
@@ -35,14 +35,21 @@ final class IpTraceable implements GedmoAnnotation
     public $field;
     /** @var mixed */
     public $value;
+    /** @var string|null */
+    public $setterMethod;
 
     /**
      * @param array<string, mixed> $data
      * @param string|string[]|null $field
      * @param mixed                $value
      */
-    public function __construct(array $data = [], string $on = 'update', $field = null, $value = null)
-    {
+    public function __construct(
+        array $data = [],
+        string $on = 'update',
+        $field = null,
+        $value = null,
+        string $setterMethod = null
+    ) {
         if ([] !== $data) {
             Deprecation::trigger(
                 'gedmo/doctrine-extensions',
@@ -56,6 +63,7 @@ final class IpTraceable implements GedmoAnnotation
             $this->on = $this->getAttributeValue($data, 'on', $args, 1, $on);
             $this->field = $this->getAttributeValue($data, 'field', $args, 2, $field);
             $this->value = $this->getAttributeValue($data, 'value', $args, 3, $value);
+            $this->setterMethod = $this->getAttributeValue($data, 'setterMethod', $args, 4, $setterMethod);
 
             return;
         }
@@ -63,5 +71,6 @@ final class IpTraceable implements GedmoAnnotation
         $this->on = $on;
         $this->field = $field;
         $this->value = $value;
+        $this->setterMethod = $setterMethod;
     }
 }

--- a/src/Mapping/Annotation/IpTraceable.php
+++ b/src/Mapping/Annotation/IpTraceable.php
@@ -35,7 +35,7 @@ final class IpTraceable implements GedmoAnnotation
     public $field;
     /** @var mixed */
     public $value;
-    /** @var string|null */
+    /** @var string */
     public $setterMethod;
 
     /**
@@ -48,7 +48,7 @@ final class IpTraceable implements GedmoAnnotation
         string $on = 'update',
         $field = null,
         $value = null,
-        ?string $setterMethod = null
+        string $setterMethod = ''
     ) {
         if ([] !== $data) {
             Deprecation::trigger(

--- a/src/Mapping/Annotation/IpTraceable.php
+++ b/src/Mapping/Annotation/IpTraceable.php
@@ -48,7 +48,7 @@ final class IpTraceable implements GedmoAnnotation
         string $on = 'update',
         $field = null,
         $value = null,
-        string $setterMethod = null
+        ?string $setterMethod = null
     ) {
         if ([] !== $data) {
             Deprecation::trigger(

--- a/src/Mapping/Annotation/SoftDeleteable.php
+++ b/src/Mapping/Annotation/SoftDeleteable.php
@@ -41,7 +41,7 @@ final class SoftDeleteable implements GedmoAnnotation
     /**
      * @param array<string, mixed> $data
      */
-    public function __construct(array $data = [], string $fieldName = 'deletedAt', bool $timeAware = false, bool $hardDelete = true, string $setterMethod = null)
+    public function __construct(array $data = [], string $fieldName = 'deletedAt', bool $timeAware = false, bool $hardDelete = true, ?string $setterMethod = null)
     {
         if ([] !== $data) {
             Deprecation::trigger(

--- a/src/Mapping/Annotation/SoftDeleteable.php
+++ b/src/Mapping/Annotation/SoftDeleteable.php
@@ -35,14 +35,19 @@ final class SoftDeleteable implements GedmoAnnotation
 
     public bool $hardDelete = true;
 
-    /** @var string|null */
+    /** @var string */
     public $setterMethod;
 
     /**
      * @param array<string, mixed> $data
      */
-    public function __construct(array $data = [], string $fieldName = 'deletedAt', bool $timeAware = false, bool $hardDelete = true, ?string $setterMethod = null)
-    {
+    public function __construct(
+        array $data = [],
+        string $fieldName = 'deletedAt',
+        bool $timeAware = false,
+        bool $hardDelete = true,
+        string $setterMethod = ''
+    ) {
         if ([] !== $data) {
             Deprecation::trigger(
                 'gedmo/doctrine-extensions',

--- a/src/Mapping/Annotation/SoftDeleteable.php
+++ b/src/Mapping/Annotation/SoftDeleteable.php
@@ -35,10 +35,13 @@ final class SoftDeleteable implements GedmoAnnotation
 
     public bool $hardDelete = true;
 
+    /** @var string|null */
+    public $setterMethod;
+
     /**
      * @param array<string, mixed> $data
      */
-    public function __construct(array $data = [], string $fieldName = 'deletedAt', bool $timeAware = false, bool $hardDelete = true)
+    public function __construct(array $data = [], string $fieldName = 'deletedAt', bool $timeAware = false, bool $hardDelete = true, string $setterMethod = null)
     {
         if ([] !== $data) {
             Deprecation::trigger(
@@ -53,6 +56,7 @@ final class SoftDeleteable implements GedmoAnnotation
             $this->fieldName = $this->getAttributeValue($data, 'fieldName', $args, 1, $fieldName);
             $this->timeAware = $this->getAttributeValue($data, 'timeAware', $args, 2, $timeAware);
             $this->hardDelete = $this->getAttributeValue($data, 'hardDelete', $args, 3, $hardDelete);
+            $this->setterMethod = $this->getAttributeValue($data, 'setterMethod', $args, 4, $setterMethod);
 
             return;
         }
@@ -60,5 +64,6 @@ final class SoftDeleteable implements GedmoAnnotation
         $this->fieldName = $fieldName;
         $this->timeAware = $timeAware;
         $this->hardDelete = $hardDelete;
+        $this->setterMethod = $setterMethod;
     }
 }

--- a/src/Mapping/Annotation/Timestampable.php
+++ b/src/Mapping/Annotation/Timestampable.php
@@ -34,14 +34,21 @@ final class Timestampable implements GedmoAnnotation
     public $field;
     /** @var mixed */
     public $value;
+    /** @var string|null */
+    public $setterMethod;
 
     /**
      * @param array<string, mixed> $data
      * @param string|string[]      $field
      * @param mixed                $value
      */
-    public function __construct(array $data = [], string $on = 'update', $field = null, $value = null)
-    {
+    public function __construct(
+        array $data = [],
+        string $on = 'update',
+        $field = null,
+        $value = null,
+        string $setterMethod = null
+    ) {
         if ([] !== $data) {
             Deprecation::trigger(
                 'gedmo/doctrine-extensions',
@@ -55,6 +62,7 @@ final class Timestampable implements GedmoAnnotation
             $this->on = $this->getAttributeValue($data, 'on', $args, 1, $on);
             $this->field = $this->getAttributeValue($data, 'field', $args, 2, $field);
             $this->value = $this->getAttributeValue($data, 'value', $args, 3, $value);
+            $this->setterMethod = $this->getAttributeValue($data, 'setterMethod', $args, 4, $setterMethod);
 
             return;
         }
@@ -62,5 +70,6 @@ final class Timestampable implements GedmoAnnotation
         $this->on = $on;
         $this->field = $field;
         $this->value = $value;
+        $this->setterMethod = $setterMethod;
     }
 }

--- a/src/Mapping/Annotation/Timestampable.php
+++ b/src/Mapping/Annotation/Timestampable.php
@@ -47,7 +47,7 @@ final class Timestampable implements GedmoAnnotation
         string $on = 'update',
         $field = null,
         $value = null,
-        string $setterMethod = null
+        ?string $setterMethod = null
     ) {
         if ([] !== $data) {
             Deprecation::trigger(

--- a/src/Mapping/Annotation/Timestampable.php
+++ b/src/Mapping/Annotation/Timestampable.php
@@ -34,7 +34,7 @@ final class Timestampable implements GedmoAnnotation
     public $field;
     /** @var mixed */
     public $value;
-    /** @var string|null */
+    /** @var string */
     public $setterMethod;
 
     /**
@@ -47,7 +47,7 @@ final class Timestampable implements GedmoAnnotation
         string $on = 'update',
         $field = null,
         $value = null,
-        ?string $setterMethod = null
+        string $setterMethod = ''
     ) {
         if ([] !== $data) {
             Deprecation::trigger(

--- a/src/Mapping/Driver/AbstractAnnotationDriver.php
+++ b/src/Mapping/Driver/AbstractAnnotationDriver.php
@@ -135,4 +135,20 @@ abstract class AbstractAnnotationDriver implements AnnotationDriverInterface
 
         return class_exists($className) ? $className : '';
     }
+
+    /**
+     * Set the setter method for the given field.
+     */
+    protected function setSetterMethod(string $field, ?string $method, array &$config): void
+    {
+        if (empty($method)) {
+            return;
+        }
+
+        if (!isset($config['setterMethod'])) {
+            $config['setterMethod'] = [];
+        }
+
+        $config['setterMethod'][$field] = $method;
+    }
 }

--- a/src/Mapping/Driver/AbstractAnnotationDriver.php
+++ b/src/Mapping/Driver/AbstractAnnotationDriver.php
@@ -139,9 +139,9 @@ abstract class AbstractAnnotationDriver implements AnnotationDriverInterface
     /**
      * Set the setter method for the given field.
      */
-    protected function setSetterMethod(string $field, ?string $method, array &$config): void
+    protected function setSetterMethod(string $field, string $method, array &$config): void
     {
-        if (empty($method)) {
+        if ('' === $method) {
             return;
         }
 

--- a/src/Mapping/Driver/File.php
+++ b/src/Mapping/Driver/File.php
@@ -160,4 +160,20 @@ abstract class File implements Driver
 
         return class_exists($className) ? $className : '';
     }
+
+    /**
+     * Set the setter method for the given field.
+     */
+    protected function setSetterMethod(string $field, ?string $method, array &$config): void
+    {
+        if (empty($method)) {
+            return;
+        }
+
+        if (!isset($config['setterMethod'])) {
+            $config['setterMethod'] = [];
+        }
+
+        $config['setterMethod'][$field] = $method;
+    }
 }

--- a/src/SoftDeleteable/Mapping/Driver/Annotation.php
+++ b/src/SoftDeleteable/Mapping/Driver/Annotation.php
@@ -37,6 +37,8 @@ class Annotation extends AbstractAnnotationDriver
         $class = $this->getMetaReflectionClass($meta);
         // class annotations
         if (null !== $class && $annot = $this->reader->getClassAnnotation($class, self::SOFT_DELETEABLE)) {
+            assert($annot instanceof SoftDeleteable);
+
             $config['softDeleteable'] = true;
 
             Validator::validateField($meta, $annot->fieldName);
@@ -57,6 +59,11 @@ class Annotation extends AbstractAnnotationDriver
                     throw new InvalidMappingException('hardDelete must be boolean. '.gettype($annot->hardDelete).' provided.');
                 }
                 $config['hardDelete'] = $annot->hardDelete;
+            }
+
+            // add the setter method for the field?
+            if (isset($annot->setterMethod)) {
+                $this->setSetterMethod($annot->fieldName, $annot->setterMethod, $config);
             }
         }
 

--- a/src/SoftDeleteable/Mapping/Driver/Annotation.php
+++ b/src/SoftDeleteable/Mapping/Driver/Annotation.php
@@ -37,8 +37,6 @@ class Annotation extends AbstractAnnotationDriver
         $class = $this->getMetaReflectionClass($meta);
         // class annotations
         if (null !== $class && $annot = $this->reader->getClassAnnotation($class, self::SOFT_DELETEABLE)) {
-            assert($annot instanceof SoftDeleteable);
-
             $config['softDeleteable'] = true;
 
             Validator::validateField($meta, $annot->fieldName);

--- a/src/SoftDeleteable/Mapping/Driver/Xml.php
+++ b/src/SoftDeleteable/Mapping/Driver/Xml.php
@@ -58,6 +58,11 @@ class Xml extends BaseXml
                 if ($this->_isAttributeSet($xml->{'soft-deleteable'}, 'hard-delete')) {
                     $config['hardDelete'] = $this->_getBooleanAttribute($xml->{'soft-deleteable'}, 'hard-delete');
                 }
+
+                if ($this->_isAttributeSet($xml, 'setterMethod')) {
+                    $setterMethod = $this->_getAttribute($xml, 'setterMethod');
+                    $this->setSetterMethod($field, $setterMethod, $config);
+                }
             }
         }
 

--- a/src/SoftDeleteable/Mapping/Driver/Yaml.php
+++ b/src/SoftDeleteable/Mapping/Driver/Yaml.php
@@ -53,6 +53,10 @@ class Yaml extends File implements Driver
 
                 Validator::validateField($meta, $fieldName);
 
+                if (isset($classMapping['soft_deleteable']['setterMethod'])) {
+                    $this->setSetterMethod($fieldName, $classMapping['soft_deleteable']['setterMethod'], $config);
+                }
+
                 $config['fieldName'] = $fieldName;
 
                 $config['timeAware'] = false;

--- a/src/SoftDeleteable/SoftDeleteableListener.php
+++ b/src/SoftDeleteable/SoftDeleteableListener.php
@@ -104,14 +104,19 @@ class SoftDeleteableListener extends MappedEventSubscriber
                 }
 
                 if (!empty($config['setterMethod'][$config['fieldName']])) {
-                    $reflectionClass = $meta->getReflectionClass();
                     $setterName = $config['setterMethod'][$config['fieldName']];
 
-                    if (!$reflectionClass->hasMethod($setterName)) {
-                        throw new InvalidMappingException("Setter method - [{$setterName}] does not exist in class - {$meta->getName()}");
+                    if (!method_exists($object, $setterName)) {
+                        throw new InvalidMappingException(
+                            sprintf(
+                                "Setter method [%s] does not exist in class %s",
+                                $setterName,
+                                $meta->getName(),
+                            ),
+                        );
                     }
 
-                    $reflectionClass->getMethod($setterName)->invoke($object, $date);
+                    $object->{$setterName}($date);
                 } else {
                     $reflProp->setValue($object, $date);
                 }

--- a/src/Timestampable/Mapping/Driver/Annotation.php
+++ b/src/Timestampable/Mapping/Driver/Annotation.php
@@ -54,15 +54,13 @@ class Annotation extends AbstractAnnotationDriver
         $class = $this->getMetaReflectionClass($meta);
         // property annotations
         foreach ($class->getProperties() as $property) {
-            if (
-                isset($meta->associationMappings[$property->name]['inherited'])
-                || ($meta->isMappedSuperclass && !$property->isPrivate())
+            if ($meta->isMappedSuperclass && !$property->isPrivate()
                 || $meta->isInheritedField($property->name)
+                || isset($meta->associationMappings[$property->name]['inherited'])
             ) {
                 continue;
             }
             if ($timestampable = $this->reader->getPropertyAnnotation($property, self::TIMESTAMPABLE)) {
-                assert($timestampable instanceof Timestampable);
                 $field = $property->getName();
                 if (!$meta->hasField($field)) {
                     throw new InvalidMappingException("Unable to find timestampable [{$field}] as mapped property in entity - {$meta->getName()}");

--- a/src/Timestampable/Mapping/Driver/Annotation.php
+++ b/src/Timestampable/Mapping/Driver/Annotation.php
@@ -55,9 +55,9 @@ class Annotation extends AbstractAnnotationDriver
         // property annotations
         foreach ($class->getProperties() as $property) {
             if (
-                isset($meta->associationMappings[$property->name]['inherited']) ||
-                ($meta->isMappedSuperclass && !$property->isPrivate()) ||
-                $meta->isInheritedField($property->name)
+                isset($meta->associationMappings[$property->name]['inherited'])
+                || ($meta->isMappedSuperclass && !$property->isPrivate())
+                || $meta->isInheritedField($property->name)
             ) {
                 continue;
             }
@@ -87,7 +87,7 @@ class Annotation extends AbstractAnnotationDriver
                     ];
                 }
                 // add the setter method for the field
-                $this->setSetterMethod($field, $timestampable->setterMethod, $config);
+                $this->setSetterMethod($property->getName(), $timestampable->setterMethod, $config);
                 // properties are unique and mapper checks that, no risk here
                 $config[$timestampable->on][] = $field;
             }

--- a/src/Timestampable/Mapping/Driver/Xml.php
+++ b/src/Timestampable/Mapping/Driver/Xml.php
@@ -72,7 +72,10 @@ class Xml extends BaseXml
                     if (!$this->_isAttributeSet($data, 'on') || !in_array($this->_getAttribute($data, 'on'), ['update', 'create', 'change'], true)) {
                         throw new InvalidMappingException("Field - [{$field}] trigger 'on' is not one of [update, create, change] in class - {$meta->getName()}");
                     }
-
+                    if ($this->_isAttributeSet($data, 'setterMethod')) {
+                        $setterMethod = $this->_getAttribute($data, 'setterMethod');
+                        $this->setSetterMethod($field, $setterMethod, $config);
+                    }
                     if ('change' === $this->_getAttribute($data, 'on')) {
                         if (!$this->_isAttributeSet($data, 'field')) {
                             throw new InvalidMappingException("Missing parameters on property - {$field}, field must be set on [change] trigger in class - {$meta->getName()}");

--- a/src/Timestampable/Mapping/Driver/Yaml.php
+++ b/src/Timestampable/Mapping/Driver/Yaml.php
@@ -68,6 +68,9 @@ class Yaml extends File implements Driver
                     if (!isset($mappingProperty['on']) || !in_array($mappingProperty['on'], ['update', 'create', 'change'], true)) {
                         throw new InvalidMappingException("Field - [{$field}] trigger 'on' is not one of [update, create, change] in class - {$meta->getName()}");
                     }
+                    if (isset($mappingProperty['setterMethod'])) {
+                        $this->setSetterMethod($field, $mappingProperty['setterMethod'], $config);
+                    }
 
                     if ('change' === $mappingProperty['on']) {
                         if (!isset($mappingProperty['field'])) {

--- a/tests/Gedmo/Blameable/BlameableTest.php
+++ b/tests/Gedmo/Blameable/BlameableTest.php
@@ -68,6 +68,7 @@ final class BlameableTest extends BaseTestCaseORM
         static::assertNull($sport->getPublished());
 
         $sportComment = $this->em->getRepository(self::COMMENT)->findOneBy(['message' => 'hello']);
+        static::assertSame('testuser', $sportComment->getCreated());
         static::assertSame('testuser', $sportComment->getModified());
         static::assertNull($sportComment->getClosed());
 

--- a/tests/Gedmo/Blameable/Fixture/Entity/Comment.php
+++ b/tests/Gedmo/Blameable/Fixture/Entity/Comment.php
@@ -53,6 +53,15 @@ class Comment implements Blameable
     private ?int $status = null;
 
     /**
+     * @Gedmo\Blameable(on="create")
+     *
+     * @ORM\Column(name="created", type="string")
+     */
+    #[ORM\Column(name: 'created', type: Types::STRING)]
+    #[Gedmo\Blameable(on: 'create', setterMethod: 'setCreated')]
+    private ?string $created = null;
+
+    /**
      * @var string|null
      *
      * @ORM\Column(name="closed", type="string", nullable=true)
@@ -102,6 +111,16 @@ class Comment implements Blameable
     public function getMessage(): ?string
     {
         return $this->message;
+    }
+
+    public function getCreated(): ?string
+    {
+        return $this->created;
+    }
+
+    public function setCreated(?string $created): void
+    {
+        $this->created = $created;
     }
 
     public function getModified(): ?string

--- a/tests/Gedmo/IpTraceable/Fixture/Comment.php
+++ b/tests/Gedmo/IpTraceable/Fixture/Comment.php
@@ -71,7 +71,7 @@ class Comment implements IpTraceable
      * @Gedmo\IpTraceable(on="update")
      */
     #[ORM\Column(name: 'modified', type: Types::STRING, length: 45)]
-    #[Gedmo\IpTraceable(on: 'update')]
+    #[Gedmo\IpTraceable(on: 'update', setterMethod: 'setModified')]
     private $modified;
 
     public function setArticle(?Article $article): void
@@ -107,6 +107,11 @@ class Comment implements IpTraceable
     public function getModified(): ?string
     {
         return $this->modified;
+    }
+
+    public function setModified(?string $modified): void
+    {
+        $this->modified = $modified;
     }
 
     public function getClosed(): ?string

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/Comment.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/Comment.php
@@ -21,7 +21,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
  * @Gedmo\SoftDeleteable(fieldName="deletedAt")
  */
 #[ORM\Entity]
-#[Gedmo\SoftDeleteable(fieldName: 'deletedAt')]
+#[Gedmo\SoftDeleteable(fieldName: 'deletedAt', setterMethod: 'setDeletedAt')]
 class Comment
 {
     /**

--- a/tests/Gedmo/SoftDeleteable/SoftDeleteableEntityTest.php
+++ b/tests/Gedmo/SoftDeleteable/SoftDeleteableEntityTest.php
@@ -434,6 +434,17 @@ final class SoftDeleteableEntityTest extends BaseTestCaseORM
         static::assertInstanceOf('DateTimeInterface', $foundArt->getDeletedAt());
         static::assertIsObject($foundComment);
         static::assertInstanceOf(self::OTHER_COMMENT_CLASS, $foundComment);
+
+        $commentField = 'comment';
+        $commentValue = 'Comment 1';
+        $commentRepo = $this->em->getRepository(self::COMMENT_CLASS);
+        $comment = $commentRepo->findOneBy([$commentField => $commentValue]);
+
+        $this->em->remove($comment);
+        $this->em->flush();
+
+        static::assertIsObject($comment->getDeletedAt());
+        static::assertInstanceOf('DateTimeInterface', $comment->getDeletedAt());
     }
 
     /**

--- a/tests/Gedmo/Timestampable/Fixture/Comment.php
+++ b/tests/Gedmo/Timestampable/Fixture/Comment.php
@@ -72,6 +72,17 @@ class Comment implements Timestampable
      *
      * @Gedmo\Timestampable(on="update")
      */
+    #[ORM\Column(name: 'created', type: Types::TIME_MUTABLE)]
+    #[Gedmo\Timestampable(on: 'create', setterMethod: 'setCreated')]
+    private $created;
+
+    /**
+     * @var \DateTime|null
+     *
+     * @ORM\Column(name="modified", type="time")
+     *
+     * @Gedmo\Timestampable(on="update")
+     */
     #[ORM\Column(name: 'modified', type: Types::TIME_MUTABLE)]
     #[Gedmo\Timestampable(on: 'update')]
     private $modified;
@@ -107,6 +118,16 @@ class Comment implements Timestampable
     public function getMessage(): ?string
     {
         return $this->message;
+    }
+
+    public function getCreated(): ?\DateTime
+    {
+        return $this->created;
+    }
+
+    public function setCreated(?\DateTime $created): void
+    {
+        $this->created = $created;
     }
 
     public function getModified(): ?\DateTime

--- a/tests/Gedmo/Timestampable/TimestampableTest.php
+++ b/tests/Gedmo/Timestampable/TimestampableTest.php
@@ -124,6 +124,7 @@ final class TimestampableTest extends BaseTestCaseORM
         $sport->setAuthor($author);
 
         $sportComment = $this->em->getRepository(self::COMMENT)->findOneBy(['message' => 'hello']);
+        static::assertInstanceOf(\DateTime::class, $sportComment->getCreated());
         static::assertNotNull($sportComment->getModified());
         static::assertNull($sportComment->getClosed());
 


### PR DESCRIPTION
**Feature request:** #2644

This change is applied in Blameable, IpTraceable, SoftDeleteable & Timestampable annotations. The new attribute "setterMethod" can be passed to specify the setter method to be used for a field. If no setter method is specified, the property value would be set directly as before.