### PR TITLE
Configure "global_namespace_import" CS rule

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -42,6 +42,7 @@ return (new PhpCsFixer\Config())
         // @todo: Change the following rule to `true` in the next major release.
         'declare_strict_types' => false,
         'error_suppression' => true,
+        'global_namespace_import' => ['import_classes' => false, 'import_constants' => false, 'import_functions' => false],
         'header_comment' => ['header' => $header],
         'is_null' => false,
         'list_syntax' => ['syntax' => 'short'],

--- a/src/Mapping/Annotation/Blameable.php
+++ b/src/Mapping/Annotation/Blameable.php
@@ -22,7 +22,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  *
  * @author David Buchmann <mail@davidbu.ch>
  */
-#[Attribute(Attribute::TARGET_PROPERTY)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class Blameable implements GedmoAnnotation
 {
     use ForwardCompatibilityTrait;

--- a/src/Mapping/Annotation/IpTraceable.php
+++ b/src/Mapping/Annotation/IpTraceable.php
@@ -22,7 +22,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  *
  * @author Pierre-Charles Bertineau <pc.bertineau@alterphp.com>
  */
-#[Attribute(Attribute::TARGET_PROPERTY)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class IpTraceable implements GedmoAnnotation
 {
     use ForwardCompatibilityTrait;

--- a/src/Mapping/Annotation/Language.php
+++ b/src/Mapping/Annotation/Language.php
@@ -21,7 +21,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
-#[Attribute(Attribute::TARGET_PROPERTY)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class Language implements GedmoAnnotation
 {
 }

--- a/src/Mapping/Annotation/Locale.php
+++ b/src/Mapping/Annotation/Locale.php
@@ -21,7 +21,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
-#[Attribute(Attribute::TARGET_PROPERTY)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class Locale implements GedmoAnnotation
 {
 }

--- a/src/Mapping/Annotation/Loggable.php
+++ b/src/Mapping/Annotation/Loggable.php
@@ -25,7 +25,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
-#[Attribute(Attribute::TARGET_CLASS)]
+#[\Attribute(\Attribute::TARGET_CLASS)]
 final class Loggable implements GedmoAnnotation
 {
     use ForwardCompatibilityTrait;

--- a/src/Mapping/Annotation/ReferenceIntegrity.php
+++ b/src/Mapping/Annotation/ReferenceIntegrity.php
@@ -22,7 +22,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  *
  * @author Evert Harmeling <evert.harmeling@freshheads.com>
  */
-#[Attribute(Attribute::TARGET_PROPERTY)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class ReferenceIntegrity implements GedmoAnnotation
 {
     use ForwardCompatibilityTrait;

--- a/src/Mapping/Annotation/ReferenceMany.php
+++ b/src/Mapping/Annotation/ReferenceMany.php
@@ -21,7 +21,7 @@ use Attribute;
  *
  * @final since gedmo/doctrine-extensions 3.11
  */
-#[Attribute(Attribute::TARGET_PROPERTY)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 class ReferenceMany extends Reference
 {
 }

--- a/src/Mapping/Annotation/ReferenceManyEmbed.php
+++ b/src/Mapping/Annotation/ReferenceManyEmbed.php
@@ -17,7 +17,7 @@ use Attribute;
  *
  * @final since gedmo/doctrine-extensions 3.11
  */
-#[Attribute(Attribute::TARGET_PROPERTY)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 class ReferenceManyEmbed extends Reference
 {
 }

--- a/src/Mapping/Annotation/ReferenceOne.php
+++ b/src/Mapping/Annotation/ReferenceOne.php
@@ -23,7 +23,7 @@ use Attribute;
  *
  * @final since gedmo/doctrine-extensions 3.11
  */
-#[Attribute(Attribute::TARGET_PROPERTY)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 class ReferenceOne extends Reference
 {
 }

--- a/src/Mapping/Annotation/Slug.php
+++ b/src/Mapping/Annotation/Slug.php
@@ -22,7 +22,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
-#[Attribute(Attribute::TARGET_PROPERTY)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class Slug implements GedmoAnnotation
 {
     use ForwardCompatibilityTrait;

--- a/src/Mapping/Annotation/SlugHandler.php
+++ b/src/Mapping/Annotation/SlugHandler.php
@@ -22,7 +22,7 @@ use Gedmo\Sluggable\Handler\SlugHandlerInterface;
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
-#[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::IS_REPEATABLE)]
 final class SlugHandler implements GedmoAnnotation
 {
     use ForwardCompatibilityTrait;

--- a/src/Mapping/Annotation/SoftDeleteable.php
+++ b/src/Mapping/Annotation/SoftDeleteable.php
@@ -22,7 +22,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * @NamedArgumentConstructor
  * @Target("CLASS")
  */
-#[Attribute(Attribute::TARGET_CLASS)]
+#[\Attribute(\Attribute::TARGET_CLASS)]
 final class SoftDeleteable implements GedmoAnnotation
 {
     use ForwardCompatibilityTrait;

--- a/src/Mapping/Annotation/SortableGroup.php
+++ b/src/Mapping/Annotation/SortableGroup.php
@@ -21,7 +21,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * @Annotation
  * @Target("PROPERTY")
  */
-#[Attribute(Attribute::TARGET_PROPERTY)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class SortableGroup implements GedmoAnnotation
 {
 }

--- a/src/Mapping/Annotation/SortablePosition.php
+++ b/src/Mapping/Annotation/SortablePosition.php
@@ -21,7 +21,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * @Annotation
  * @Target("PROPERTY")
  */
-#[Attribute(Attribute::TARGET_PROPERTY)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class SortablePosition implements GedmoAnnotation
 {
 }

--- a/src/Mapping/Annotation/Timestampable.php
+++ b/src/Mapping/Annotation/Timestampable.php
@@ -22,7 +22,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
-#[Attribute(Attribute::TARGET_PROPERTY)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class Timestampable implements GedmoAnnotation
 {
     use ForwardCompatibilityTrait;

--- a/src/Mapping/Annotation/Translatable.php
+++ b/src/Mapping/Annotation/Translatable.php
@@ -22,7 +22,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
-#[Attribute(Attribute::TARGET_PROPERTY)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class Translatable implements GedmoAnnotation
 {
     use ForwardCompatibilityTrait;

--- a/src/Mapping/Annotation/TranslationEntity.php
+++ b/src/Mapping/Annotation/TranslationEntity.php
@@ -22,7 +22,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
-#[Attribute(Attribute::TARGET_CLASS)]
+#[\Attribute(\Attribute::TARGET_CLASS)]
 final class TranslationEntity implements GedmoAnnotation
 {
     use ForwardCompatibilityTrait;

--- a/src/Mapping/Annotation/Tree.php
+++ b/src/Mapping/Annotation/Tree.php
@@ -22,7 +22,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
-#[Attribute(Attribute::TARGET_CLASS)]
+#[\Attribute(\Attribute::TARGET_CLASS)]
 final class Tree implements GedmoAnnotation
 {
     use ForwardCompatibilityTrait;

--- a/src/Mapping/Annotation/TreeClosure.php
+++ b/src/Mapping/Annotation/TreeClosure.php
@@ -23,7 +23,7 @@ use Gedmo\Tree\Entity\MappedSuperclass\AbstractClosure;
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
-#[Attribute(Attribute::TARGET_CLASS)]
+#[\Attribute(\Attribute::TARGET_CLASS)]
 final class TreeClosure implements GedmoAnnotation
 {
     use ForwardCompatibilityTrait;

--- a/src/Mapping/Annotation/TreeLeft.php
+++ b/src/Mapping/Annotation/TreeLeft.php
@@ -21,7 +21,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
-#[Attribute(Attribute::TARGET_PROPERTY)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class TreeLeft implements GedmoAnnotation
 {
 }

--- a/src/Mapping/Annotation/TreeLevel.php
+++ b/src/Mapping/Annotation/TreeLevel.php
@@ -22,7 +22,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
-#[Attribute(Attribute::TARGET_PROPERTY)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class TreeLevel implements GedmoAnnotation
 {
     use ForwardCompatibilityTrait;

--- a/src/Mapping/Annotation/TreeLockTime.php
+++ b/src/Mapping/Annotation/TreeLockTime.php
@@ -22,7 +22,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * @author Gustavo Falco <comfortablynumb84@gmail.com>
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
-#[Attribute(Attribute::TARGET_PROPERTY)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class TreeLockTime implements GedmoAnnotation
 {
 }

--- a/src/Mapping/Annotation/TreeParent.php
+++ b/src/Mapping/Annotation/TreeParent.php
@@ -21,7 +21,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
-#[Attribute(Attribute::TARGET_PROPERTY)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class TreeParent implements GedmoAnnotation
 {
 }

--- a/src/Mapping/Annotation/TreePath.php
+++ b/src/Mapping/Annotation/TreePath.php
@@ -24,7 +24,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  * @author <rocco@roccosportal.com>
  */
-#[Attribute(Attribute::TARGET_PROPERTY)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class TreePath implements GedmoAnnotation
 {
     use ForwardCompatibilityTrait;

--- a/src/Mapping/Annotation/TreePathHash.php
+++ b/src/Mapping/Annotation/TreePathHash.php
@@ -21,7 +21,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  *
  * @author <rocco@roccosportal.com>
  */
-#[Attribute(Attribute::TARGET_PROPERTY)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class TreePathHash implements GedmoAnnotation
 {
 }

--- a/src/Mapping/Annotation/TreePathSource.php
+++ b/src/Mapping/Annotation/TreePathSource.php
@@ -22,7 +22,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * @author Gustavo Falco <comfortablynumb84@gmail.com>
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
-#[Attribute(Attribute::TARGET_PROPERTY)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class TreePathSource implements GedmoAnnotation
 {
 }

--- a/src/Mapping/Annotation/TreeRight.php
+++ b/src/Mapping/Annotation/TreeRight.php
@@ -21,7 +21,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
-#[Attribute(Attribute::TARGET_PROPERTY)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class TreeRight implements GedmoAnnotation
 {
 }

--- a/src/Mapping/Annotation/TreeRoot.php
+++ b/src/Mapping/Annotation/TreeRoot.php
@@ -22,7 +22,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
-#[Attribute(Attribute::TARGET_PROPERTY)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class TreeRoot implements GedmoAnnotation
 {
     use ForwardCompatibilityTrait;

--- a/src/Mapping/Annotation/Uploadable.php
+++ b/src/Mapping/Annotation/Uploadable.php
@@ -25,7 +25,7 @@ use Gedmo\Uploadable\Mapping\Validator;
  * @author Gustavo Falco <comfortablynumb84@gmail.com>
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
-#[Attribute(Attribute::TARGET_CLASS)]
+#[\Attribute(\Attribute::TARGET_CLASS)]
 final class Uploadable implements GedmoAnnotation
 {
     use ForwardCompatibilityTrait;

--- a/src/Mapping/Annotation/UploadableFileMimeType.php
+++ b/src/Mapping/Annotation/UploadableFileMimeType.php
@@ -22,7 +22,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * @author Gustavo Falco <comfortablynumb84@gmail.com>
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
-#[Attribute(Attribute::TARGET_PROPERTY)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class UploadableFileMimeType implements GedmoAnnotation
 {
 }

--- a/src/Mapping/Annotation/UploadableFileName.php
+++ b/src/Mapping/Annotation/UploadableFileName.php
@@ -21,7 +21,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  *
  * @author tiger-seo <tiger.seo@gmail.com>
  */
-#[Attribute(Attribute::TARGET_PROPERTY)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class UploadableFileName implements GedmoAnnotation
 {
 }

--- a/src/Mapping/Annotation/UploadableFilePath.php
+++ b/src/Mapping/Annotation/UploadableFilePath.php
@@ -22,7 +22,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * @author Gustavo Falco <comfortablynumb84@gmail.com>
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
-#[Attribute(Attribute::TARGET_PROPERTY)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class UploadableFilePath implements GedmoAnnotation
 {
 }

--- a/src/Mapping/Annotation/UploadableFileSize.php
+++ b/src/Mapping/Annotation/UploadableFileSize.php
@@ -22,7 +22,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * @author Gustavo Falco <comfortablynumb84@gmail.com>
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
-#[Attribute(Attribute::TARGET_PROPERTY)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class UploadableFileSize implements GedmoAnnotation
 {
 }

--- a/src/Mapping/Annotation/Versioned.php
+++ b/src/Mapping/Annotation/Versioned.php
@@ -22,7 +22,7 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
-#[Attribute(Attribute::TARGET_PROPERTY)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class Versioned implements GedmoAnnotation
 {
 }

--- a/src/Mapping/Driver/AttributeAnnotationReader.php
+++ b/src/Mapping/Driver/AttributeAnnotationReader.php
@@ -11,8 +11,6 @@ namespace Gedmo\Mapping\Driver;
 
 use Doctrine\Common\Annotations\Reader;
 use Gedmo\Mapping\Annotation\Annotation;
-use ReflectionClass;
-use ReflectionMethod;
 
 /**
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
@@ -41,7 +39,7 @@ final class AttributeAnnotationReader implements Reader
     /**
      * @return Annotation[]
      */
-    public function getClassAnnotations(ReflectionClass $class): array
+    public function getClassAnnotations(\ReflectionClass $class): array
     {
         $annotations = $this->attributeReader->getClassAnnotations($class);
 
@@ -59,7 +57,7 @@ final class AttributeAnnotationReader implements Reader
      *
      * @template T
      */
-    public function getClassAnnotation(ReflectionClass $class, $annotationName)
+    public function getClassAnnotation(\ReflectionClass $class, $annotationName)
     {
         $annotation = $this->attributeReader->getClassAnnotation($class, $annotationName);
 
@@ -102,7 +100,7 @@ final class AttributeAnnotationReader implements Reader
         return $this->annotationReader->getPropertyAnnotation($property, $annotationName);
     }
 
-    public function getMethodAnnotations(ReflectionMethod $method): array
+    public function getMethodAnnotations(\ReflectionMethod $method): array
     {
         throw new \BadMethodCallException('Not implemented');
     }
@@ -110,7 +108,7 @@ final class AttributeAnnotationReader implements Reader
     /**
      * @return mixed
      */
-    public function getMethodAnnotation(ReflectionMethod $method, $annotationName)
+    public function getMethodAnnotation(\ReflectionMethod $method, $annotationName)
     {
         throw new \BadMethodCallException('Not implemented');
     }

--- a/src/Mapping/Driver/AttributeReader.php
+++ b/src/Mapping/Driver/AttributeReader.php
@@ -9,9 +9,7 @@
 
 namespace Gedmo\Mapping\Driver;
 
-use Attribute;
 use Gedmo\Mapping\Annotation\Annotation;
-use ReflectionClass;
 
 /**
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
@@ -26,7 +24,7 @@ final class AttributeReader
     /**
      * @return array<Annotation|Annotation[]>
      */
-    public function getClassAnnotations(ReflectionClass $class): array
+    public function getClassAnnotations(\ReflectionClass $class): array
     {
         return $this->convertToAttributeInstances($class->getAttributes());
     }
@@ -36,7 +34,7 @@ final class AttributeReader
      *
      * @return Annotation|Annotation[]|null
      */
-    public function getClassAnnotation(ReflectionClass $class, string $annotationName)
+    public function getClassAnnotation(\ReflectionClass $class, string $annotationName)
     {
         return $this->getClassAnnotations($class)[$annotationName] ?? null;
     }
@@ -99,9 +97,9 @@ final class AttributeReader
             return $this->isRepeatableAttribute[$attributeClassName];
         }
 
-        $reflectionClass = new ReflectionClass($attributeClassName);
+        $reflectionClass = new \ReflectionClass($attributeClassName);
         $attribute = $reflectionClass->getAttributes()[0]->newInstance();
 
-        return $this->isRepeatableAttribute[$attributeClassName] = ($attribute->flags & Attribute::IS_REPEATABLE) > 0;
+        return $this->isRepeatableAttribute[$attributeClassName] = ($attribute->flags & \Attribute::IS_REPEATABLE) > 0;
     }
 }

--- a/src/Mapping/Driver/Xml.php
+++ b/src/Mapping/Driver/Xml.php
@@ -10,7 +10,6 @@
 namespace Gedmo\Mapping\Driver;
 
 use Gedmo\Exception\InvalidMappingException;
-use SimpleXMLElement;
 
 /**
  * The mapping XmlDriver abstract class, defines the
@@ -41,7 +40,7 @@ abstract class Xml extends File
      *
      * @return string
      */
-    protected function _getAttribute(SimpleXmlElement $node, $attributeName)
+    protected function _getAttribute(\SimpleXMLElement $node, $attributeName)
     {
         $attributes = $node->attributes();
 
@@ -56,7 +55,7 @@ abstract class Xml extends File
      *
      * @return bool
      */
-    protected function _getBooleanAttribute(SimpleXmlElement $node, $attributeName)
+    protected function _getBooleanAttribute(\SimpleXMLElement $node, $attributeName)
     {
         $rawValue = strtolower($this->_getAttribute($node, $attributeName));
         if ('1' === $rawValue || 'true' === $rawValue) {
@@ -77,7 +76,7 @@ abstract class Xml extends File
      *
      * @return bool
      */
-    protected function _isAttributeSet(SimpleXmlElement $node, $attributeName)
+    protected function _isAttributeSet(\SimpleXMLElement $node, $attributeName)
     {
         $attributes = $node->attributes();
 

--- a/src/Mapping/MappedEventSubscriber.php
+++ b/src/Mapping/MappedEventSubscriber.php
@@ -9,8 +9,6 @@
 
 namespace Gedmo\Mapping;
 
-use function class_exists;
-
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\PsrCachedReader;
 use Doctrine\Common\Annotations\Reader;
@@ -263,7 +261,7 @@ abstract class MappedEventSubscriber implements EventSubscriber
         if (preg_match('@Doctrine\\\([^\\\]+)@', $class, $m) && in_array($m[1], ['ODM', 'ORM'], true)) {
             if (!isset($this->adapters[$m[1]])) {
                 $adapterClass = $this->getNamespace().'\\Mapping\\Event\\Adapter\\'.$m[1];
-                if (!class_exists($adapterClass)) {
+                if (!\class_exists($adapterClass)) {
                     $adapterClass = 'Gedmo\\Mapping\\Event\\Adapter\\'.$m[1];
                 }
                 $this->adapters[$m[1]] = new $adapterClass();

--- a/src/SoftDeleteable/Traits/SoftDeleteable.php
+++ b/src/SoftDeleteable/Traits/SoftDeleteable.php
@@ -9,8 +9,6 @@
 
 namespace Gedmo\SoftDeleteable\Traits;
 
-use DateTime;
-
 /**
  * A generic trait to use on your self-deletable entities.
  * There is no mapping information defined in this trait.
@@ -20,7 +18,7 @@ use DateTime;
 trait SoftDeleteable
 {
     /**
-     * @var DateTime|null
+     * @var \DateTime|null
      */
     protected $deletedAt;
 
@@ -29,7 +27,7 @@ trait SoftDeleteable
      *
      * @return self
      */
-    public function setDeletedAt(?DateTime $deletedAt = null)
+    public function setDeletedAt(?\DateTime $deletedAt = null)
     {
         $this->deletedAt = $deletedAt;
 
@@ -40,7 +38,7 @@ trait SoftDeleteable
      * Get the deleted at timestamp value. Will return null if
      * the entity has not been soft deleted.
      *
-     * @return DateTime|null
+     * @return \DateTime|null
      */
     public function getDeletedAt()
     {

--- a/src/SoftDeleteable/Traits/SoftDeleteableDocument.php
+++ b/src/SoftDeleteable/Traits/SoftDeleteableDocument.php
@@ -9,7 +9,6 @@
 
 namespace Gedmo\SoftDeleteable\Traits;
 
-use DateTime;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Types\Type;
 
@@ -24,7 +23,7 @@ trait SoftDeleteableDocument
     /**
      * @ODM\Field(type="date")
      *
-     * @var DateTime|null
+     * @var \DateTime|null
      */
     #[ODM\Field(type: Type::DATE)]
     protected $deletedAt;
@@ -34,7 +33,7 @@ trait SoftDeleteableDocument
      *
      * @return self
      */
-    public function setDeletedAt(?DateTime $deletedAt = null)
+    public function setDeletedAt(?\DateTime $deletedAt = null)
     {
         $this->deletedAt = $deletedAt;
 
@@ -45,7 +44,7 @@ trait SoftDeleteableDocument
      * Get the deleted at timestamp value. Will return null if
      * the entity has not been soft deleted.
      *
-     * @return DateTime|null
+     * @return \DateTime|null
      */
     public function getDeletedAt()
     {

--- a/src/SoftDeleteable/Traits/SoftDeleteableEntity.php
+++ b/src/SoftDeleteable/Traits/SoftDeleteableEntity.php
@@ -24,7 +24,7 @@ trait SoftDeleteableEntity
     /**
      * @ORM\Column(type="datetime", nullable=true)
      *
-     * @var DateTime|null
+     * @var \DateTime|null
      */
     #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
     protected $deletedAt;
@@ -34,7 +34,7 @@ trait SoftDeleteableEntity
      *
      * @return self
      */
-    public function setDeletedAt(?DateTime $deletedAt = null)
+    public function setDeletedAt(?\DateTime $deletedAt = null)
     {
         $this->deletedAt = $deletedAt;
 
@@ -45,7 +45,7 @@ trait SoftDeleteableEntity
      * Get the deleted at timestamp value. Will return null if
      * the entity has not been soft deleted.
      *
-     * @return DateTime|null
+     * @return \DateTime|null
      */
     public function getDeletedAt()
     {

--- a/tests/Gedmo/Timestampable/CarbonTest.php
+++ b/tests/Gedmo/Timestampable/CarbonTest.php
@@ -95,7 +95,7 @@ final class CarbonTest extends BaseTestCaseORM
 
         /** @var CommentCarbon $sportComment */
         $sportComment = $this->em->getRepository(self::COMMENT)->findOneBy(['message' => 'hello']);
-        static::assertInstanceOf(DateTime::class, $sportComment->getModified(), 'Type TIME_MUTABLE should stay DateTime');
+        static::assertInstanceOf(\DateTime::class, $sportComment->getModified(), 'Type TIME_MUTABLE should stay DateTime');
 
         static::assertNotNull($scm = $sportComment->getModified());
         static::assertNull($sportComment->getClosed());


### PR DESCRIPTION
Ref https://github.com/doctrine-extensions/DoctrineExtensions/pull/2626#issuecomment-1596006700

We should choose what we want to import, [Symfony uses](https://cs.symfony.com/doc/rules/import/global_namespace_import.html#rule-sets):  

`['import_classes' => false, 'import_constants' => false, 'import_functions' => false],`

I've added that, but personally I import classes, so if we want to change this, no objection.