### PR TITLE
Remove conflict with doctrine/orm >= 2.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,8 @@ a release.
 ---
 
 ## [Unreleased]
-### Changed
-- Add conflict with "doctrine/orm" >=2.16 (temporary change until code is fixed)
 ### Fixed
 - References: fixed condition in `XML` Driver that did not allow to retrieve from the entity definition the `mappedBy` and `inversedBy` fields.
-
-### Fixed
 - Fix bug collecting metadata for inherited mapped classes
 
 ## [3.12.0] - 2023-07-08

--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
     "conflict": {
         "doctrine/dbal": "<2.13.1 || ^3.0 <3.2",
         "doctrine/mongodb-odm": "<2.3",
-        "doctrine/orm": "<2.10.2 || >= 2.16.0",
+        "doctrine/orm": "<2.10.2 || 2.16.0 || 2.16.1",
         "sebastian/comparator": "<2.0"
     },
     "suggest": {


### PR DESCRIPTION
Reverts https://github.com/doctrine-extensions/DoctrineExtensions/pull/2661 (there was no release)

should we add a conflict with `2.16.0` and `2.16.1`?