### PR TITLE
Remove workaround introduced in #236

### DIFF
--- a/src/Mapping/Driver/AbstractAnnotationDriver.php
+++ b/src/Mapping/Driver/AbstractAnnotationDriver.php
@@ -82,15 +82,7 @@ abstract class AbstractAnnotationDriver implements AnnotationDriverInterface
      */
     public function getMetaReflectionClass($meta)
     {
-        $class = $meta->getReflectionClass();
-        if (!$class) {
-            // based on recent doctrine 2.3.0-DEV maybe will be fixed in some way
-            // this happens when running annotation driver in combination with
-            // static reflection services. This is not the nicest fix
-            $class = new \ReflectionClass($meta->getName());
-        }
-
-        return $class;
+        return $meta->getReflectionClass();
     }
 
     /**


### PR DESCRIPTION
See:
* #236;
* 8c812c33df673e58f9313a360b0e03a694a3c64c.

As [`ClassMetadata::getReflectionClass()`](https://github.com/doctrine/persistence/blob/8a710c21dfe6e88df21c371012be1bf6f2337525/src/Persistence/Mapping/ClassMetadata.php#L34-L39) can't return falsy values, I guess we must remove this workaround and trust the contract defined there.
If some implementation is not respecting the contract, we should focus our efforts on fixing that implementation if it's worth it.

WDYT?