### PR TITLE
Use the Persistence Proxy interface for checking ORM proxy objects

### DIFF
--- a/src/References/Mapping/Event/Adapter/ODM.php
+++ b/src/References/Mapping/Event/Adapter/ODM.php
@@ -11,7 +11,7 @@ namespace Gedmo\References\Mapping\Event\Adapter;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Proxy\Proxy as ORMProxy;
+use Doctrine\Persistence\Proxy as PersistenceProxy;
 use Gedmo\Mapping\Event\Adapter\ODM as BaseAdapterODM;
 use Gedmo\References\Mapping\Event\ReferencesAdapter;
 use ProxyManager\Proxy\GhostObjectInterface;
@@ -32,7 +32,7 @@ final class ODM extends BaseAdapterODM implements ReferencesAdapter
         }
 
         if ($om instanceof EntityManagerInterface) {
-            if ($object instanceof ORMProxy) {
+            if ($object instanceof PersistenceProxy) {
                 $id = $om->getUnitOfWork()->getEntityIdentifier($object);
             } else {
                 $meta = $om->getClassMetadata(get_class($object));

--- a/src/References/Mapping/Event/Adapter/ORM.php
+++ b/src/References/Mapping/Event/Adapter/ORM.php
@@ -12,7 +12,7 @@ namespace Gedmo\References\Mapping\Event\Adapter;
 use Doctrine\ODM\MongoDB\DocumentManager as MongoDocumentManager;
 use Doctrine\ODM\PHPCR\DocumentManager as PhpcrDocumentManager;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Proxy\Proxy as ORMProxy;
+use Doctrine\Persistence\Proxy as PersistenceProxy;
 use Gedmo\Exception\InvalidArgumentException;
 use Gedmo\Mapping\Event\Adapter\ORM as BaseAdapterORM;
 use Gedmo\References\Mapping\Event\ReferencesAdapter;
@@ -79,7 +79,7 @@ final class ORM extends BaseAdapterORM implements ReferencesAdapter
 
     public function extractIdentifier($om, $object, $single = true)
     {
-        if ($object instanceof ORMProxy) {
+        if ($object instanceof PersistenceProxy) {
             $id = $om->getUnitOfWork()->getEntityIdentifier($object);
         } else {
             $meta = $om->getClassMetadata(get_class($object));

--- a/src/Tool/Wrapper/EntityWrapper.php
+++ b/src/Tool/Wrapper/EntityWrapper.php
@@ -12,7 +12,6 @@ namespace Gedmo\Tool\Wrapper;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Proxy\Proxy;
 use Doctrine\Persistence\Proxy as PersistenceProxy;
 
 /**

--- a/src/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/src/Tree/Entity/Repository/NestedTreeRepository.php
@@ -10,9 +10,9 @@
 namespace Gedmo\Tree\Entity\Repository;
 
 use Doctrine\ORM\Exception\ORMException;
-use Doctrine\ORM\Proxy\Proxy;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
+use Doctrine\Persistence\Proxy;
 use Gedmo\Exception\InvalidArgumentException;
 use Gedmo\Exception\RuntimeException;
 use Gedmo\Exception\UnexpectedValueException;

--- a/src/Tree/Strategy/ORM/Nested.php
+++ b/src/Tree/Strategy/ORM/Nested.php
@@ -12,7 +12,7 @@ namespace Gedmo\Tree\Strategy\ORM;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Proxy\Proxy;
+use Doctrine\Persistence\Proxy;
 use Gedmo\Exception\InvalidArgumentException;
 use Gedmo\Exception\UnexpectedValueException;
 use Gedmo\Mapping\Event\AdapterInterface;

--- a/tests/Gedmo/Timestampable/TimestampableTest.php
+++ b/tests/Gedmo/Timestampable/TimestampableTest.php
@@ -12,8 +12,7 @@ declare(strict_types=1);
 namespace Gedmo\Tests\Timestampable;
 
 use Doctrine\Common\EventManager;
-use Doctrine\ORM\Proxy\Proxy;
-use Gedmo\Tests\Mapping\Fixture\Xml\Timestampable;
+use Doctrine\Persistence\Proxy;
 use Gedmo\Tests\Timestampable\Fixture\Article;
 use Gedmo\Tests\Timestampable\Fixture\Author;
 use Gedmo\Tests\Timestampable\Fixture\Comment;

--- a/tests/Gedmo/Translatable/Issue/Issue84Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue84Test.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace Gedmo\Tests\Translatable\Issue;
 
 use Doctrine\Common\EventManager;
-use Doctrine\ORM\Proxy\Proxy;
+use Doctrine\Persistence\Proxy;
 use Gedmo\Tests\Tool\BaseTestCaseORM;
 use Gedmo\Tests\Translatable\Fixture\Article;
 use Gedmo\Translatable\Entity\Translation;

--- a/tests/Gedmo/Wrapper/EntityWrapperTest.php
+++ b/tests/Gedmo/Wrapper/EntityWrapperTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace Gedmo\Tests\Wrapper;
 
 use Doctrine\Common\EventManager;
-use Doctrine\ORM\Proxy\Proxy;
+use Doctrine\Persistence\Proxy;
 use Gedmo\Tests\Tool\BaseTestCaseORM;
 use Gedmo\Tests\Wrapper\Fixture\Entity\Article;
 use Gedmo\Tests\Wrapper\Fixture\Entity\Composite;


### PR DESCRIPTION
Ref: #2708

In ORM 2.14, `Doctrine\ORM\Proxy\Proxy` was deprecated and the upgrade guide suggests using `Doctrine\Persistence\Proxy` instead, with the ORM interface removed in 3.0.  This updates all checks to reflect this deprecation.