### PR TITLE
Do not rely on autoincremental ids in materialized path tests

### DIFF
--- a/tests/Gedmo/Tree/MaterializedPathORMTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathORMTest.php
@@ -87,10 +87,10 @@ final class MaterializedPathORMTest extends BaseTestCaseORM
         static::assertSame(3, $category3->getLevel());
         static::assertSame(1, $category4->getLevel());
 
-        static::assertSame('1-4', $category->getTreeRootValue());
-        static::assertSame('1-4', $category2->getTreeRootValue());
-        static::assertSame('1-4', $category3->getTreeRootValue());
-        static::assertSame('4-1', $category4->getTreeRootValue());
+        static::assertSame($this->getTreeRootValueOfRootNode($category), $category->getTreeRootValue());
+        static::assertSame($this->getTreeRootValueOfRootNode($category2), $category2->getTreeRootValue());
+        static::assertSame($this->getTreeRootValueOfRootNode($category3), $category3->getTreeRootValue());
+        static::assertSame($this->getTreeRootValueOfRootNode($category4), $category4->getTreeRootValue());
 
         // Update
         $category2->setParent(null);
@@ -110,10 +110,10 @@ final class MaterializedPathORMTest extends BaseTestCaseORM
         static::assertSame(2, $category3->getLevel());
         static::assertSame(1, $category4->getLevel());
 
-        static::assertSame('1-4', $category->getTreeRootValue());
-        static::assertSame('2-3', $category2->getTreeRootValue());
-        static::assertSame('2-3', $category3->getTreeRootValue());
-        static::assertSame('4-1', $category4->getTreeRootValue());
+        static::assertSame($this->getTreeRootValueOfRootNode($category), $category->getTreeRootValue());
+        static::assertSame($this->getTreeRootValueOfRootNode($category2), $category2->getTreeRootValue());
+        static::assertSame($this->getTreeRootValueOfRootNode($category3), $category3->getTreeRootValue());
+        static::assertSame($this->getTreeRootValueOfRootNode($category4), $category4->getTreeRootValue());
 
         // Remove
         $this->em->remove($category);
@@ -127,7 +127,7 @@ final class MaterializedPathORMTest extends BaseTestCaseORM
         static::assertCount(1, $result);
         static::assertSame('4', $firstResult->getTitle());
         static::assertSame(1, $firstResult->getLevel());
-        static::assertSame('4-1', $firstResult->getTreeRootValue());
+        static::assertSame($this->getTreeRootValueOfRootNode($firstResult), $firstResult->getTreeRootValue());
     }
 
     public function testUseOfSeparatorInPathSourceShouldThrowAnException(): void
@@ -164,5 +164,14 @@ final class MaterializedPathORMTest extends BaseTestCaseORM
         return [
             self::CATEGORY,
         ];
+    }
+
+    private function getTreeRootValueOfRootNode(MPCategory $category): string
+    {
+        while (null !== $category->getParent()) {
+            $category = $category->getParent();
+        }
+
+        return $category->getTreeRootValue();
     }
 }


### PR DESCRIPTION
First of all, I'm not sure if this is the right change, I'm not familiarized with materialized path, I've seen is that it stores the ids in the path, since we cannot rely on the autoincremental ids, this PR finds the root node of a particular node and compares that their `treeNodeValue` are the same.

This tries to fix the remaining failing test when using [`doctrine/orm` 2.16.2](https://github.com/doctrine-extensions/DoctrineExtensions/issues/2659#issuecomment-1690594815)