### PR TITLE
chore: drop pinned versions for dockerfile

### DIFF
--- a/.docker/php/Dockerfile
+++ b/.docker/php/Dockerfile
@@ -10,11 +10,11 @@ COPY --from=composer /usr/bin/composer /usr/bin/composer
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-    git=1:2.30.2-1 \
-    libzip-dev=1.7.3-1 \
-    unzip=6.0-26+deb11u1 \
-    zip=3.0-12 \
-    zlib1g-dev=1:1.2.11.dfsg-2+deb11u2 \
+    git \
+    libzip-dev \
+    unzip \
+    zip \
+    zlib1g-dev \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \


### PR DESCRIPTION
Will fix https://github.com/doctrine-extensions/DoctrineExtensions/issues/2624
The other fixed versions are a problem today (they worked at the time at the creation of the issue). It looks that these versions are not available/reachable anymore on mac.

Are the fixed versions necessary?
If yes, i would suggest do duplicate the actual Docker-File `Dockerfile-fallback-mac`? as fallback for mac.