### PR TITLE
Fix generic type implementations

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -13,8 +13,6 @@ parameters:
     treatPhpDocTypesAsCertain: false
     checkMissingVarTagTypehint: true
     checkMissingTypehints: true
-    # @todo: Remove the "checkGenericClassInNonGenericObjectType" definition.
-    checkGenericClassInNonGenericObjectType: false
     ignoreErrors:
         - '#^Property Gedmo\\Tests\\.+\\Fixture\\[^:]+::\$\w+ is never written, only read\.$#'
         - '#^Property Gedmo\\Tests\\.+\\Fixture\\[^:]+::\$\w+ is never read, only written\.$#'

--- a/src/AbstractTrackingListener.php
+++ b/src/AbstractTrackingListener.php
@@ -47,6 +47,7 @@ abstract class AbstractTrackingListener extends MappedEventSubscriber
      * Maps additional metadata for the object.
      *
      * @param LoadClassMetadataEventArgs $eventArgs
+     * @phpstan-param LoadClassMetadataEventArgs<ClassMetadata<object>, ObjectManager> $eventArgs
      *
      * @return void
      */

--- a/src/Loggable/LoggableListener.php
+++ b/src/Loggable/LoggableListener.php
@@ -10,8 +10,9 @@
 namespace Gedmo\Loggable;
 
 use Doctrine\Common\EventArgs;
-use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\ClassMetadata as ORMClassMetadata;
 use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\ObjectManager;
 use Gedmo\Exception\InvalidArgumentException;
 use Gedmo\Loggable\Entity\LogEntry;
@@ -125,6 +126,7 @@ class LoggableListener extends MappedEventSubscriber
      * Maps additional metadata
      *
      * @param LoadClassMetadataEventArgs $eventArgs
+     * @phpstan-param LoadClassMetadataEventArgs<ClassMetadata<object>, ObjectManager> $eventArgs
      *
      * @return void
      */
@@ -312,7 +314,7 @@ class LoggableListener extends MappedEventSubscriber
         if ($config = $this->getConfiguration($om, $meta->getName())) {
             $logEntryClass = $this->getLogEntryClass($ea, $meta->getName());
             $logEntryMeta = $om->getClassMetadata($logEntryClass);
-            /** @var LogEntryInterface $logEntry */
+            /** @var LogEntryInterface<T> $logEntry */
             $logEntry = $logEntryMeta->newInstance();
 
             $logEntry->setAction($action);
@@ -322,7 +324,7 @@ class LoggableListener extends MappedEventSubscriber
 
             // check for the availability of the primary key
             $uow = $om->getUnitOfWork();
-            if (LogEntryInterface::ACTION_CREATE === $action && ($ea->isPostInsertGenerator($meta) || ($meta instanceof ClassMetadata && $meta->isIdentifierComposite))) {
+            if (LogEntryInterface::ACTION_CREATE === $action && ($ea->isPostInsertGenerator($meta) || ($meta instanceof ORMClassMetadata && $meta->isIdentifierComposite))) {
                 $this->pendingLogEntryInserts[spl_object_id($object)] = $logEntry;
             } else {
                 $logEntry->setObjectId($wrapped->getIdentifier(false, true));

--- a/src/Mapping/Driver/AbstractAnnotationDriver.php
+++ b/src/Mapping/Driver/AbstractAnnotationDriver.php
@@ -79,6 +79,7 @@ abstract class AbstractAnnotationDriver implements AnnotationDriverInterface
      * @param ClassMetadata $meta
      *
      * @return \ReflectionClass
+     * @phpstan-return \ReflectionClass<object>
      */
     public function getMetaReflectionClass($meta)
     {

--- a/src/Mapping/Driver/AttributeAnnotationReader.php
+++ b/src/Mapping/Driver/AttributeAnnotationReader.php
@@ -37,6 +37,8 @@ final class AttributeAnnotationReader implements Reader
     }
 
     /**
+     * @phpstan-param \ReflectionClass<object> $class
+     *
      * @return Annotation[]
      */
     public function getClassAnnotations(\ReflectionClass $class): array
@@ -51,7 +53,10 @@ final class AttributeAnnotationReader implements Reader
     }
 
     /**
-     * @param class-string<T> $annotationName the name of the annotation
+     * @param string $annotationName
+     *
+     * @phpstan-param \ReflectionClass<object> $class
+     * @phpstan-param class-string<T> $annotationName the name of the annotation
      *
      * @return T|null the Annotation or NULL, if the requested annotation does not exist
      *

--- a/src/Mapping/Driver/AttributeReader.php
+++ b/src/Mapping/Driver/AttributeReader.php
@@ -22,6 +22,8 @@ final class AttributeReader
     private $isRepeatableAttribute = [];
 
     /**
+     * @phpstan-param \ReflectionClass<object> $class
+     *
      * @return array<Annotation|Annotation[]>
      */
     public function getClassAnnotations(\ReflectionClass $class): array
@@ -30,6 +32,7 @@ final class AttributeReader
     }
 
     /**
+     * @phpstan-param \ReflectionClass<object> $class
      * @phpstan-param class-string $annotationName
      *
      * @return Annotation|Annotation[]|null
@@ -58,11 +61,12 @@ final class AttributeReader
     }
 
     /**
-     * @param array<\ReflectionAttribute> $attributes
+     * @param iterable<\ReflectionAttribute> $attributes
+     * @phpstan-param iterable<\ReflectionAttribute<object>> $attributes
      *
      * @return array<string, Annotation|Annotation[]>
      */
-    private function convertToAttributeInstances(array $attributes): array
+    private function convertToAttributeInstances(iterable $attributes): array
     {
         $instances = [];
 

--- a/src/ReferenceIntegrity/ReferenceIntegrityListener.php
+++ b/src/ReferenceIntegrity/ReferenceIntegrityListener.php
@@ -11,6 +11,8 @@ namespace Gedmo\ReferenceIntegrity;
 
 use Doctrine\Common\EventArgs;
 use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
+use Doctrine\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\ObjectManager;
 use Gedmo\Exception\InvalidMappingException;
 use Gedmo\Exception\ReferenceIntegrityStrictException;
 use Gedmo\Mapping\MappedEventSubscriber;
@@ -40,6 +42,7 @@ class ReferenceIntegrityListener extends MappedEventSubscriber
      * Maps additional metadata for the Document
      *
      * @param LoadClassMetadataEventArgs $eventArgs
+     * @phpstan-param LoadClassMetadataEventArgs<ClassMetadata<object>, ObjectManager> $eventArgs
      *
      * @return void
      */

--- a/src/References/ReferencesListener.php
+++ b/src/References/ReferencesListener.php
@@ -12,6 +12,7 @@ namespace Gedmo\References;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\EventArgs;
 use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\ObjectManager;
 use Gedmo\Mapping\MappedEventSubscriber;
 
@@ -61,6 +62,7 @@ class ReferencesListener extends MappedEventSubscriber
 
     /**
      * @param LoadClassMetadataEventArgs $eventArgs
+     * @phpstan-param LoadClassMetadataEventArgs<ClassMetadata<object>, ObjectManager> $eventArgs
      *
      * @return void
      */

--- a/src/Sluggable/SluggableListener.php
+++ b/src/Sluggable/SluggableListener.php
@@ -11,6 +11,7 @@ namespace Gedmo\Sluggable;
 
 use Doctrine\Common\EventArgs;
 use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\ObjectManager;
 use Gedmo\Exception\InvalidArgumentException;
 use Gedmo\Mapping\MappedEventSubscriber;
@@ -225,6 +226,7 @@ class SluggableListener extends MappedEventSubscriber
      * Mapps additional metadata
      *
      * @param LoadClassMetadataEventArgs $eventArgs
+     * @phpstan-param LoadClassMetadataEventArgs<ClassMetadata<object>, ObjectManager> $eventArgs
      *
      * @return void
      */

--- a/src/SoftDeleteable/SoftDeleteableListener.php
+++ b/src/SoftDeleteable/SoftDeleteableListener.php
@@ -14,6 +14,8 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\UnitOfWork as MongoDBUnitOfWork;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
+use Doctrine\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\ObjectManager;
 use Gedmo\Mapping\MappedEventSubscriber;
 
 /**
@@ -108,6 +110,7 @@ class SoftDeleteableListener extends MappedEventSubscriber
      * Maps additional metadata
      *
      * @param LoadClassMetadataEventArgs $eventArgs
+     * @phpstan-param LoadClassMetadataEventArgs<ClassMetadata<object>, ObjectManager> $eventArgs
      *
      * @return void
      */

--- a/src/Sortable/Entity/Repository/SortableRepository.php
+++ b/src/Sortable/Entity/Repository/SortableRepository.php
@@ -21,6 +21,8 @@ use Gedmo\Sortable\SortableListener;
  * Sortable Repository
  *
  * @author Lukas Botsch <lukas.botsch@gmail.com>
+ *
+ * @phpstan-extends EntityRepository<object>
  */
 class SortableRepository extends EntityRepository
 {

--- a/src/Sortable/SortableListener.php
+++ b/src/Sortable/SortableListener.php
@@ -87,6 +87,7 @@ class SortableListener extends MappedEventSubscriber
      * Maps additional metadata
      *
      * @param LoadClassMetadataEventArgs $args
+     * @phpstan-param LoadClassMetadataEventArgs<ClassMetadata<object>, ObjectManager> $args
      *
      * @return void
      */

--- a/src/Tool/Wrapper/AbstractWrapper.php
+++ b/src/Tool/Wrapper/AbstractWrapper.php
@@ -60,7 +60,7 @@ abstract class AbstractWrapper implements WrapperInterface
      *
      * @throws UnsupportedObjectManagerException
      *
-     * @return WrapperInterface
+     * @return WrapperInterface<ClassMetadata>
      */
     public static function wrap($object, ObjectManager $om)
     {

--- a/src/Tool/WrapperInterface.php
+++ b/src/Tool/WrapperInterface.php
@@ -14,7 +14,7 @@ use Doctrine\Persistence\Mapping\ClassMetadata;
 /**
  * Interface for a wrapper of a managed object.
  *
- * @phpstan-template TClassMetadata of ClassMetadata
+ * @phpstan-template-covariant TClassMetadata of ClassMetadata
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */

--- a/src/Translatable/Document/Repository/TranslationRepository.php
+++ b/src/Translatable/Document/Repository/TranslationRepository.php
@@ -27,6 +27,8 @@ use Gedmo\Translatable\TranslatableListener;
  * to interact with translations.
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ *
+ * @phpstan-extends DocumentRepository<object>
  */
 class TranslationRepository extends DocumentRepository
 {

--- a/src/Translatable/Entity/Repository/TranslationRepository.php
+++ b/src/Translatable/Entity/Repository/TranslationRepository.php
@@ -27,6 +27,8 @@ use Gedmo\Translatable\TranslatableListener;
  * to interact with translations.
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ *
+ * @phpstan-extends EntityRepository<object>
  */
 class TranslationRepository extends EntityRepository
 {

--- a/src/Translatable/Mapping/Event/TranslatableAdapter.php
+++ b/src/Translatable/Mapping/Event/TranslatableAdapter.php
@@ -9,6 +9,7 @@
 
 namespace Gedmo\Translatable\Mapping\Event;
 
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use Gedmo\Mapping\Event\AdapterInterface;
 use Gedmo\Tool\Wrapper\AbstractWrapper;
 
@@ -61,6 +62,7 @@ interface TranslatableAdapter extends AdapterInterface
      * @param string $translationClass
      * @param string $objectClass
      *
+     * @phpstan-param AbstractWrapper<ClassMetadata<object>> $wrapped
      * @phpstan-param class-string $translationClass
      * @phpstan-param class-string $objectClass
      *
@@ -74,6 +76,7 @@ interface TranslatableAdapter extends AdapterInterface
      * @param string $transClass
      * @param string $objectClass
      *
+     * @phpstan-param AbstractWrapper<ClassMetadata<object>> $wrapped
      * @phpstan-param class-string $transClass
      * @phpstan-param class-string $objectClass
      *

--- a/src/Translatable/TranslatableListener.php
+++ b/src/Translatable/TranslatableListener.php
@@ -217,6 +217,7 @@ class TranslatableListener extends MappedEventSubscriber
      * Maps additional metadata
      *
      * @param LoadClassMetadataEventArgs $eventArgs
+     * @phpstan-param LoadClassMetadataEventArgs<ClassMetadata<object>, ObjectManager> $eventArgs
      *
      * @return void
      */

--- a/src/Tree/Document/MongoDB/Repository/AbstractTreeRepository.php
+++ b/src/Tree/Document/MongoDB/Repository/AbstractTreeRepository.php
@@ -21,6 +21,9 @@ use Gedmo\Tree\RepositoryUtils;
 use Gedmo\Tree\RepositoryUtilsInterface;
 use Gedmo\Tree\TreeListener;
 
+/**
+ * @phpstan-extends DocumentRepository<object>
+ */
 abstract class AbstractTreeRepository extends DocumentRepository implements RepositoryInterface
 {
     /**

--- a/src/Tree/Document/MongoDB/Repository/MaterializedPathRepository.php
+++ b/src/Tree/Document/MongoDB/Repository/MaterializedPathRepository.php
@@ -55,6 +55,8 @@ class MaterializedPathRepository extends AbstractTreeRepository
      * Get tree
      *
      * @param object|null $rootNode
+     *
+     * @phpstan-return Iterator<object>
      */
     public function getTree($rootNode = null): Iterator
     {

--- a/src/Tree/Entity/Repository/AbstractTreeRepository.php
+++ b/src/Tree/Entity/Repository/AbstractTreeRepository.php
@@ -22,6 +22,9 @@ use Gedmo\Tree\RepositoryUtils;
 use Gedmo\Tree\RepositoryUtilsInterface;
 use Gedmo\Tree\TreeListener;
 
+/**
+ * @phpstan-extends EntityRepository<object>
+ */
 abstract class AbstractTreeRepository extends EntityRepository implements RepositoryInterface
 {
     /**

--- a/src/Tree/TreeListener.php
+++ b/src/Tree/TreeListener.php
@@ -13,6 +13,7 @@ use Doctrine\Common\EventArgs;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\ObjectManager;
 use Gedmo\Exception\InvalidArgumentException;
 use Gedmo\Exception\UnexpectedValueException;
@@ -287,6 +288,8 @@ class TreeListener extends MappedEventSubscriber
      * Mapps additional metadata
      *
      * @param LoadClassMetadataEventArgs $eventArgs
+     *
+     * @phpstan-param LoadClassMetadataEventArgs<ClassMetadata<object>, ObjectManager> $eventArgs
      *
      * @return void
      */

--- a/src/Uploadable/UploadableListener.php
+++ b/src/Uploadable/UploadableListener.php
@@ -15,6 +15,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\NotifyPropertyChanged;
+use Doctrine\Persistence\ObjectManager;
 use Gedmo\Exception\InvalidArgumentException;
 use Gedmo\Exception\UploadableCantWriteException;
 use Gedmo\Exception\UploadableCouldntGuessMimeTypeException;
@@ -522,6 +523,8 @@ class UploadableListener extends MappedEventSubscriber
      * Maps additional metadata
      *
      * @param LoadClassMetadataEventArgs $eventArgs
+     *
+     * @phpstan-param LoadClassMetadataEventArgs<ClassMetadata<object>, ObjectManager> $eventArgs
      *
      * @return void
      */

--- a/tests/Gedmo/Mapping/Fixture/Yaml/Category.php
+++ b/tests/Gedmo/Mapping/Fixture/Yaml/Category.php
@@ -32,12 +32,12 @@ class Category extends BaseCategory
     private $slug;
 
     /**
-     * @var Collection<int, Category>
+     * @var Collection<int, self>
      */
     private $children;
 
     /**
-     * @var Category
+     * @var self
      */
     private $parent;
 
@@ -82,16 +82,13 @@ class Category extends BaseCategory
         return $this->slug;
     }
 
-    /**
-     * @param Category $children
-     */
     public function addChildren(self $children): void
     {
         $this->children[] = $children;
     }
 
     /**
-     * @return Collection $children
+     * @return Collection<int, self> $children
      */
     public function getChildren()
     {
@@ -104,7 +101,7 @@ class Category extends BaseCategory
     }
 
     /**
-     * @return Category $parent
+     * @return self $parent
      */
     public function getParent(): self
     {

--- a/tests/Gedmo/Mapping/Mock/Extension/Encoder/EncoderListener.php
+++ b/tests/Gedmo/Mapping/Mock/Extension/Encoder/EncoderListener.php
@@ -13,6 +13,8 @@ namespace Gedmo\Tests\Mapping\Mock\Extension\Encoder;
 
 use Doctrine\Common\EventArgs;
 use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
+use Doctrine\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\ObjectManager;
 use Gedmo\Mapping\Event\AdapterInterface as EventAdapterInterface;
 use Gedmo\Mapping\MappedEventSubscriber;
 
@@ -26,6 +28,9 @@ class EncoderListener extends MappedEventSubscriber
         ];
     }
 
+    /**
+     * @phpstan-param LoadClassMetadataEventArgs<ClassMetadata<object>, ObjectManager> $args
+     */
     public function loadClassMetadata(LoadClassMetadataEventArgs $args): void
     {
         $ea = $this->getEventAdapter($args);

--- a/tests/Gedmo/Timestampable/Fixture/Article.php
+++ b/tests/Gedmo/Timestampable/Fixture/Article.php
@@ -186,6 +186,9 @@ class Article implements Timestampable
         $this->comments[] = $comment;
     }
 
+    /**
+     * @return Collection<int, Comment>
+     */
     public function getComments(): Collection
     {
         return $this->comments;

--- a/tests/Gedmo/Timestampable/Fixture/ArticleCarbon.php
+++ b/tests/Gedmo/Timestampable/Fixture/ArticleCarbon.php
@@ -189,6 +189,9 @@ class ArticleCarbon implements Timestampable
         $this->comments[] = $comment;
     }
 
+    /**
+     * @return Collection<int, Comment>
+     */
     public function getComments(): Collection
     {
         return $this->comments;

--- a/tests/Gedmo/Translatable/TranslatableWithEmbeddedTest.php
+++ b/tests/Gedmo/Translatable/TranslatableWithEmbeddedTest.php
@@ -68,7 +68,7 @@ final class TranslatableWithEmbeddedTest extends BaseTestCaseORM
 
     public function testTranslate(): void
     {
-        /** @var EntityRepository $repo */
+        /** @var EntityRepository<Company> $repo */
         $repo = $this->em->getRepository(self::FIXTURE);
 
         /** @var Company $entity */

--- a/tests/Gedmo/Tree/Fixture/ForeignRootCategory.php
+++ b/tests/Gedmo/Tree/Fixture/ForeignRootCategory.php
@@ -166,6 +166,9 @@ class ForeignRootCategory
         return $this->children;
     }
 
+    /**
+     * @param Collection<int, self> $children
+     */
     public function setChildren(Collection $children): void
     {
         $this->children = $children;

--- a/tests/Gedmo/Tree/MaterializedPathODMMongoDBRepositoryTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathODMMongoDBRepositoryTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace Gedmo\Tests\Tree;
 
 use Doctrine\Common\EventManager;
-use Doctrine\ODM\MongoDB\Iterator\CachingIterator;
 use Doctrine\ODM\MongoDB\Iterator\Iterator;
 use Gedmo\Exception\InvalidArgumentException;
 use Gedmo\Tests\Tool\BaseTestCaseMongoODM;
@@ -50,12 +49,10 @@ final class MaterializedPathODMMongoDBRepositoryTest extends BaseTestCaseMongoOD
 
     public function testGetRootNodes(): void
     {
-        /** @var CachingIterator $result */
         $result = $this->repo->getRootNodes('title');
 
+        static::assertInstanceOf(Iterator::class, $result);
         static::assertSame(3, \iterator_count($result));
-        $result->rewind();
-
         $result->rewind();
 
         static::assertSame('Drinks', $result->current()->getTitle());
@@ -70,13 +67,12 @@ final class MaterializedPathODMMongoDBRepositoryTest extends BaseTestCaseMongoOD
         $root = $this->repo->findOneBy(['title' => 'Food']);
 
         // Get all children from the root, including it
-        /** @var CachingIterator $result */
         $result = $this->repo->getChildren($root, false, 'title', 'asc', true);
 
+        static::assertInstanceOf(Iterator::class, $result);
         static::assertSame(5, \iterator_count($result));
         $result->rewind();
 
-        $result->rewind();
         static::assertSame('Carrots', $result->current()->getTitle());
         $result->next();
         static::assertSame('Food', $result->current()->getTitle());
@@ -88,11 +84,10 @@ final class MaterializedPathODMMongoDBRepositoryTest extends BaseTestCaseMongoOD
         static::assertSame('Vegitables', $result->current()->getTitle());
 
         // Get all children from the root, NOT including it
-        /** @var CachingIterator $result */
         $result = $this->repo->getChildren($root, false, 'title', 'asc', false);
 
+        static::assertInstanceOf(Iterator::class, $result);
         static::assertSame(4, \iterator_count($result));
-        $result->rewind();
         $result->rewind();
         static::assertSame('Carrots', $result->current()->getTitle());
         $result->next();
@@ -103,11 +98,10 @@ final class MaterializedPathODMMongoDBRepositoryTest extends BaseTestCaseMongoOD
         static::assertSame('Vegitables', $result->current()->getTitle());
 
         // Get direct children from the root, including it
-        /** @var CachingIterator $result */
         $result = $this->repo->getChildren($root, true, 'title', 'asc', true);
 
+        static::assertInstanceOf(Iterator::class, $result);
         static::assertSame(3, \iterator_count($result));
-        $result->rewind();
         $result->rewind();
         static::assertSame('Food', $result->current()->getTitle());
         $result->next();
@@ -116,7 +110,6 @@ final class MaterializedPathODMMongoDBRepositoryTest extends BaseTestCaseMongoOD
         static::assertSame('Vegitables', $result->current()->getTitle());
 
         // Get direct children from the root, NOT including it
-        /** @var CachingIterator $result */
         $result = $this->repo->getChildren($root, true, 'title', 'asc', false);
         static::assertInstanceOf(Iterator::class, $result);
 


### PR DESCRIPTION
Follows #2686.

Extra calls to `Iterator::rewind()` in `MaterializedPathODMMongoDBRepositoryTest` were also removed.