### PR TITLE
Refactor ORM `QueryBuilder::setParameters()` calls to use `setParameter()` instead due to a stricter type in 3.0

### DIFF
--- a/src/Translatable/Entity/Repository/TranslationRepository.php
+++ b/src/Translatable/Entity/Repository/TranslationRepository.php
@@ -149,10 +149,8 @@ class TranslationRepository extends EntityRepository
                 ->from($translationClass, 'trans')
                 ->where('trans.foreignKey = :entityId', 'trans.objectClass = :entityClass')
                 ->orderBy('trans.locale')
-                ->setParameters([
-                    'entityId' => $entityId,
-                    'entityClass' => $entityClass,
-                ]);
+                ->setParameter('entityId', $entityId)
+                ->setParameter('entityClass', $entityClass);
 
             foreach ($qb->getQuery()->toIterable([], Query::HYDRATE_ARRAY) as $row) {
                 $result[$row['locale']][$row['field']] = $row['content'];

--- a/src/Translatable/Mapping/Event/Adapter/ORM.php
+++ b/src/Translatable/Mapping/Event/Adapter/ORM.php
@@ -142,11 +142,10 @@ final class ORM extends BaseAdapterORM implements TranslatableAdapter
                 'trans.locale = :locale',
                 'trans.field = :field'
             )
+            ->setParameter('locale', $locale)
+            ->setParameter('field', $field)
         ;
-        $qb->setParameters([
-            'locale' => $locale,
-            'field' => $field,
-        ]);
+
         if ($this->usesPersonalTranslation($translationClass)) {
             $qb->andWhere('trans.object = :object');
             if ($wrapped->getIdentifier()) {

--- a/src/Tree/Strategy/ORM/Nested.php
+++ b/src/Tree/Strategy/ORM/Nested.php
@@ -215,7 +215,8 @@ class Nested implements Strategy
             $qb->select('node')
                 ->from($config['useObjectClass'], 'node')
                 ->where($qb->expr()->between('node.'.$config['left'], '?1', '?2'))
-                ->setParameters([1 => $leftValue, 2 => $rightValue]);
+                ->setParameter(1, $leftValue)
+                ->setParameter(2, $rightValue);
 
             if (isset($config['root'])) {
                 $qb->andWhere($qb->expr()->eq('node.'.$config['root'], ':rid'));


### PR DESCRIPTION
For B/C, the ORM's `QueryBuilder::setParameters()` (plural) method has continued to accept a plain array throughout 2.x, but in 3.0 it is typehinted as an `ArrayCollection`.  So instead of having to pass a collection of Parameter objects, emulating the internals of `setParameter()` (singular), this just updates the code to call the `setParameter()` method one-by-one (which shouldn't hurt any since these are only 2-item arrays).

After #2639 it should be more feasible to see where some of the pain points lie, but for now, another piece of low-hanging fruit is knocked down.