### PR TITLE
[Docker] Update `healtcheck` property at "mysql" service in order to use the `CMD-SHELL` test

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -18,7 +18,7 @@ services:
   mysql:
     image: mysql:8.0
     healthcheck:
-      test: ['CMD', 'mysql', '-h', 'mysql', '--user=root', '--password=${MYSQL_ROOT_PASSWORD}', '-e', 'status']
+      test: ["CMD-SHELL", "mysql -h mysql --user=root --password=$${MYSQL_ROOT_PASSWORD} -e status"]
       interval: 10s
       timeout: 2s
       retries: 5


### PR DESCRIPTION
With the `CMD` test, the environment variable `MYSQL_ROOT_PASSWORD` is not properly extrapolated:
```
WARN[0000] The "MYSQL_ROOT_PASSWORD" variable is not set. Defaulting to a blank string.
```

Follows #2688.