### PR TITLE
fix: add conflict for doctrine/orm >= 2.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ a release.
 ---
 
 ## [Unreleased]
+### Changed
+- Add conflict with "doctrine/orm" >=2.16 (temporary change until code is fixed)
 
 ## [3.12.0] - 2023-07-08
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
     "conflict": {
         "doctrine/dbal": "<2.13.1 || ^3.0 <3.2",
         "doctrine/mongodb-odm": "<2.3",
-        "doctrine/orm": "<2.10.2",
+        "doctrine/orm": "<2.10.2 || >= 2.16.0",
         "sebastian/comparator": "<2.0"
     },
     "suggest": {


### PR DESCRIPTION
https://github.com/doctrine-extensions/DoctrineExtensions/issues/2659

This helps to get the ci green. 
But does not prevent the installation on userside of older versions with 3.12.0 and doctrine-orm >= 2.16.0