### PR TITLE
Allow "php" container to send `SIGINT` signal to the foreground processes

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -13,9 +13,15 @@ services:
       MONGODB_SERVER: 'mongodb://mongodb:27017'
     tty: true
     stdin_open: true
+    init: true
 
   mysql:
     image: mysql:8.0
+    healthcheck:
+      test: ['CMD', 'mysql', '-h', 'mysql', '--user=root', '--password=${MYSQL_ROOT_PASSWORD}', '-e', 'status']
+      interval: 10s
+      timeout: 2s
+      retries: 5
     environment:
       MYSQL_ROOT_PASSWORD: de_root_password
       MYSQL_DATABASE: de_testing


### PR DESCRIPTION
See:
* https://docs.docker.com/compose/compose-file/compose-file-v2/#init;
* https://github.com/docker-library/php/issues/505.

This PR also adds the `healthcheck` definition for the `mysql` service. See https://docs.docker.com/compose/compose-file/compose-file-v3/#healthcheck.