### PR TITLE
Parse attributes from class traits

### DIFF
--- a/src/Mapping/Driver/AttributeReader.php
+++ b/src/Mapping/Driver/AttributeReader.php
@@ -28,7 +28,7 @@ final class AttributeReader
      */
     public function getClassAnnotations(\ReflectionClass $class): array
     {
-        return $this->convertToAttributeInstances($class->getAttributes());
+        return $this->convertToAttributeInstances($this->getClassAndTraitsAttributes($class));
     }
 
     /**
@@ -93,6 +93,24 @@ final class AttributeReader
         }
 
         return $instances;
+    }
+
+    /**
+     * Get attributes from a class including those from traits.
+     *
+     * @phpstan-param \ReflectionClass<object> $class
+     *
+     * @return \ReflectionAttribute<object>[]
+     */
+    private function getClassAndTraitsAttributes(\ReflectionClass $class): array
+    {
+        $traitAttributes = array_reduce(
+            $class->getTraits(),
+            static fn (array $carry, \ReflectionClass $trait) => array_merge($trait->getAttributes(), $carry),
+            []
+        );
+
+        return array_merge($class->getAttributes(), $traitAttributes);
     }
 
     private function isRepeatable(string $attributeClassName): bool


### PR DESCRIPTION
This allows using traits in Entities to configure settings with attributes.

This change vastly enhances the usability for cases where a custom translation table is used. Instead of having to add an annotation to every entity with a translatable field to configure the usage of a custom translation table, it's sufficient to write a Trait that has the annotation.

**Example**:

<details>
<summary>App\Entity\Traits\HasTranslationTrait.php</summary>

~~~php
<?php

namespace App\Entity\Traits;

use App\Entity\Translation;
use Gedmo\Mapping\Annotation as Gedmo;

/**
 * This trait handles relations between the translation table and foreign keys referencing that table.
 *
 */
#[Gedmo\TranslationEntity(class: Translation::class)]
trait HasTranslationTrait
{
    #[Gedmo\Locale]
    private ?string $locale = null;

    public function setLocale(string $locale): static
    {
        $this->locale = $locale;

        return $this;
    }
}
~~~

</details>

<details>
<summary>App\Entity\Translation.php</summary>

~~~php
<?php

namespace App\Entity;

use App\Repository\TranslationRepository;
use Doctrine\ORM\{Mapping as ORM, Mapping\Entity, Mapping\Index, Mapping\Table, Mapping\UniqueConstraint};
use Gedmo\Translatable\Entity\MappedSuperclass\AbstractTranslation;

#[Entity(repositoryClass: TranslationRepository::class)]
#[Table(name: 'my_translation')]
#[Index(columns: ['locale', 'object_class', 'foreign_key'], name: 'translation_lookup_idx')]
#[Index(columns: ['object_class', 'foreign_key'], name: 'translation_general_idx')]
#[UniqueConstraint(name: 'translation_unique_idx', columns: ['locale', 'object_class', 'field', 'foreign_key'])]
#[Index(columns: ['content'], name: 'translation_content_ftidx', flags: ['fulltext'])]
#[Index(columns: ['additional_field'], name: 'translation_additional_field_idx')]
class Translation extends AbstractTranslation
{
    #[ORM\Column(
        name: 'additional_field'
    )]
    protected ?string $additionalField = null;

    /**
     * Get additional field.
     *
     * @return ?string
     */
    public function getAdditionalField(): ?string
    {
        return $this->additionalField;
    }
}
~~~

</details>

<details>
<summary>App\Repository\TranslationRepository.php</summary>

~~~php
<?php

namespace App\Repository;

use App\Entity\Translation;
use Doctrine\ORM\EntityManagerInterface;
use Doctrine\ORM\Mapping\ClassMetadata;
use Doctrine\ORM\Query\ResultSetMappingBuilder;
use Gedmo\Translatable\Entity\Repository\TranslationRepository as GedmoTranslationRepository;

/**
 * @extends GedmoTranslationRepository<Translation>
 *
 * @method Translation|null find($id, $lockMode = null, $lockVersion = null)
 * @method Translation|null findOneBy(array $criteria, array $orderBy = null)
 * @method Translation[]    findAll()
 * @method Translation[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
 */
class TranslationRepository extends GedmoTranslationRepository
{
    public function __construct(EntityManagerInterface $em, ClassMetadata $class)
    {
        parent::__construct($em, $class);
    }

    public function findObjectByAdditionalField($field, $value, $class): ?object
    {
        // Custom Query for additional field here.
    }
}
~~~

</details>

Without this change, one has to add the attribute to use the Translation table to every Entity having a translatable field. With this change applied, it's sufficient to use the HasTranslationTrait to use the custom table as well as having the benefit that the field for the locale with the proper attribute is already added.