### PR TITLE
Remplace getEntityManager by getObjectManager to remove deprecation message symfony 6.3 (#2664)

### DIFF
--- a/src/Mapping/Event/Adapter/ORM.php
+++ b/src/Mapping/Event/Adapter/ORM.php
@@ -95,7 +95,7 @@ class ORM implements AdapterInterface
             throw new \LogicException(sprintf('Event args must be set before calling "%s()".', __METHOD__));
         }
 
-        return $this->args->getEntityManager();
+        return method_exists($this->args, 'getObjectManager') ? $this->args->getObjectManager() : $this->args->getEntityManager();
     }
 
     public function getObject(): object


### PR DESCRIPTION
https://github.com/doctrine-extensions/DoctrineExtensions/issues/2664