### PR TITLE
ORM 3 compat fixes

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -376,6 +376,16 @@ parameters:
 			path: src/Tool/Wrapper/MongoDocumentWrapper.php
 
 		-
+			message: "#^Access to an undefined property Gedmo\\\\Translatable\\\\Hydrator\\\\ORM\\\\ObjectHydrator\\:\\:\\$em\\.$#"
+			count: 1
+			path: src/Translatable/Hydrator/ORM/ObjectHydrator.php
+
+		-
+			message: "#^Access to an undefined property Gedmo\\\\Translatable\\\\Hydrator\\\\ORM\\\\SimpleObjectHydrator\\:\\:\\$em\\.$#"
+			count: 1
+			path: src/Translatable/Hydrator/ORM/SimpleObjectHydrator.php
+
+		-
 			message: "#^Access to offset 'association' on an unknown class Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\FieldMapping\\.$#"
 			count: 2
 			path: src/Translatable/Mapping/Event/Adapter/ODM.php
@@ -449,6 +459,11 @@ parameters:
 			message: "#^Call to an undefined method Gedmo\\\\Tree\\\\Strategy\\:\\:updateNode\\(\\)\\.$#"
 			count: 2
 			path: src/Tree/Entity/Repository/NestedTreeRepository.php
+
+		-
+			message: "#^Access to an undefined property Gedmo\\\\Tree\\\\Hydrator\\\\ORM\\\\TreeObjectHydrator\\:\\:\\$em\\.$#"
+			count: 1
+			path: src/Tree/Hydrator/ORM/TreeObjectHydrator.php
 
 		-
 			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:getFieldMapping\\(\\)\\.$#"

--- a/src/Loggable/Entity/Repository/LogEntryRepository.php
+++ b/src/Loggable/Entity/Repository/LogEntryRepository.php
@@ -67,7 +67,7 @@ class LogEntryRepository extends EntityRepository
      */
     public function getLogEntriesQuery($entity)
     {
-        $wrapped = new EntityWrapper($entity, $this->_em);
+        $wrapped = new EntityWrapper($entity, $this->getEntityManager());
         $objectClass = $wrapped->getMetadata()->getName();
         $meta = $this->getClassMetadata();
         $dql = "SELECT log FROM {$meta->getName()} log";
@@ -76,7 +76,7 @@ class LogEntryRepository extends EntityRepository
         $dql .= ' ORDER BY log.version DESC';
 
         $objectId = (string) $wrapped->getIdentifier(false, true);
-        $q = $this->_em->createQuery($dql);
+        $q = $this->getEntityManager()->createQuery($dql);
         $q->setParameters([
             'objectId' => $objectId,
             'objectClass' => $objectClass,
@@ -102,7 +102,7 @@ class LogEntryRepository extends EntityRepository
      */
     public function revert($entity, $version = 1)
     {
-        $wrapped = new EntityWrapper($entity, $this->_em);
+        $wrapped = new EntityWrapper($entity, $this->getEntityManager());
         $objectMeta = $wrapped->getMetadata();
         $objectClass = $objectMeta->getName();
         $meta = $this->getClassMetadata();
@@ -113,14 +113,14 @@ class LogEntryRepository extends EntityRepository
         $dql .= ' ORDER BY log.version DESC';
 
         $objectId = (string) $wrapped->getIdentifier(false, true);
-        $q = $this->_em->createQuery($dql);
+        $q = $this->getEntityManager()->createQuery($dql);
         $q->setParameters([
             'objectId' => $objectId,
             'objectClass' => $objectClass,
             'version' => $version,
         ]);
 
-        $config = $this->getLoggableListener()->getConfiguration($this->_em, $objectMeta->getName());
+        $config = $this->getLoggableListener()->getConfiguration($this->getEntityManager(), $objectMeta->getName());
         $fields = $config['versioned'];
         $filled = false;
         $logsFound = false;
@@ -167,7 +167,7 @@ class LogEntryRepository extends EntityRepository
         }
 
         $mapping = $objectMeta->getAssociationMapping($field);
-        $value = $value ? $this->_em->getReference($mapping['targetEntity'], $value) : null;
+        $value = $value ? $this->getEntityManager()->getReference($mapping['targetEntity'], $value) : null;
     }
 
     /**
@@ -180,7 +180,7 @@ class LogEntryRepository extends EntityRepository
     private function getLoggableListener(): LoggableListener
     {
         if (null === $this->listener) {
-            foreach ($this->_em->getEventManager()->getAllListeners() as $listeners) {
+            foreach ($this->getEntityManager()->getEventManager()->getAllListeners() as $listeners) {
                 foreach ($listeners as $listener) {
                     if ($listener instanceof LoggableListener) {
                         $this->listener = $listener;

--- a/src/Sortable/Entity/Repository/SortableRepository.php
+++ b/src/Sortable/Entity/Repository/SortableRepository.php
@@ -63,7 +63,7 @@ class SortableRepository extends EntityRepository
 
         $this->listener = $sortableListener;
         $this->meta = $this->getClassMetadata();
-        $this->config = $this->listener->getConfiguration($this->_em, $this->meta->getName());
+        $this->config = $this->listener->getConfiguration($this->getEntityManager(), $this->meta->getName());
     }
 
     /**

--- a/src/Tool/ORM/Hydration/EntityManagerRetriever.php
+++ b/src/Tool/ORM/Hydration/EntityManagerRetriever.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tool\ORM\Hydration;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Internal\Hydration\AbstractHydrator;
+
+/**
+ * Helper method to retrieve the entity manager for ORM hydrator classes.
+ *
+ * This trait includes a compatibility layer for the renamed `Doctrine\ORM\Internal\Hydration\AbstractHydrator::$_em`
+ * property between ORM 2.x and 3.x.
+ *
+ * @mixin AbstractHydrator
+ *
+ * @internal
+ */
+trait EntityManagerRetriever
+{
+    protected function getEntityManager(): EntityManagerInterface
+    {
+        return property_exists($this, '_em') ? $this->_em : $this->em;
+    }
+}

--- a/src/Translatable/Hydrator/ORM/ObjectHydrator.php
+++ b/src/Translatable/Hydrator/ORM/ObjectHydrator.php
@@ -11,6 +11,7 @@ namespace Gedmo\Translatable\Hydrator\ORM;
 
 use Doctrine\ORM\Internal\Hydration\ObjectHydrator as BaseObjectHydrator;
 use Gedmo\Exception\RuntimeException;
+use Gedmo\Tool\ORM\Hydration\EntityManagerRetriever;
 use Gedmo\Translatable\TranslatableListener;
 
 /**
@@ -25,6 +26,8 @@ use Gedmo\Translatable\TranslatableListener;
  */
 class ObjectHydrator extends BaseObjectHydrator
 {
+    use EntityManagerRetriever;
+
     /**
      * State of skipOnLoad for listener between hydrations
      *
@@ -65,7 +68,7 @@ class ObjectHydrator extends BaseObjectHydrator
      */
     protected function getTranslatableListener()
     {
-        foreach ($this->_em->getEventManager()->getAllListeners() as $listeners) {
+        foreach ($this->getEntityManager()->getEventManager()->getAllListeners() as $listeners) {
             foreach ($listeners as $listener) {
                 if ($listener instanceof TranslatableListener) {
                     return $listener;

--- a/src/Translatable/Hydrator/ORM/SimpleObjectHydrator.php
+++ b/src/Translatable/Hydrator/ORM/SimpleObjectHydrator.php
@@ -11,6 +11,7 @@ namespace Gedmo\Translatable\Hydrator\ORM;
 
 use Doctrine\ORM\Internal\Hydration\SimpleObjectHydrator as BaseSimpleObjectHydrator;
 use Gedmo\Exception\RuntimeException;
+use Gedmo\Tool\ORM\Hydration\EntityManagerRetriever;
 use Gedmo\Translatable\TranslatableListener;
 
 /**
@@ -25,6 +26,8 @@ use Gedmo\Translatable\TranslatableListener;
  */
 class SimpleObjectHydrator extends BaseSimpleObjectHydrator
 {
+    use EntityManagerRetriever;
+
     /**
      * State of skipOnLoad for listener between hydrations
      *
@@ -65,7 +68,7 @@ class SimpleObjectHydrator extends BaseSimpleObjectHydrator
      */
     protected function getTranslatableListener()
     {
-        foreach ($this->_em->getEventManager()->getAllListeners() as $listeners) {
+        foreach ($this->getEntityManager()->getEventManager()->getAllListeners() as $listeners) {
             foreach ($listeners as $listener) {
                 if ($listener instanceof TranslatableListener) {
                     return $listener;

--- a/src/Tree/Entity/Repository/AbstractTreeRepository.php
+++ b/src/Tree/Entity/Repository/AbstractTreeRepository.php
@@ -64,7 +64,7 @@ abstract class AbstractTreeRepository extends EntityRepository implements Reposi
             throw new InvalidMappingException('This repository cannot be used for tree type: '.$treeListener->getStrategy($em, $class->getName())->getName());
         }
 
-        $this->repoUtils = new RepositoryUtils($this->_em, $this->getClassMetadata(), $this->listener, $this);
+        $this->repoUtils = new RepositoryUtils($this->getEntityManager(), $this->getClassMetadata(), $this->listener, $this);
     }
 
     /**
@@ -98,7 +98,7 @@ abstract class AbstractTreeRepository extends EntityRepository implements Reposi
                 throw new InvalidArgumentException('Node is not related to this repository');
             }
 
-            $wrapped = new EntityWrapper($node, $this->_em);
+            $wrapped = new EntityWrapper($node, $this->getEntityManager());
 
             if (!$wrapped->hasValidIdentifier()) {
                 throw new InvalidArgumentException('Node is not managed by UnitOfWork');

--- a/src/Tree/Entity/Repository/ClosureTreeRepository.php
+++ b/src/Tree/Entity/Repository/ClosureTreeRepository.php
@@ -32,7 +32,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
     public function getRootNodesQueryBuilder($sortByField = null, $direction = 'asc')
     {
         $meta = $this->getClassMetadata();
-        $config = $this->listener->getConfiguration($this->_em, $meta->getName());
+        $config = $this->listener->getConfiguration($this->getEntityManager(), $meta->getName());
         $qb = $this->getQueryBuilder();
         $qb->select('node')
             ->from($config['useObjectClass'], 'node')
@@ -77,17 +77,17 @@ class ClosureTreeRepository extends AbstractTreeRepository
         if (!is_a($node, $meta->getName())) {
             throw new InvalidArgumentException('Node is not related to this repository');
         }
-        if (!$this->_em->getUnitOfWork()->isInIdentityMap($node)) {
+        if (!$this->getEntityManager()->getUnitOfWork()->isInIdentityMap($node)) {
             throw new InvalidArgumentException('Node is not managed by UnitOfWork');
         }
-        $config = $this->listener->getConfiguration($this->_em, $meta->getName());
-        $closureMeta = $this->_em->getClassMetadata($config['closure']);
+        $config = $this->listener->getConfiguration($this->getEntityManager(), $meta->getName());
+        $closureMeta = $this->getEntityManager()->getClassMetadata($config['closure']);
 
         $dql = "SELECT c, node FROM {$closureMeta->getName()} c";
         $dql .= ' INNER JOIN c.ancestor node';
         $dql .= ' WHERE c.descendant = :node';
         $dql .= ' ORDER BY c.depth DESC';
-        $q = $this->_em->createQuery($dql);
+        $q = $this->getEntityManager()->createQuery($dql);
         $q->setParameter('node', $node);
 
         return $q;
@@ -121,12 +121,12 @@ class ClosureTreeRepository extends AbstractTreeRepository
     public function childrenQueryBuilder($node = null, $direct = false, $sortByField = null, $direction = 'ASC', $includeNode = false)
     {
         $meta = $this->getClassMetadata();
-        $config = $this->listener->getConfiguration($this->_em, $meta->getName());
+        $config = $this->listener->getConfiguration($this->getEntityManager(), $meta->getName());
 
         $qb = $this->getQueryBuilder();
         if (null !== $node) {
             if (is_a($node, $meta->getName())) {
-                if (!$this->_em->getUnitOfWork()->isInIdentityMap($node)) {
+                if (!$this->getEntityManager()->getUnitOfWork()->isInIdentityMap($node)) {
                     throw new InvalidArgumentException('Node is not managed by UnitOfWork');
                 }
 
@@ -259,22 +259,22 @@ class ClosureTreeRepository extends AbstractTreeRepository
         if (!is_a($node, $meta->getName())) {
             throw new InvalidArgumentException('Node is not related to this repository');
         }
-        $wrapped = new EntityWrapper($node, $this->_em);
+        $wrapped = new EntityWrapper($node, $this->getEntityManager());
         if (!$wrapped->hasValidIdentifier()) {
             throw new InvalidArgumentException('Node is not managed by UnitOfWork');
         }
-        $config = $this->listener->getConfiguration($this->_em, $meta->getName());
+        $config = $this->listener->getConfiguration($this->getEntityManager(), $meta->getName());
         $pk = $meta->getSingleIdentifierFieldName();
         $nodeId = $wrapped->getIdentifier();
         $parent = $wrapped->getPropertyValue($config['parent']);
 
         $dql = "SELECT node FROM {$config['useObjectClass']} node";
         $dql .= " WHERE node.{$config['parent']} = :node";
-        $q = $this->_em->createQuery($dql);
+        $q = $this->getEntityManager()->createQuery($dql);
         $q->setParameter('node', $node);
         $nodesToReparent = $q->toIterable();
         // process updates in transaction
-        $this->_em->getConnection()->beginTransaction();
+        $this->getEntityManager()->getConnection()->beginTransaction();
 
         try {
             foreach ($nodesToReparent as $nodeToReparent) {
@@ -285,7 +285,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
                 $dql .= " SET node.{$config['parent']} = :parent";
                 $dql .= " WHERE node.{$pk} = :id";
 
-                $q = $this->_em->createQuery($dql);
+                $q = $this->getEntityManager()->createQuery($dql);
                 $q->setParameters([
                     'parent' => $parent,
                     'id' => $id,
@@ -293,35 +293,35 @@ class ClosureTreeRepository extends AbstractTreeRepository
                 $q->getSingleScalarResult();
 
                 $this->listener
-                    ->getStrategy($this->_em, $meta->getName())
-                    ->updateNode($this->_em, $nodeToReparent, $node);
+                    ->getStrategy($this->getEntityManager(), $meta->getName())
+                    ->updateNode($this->getEntityManager(), $nodeToReparent, $node);
 
                 $oid = spl_object_id($nodeToReparent);
-                $this->_em->getUnitOfWork()->setOriginalEntityProperty($oid, $config['parent'], $parent);
+                $this->getEntityManager()->getUnitOfWork()->setOriginalEntityProperty($oid, $config['parent'], $parent);
             }
 
             $dql = "DELETE {$config['useObjectClass']} node";
             $dql .= " WHERE node.{$pk} = :nodeId";
 
-            $q = $this->_em->createQuery($dql);
+            $q = $this->getEntityManager()->createQuery($dql);
             $q->setParameter('nodeId', $nodeId);
             $q->getSingleScalarResult();
-            $this->_em->getConnection()->commit();
+            $this->getEntityManager()->getConnection()->commit();
         } catch (\Exception $e) {
-            $this->_em->close();
-            $this->_em->getConnection()->rollback();
+            $this->getEntityManager()->close();
+            $this->getEntityManager()->getConnection()->rollback();
 
             throw new \Gedmo\Exception\RuntimeException('Transaction failed: '.$e->getMessage(), $e->getCode(), $e);
         }
         // remove from identity map
-        $this->_em->getUnitOfWork()->removeFromIdentityMap($node);
+        $this->getEntityManager()->getUnitOfWork()->removeFromIdentityMap($node);
         $node = null;
     }
 
     public function buildTreeArray(array $nodes)
     {
         $meta = $this->getClassMetadata();
-        $config = $this->listener->getConfiguration($this->_em, $meta->getName());
+        $config = $this->listener->getConfiguration($this->getEntityManager(), $meta->getName());
         $nestedTree = [];
         $idField = $meta->getSingleIdentifierFieldName();
         $hasLevelProp = !empty($config['level']);
@@ -372,7 +372,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
     public function getNodesHierarchyQueryBuilder($node = null, $direct = false, array $options = [], $includeNode = false)
     {
         $meta = $this->getClassMetadata();
-        $config = $this->listener->getConfiguration($this->_em, $meta->getName());
+        $config = $this->listener->getConfiguration($this->getEntityManager(), $meta->getName());
         $idField = $meta->getSingleIdentifierFieldName();
         $subQuery = '';
         $hasLevelProp = isset($config['level']) && $config['level'];
@@ -382,7 +382,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
             $subQuery .= ' c2 WHERE c2.descendant = c.descendant GROUP BY c2.descendant) AS '.self::SUBQUERY_LEVEL;
         }
 
-        $q = $this->_em->createQueryBuilder()
+        $q = $this->getEntityManager()->createQueryBuilder()
             ->select('c, node, p.'.$idField.' AS parent_id'.$subQuery)
             ->from($config['closure'], 'c')
             ->innerJoin('c.descendant', 'node')
@@ -421,11 +421,11 @@ class ClosureTreeRepository extends AbstractTreeRepository
     {
         $nodeMeta = $this->getClassMetadata();
         $nodeIdField = $nodeMeta->getSingleIdentifierFieldName();
-        $config = $this->listener->getConfiguration($this->_em, $nodeMeta->getName());
-        $closureMeta = $this->_em->getClassMetadata($config['closure']);
+        $config = $this->listener->getConfiguration($this->getEntityManager(), $nodeMeta->getName());
+        $closureMeta = $this->getEntityManager()->getClassMetadata($config['closure']);
         $errors = [];
 
-        $q = $this->_em->createQuery("
+        $q = $this->getEntityManager()->createQuery("
           SELECT COUNT(node)
           FROM {$nodeMeta->getName()} AS node
           LEFT JOIN {$closureMeta->getName()} AS c WITH c.ancestor = node AND c.depth = 0
@@ -436,7 +436,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
             $errors[] = "Missing $missingSelfRefsCount self referencing closures";
         }
 
-        $q = $this->_em->createQuery("
+        $q = $this->getEntityManager()->createQuery("
           SELECT COUNT(node)
           FROM {$nodeMeta->getName()} AS node
           INNER JOIN {$closureMeta->getName()} AS c1 WITH c1.descendant = node.{$config['parent']}
@@ -448,7 +448,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
             $errors[] = "Missing $missingClosuresCount closures";
         }
 
-        $q = $this->_em->createQuery("
+        $q = $this->getEntityManager()->createQuery("
             SELECT COUNT(c1.id)
             FROM {$closureMeta->getName()} AS c1
             LEFT JOIN {$nodeMeta->getName()} AS node WITH c1.descendant = node.$nodeIdField
@@ -463,7 +463,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
         if (!empty($config['level'])) {
             $levelField = $config['level'];
             $maxResults = 1000;
-            $q = $this->_em->createQuery("
+            $q = $this->getEntityManager()->createQuery("
                 SELECT node.$nodeIdField AS id, node.$levelField AS node_level, MAX(c.depth) AS closure_level
                 FROM {$nodeMeta->getName()} AS node
                 INNER JOIN {$closureMeta->getName()} AS c WITH c.descendant = node.$nodeIdField
@@ -498,8 +498,8 @@ class ClosureTreeRepository extends AbstractTreeRepository
     public function rebuildClosure()
     {
         $nodeMeta = $this->getClassMetadata();
-        $config = $this->listener->getConfiguration($this->_em, $nodeMeta->getName());
-        $closureMeta = $this->_em->getClassMetadata($config['closure']);
+        $config = $this->listener->getConfiguration($this->getEntityManager(), $nodeMeta->getName());
+        $closureMeta = $this->getEntityManager()->getClassMetadata($config['closure']);
 
         $insertClosures = function ($entries) use ($closureMeta) {
             $closureTable = $closureMeta->getTableName();
@@ -507,7 +507,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
             $descendantColumnName = $this->getJoinColumnFieldName($closureMeta->getAssociationMapping('descendant'));
             $depthColumnName = $closureMeta->getColumnName('depth');
 
-            $conn = $this->_em->getConnection();
+            $conn = $this->getEntityManager()->getConnection();
             $conn->beginTransaction();
             foreach ($entries as $entry) {
                 $conn->insert($closureTable, array_combine(
@@ -521,7 +521,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
         $buildClosures = function ($dql) use ($insertClosures) {
             $newClosuresCount = 0;
             $batchSize = 1000;
-            $q = $this->_em->createQuery($dql)->setMaxResults($batchSize)->setCacheable(false);
+            $q = $this->getEntityManager()->createQuery($dql)->setMaxResults($batchSize)->setCacheable(false);
             do {
                 $entries = $q->getScalarResult();
                 $insertClosures($entries);
@@ -554,11 +554,11 @@ class ClosureTreeRepository extends AbstractTreeRepository
      */
     public function cleanUpClosure()
     {
-        $conn = $this->_em->getConnection();
+        $conn = $this->getEntityManager()->getConnection();
         $nodeMeta = $this->getClassMetadata();
         $nodeIdField = $nodeMeta->getSingleIdentifierFieldName();
-        $config = $this->listener->getConfiguration($this->_em, $nodeMeta->getName());
-        $closureMeta = $this->_em->getClassMetadata($config['closure']);
+        $config = $this->listener->getConfiguration($this->getEntityManager(), $nodeMeta->getName());
+        $closureMeta = $this->getEntityManager()->getClassMetadata($config['closure']);
         $closureTableName = $closureMeta->getTableName();
 
         $dql = "
@@ -571,7 +571,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
 
         $deletedClosuresCount = 0;
         $batchSize = 1000;
-        $q = $this->_em->createQuery($dql)->setMaxResults($batchSize)->setCacheable(false);
+        $q = $this->getEntityManager()->createQuery($dql)->setMaxResults($batchSize)->setCacheable(false);
 
         while (($ids = $q->getScalarResult()) && [] !== $ids) {
             $ids = array_map(static function (array $el) {
@@ -593,16 +593,16 @@ class ClosureTreeRepository extends AbstractTreeRepository
     public function updateLevelValues()
     {
         $nodeMeta = $this->getClassMetadata();
-        $config = $this->listener->getConfiguration($this->_em, $nodeMeta->getName());
+        $config = $this->listener->getConfiguration($this->getEntityManager(), $nodeMeta->getName());
         $levelUpdatesCount = 0;
 
         if (!empty($config['level'])) {
             $levelField = $config['level'];
             $nodeIdField = $nodeMeta->getSingleIdentifierFieldName();
-            $closureMeta = $this->_em->getClassMetadata($config['closure']);
+            $closureMeta = $this->getEntityManager()->getClassMetadata($config['closure']);
 
             $batchSize = 1000;
-            $q = $this->_em->createQuery("
+            $q = $this->getEntityManager()->createQuery("
                 SELECT node.$nodeIdField AS id, node.$levelField AS node_level, MAX(c.depth) AS closure_level
                 FROM {$nodeMeta->getName()} AS node
                 INNER JOIN {$closureMeta->getName()} AS c WITH c.descendant = node.$nodeIdField
@@ -611,14 +611,14 @@ class ClosureTreeRepository extends AbstractTreeRepository
             ")->setMaxResults($batchSize)->setCacheable(false);
             do {
                 $entries = $q->getScalarResult();
-                $this->_em->getConnection()->beginTransaction();
+                $this->getEntityManager()->getConnection()->beginTransaction();
                 foreach ($entries as $entry) {
                     unset($entry['node_level']);
-                    $this->_em->createQuery("
+                    $this->getEntityManager()->createQuery("
                       UPDATE {$nodeMeta->getName()} AS node SET node.$levelField = (:closure_level + 1) WHERE node.$nodeIdField = :id
                     ")->execute($entry);
                 }
-                $this->_em->getConnection()->commit();
+                $this->getEntityManager()->getConnection()->commit();
                 $levelUpdatesCount += count($entries);
             } while ([] !== $entries);
         }
@@ -628,7 +628,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
 
     protected function validate()
     {
-        return Strategy::CLOSURE === $this->listener->getStrategy($this->_em, $this->getClassMetadata()->name)->getName();
+        return Strategy::CLOSURE === $this->listener->getStrategy($this->getEntityManager(), $this->getClassMetadata()->name)->getName();
     }
 
     /**

--- a/src/Tree/Entity/Repository/MaterializedPathRepository.php
+++ b/src/Tree/Entity/Repository/MaterializedPathRepository.php
@@ -85,13 +85,13 @@ class MaterializedPathRepository extends AbstractTreeRepository
     public function getPathQueryBuilder($node)
     {
         $meta = $this->getClassMetadata();
-        $config = $this->listener->getConfiguration($this->_em, $meta->getName());
+        $config = $this->listener->getConfiguration($this->getEntityManager(), $meta->getName());
         $alias = 'materialized_path_entity';
         $qb = $this->getQueryBuilder()
             ->select($alias)
             ->from($config['useObjectClass'], $alias);
 
-        $node = new EntityWrapper($node, $this->_em);
+        $node = new EntityWrapper($node, $this->getEntityManager());
         $nodePath = $node->getPropertyValue($config['path']);
         $paths = [];
         $nodePathLength = strlen($nodePath);
@@ -148,7 +148,7 @@ class MaterializedPathRepository extends AbstractTreeRepository
     public function getChildrenQueryBuilder($node = null, $direct = false, $sortByField = null, $direction = 'asc', $includeNode = false)
     {
         $meta = $this->getClassMetadata();
-        $config = $this->listener->getConfiguration($this->_em, $meta->getName());
+        $config = $this->listener->getConfiguration($this->getEntityManager(), $meta->getName());
         $separator = addcslashes($config['path_separator'], '%');
         $alias = 'materialized_path_entity';
         $path = $config['path'];
@@ -159,7 +159,7 @@ class MaterializedPathRepository extends AbstractTreeRepository
         $includeNodeExpr = '';
 
         if (is_a($node, $meta->getName())) {
-            $node = new EntityWrapper($node, $this->_em);
+            $node = new EntityWrapper($node, $this->getEntityManager());
             $nodePath = $node->getPropertyValue($path);
             $expr = $qb->expr()->andx()->add(
                 $qb->expr()->like(
@@ -244,7 +244,7 @@ class MaterializedPathRepository extends AbstractTreeRepository
     public function getNodesHierarchy($node = null, $direct = false, array $options = [], $includeNode = false)
     {
         $meta = $this->getClassMetadata();
-        $config = $this->listener->getConfiguration($this->_em, $meta->getName());
+        $config = $this->listener->getConfiguration($this->getEntityManager(), $meta->getName());
         $path = $config['path'];
 
         $nodes = $this->getNodesHierarchyQuery($node, $direct, $options, $includeNode)->getArrayResult();
@@ -260,6 +260,6 @@ class MaterializedPathRepository extends AbstractTreeRepository
 
     protected function validate()
     {
-        return Strategy::MATERIALIZED_PATH === $this->listener->getStrategy($this->_em, $this->getClassMetadata()->name)->getName();
+        return Strategy::MATERIALIZED_PATH === $this->listener->getStrategy($this->getEntityManager(), $this->getClassMetadata()->name)->getName();
     }
 }

--- a/src/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/src/Tree/Entity/Repository/NestedTreeRepository.php
@@ -67,9 +67,9 @@ class NestedTreeRepository extends AbstractTreeRepository
                 throw new InvalidArgumentException('Node to persist must be available as first argument.');
             }
             $node = $args[0];
-            $wrapped = new EntityWrapper($node, $this->_em);
+            $wrapped = new EntityWrapper($node, $this->getEntityManager());
             $meta = $this->getClassMetadata();
-            $config = $this->listener->getConfiguration($this->_em, $meta->getName());
+            $config = $this->listener->getConfiguration($this->getEntityManager(), $meta->getName());
             $position = substr($method, 9);
             if ('Of' === substr($method, -2)) {
                 if (!isset($args[1])) {
@@ -77,7 +77,7 @@ class NestedTreeRepository extends AbstractTreeRepository
                 }
                 $parentOrSibling = $args[1];
                 if (strstr($method, 'Sibling')) {
-                    $wrappedParentOrSibling = new EntityWrapper($parentOrSibling, $this->_em);
+                    $wrappedParentOrSibling = new EntityWrapper($parentOrSibling, $this->getEntityManager());
                     $newParent = $wrappedParentOrSibling->getPropertyValue($config['parent']);
                     if (null === $newParent && isset($config['root'])) {
                         throw new UnexpectedValueException('Cannot persist sibling for a root node, tree operation is not possible');
@@ -116,11 +116,11 @@ class NestedTreeRepository extends AbstractTreeRepository
             $wrapped->setPropertyValue($config['left'], 0); // simulate changeset
             $oid = spl_object_id($node);
             $this->listener
-                ->getStrategy($this->_em, $meta->getName())
+                ->getStrategy($this->getEntityManager(), $meta->getName())
                 ->setNodePosition($oid, $position)
             ;
 
-            $this->_em->persist($node);
+            $this->getEntityManager()->persist($node);
 
             return $this;
         }
@@ -131,7 +131,7 @@ class NestedTreeRepository extends AbstractTreeRepository
     public function getRootNodesQueryBuilder($sortByField = null, $direction = 'asc')
     {
         $meta = $this->getClassMetadata();
-        $config = $this->listener->getConfiguration($this->_em, $meta->getName());
+        $config = $this->listener->getConfiguration($this->getEntityManager(), $meta->getName());
         $qb = $this->getQueryBuilder();
         $qb
             ->select('node')
@@ -194,8 +194,8 @@ class NestedTreeRepository extends AbstractTreeRepository
         if (!is_a($node, $meta->getName())) {
             throw new InvalidArgumentException('Node is not related to this repository');
         }
-        $config = $this->listener->getConfiguration($this->_em, $meta->getName());
-        $wrapped = new EntityWrapper($node, $this->_em);
+        $config = $this->listener->getConfiguration($this->getEntityManager(), $meta->getName());
+        $wrapped = new EntityWrapper($node, $this->getEntityManager());
         if (!$wrapped->hasValidIdentifier()) {
             throw new InvalidArgumentException('Node is not managed by UnitOfWork');
         }
@@ -318,7 +318,7 @@ class NestedTreeRepository extends AbstractTreeRepository
     public function childrenQueryBuilder($node = null, $direct = false, $sortByField = null, $direction = 'ASC', $includeNode = false)
     {
         $meta = $this->getClassMetadata();
-        $config = $this->listener->getConfiguration($this->_em, $meta->getName());
+        $config = $this->listener->getConfiguration($this->getEntityManager(), $meta->getName());
 
         $qb = $this->getQueryBuilder();
         $qb->select('node')
@@ -326,7 +326,7 @@ class NestedTreeRepository extends AbstractTreeRepository
         ;
         if (null !== $node) {
             if (is_a($node, $meta->getName())) {
-                $wrapped = new EntityWrapper($node, $this->_em);
+                $wrapped = new EntityWrapper($node, $this->getEntityManager());
                 if (!$wrapped->hasValidIdentifier()) {
                     throw new InvalidArgumentException('Node is not managed by UnitOfWork');
                 }
@@ -446,7 +446,7 @@ class NestedTreeRepository extends AbstractTreeRepository
     public function getLeafsQueryBuilder($root = null, $sortByField = null, $direction = 'ASC')
     {
         $meta = $this->getClassMetadata();
-        $config = $this->listener->getConfiguration($this->_em, $meta->getName());
+        $config = $this->listener->getConfiguration($this->getEntityManager(), $meta->getName());
 
         if (isset($config['root']) && null === $root) {
             throw new InvalidArgumentException('If tree has root, getLeafs method requires any node of this tree');
@@ -459,7 +459,7 @@ class NestedTreeRepository extends AbstractTreeRepository
         ;
         if (isset($config['root'])) {
             if (is_a($root, $meta->getName())) {
-                $wrapped = new EntityWrapper($root, $this->_em);
+                $wrapped = new EntityWrapper($root, $this->getEntityManager());
                 $rootId = $wrapped->getPropertyValue($config['root']);
                 if (!$rootId) {
                     throw new InvalidArgumentException('Root node must be managed');
@@ -534,12 +534,12 @@ class NestedTreeRepository extends AbstractTreeRepository
         if (!is_a($node, $meta->getName())) {
             throw new InvalidArgumentException('Node is not related to this repository');
         }
-        $wrapped = new EntityWrapper($node, $this->_em);
+        $wrapped = new EntityWrapper($node, $this->getEntityManager());
         if (!$wrapped->hasValidIdentifier()) {
             throw new InvalidArgumentException('Node is not managed by UnitOfWork');
         }
 
-        $config = $this->listener->getConfiguration($this->_em, $meta->getName());
+        $config = $this->listener->getConfiguration($this->getEntityManager(), $meta->getName());
         $parent = $wrapped->getPropertyValue($config['parent']);
 
         $left = $wrapped->getPropertyValue($config['left']);
@@ -554,7 +554,7 @@ class NestedTreeRepository extends AbstractTreeRepository
             ->orderBy("node.{$config['left']}", 'ASC')
         ;
         if ($parent) {
-            $wrappedParent = new EntityWrapper($parent, $this->_em);
+            $wrappedParent = new EntityWrapper($parent, $this->getEntityManager());
             $qb->andWhere($qb->expr()->eq('node.'.$config['parent'], ':pid'));
             $qb->setParameter('pid', $wrappedParent->getIdentifier());
         } elseif (isset($config['root'])) {
@@ -614,12 +614,12 @@ class NestedTreeRepository extends AbstractTreeRepository
         if (!is_a($node, $meta->getName())) {
             throw new InvalidArgumentException('Node is not related to this repository');
         }
-        $wrapped = new EntityWrapper($node, $this->_em);
+        $wrapped = new EntityWrapper($node, $this->getEntityManager());
         if (!$wrapped->hasValidIdentifier()) {
             throw new InvalidArgumentException('Node is not managed by UnitOfWork');
         }
 
-        $config = $this->listener->getConfiguration($this->_em, $meta->getName());
+        $config = $this->listener->getConfiguration($this->getEntityManager(), $meta->getName());
         $parent = $wrapped->getPropertyValue($config['parent']);
 
         $left = $wrapped->getPropertyValue($config['left']);
@@ -634,7 +634,7 @@ class NestedTreeRepository extends AbstractTreeRepository
             ->orderBy("node.{$config['left']}", 'ASC')
         ;
         if ($parent) {
-            $wrappedParent = new EntityWrapper($parent, $this->_em);
+            $wrappedParent = new EntityWrapper($parent, $this->getEntityManager());
             $qb->andWhere($qb->expr()->eq('node.'.$config['parent'], ':pid'));
             $qb->setParameter('pid', $wrappedParent->getIdentifier());
         } elseif (isset($config['root'])) {
@@ -702,8 +702,8 @@ class NestedTreeRepository extends AbstractTreeRepository
                     $number = $numSiblings;
                 }
                 $this->listener
-                    ->getStrategy($this->_em, $meta->getName())
-                    ->updateNode($this->_em, $node, $nextSiblings[$number - 1], Nested::NEXT_SIBLING);
+                    ->getStrategy($this->getEntityManager(), $meta->getName())
+                    ->updateNode($this->getEntityManager(), $node, $nextSiblings[$number - 1], Nested::NEXT_SIBLING);
             }
         } else {
             throw new InvalidArgumentException('Node is not related to this repository');
@@ -737,8 +737,8 @@ class NestedTreeRepository extends AbstractTreeRepository
                     $number = $numSiblings;
                 }
                 $this->listener
-                    ->getStrategy($this->_em, $meta->getName())
-                    ->updateNode($this->_em, $node, $prevSiblings[$number - 1], Nested::PREV_SIBLING);
+                    ->getStrategy($this->getEntityManager(), $meta->getName())
+                    ->updateNode($this->getEntityManager(), $node, $prevSiblings[$number - 1], Nested::PREV_SIBLING);
             }
         } else {
             throw new InvalidArgumentException('Node is not related to this repository');
@@ -762,8 +762,8 @@ class NestedTreeRepository extends AbstractTreeRepository
     {
         $meta = $this->getClassMetadata();
         if (is_a($node, $meta->getName())) {
-            $wrapped = new EntityWrapper($node, $this->_em);
-            $config = $this->listener->getConfiguration($this->_em, $meta->getName());
+            $wrapped = new EntityWrapper($node, $this->getEntityManager());
+            $config = $this->listener->getConfiguration($this->getEntityManager(), $meta->getName());
             $right = $wrapped->getPropertyValue($config['right']);
             $left = $wrapped->getPropertyValue($config['left']);
             $rootId = isset($config['root']) ? $wrapped->getPropertyValue($config['root']) : null;
@@ -772,19 +772,19 @@ class NestedTreeRepository extends AbstractTreeRepository
             if ($right == $left + 1) {
                 $this->removeSingle($wrapped);
                 $this->listener
-                    ->getStrategy($this->_em, $meta->getName())
-                    ->shiftRL($this->_em, $config['useObjectClass'], $right, -2, $rootId);
+                    ->getStrategy($this->getEntityManager(), $meta->getName())
+                    ->shiftRL($this->getEntityManager(), $config['useObjectClass'], $right, -2, $rootId);
 
                 return; // node was a leaf
             }
             // process updates in transaction
-            $this->_em->getConnection()->beginTransaction();
+            $this->getEntityManager()->getConnection()->beginTransaction();
 
             try {
                 $parent = $wrapped->getPropertyValue($config['parent']);
                 $parentId = null;
                 if ($parent) {
-                    $wrappedParent = new EntityWrapper($parent, $this->_em);
+                    $wrappedParent = new EntityWrapper($parent, $this->getEntityManager());
                     $parentId = $wrappedParent->getIdentifier();
                 }
                 $pk = $meta->getSingleIdentifierFieldName();
@@ -833,11 +833,11 @@ class NestedTreeRepository extends AbstractTreeRepository
 
                         // fix left, right and level values for the newly formed tree
                         $this->listener
-                            ->getStrategy($this->_em, $meta->getName())
-                            ->shiftRangeRL($this->_em, $config['useObjectClass'], $left, $right, $shift, $rootId, $rootId, -1);
+                            ->getStrategy($this->getEntityManager(), $meta->getName())
+                            ->shiftRangeRL($this->getEntityManager(), $config['useObjectClass'], $left, $right, $shift, $rootId, $rootId, -1);
                         $this->listener
-                            ->getStrategy($this->_em, $meta->getName())
-                            ->shiftRL($this->_em, $config['useObjectClass'], $right, -2, $rootId);
+                            ->getStrategy($this->getEntityManager(), $meta->getName())
+                            ->shiftRL($this->getEntityManager(), $config['useObjectClass'], $right, -2, $rootId);
                     }
                 } else {
                     // set parent of all direct children to be the parent of the node being deleted
@@ -855,18 +855,18 @@ class NestedTreeRepository extends AbstractTreeRepository
 
                     // fix left, right and level values for the node's children
                     $this->listener
-                        ->getStrategy($this->_em, $meta->getName())
-                        ->shiftRangeRL($this->_em, $config['useObjectClass'], $left, $right, $shift, $rootId, $rootId, -1);
+                        ->getStrategy($this->getEntityManager(), $meta->getName())
+                        ->shiftRangeRL($this->getEntityManager(), $config['useObjectClass'], $left, $right, $shift, $rootId, $rootId, -1);
 
                     $this->listener
-                        ->getStrategy($this->_em, $meta->getName())
-                        ->shiftRL($this->_em, $config['useObjectClass'], $right, -2, $rootId);
+                        ->getStrategy($this->getEntityManager(), $meta->getName())
+                        ->shiftRL($this->getEntityManager(), $config['useObjectClass'], $right, -2, $rootId);
                 }
                 $this->removeSingle($wrapped);
-                $this->_em->getConnection()->commit();
+                $this->getEntityManager()->getConnection()->commit();
             } catch (\Exception $e) {
-                $this->_em->close();
-                $this->_em->getConnection()->rollback();
+                $this->getEntityManager()->close();
+                $this->getEntityManager()->getConnection()->rollback();
 
                 throw new RuntimeException('Transaction failed', $e->getCode(), $e);
             }
@@ -891,14 +891,14 @@ class NestedTreeRepository extends AbstractTreeRepository
     {
         $meta = $this->getClassMetadata();
         if (null === $node || is_a($node, $meta->getName())) {
-            $config = $this->listener->getConfiguration($this->_em, $meta->getName());
+            $config = $this->listener->getConfiguration($this->getEntityManager(), $meta->getName());
             if ($verify && is_array($this->verify())) {
                 return;
             }
 
             $nodes = $this->children($node, true, $sortByField, $direction);
             foreach ($nodes as $node) {
-                $wrapped = new EntityWrapper($node, $this->_em);
+                $wrapped = new EntityWrapper($node, $this->getEntityManager());
                 $right = $wrapped->getPropertyValue($config['right']);
                 $left = $wrapped->getPropertyValue($config['left']);
                 $this->moveDown($node, true);
@@ -955,7 +955,7 @@ class NestedTreeRepository extends AbstractTreeRepository
 
         $errors = [];
         $meta = $this->getClassMetadata();
-        $config = $this->listener->getConfiguration($this->_em, $meta->getName());
+        $config = $this->listener->getConfiguration($this->getEntityManager(), $meta->getName());
         if (isset($config['root'])) {
             $trees = $this->getRootNodes();
             foreach ($trees as $tree) {
@@ -1091,8 +1091,8 @@ class NestedTreeRepository extends AbstractTreeRepository
         }
 
         $meta = $this->getClassMetadata();
-        $config = $this->listener->getConfiguration($this->_em, $meta->getName());
-        $em = $this->_em;
+        $config = $this->listener->getConfiguration($this->getEntityManager(), $meta->getName());
+        $em = $this->getEntityManager();
 
         $doRecover = function ($root, &$count, &$lvl) use ($meta, $config, $em, $options, &$doRecover) {
             $left = $count++;
@@ -1141,7 +1141,7 @@ class NestedTreeRepository extends AbstractTreeRepository
     public function getNodesHierarchyQueryBuilder($node = null, $direct = false, array $options = [], $includeNode = false)
     {
         $meta = $this->getClassMetadata();
-        $config = $this->listener->getConfiguration($this->_em, $meta->getName());
+        $config = $this->listener->getConfiguration($this->getEntityManager(), $meta->getName());
 
         return $this->childrenQueryBuilder(
             $node,
@@ -1164,7 +1164,7 @@ class NestedTreeRepository extends AbstractTreeRepository
 
     protected function validate()
     {
-        return Strategy::NESTED === $this->listener->getStrategy($this->_em, $this->getClassMetadata()->name)->getName();
+        return Strategy::NESTED === $this->listener->getStrategy($this->getEntityManager(), $this->getClassMetadata()->name)->getName();
     }
 
     /**
@@ -1176,7 +1176,7 @@ class NestedTreeRepository extends AbstractTreeRepository
     private function verifyTree(array &$errors, ?object $root = null): void
     {
         $meta = $this->getClassMetadata();
-        $config = $this->listener->getConfiguration($this->_em, $meta->getName());
+        $config = $this->listener->getConfiguration($this->getEntityManager(), $meta->getName());
 
         $identifier = $meta->getSingleIdentifierFieldName();
         if (isset($config['root'])) {
@@ -1197,7 +1197,7 @@ class NestedTreeRepository extends AbstractTreeRepository
             $qb->setParameter('rid', $rootId);
         }
         $min = (int) $qb->getQuery()->getSingleScalarResult();
-        $edge = $this->listener->getStrategy($this->_em, $meta->getName())->max($this->_em, $config['useObjectClass'], $rootId);
+        $edge = $this->listener->getStrategy($this->getEntityManager(), $meta->getName())->max($this->getEntityManager(), $config['useObjectClass'], $rootId);
         // check duplicate right and left values
         for ($i = $min; $i <= $edge; ++$i) {
             $qb = $this->getQueryBuilder();
@@ -1286,7 +1286,7 @@ class NestedTreeRepository extends AbstractTreeRepository
                 $errors[] = "node [{$id}] has identical left and right values";
             } elseif ($parent) {
                 if ($parent instanceof Proxy && !$parent->__isInitialized()) {
-                    $this->_em->refresh($parent);
+                    $this->getEntityManager()->refresh($parent);
                 }
                 $parentRight = $meta->getReflectionProperty($config['right'])->getValue($parent);
                 $parentLeft = $meta->getReflectionProperty($config['left'])->getValue($parent);
@@ -1340,7 +1340,7 @@ class NestedTreeRepository extends AbstractTreeRepository
     private function removeSingle(EntityWrapper $wrapped): void
     {
         $meta = $this->getClassMetadata();
-        $config = $this->listener->getConfiguration($this->_em, $meta->getName());
+        $config = $this->listener->getConfiguration($this->getEntityManager(), $meta->getName());
 
         $pk = $meta->getSingleIdentifierFieldName();
         $nodeId = $wrapped->getIdentifier();
@@ -1362,6 +1362,6 @@ class NestedTreeRepository extends AbstractTreeRepository
         $qb->getQuery()->getSingleScalarResult();
 
         // remove from identity map
-        $this->_em->getUnitOfWork()->removeFromIdentityMap($wrapped->getObject());
+        $this->getEntityManager()->getUnitOfWork()->removeFromIdentityMap($wrapped->getObject());
     }
 }

--- a/src/Tree/Hydrator/ORM/TreeObjectHydrator.php
+++ b/src/Tree/Hydrator/ORM/TreeObjectHydrator.php
@@ -14,6 +14,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Internal\Hydration\ObjectHydrator;
 use Doctrine\ORM\PersistentCollection;
 use Gedmo\Exception\InvalidMappingException;
+use Gedmo\Tool\ORM\Hydration\EntityManagerRetriever;
 use Gedmo\Tree\TreeListener;
 
 /**
@@ -25,6 +26,8 @@ use Gedmo\Tree\TreeListener;
  */
 class TreeObjectHydrator extends ObjectHydrator
 {
+    use EntityManagerRetriever;
+
     /**
      * @var array<string, mixed>
      */
@@ -54,7 +57,7 @@ class TreeObjectHydrator extends ObjectHydrator
      */
     public function setPropertyValue($object, $property, $value)
     {
-        $meta = $this->_em->getClassMetadata(get_class($object));
+        $meta = $this->getEntityManager()->getClassMetadata(get_class($object));
         $meta->getReflectionProperty($property)->setValue($object, $value);
     }
 
@@ -71,9 +74,9 @@ class TreeObjectHydrator extends ObjectHydrator
             return $data;
         }
 
-        $listener = $this->getTreeListener($this->_em);
+        $listener = $this->getTreeListener($this->getEntityManager());
         $entityClass = $this->getEntityClassFromHydratedData($data);
-        $this->config = $listener->getConfiguration($this->_em, $entityClass);
+        $this->config = $listener->getConfiguration($this->getEntityManager(), $entityClass);
         $this->idField = $this->getIdField($entityClass);
         $this->parentField = $this->getParentField();
         $this->childrenField = $this->getChildrenField($entityClass);
@@ -278,7 +281,7 @@ class TreeObjectHydrator extends ObjectHydrator
         $firstMappedEntity = array_values($data);
         $firstMappedEntity = $firstMappedEntity[0];
 
-        return $this->_em->getClassMetadata(get_class($firstMappedEntity))->rootEntityName;
+        return $this->getEntityManager()->getClassMetadata(get_class($firstMappedEntity))->rootEntityName;
     }
 
     /**
@@ -289,7 +292,7 @@ class TreeObjectHydrator extends ObjectHydrator
      */
     protected function getPropertyValue($object, $property)
     {
-        $meta = $this->_em->getClassMetadata(get_class($object));
+        $meta = $this->getEntityManager()->getClassMetadata(get_class($object));
 
         return $meta->getReflectionProperty($property)->getValue($object);
     }

--- a/tests/Gedmo/Mapping/Fixture/Sluggable.php
+++ b/tests/Gedmo/Mapping/Fixture/Sluggable.php
@@ -11,12 +11,16 @@ declare(strict_types=1);
 
 namespace Gedmo\Tests\Mapping\Fixture;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
+use Gedmo\Sluggable\Handler\RelativeSlugHandler;
+use Gedmo\Sluggable\Handler\TreeSlugHandler;
 
 /**
  * @ORM\Entity
  */
+#[ORM\Entity]
 class Sluggable
 {
     /**
@@ -26,6 +30,9 @@ class Sluggable
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
      */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     /**
@@ -33,6 +40,7 @@ class Sluggable
      *
      * @ORM\Column(name="title", type="string", length=64)
      */
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
     private $title;
 
     /**
@@ -40,6 +48,7 @@ class Sluggable
      *
      * @ORM\Column(name="code", type="string", length=16)
      */
+    #[ORM\Column(name: 'code', type: Types::STRING, length: 64, nullable: true)]
     private $code;
 
     /**
@@ -58,6 +67,10 @@ class Sluggable
      * }, separator="-", updatable=false, fields={"title", "code"})
      * @ORM\Column(name="slug", type="string", length=64, unique=true)
      */
+    #[Gedmo\Slug(separator: '-', updatable: false, fields: ['title', 'code'])]
+    #[Gedmo\SlugHandler(class: TreeSlugHandler::class, options: ['parentRelationField' => 'parent', 'separator' => '/'])]
+    #[Gedmo\SlugHandler(class: RelativeSlugHandler::class, options: ['relationField' => 'user', 'relationSlugField' => 'slug', 'separator' => '/'])]
+    #[ORM\Column(name: 'slug', type: Types::STRING, length: 64, unique: true)]
     private $slug;
 
     /**
@@ -65,6 +78,7 @@ class Sluggable
      *
      * @ORM\ManyToOne(targetEntity="Sluggable")
      */
+    #[ORM\ManyToOne(targetEntity: self::class)]
     private $parent;
 
     /**
@@ -72,6 +86,7 @@ class Sluggable
      *
      * @ORM\ManyToOne(targetEntity="User")
      */
+    #[ORM\ManyToOne(targetEntity: User::class)]
     private $user;
 
     public function getId(): ?int

--- a/tests/Gedmo/Mapping/LoggableORMMappingTest.php
+++ b/tests/Gedmo/Mapping/LoggableORMMappingTest.php
@@ -16,6 +16,7 @@ use Doctrine\Common\EventManager;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Gedmo\Loggable\Entity\LogEntry;
@@ -47,14 +48,16 @@ final class LoggableORMMappingTest extends ORMMappingTestCase
 
         $config = $this->getBasicConfiguration();
 
-        $reader = new AnnotationReader();
-        $annotationDriver = new AnnotationDriver($reader);
-
-        $yamlDriver = new YamlDriver(__DIR__.'/Driver/Yaml');
-
         $chain = new MappingDriverChain();
-        $chain->addDriver($yamlDriver, 'Gedmo\Tests\Mapping\Fixture\Yaml');
-        $chain->addDriver($annotationDriver, 'Gedmo\Tests\Mapping\Fixture');
+
+        // TODO - The ORM's YAML mapping is deprecated and removed in 3.0
+        $chain->addDriver(new YamlDriver(__DIR__.'/Driver/Yaml'), 'Gedmo\Tests\Mapping\Fixture\Yaml');
+
+        if (PHP_VERSION_ID >= 80000 && class_exists(AttributeDriver::class)) {
+            $chain->addDriver(new AttributeDriver([]), 'Gedmo\Tests\Mapping\Fixture');
+        } else {
+            $chain->addDriver(new AnnotationDriver(new AnnotationReader()), 'Gedmo\Tests\Mapping\Fixture');
+        }
 
         $config->setMetadataDriverImpl($chain);
 

--- a/tests/Gedmo/Mapping/MetadataFactory/ForcedMetadataTest.php
+++ b/tests/Gedmo/Mapping/MetadataFactory/ForcedMetadataTest.php
@@ -21,6 +21,7 @@ use Doctrine\ORM\Events;
 use Doctrine\ORM\Id\IdentityGenerator;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Tools\SchemaTool;
 use Gedmo\Tests\Mapping\Fixture\Unmapped\Timestampable;
 use Gedmo\Timestampable\TimestampableListener;
@@ -48,9 +49,12 @@ final class ForcedMetadataTest extends TestCase
         $config = new Configuration();
         $config->setProxyDir(TESTS_TEMP_DIR);
         $config->setProxyNamespace('Gedmo\Mapping\Proxy');
-        $config->setMetadataDriverImpl(
-            new AnnotationDriver($_ENV['annotation_reader'])
-        );
+
+        if (PHP_VERSION_ID >= 80000 && class_exists(AttributeDriver::class)) {
+            $config->setMetadataDriverImpl(new AttributeDriver([]));
+        } else {
+            $config->setMetadataDriverImpl(new AnnotationDriver($_ENV['annotation_reader']));
+        }
 
         $conn = [
             'driver' => 'pdo_sqlite',

--- a/tests/Gedmo/Mapping/SluggableMappingTest.php
+++ b/tests/Gedmo/Mapping/SluggableMappingTest.php
@@ -16,6 +16,7 @@ use Doctrine\Common\EventManager;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Gedmo\Mapping\ExtensionMetadataFactory;
@@ -45,17 +46,19 @@ final class SluggableMappingTest extends ORMMappingTestCase
         parent::setUp();
 
         $config = $this->getBasicConfiguration();
-        $chainDriverImpl = new MappingDriverChain();
-        $chainDriverImpl->addDriver(
-            new YamlDriver([__DIR__.'/Driver/Yaml']),
-            'Gedmo\Tests\Mapping\Fixture\Yaml'
-        );
-        $reader = new AnnotationReader();
-        $chainDriverImpl->addDriver(
-            new AnnotationDriver($reader),
-            'Gedmo\Tests\Mapping\Fixture'
-        );
-        $config->setMetadataDriverImpl($chainDriverImpl);
+
+        $chain = new MappingDriverChain();
+
+        // TODO - The ORM's YAML mapping is deprecated and removed in 3.0
+        $chain->addDriver(new YamlDriver(__DIR__.'/Driver/Yaml'), 'Gedmo\Tests\Mapping\Fixture\Yaml');
+
+        if (PHP_VERSION_ID >= 80000 && class_exists(AttributeDriver::class)) {
+            $chain->addDriver(new AttributeDriver([]), 'Gedmo\Tests\Mapping\Fixture');
+        } else {
+            $chain->addDriver(new AnnotationDriver(new AnnotationReader()), 'Gedmo\Tests\Mapping\Fixture');
+        }
+
+        $config->setMetadataDriverImpl($chain);
 
         $conn = [
             'driver' => 'pdo_sqlite',

--- a/tests/Gedmo/Mapping/TimestampableMappingTest.php
+++ b/tests/Gedmo/Mapping/TimestampableMappingTest.php
@@ -39,12 +39,13 @@ final class TimestampableMappingTest extends ORMMappingTestCase
         parent::setUp();
 
         $config = $this->getBasicConfiguration();
-        $chainDriverImpl = new MappingDriverChain();
-        $chainDriverImpl->addDriver(
-            new YamlDriver([__DIR__.'/Driver/Yaml']),
-            'Gedmo\Tests\Mapping\Fixture\Yaml'
-        );
-        $config->setMetadataDriverImpl($chainDriverImpl);
+
+        $chain = new MappingDriverChain();
+
+        // TODO - The ORM's YAML mapping is deprecated and removed in 3.0
+        $chain->addDriver(new YamlDriver(__DIR__.'/Driver/Yaml'), 'Gedmo\Tests\Mapping\Fixture\Yaml');
+
+        $config->setMetadataDriverImpl($chain);
 
         $conn = [
             'driver' => 'pdo_sqlite',

--- a/tests/Gedmo/Mapping/TranslatableMappingTest.php
+++ b/tests/Gedmo/Mapping/TranslatableMappingTest.php
@@ -46,12 +46,13 @@ final class TranslatableMappingTest extends ORMMappingTestCase
         parent::setUp();
 
         $config = $this->getBasicConfiguration();
-        $chainDriverImpl = new MappingDriverChain();
-        $chainDriverImpl->addDriver(
-            new YamlDriver([__DIR__.'/Driver/Yaml']),
-            'Gedmo\Tests\Mapping\Fixture\Yaml'
-        );
-        $config->setMetadataDriverImpl($chainDriverImpl);
+
+        $chain = new MappingDriverChain();
+
+        // TODO - The ORM's YAML mapping is deprecated and removed in 3.0
+        $chain->addDriver(new YamlDriver(__DIR__.'/Driver/Yaml'), 'Gedmo\Tests\Mapping\Fixture\Yaml');
+
+        $config->setMetadataDriverImpl($chain);
 
         $conn = [
             'driver' => 'pdo_sqlite',


### PR DESCRIPTION
This is some low-hanging fruit working as a very first pass for #2708.  Best viewed by individual commits.

Three things are tackled:

- The `Doctrine\ORM\EntityRepository::$_em` property was made private, the getter method is used instead
- The `Doctrine\ORM\Internal\Hydration\AbstractHydrator::$_em` property was renamed to `$em`, and it has no getter method; an internal trait was introduced and implemented in all ORM hydrators to support retrieving the entity manager from the parent class in a cross-version compatible manner
- The unit tests will now use the ORM's `AttributeDriver` instead of the deprecated `AnnotationDriver` when running on PHP 8 when configuring an entity manager