### PR TITLE
Use different methods than `execute()` when retrieving results

### DIFF
--- a/src/Loggable/Document/Repository/LogEntryRepository.php
+++ b/src/Loggable/Document/Repository/LogEntryRepository.php
@@ -59,14 +59,8 @@ class LogEntryRepository extends DocumentRepository
         $qb->field('objectId')->equals($objectId);
         $qb->field('objectClass')->equals($wrapped->getMetadata()->getName());
         $qb->sort('version', 'DESC');
-        $q = $qb->getQuery();
 
-        $result = $q->execute();
-        if ($result instanceof Iterator) {
-            $result = $result->toArray();
-        }
-
-        return $result;
+        return $qb->getQuery()->getIterator()->toArray();
     }
 
     /**
@@ -95,12 +89,8 @@ class LogEntryRepository extends DocumentRepository
         $qb->field('objectClass')->equals($objectMeta->getName());
         $qb->field('version')->lte((int) $version);
         $qb->sort('version', 'ASC');
-        $q = $qb->getQuery();
 
-        $logs = $q->execute();
-        if ($logs instanceof Iterator) {
-            $logs = $logs->toArray();
-        }
+        $logs = $qb->getQuery()->getIterator()->toArray();
 
         if ([] === $logs) {
             throw new UnexpectedValueException('Count not find any log entries under version: '.$version);

--- a/src/Loggable/Document/Repository/LogEntryRepository.php
+++ b/src/Loggable/Document/Repository/LogEntryRepository.php
@@ -9,7 +9,6 @@
 
 namespace Gedmo\Loggable\Document\Repository;
 
-use Doctrine\ODM\MongoDB\Iterator\Iterator;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
 use Gedmo\Exception\RuntimeException;

--- a/src/Loggable/Entity/Repository/LogEntryRepository.php
+++ b/src/Loggable/Entity/Repository/LogEntryRepository.php
@@ -79,7 +79,10 @@ class LogEntryRepository extends EntityRepository
 
         $objectId = (string) $wrapped->getIdentifier(false, true);
         $q = $this->_em->createQuery($dql);
-        $q->setParameters(compact('objectId', 'objectClass'));
+        $q->setParameters([
+            'objectId' => $objectId,
+            'objectClass' => $objectClass,
+        ]);
 
         return $q;
     }
@@ -113,7 +116,11 @@ class LogEntryRepository extends EntityRepository
 
         $objectId = (string) $wrapped->getIdentifier(false, true);
         $q = $this->_em->createQuery($dql);
-        $q->setParameters(compact('objectId', 'objectClass', 'version'));
+        $q->setParameters([
+            'objectId' => $objectId,
+            'objectClass' => $objectClass,
+            'version' => $version,
+        ]);
         $logs = $q->getResult();
 
         if ([] === $logs) {

--- a/src/Sluggable/Mapping/Event/Adapter/ODM.php
+++ b/src/Sluggable/Mapping/Event/Adapter/ODM.php
@@ -47,12 +47,7 @@ final class ODM extends BaseAdapterODM implements SluggableAdapter
         $q = $qb->getQuery();
         $q->setHydrate(false);
 
-        $result = $q->execute();
-        if ($result instanceof Iterator) {
-            $result = $result->toArray();
-        }
-
-        return $result;
+        return $q->getIterator()->toArray();
     }
 
     /**
@@ -74,14 +69,11 @@ final class ODM extends BaseAdapterODM implements SluggableAdapter
             ->getQuery()
         ;
         $q->setHydrate(false);
-        $result = $q->execute();
+        $result = $q->getIterator();
+        $count = 0;
 
-        if (!$result instanceof Iterator) {
-            return 0;
-        }
-
-        $result = $result->toArray();
         foreach ($result as $targetObject) {
+            ++$count;
             $slug = preg_replace("@^{$target}@smi", $replacement.$config['pathSeparator'], $targetObject[$config['slug']]);
             $dm
                 ->createQueryBuilder()
@@ -93,7 +85,7 @@ final class ODM extends BaseAdapterODM implements SluggableAdapter
             ;
         }
 
-        return count($result);
+        return $count;
     }
 
     /**
@@ -113,14 +105,11 @@ final class ODM extends BaseAdapterODM implements SluggableAdapter
             ->getQuery()
         ;
         $q->setHydrate(false);
-        $result = $q->execute();
+        $result = $q->getIterator();
+        $count = 0;
 
-        if (!$result instanceof Iterator) {
-            return 0;
-        }
-
-        $result = $result->toArray();
         foreach ($result as $targetObject) {
+            ++$count;
             $slug = preg_replace("@^{$replacement}@smi", $target, $targetObject[$config['slug']]);
             $dm
                 ->createQueryBuilder()
@@ -132,6 +121,6 @@ final class ODM extends BaseAdapterODM implements SluggableAdapter
             ;
         }
 
-        return count($result);
+        return $count;
     }
 }

--- a/src/Sluggable/Mapping/Event/Adapter/ODM.php
+++ b/src/Sluggable/Mapping/Event/Adapter/ODM.php
@@ -9,7 +9,6 @@
 
 namespace Gedmo\Sluggable\Mapping\Event\Adapter;
 
-use Doctrine\ODM\MongoDB\Iterator\Iterator;
 use Gedmo\Mapping\Event\Adapter\ODM as BaseAdapterODM;
 use Gedmo\Sluggable\Mapping\Event\SluggableAdapter;
 use Gedmo\Tool\Wrapper\AbstractWrapper;

--- a/src/Sluggable/Mapping/Event/Adapter/ORM.php
+++ b/src/Sluggable/Mapping/Event/Adapter/ORM.php
@@ -10,7 +10,6 @@
 namespace Gedmo\Sluggable\Mapping\Event\Adapter;
 
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
-use Doctrine\ORM\Query;
 use Gedmo\Mapping\Event\Adapter\ORM as BaseAdapterORM;
 use Gedmo\Sluggable\Mapping\Event\SluggableAdapter;
 use Gedmo\Tool\Wrapper\AbstractWrapper;
@@ -76,10 +75,8 @@ class ORM extends BaseAdapterORM implements SluggableAdapter
                 $qb->setParameter($namedId, $value, $meta->getTypeOfField($namedId));
             }
         }
-        $q = $qb->getQuery();
-        $q->setHydrationMode(Query::HYDRATE_ARRAY);
 
-        return $q->execute();
+        return $qb->getQuery()->getArrayResult();
     }
 
     public function replaceRelative($object, array $config, $target, $replacement)

--- a/src/Translatable/Document/Repository/TranslationRepository.php
+++ b/src/Translatable/Document/Repository/TranslationRepository.php
@@ -10,7 +10,6 @@
 namespace Gedmo\Translatable\Document\Repository;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
-use Doctrine\ODM\MongoDB\Iterator\Iterator;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
 use Doctrine\ODM\MongoDB\Types\Type;

--- a/src/Translatable/Document/Repository/TranslationRepository.php
+++ b/src/Translatable/Document/Repository/TranslationRepository.php
@@ -142,12 +142,9 @@ class TranslationRepository extends DocumentRepository
                 ->getQuery();
 
             $q->setHydrate(false);
-            $data = $q->execute();
 
-            if (is_iterable($data)) {
-                foreach ($data as $row) {
-                    $result[$row['locale']][$row['field']] = $row['content'];
-                }
+            foreach ($q->getIterator() as $row) {
+                $result[$row['locale']][$row['field']] = $row['content'];
             }
         }
 
@@ -182,11 +179,7 @@ class TranslationRepository extends DocumentRepository
             ->getQuery();
 
         $q->setHydrate(false);
-        $result = $q->execute();
-
-        if ($result instanceof Iterator) {
-            $result = $result->toArray();
-        }
+        $result = $q->getIterator()->toArray();
 
         $id = $result[0]['foreign_key'] ?? null;
 
@@ -216,12 +209,9 @@ class TranslationRepository extends DocumentRepository
                 ->getQuery();
 
             $q->setHydrate(false);
-            $data = $q->execute();
 
-            if (is_iterable($data)) {
-                foreach ($data as $row) {
-                    $result[$row['locale']][$row['field']] = $row['content'];
-                }
+            foreach ($q->getIterator() as $row) {
+                $result[$row['locale']][$row['field']] = $row['content'];
             }
         }
 

--- a/src/Translatable/Document/Repository/TranslationRepository.php
+++ b/src/Translatable/Document/Repository/TranslationRepository.php
@@ -81,7 +81,12 @@ class TranslationRepository extends DocumentRepository
             $foreignKey = $meta->getReflectionProperty($meta->getIdentifier()[0])->getValue($document);
             $objectClass = $config['useObjectClass'];
             $transMeta = $this->dm->getClassMetadata($class);
-            $trans = $this->findOneBy(compact('locale', 'field', 'objectClass', 'foreignKey'));
+            $trans = $this->findOneBy([
+                'locale' => $locale,
+                'field' => $field,
+                'objectClass' => $objectClass,
+                'foreignKey' => $foreignKey,
+            ]);
             if (!$trans) {
                 $trans = $transMeta->newInstance();
                 $transMeta->getReflectionProperty('foreignKey')->setValue($trans, $foreignKey);

--- a/src/Translatable/Entity/Repository/TranslationRepository.php
+++ b/src/Translatable/Entity/Repository/TranslationRepository.php
@@ -81,7 +81,12 @@ class TranslationRepository extends EntityRepository
             $foreignKey = $meta->getReflectionProperty($meta->getSingleIdentifierFieldName())->getValue($entity);
             $objectClass = $config['useObjectClass'];
             $transMeta = $this->_em->getClassMetadata($class);
-            $trans = $this->findOneBy(compact('locale', 'objectClass', 'field', 'foreignKey'));
+            $trans = $this->findOneBy([
+                'locale' => $locale,
+                'objectClass' => $objectClass,
+                'field' => $field,
+                'foreignKey' => $foreignKey,
+            ]);
             if (!$trans) {
                 $trans = $transMeta->newInstance();
                 $transMeta->getReflectionProperty('foreignKey')->setValue($trans, $foreignKey);
@@ -180,7 +185,11 @@ class TranslationRepository extends EntityRepository
             $dql .= ' AND trans.field = :field';
             $dql .= ' AND trans.content = :value';
             $q = $this->_em->createQuery($dql);
-            $q->setParameters(compact('class', 'field', 'value'));
+            $q->setParameters([
+                'class' => $class,
+                'field' => $field,
+                'value' => $value,
+            ]);
             $q->setMaxResults(1);
             $result = $q->getArrayResult();
             $id = $result[0]['foreignKey'] ?? null;

--- a/src/Translatable/Entity/Repository/TranslationRepository.php
+++ b/src/Translatable/Entity/Repository/TranslationRepository.php
@@ -141,14 +141,14 @@ class TranslationRepository extends EntityRepository
             $qb->select('trans.content, trans.field, trans.locale')
                 ->from($translationClass, 'trans')
                 ->where('trans.foreignKey = :entityId', 'trans.objectClass = :entityClass')
-                ->orderBy('trans.locale');
+                ->orderBy('trans.locale')
+                ->setParameters([
+                    'entityId' => $entityId,
+                    'entityClass' => $entityClass,
+                ]);
             $q = $qb->getQuery();
-            $data = $q->execute(
-                compact('entityId', 'entityClass'),
-                Query::HYDRATE_ARRAY
-            );
 
-            foreach ($data as $row) {
+            foreach ($q->getArrayResult() as $row) {
                 $result[$row['locale']][$row['field']] = $row['content'];
             }
         }
@@ -210,14 +210,11 @@ class TranslationRepository extends EntityRepository
             $qb->select('trans.content, trans.field, trans.locale')
                 ->from($translationMeta->rootEntityName, 'trans')
                 ->where('trans.foreignKey = :entityId')
-                ->orderBy('trans.locale');
+                ->orderBy('trans.locale')
+                ->setParameter('entityId', $id);
             $q = $qb->getQuery();
-            $data = $q->execute(
-                ['entityId' => $id],
-                Query::HYDRATE_ARRAY
-            );
 
-            foreach ($data as $row) {
+            foreach ($q->getArrayResult() as $row) {
                 $result[$row['locale']][$row['field']] = $row['content'];
             }
         }

--- a/src/Translatable/Mapping/Event/Adapter/ODM.php
+++ b/src/Translatable/Mapping/Event/Adapter/ODM.php
@@ -9,7 +9,6 @@
 
 namespace Gedmo\Translatable\Mapping\Event\Adapter;
 
-use Doctrine\ODM\MongoDB\Iterator\Iterator;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Types\Type;
 use Gedmo\Exception\RuntimeException;

--- a/src/Translatable/Mapping/Event/Adapter/ODM.php
+++ b/src/Translatable/Mapping/Event/Adapter/ODM.php
@@ -90,12 +90,8 @@ final class ODM extends BaseAdapterODM implements TranslatableAdapter
             ;
         }
         $q->setHydrate(false);
-        $result = $q->execute();
-        if ($result instanceof Iterator) {
-            $result = $result->toArray();
-        }
 
-        return $result;
+        return $q->getIterator()->toArray();
     }
 
     public function findTranslation(AbstractWrapper $wrapped, $locale, $field, $translationClass, $objectClass)

--- a/src/Translatable/Mapping/Event/Adapter/ORM.php
+++ b/src/Translatable/Mapping/Event/Adapter/ORM.php
@@ -80,7 +80,10 @@ final class ORM extends BaseAdapterORM implements TranslatableAdapter
                 $dql .= ' AND t.object = :object';
 
                 $q = $em->createQuery($dql);
-                $q->setParameters(compact('object', 'locale'));
+                $q->setParameters([
+                    'object' => $object,
+                    'locale' => $locale,
+                ]);
                 $result = $q->getArrayResult();
             }
         } else {
@@ -93,7 +96,11 @@ final class ORM extends BaseAdapterORM implements TranslatableAdapter
             $dql .= ' AND t.objectClass = :objectClass';
             // fetch results
             $q = $em->createQuery($dql);
-            $q->setParameters(compact('objectId', 'locale', 'objectClass'));
+            $q->setParameters([
+                'objectId' => $objectId,
+                'locale' => $locale,
+                'objectClass' => $objectClass,
+            ]);
             $result = $q->getArrayResult();
         }
 
@@ -136,7 +143,10 @@ final class ORM extends BaseAdapterORM implements TranslatableAdapter
                 'trans.field = :field'
             )
         ;
-        $qb->setParameters(compact('locale', 'field'));
+        $qb->setParameters([
+            'locale' => $locale,
+            'field' => $field,
+        ]);
         if ($this->usesPersonalTranslation($translationClass)) {
             $qb->andWhere('trans.object = :object');
             if ($wrapped->getIdentifier()) {

--- a/src/Tree/Document/MongoDB/Repository/MaterializedPathRepository.php
+++ b/src/Tree/Document/MongoDB/Repository/MaterializedPathRepository.php
@@ -58,7 +58,7 @@ class MaterializedPathRepository extends AbstractTreeRepository
      */
     public function getTree($rootNode = null): Iterator
     {
-        return $this->getTreeQuery($rootNode)->execute();
+        return $this->getTreeQuery($rootNode)->getIterator();
     }
 
     public function getRootNodesQueryBuilder($sortByField = null, $direction = 'asc')
@@ -152,7 +152,7 @@ class MaterializedPathRepository extends AbstractTreeRepository
 
     public function getChildren($node = null, $direct = false, $sortByField = null, $direction = 'asc', $includeNode = false)
     {
-        return $this->getChildrenQuery($node, $direct, $sortByField, $direction, $includeNode)->execute();
+        return $this->getChildrenQuery($node, $direct, $sortByField, $direction, $includeNode)->getIterator();
     }
 
     public function getNodesHierarchyQueryBuilder($node = null, $direct = false, array $options = [], $includeNode = false)

--- a/src/Tree/Entity/Repository/ClosureTreeRepository.php
+++ b/src/Tree/Entity/Repository/ClosureTreeRepository.php
@@ -88,7 +88,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
         $dql .= ' WHERE c.descendant = :node';
         $dql .= ' ORDER BY c.depth DESC';
         $q = $this->_em->createQuery($dql);
-        $q->setParameters(compact('node'));
+        $q->setParameter('node', $node);
 
         return $q;
     }
@@ -271,7 +271,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
         $dql = "SELECT node FROM {$config['useObjectClass']} node";
         $dql .= " WHERE node.{$config['parent']} = :node";
         $q = $this->_em->createQuery($dql);
-        $q->setParameters(compact('node'));
+        $q->setParameter('node', $node);
         $nodesToReparent = $q->getResult();
         // process updates in transaction
         $this->_em->getConnection()->beginTransaction();
@@ -286,7 +286,10 @@ class ClosureTreeRepository extends AbstractTreeRepository
                 $dql .= " WHERE node.{$pk} = :id";
 
                 $q = $this->_em->createQuery($dql);
-                $q->setParameters(compact('parent', 'id'));
+                $q->setParameters([
+                    'parent' => $parent,
+                    'id' => $id,
+                ]);
                 $q->getSingleScalarResult();
 
                 $this->listener
@@ -301,7 +304,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
             $dql .= " WHERE node.{$pk} = :nodeId";
 
             $q = $this->_em->createQuery($dql);
-            $q->setParameters(compact('nodeId'));
+            $q->setParameter('nodeId', $nodeId);
             $q->getSingleScalarResult();
             $this->_em->getConnection()->commit();
         } catch (\Exception $e) {
@@ -388,7 +391,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
 
         if (null !== $node) {
             $q->where('c.ancestor = :node');
-            $q->setParameters(compact('node'));
+            $q->setParameter('node', $node);
         } else {
             $q->groupBy('c.descendant');
         }

--- a/src/Tree/Entity/Repository/MaterializedPathRepository.php
+++ b/src/Tree/Entity/Repository/MaterializedPathRepository.php
@@ -57,7 +57,7 @@ class MaterializedPathRepository extends AbstractTreeRepository
      */
     public function getTree($rootNode = null)
     {
-        return $this->getTreeQuery($rootNode)->execute();
+        return $this->getTreeQuery($rootNode)->getResult();
     }
 
     public function getRootNodesQueryBuilder($sortByField = null, $direction = 'asc')
@@ -72,7 +72,7 @@ class MaterializedPathRepository extends AbstractTreeRepository
 
     public function getRootNodes($sortByField = null, $direction = 'asc')
     {
-        return $this->getRootNodesQuery($sortByField, $direction)->execute();
+        return $this->getRootNodesQuery($sortByField, $direction)->getResult();
     }
 
     /**
@@ -219,7 +219,7 @@ class MaterializedPathRepository extends AbstractTreeRepository
 
     public function getChildren($node = null, $direct = false, $sortByField = null, $direction = 'asc', $includeNode = false)
     {
-        return $this->getChildrenQuery($node, $direct, $sortByField, $direction, $includeNode)->execute();
+        return $this->getChildrenQuery($node, $direct, $sortByField, $direction, $includeNode)->getResult();
     }
 
     public function getNodesHierarchyQueryBuilder($node = null, $direct = false, array $options = [], $includeNode = false)

--- a/src/Tree/RepositoryInterface.php
+++ b/src/Tree/RepositoryInterface.php
@@ -50,7 +50,7 @@ interface RepositoryInterface extends RepositoryUtilsInterface
      * @param string|string[]      $direction   Sort order ('asc'|'desc'|'ASC'|'DESC'). If $sortByField is an array, this may also be an array with matching number of elements
      * @param bool                 $includeNode Include the root node in results?
      *
-     * @return iterable|null List of children
+     * @return iterable<int|string, object> List of children
      *
      * @phpstan-param 'asc'|'desc'|'ASC'|'DESC'|array<int, 'asc'|'desc'|'ASC'|'DESC'> $direction
      */

--- a/src/Tree/RepositoryInterface.php
+++ b/src/Tree/RepositoryInterface.php
@@ -50,7 +50,7 @@ interface RepositoryInterface extends RepositoryUtilsInterface
      * @param string|string[]      $direction   Sort order ('asc'|'desc'|'ASC'|'DESC'). If $sortByField is an array, this may also be an array with matching number of elements
      * @param bool                 $includeNode Include the root node in results?
      *
-     * @return array<int|string, object> List of children
+     * @return iterable|null List of children
      *
      * @phpstan-param 'asc'|'desc'|'ASC'|'DESC'|array<int, 'asc'|'desc'|'ASC'|'DESC'> $direction
      */

--- a/src/Tree/Strategy/ODM/MongoDB/MaterializedPath.php
+++ b/src/Tree/Strategy/ODM/MongoDB/MaterializedPath.php
@@ -38,7 +38,7 @@ class MaterializedPath extends AbstractMaterializedPath
             ->find($meta->getName())
             ->field($config['path'])->equals(new Regex('^'.preg_quote($wrapped->getPropertyValue($config['path'])).'.?+'))
             ->getQuery()
-            ->execute();
+            ->getIterator();
 
         foreach ($results as $node) {
             $uow->scheduleForDelete($node);
@@ -55,7 +55,7 @@ class MaterializedPath extends AbstractMaterializedPath
             ->field($config['path'])->equals(new Regex('^'.preg_quote($originalPath).'.+'))
             ->sort($config['path'], 'asc')      // This may save some calls to updateNode
             ->getQuery()
-            ->execute();
+            ->getIterator();
     }
 
     /**

--- a/src/Tree/Strategy/ORM/Closure.php
+++ b/src/Tree/Strategy/ORM/Closure.php
@@ -301,7 +301,7 @@ class Closure implements Strategy
                 $dql .= ' JOIN c.ancestor a';
                 $dql .= ' WHERE c.descendant = :parent';
                 $q = $em->createQuery($dql);
-                $q->setParameters(compact('parent'));
+                $q->setParameter('parent', $parent);
                 $ancestors = $q->getArrayResult();
 
                 if ([] === $ancestors) {
@@ -400,7 +400,10 @@ class Closure implements Strategy
             $dql .= ' WHERE c.ancestor = :node';
             $dql .= ' AND c.descendant = :parent';
             $q = $em->createQuery($dql);
-            $q->setParameters(compact('node', 'parent'));
+            $q->setParameters([
+                'node' => $node,
+                'parent' => $parent,
+            ]);
             if ($q->getSingleScalarResult()) {
                 throw new UnexpectedValueException("Cannot set child as parent to node: {$nodeId}");
             }
@@ -411,7 +414,7 @@ class Closure implements Strategy
             $subQuery .= " JOIN {$table} c2 ON c1.descendant = c2.descendant";
             $subQuery .= ' WHERE c1.ancestor = :nodeId AND c2.depth > c1.depth';
 
-            $ids = $conn->executeQuery($subQuery, compact('nodeId'))->fetchFirstColumn();
+            $ids = $conn->executeQuery($subQuery, ['nodeId' => $nodeId])->fetchFirstColumn();
             if ([] !== $ids) {
                 // using subquery directly, sqlite acts unfriendly
                 $query = "DELETE FROM {$table} WHERE id IN (".implode(', ', $ids).')';
@@ -429,7 +432,7 @@ class Closure implements Strategy
             $query .= ' WHERE c1.descendant = :parentId';
             $query .= ' AND c2.ancestor = :nodeId';
 
-            $closures = $conn->executeQuery($query, compact('nodeId', 'parentId'))->fetchAllAssociative();
+            $closures = $conn->executeQuery($query, ['nodeId' => $nodeId, 'parentId' => $parentId])->fetchAllAssociative();
 
             foreach ($closures as $closure) {
                 if (!$conn->insert($table, $closure)) {

--- a/src/Tree/Strategy/ORM/MaterializedPath.php
+++ b/src/Tree/Strategy/ORM/MaterializedPath.php
@@ -50,7 +50,7 @@ class MaterializedPath extends AbstractMaterializedPath
         }
 
         $results = $qb->getQuery()
-            ->execute();
+            ->toIterable();
 
         foreach ($results as $node) {
             $uow->scheduleForDelete($node);
@@ -71,7 +71,6 @@ class MaterializedPath extends AbstractMaterializedPath
             ->orderBy('e.'.$config['path'], 'asc');      // This may save some calls to updateNode
         $qb->setParameter('path', $path);
 
-        return $qb->getQuery()
-            ->execute();
+        return $qb->getQuery()->getResult();
     }
 }

--- a/tests/Gedmo/Translatable/TranslatableTest.php
+++ b/tests/Gedmo/Translatable/TranslatableTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace Gedmo\Tests\Translatable;
 
 use Doctrine\Common\EventManager;
-use Doctrine\ORM\Query;
 use Gedmo\Tests\Tool\BaseTestCaseORM;
 use Gedmo\Tests\Translatable\Fixture\Article;
 use Gedmo\Tests\Translatable\Fixture\Comment;
@@ -144,12 +143,10 @@ final class TranslatableTest extends BaseTestCaseORM
         $qb = $this->em->createQueryBuilder();
         $qb->select('art')
             ->from(self::ARTICLE, 'art')
-            ->where('art.id = :id');
+            ->where('art.id = :id')
+            ->setParameter('id', $article->getId());
         $q = $qb->getQuery();
-        $result = $q->execute(
-            ['id' => $article->getId()],
-            Query::HYDRATE_ARRAY
-        );
+        $result = $q->getArrayResult();
         static::assertCount(1, $result);
         static::assertSame('title in en', $result[0]['title']);
         static::assertSame('content in en', $result[0]['content']);

--- a/tests/Gedmo/Translator/TranslatableTest.php
+++ b/tests/Gedmo/Translator/TranslatableTest.php
@@ -66,7 +66,7 @@ final class TranslatableTest extends BaseTestCaseORM
             ->select('p, t')
             ->join('p.translations', 't')
             ->getQuery()
-            ->execute();
+            ->getResult();
         $person = $persons[0];
 
         static::assertSame('Jen', $person->getName());
@@ -84,7 +84,7 @@ final class TranslatableTest extends BaseTestCaseORM
             ->select('p, t')
             ->join('p.translations', 't')
             ->getQuery()
-            ->execute();
+            ->getResult();
         $person = $persons[0];
 
         static::assertSame('Jen', $person->getName());
@@ -208,7 +208,7 @@ final class TranslatableTest extends BaseTestCaseORM
             ->select('p, t')
             ->join('p.translations', 't')
             ->getQuery()
-            ->execute();
+            ->getResult();
         $person = $persons[0];
 
         static::assertSame('Jen', $person->getName());
@@ -226,7 +226,7 @@ final class TranslatableTest extends BaseTestCaseORM
             ->select('p, t')
             ->join('p.translations', 't')
             ->getQuery()
-            ->execute();
+            ->getResult();
         $person = $persons[0];
 
         static::assertSame('Jen', $person->getName());

--- a/tests/Gedmo/Tree/MaterializedPathODMMongoDBTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathODMMongoDBTest.php
@@ -111,7 +111,7 @@ final class MaterializedPathODMMongoDBTest extends BaseTestCaseMongoODM
         $this->dm->remove($category2);
         $this->dm->flush();
 
-        $result = $this->dm->createQueryBuilder()->find(self::CATEGORY)->getQuery()->execute();
+        $result = $this->dm->createQueryBuilder()->find(self::CATEGORY)->getQuery()->getIterator();
 
         static::assertInstanceOf(Iterator::class, $result);
 

--- a/tests/Gedmo/Tree/MaterializedPathORMRootAssociationTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathORMRootAssociationTest.php
@@ -119,7 +119,7 @@ final class MaterializedPathORMRootAssociationTest extends BaseTestCaseORM
         $this->em->remove($category2);
         $this->em->flush();
 
-        $result = $this->em->createQueryBuilder()->select('c')->from(self::CATEGORY, 'c')->getQuery()->execute();
+        $result = $this->em->createQueryBuilder()->select('c')->from(self::CATEGORY, 'c')->getQuery()->getResult();
 
         $firstResult = $result[0];
 

--- a/tests/Gedmo/Tree/MaterializedPathORMTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathORMTest.php
@@ -120,7 +120,7 @@ final class MaterializedPathORMTest extends BaseTestCaseORM
         $this->em->remove($category2);
         $this->em->flush();
 
-        $result = $this->em->createQueryBuilder()->select('c')->from(self::CATEGORY, 'c')->getQuery()->execute();
+        $result = $this->em->createQueryBuilder()->select('c')->from(self::CATEGORY, 'c')->getQuery()->getResult();
 
         $firstResult = $result[0];
 

--- a/tests/Gedmo/Tree/NestedTreeRootRepositoryTest.php
+++ b/tests/Gedmo/Tree/NestedTreeRootRepositoryTest.php
@@ -131,7 +131,7 @@ final class NestedTreeRootRepositoryTest extends BaseTestCaseORM
         $repo = $this->em->getRepository(self::CATEGORY);
         $food = $repo->findOneBy(['title' => 'Food']);
         $decorate = true;
-        $defaultHtmlTree = $repo->childrenHierarchy($food, false, compact('decorate'));
+        $defaultHtmlTree = $repo->childrenHierarchy($food, false, ['decorate' => $decorate]);
 
         static::assertSame(
             '<ul><li>Fruits</li><li>Vegitables<ul><li>Carrots</li><li>Potatoes</li></ul></li></ul>',
@@ -146,7 +146,10 @@ final class NestedTreeRootRepositoryTest extends BaseTestCaseORM
         $decoratedHtmlTree = $repo->childrenHierarchy(
             $food,
             false,
-            compact('decorate', 'nodeDecorator')
+            [
+                'decorate' => $decorate,
+                'nodeDecorator' => $nodeDecorator,
+            ]
         );
 
         static::assertSame(
@@ -165,7 +168,14 @@ final class NestedTreeRootRepositoryTest extends BaseTestCaseORM
         $decoratedCliTree = $repo->childrenHierarchy(
             $food,
             false,
-            compact('decorate', 'nodeDecorator', 'rootOpen', 'rootClose', 'childOpen', 'childClose')
+            [
+                'decorate' => $decorate,
+                'nodeDecorator' => $nodeDecorator,
+                'rootOpen' => $rootOpen,
+                'rootClose' => $rootClose,
+                'childOpen' => $childOpen,
+                'childClose' => $childClose,
+            ]
         );
         static::assertSame(
             "-Fruits\n-Vegitables\n--Carrots\n--Potatoes\n",
@@ -185,7 +195,13 @@ final class NestedTreeRootRepositoryTest extends BaseTestCaseORM
         $decoratedHtmlTree = $repo->childrenHierarchy(
             $food,
             false,
-            compact('decorate', 'rootOpen', 'rootClose', 'childOpen', 'childClose')
+            [
+                'decorate' => $decorate,
+                'rootOpen' => $rootOpen,
+                'rootClose' => $rootClose,
+                'childOpen' => $childOpen,
+                'childClose' => $childClose,
+            ]
         );
 
         static::assertSame(


### PR DESCRIPTION
This should also contribute reducing the resource consumption where iterators are used instead of arrays.
Calls to `compact()` were also replaced in order to consume the related variables explicitly.