### PR TITLE
Do not rely on autoincremental ids

### DIFF
--- a/tests/Gedmo/Translatable/Fixture/File.php
+++ b/tests/Gedmo/Translatable/Fixture/File.php
@@ -57,6 +57,11 @@ class File
     #[ORM\Column(type: Types::INTEGER)]
     private $size;
 
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
     public function setName(?string $name): void
     {
         $this->name = $name;

--- a/tests/Gedmo/Translatable/InheritanceTest.php
+++ b/tests/Gedmo/Translatable/InheritanceTest.php
@@ -120,16 +120,21 @@ final class InheritanceTest extends BaseTestCaseORM
         $this->em->persist($file);
         $this->em->persist($image);
         $this->em->flush();
+
+        $fileId = $file->getId();
+        $imageId = $image->getId();
+
         $this->em->clear();
 
-        $dql = 'SELECT f FROM '.self::FILE.' f';
+        $dql = 'SELECT f FROM '.self::FILE.' f INDEX BY f.id';
         $q = $this->em->createQuery($dql);
         $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, self::TREE_WALKER_TRANSLATION);
 
         $files = $q->getArrayResult();
         static::assertCount(2, $files);
-        static::assertSame('image de', $files[0]['name']);
-        static::assertSame('file de', $files[1]['name']);
+
+        static::assertSame('image de', $files[$imageId]['name']);
+        static::assertSame('file de', $files[$fileId]['name']);
 
         // test loading in locale
         $images = $this->em->getRepository(self::IMAGE)->findAll();

--- a/tests/Gedmo/Translator/TranslatableTest.php
+++ b/tests/Gedmo/Translator/TranslatableTest.php
@@ -102,7 +102,7 @@ final class TranslatableTest extends BaseTestCaseORM
         $person->translate('ru')->setDescription('multilingual description');
 
         $parent = new Person();
-        $parent->setName('Jen');
+        $parent->setName('Jen parent');
         $parent->translate('ru')->setName('Женя starshai');
         $parent->translate('fr')->setName('zenia');
         $parent->setDescription('description');


### PR DESCRIPTION
These tests fails using `doctrine/orm` 2.16 since they rely on autoincremental ids