### PR TITLE
Accept both `ClassMetadata` and `ClassMetadataInfo` objects from the ORM

### DIFF
--- a/src/Mapping/ExtensionMetadataFactory.php
+++ b/src/Mapping/ExtensionMetadataFactory.php
@@ -12,7 +12,8 @@ namespace Gedmo\Mapping;
 use Doctrine\Bundle\DoctrineBundle\Mapping\MappingDriver as DoctrineBundleMappingDriver;
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata as DocumentClassMetadata;
-use Doctrine\ORM\Mapping\ClassMetadataInfo as EntityClassMetadata;
+use Doctrine\ORM\Mapping\ClassMetadata as EntityClassMetadata;
+use Doctrine\ORM\Mapping\ClassMetadataInfo as LegacyEntityClassMetadata;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\Driver\DefaultFileLocator;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
@@ -95,7 +96,7 @@ class ExtensionMetadataFactory
     /**
      * Reads extension metadata
      *
-     * @param ClassMetadata&(DocumentClassMetadata|EntityClassMetadata) $meta
+     * @param ClassMetadata&(DocumentClassMetadata|EntityClassMetadata|LegacyEntityClassMetadata) $meta
      *
      * @return array<string, mixed> the metatada configuration
      */
@@ -116,7 +117,7 @@ class ExtensionMetadataFactory
 
                     $class = $this->objectManager->getClassMetadata($parentClass);
 
-                    assert($class instanceof DocumentClassMetadata || $class instanceof EntityClassMetadata);
+                    assert($class instanceof DocumentClassMetadata || $class instanceof EntityClassMetadata || $class instanceof LegacyEntityClassMetadata);
 
                     $extendedMetadata = $this->driver->readExtendedMetadata($class, $config);
 

--- a/src/Mapping/MappedEventSubscriber.php
+++ b/src/Mapping/MappedEventSubscriber.php
@@ -17,7 +17,8 @@ use Doctrine\Common\EventSubscriber;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata as DocumentClassMetadata;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Mapping\ClassMetadataInfo as EntityClassMetadata;
+use Doctrine\ORM\Mapping\ClassMetadata as EntityClassMetadata;
+use Doctrine\ORM\Mapping\ClassMetadataInfo as LegacyEntityClassMetadata;
 use Doctrine\Persistence\Mapping\AbstractClassMetadataFactory;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\ObjectManager;
@@ -229,7 +230,7 @@ abstract class MappedEventSubscriber implements EventSubscriber
      */
     public function loadMetadataForObjectClass(ObjectManager $objectManager, $metadata)
     {
-        assert($metadata instanceof DocumentClassMetadata || $metadata instanceof EntityClassMetadata);
+        assert($metadata instanceof DocumentClassMetadata || $metadata instanceof EntityClassMetadata || $metadata instanceof LegacyEntityClassMetadata);
 
         $factory = $this->getExtensionMetadataFactory($objectManager);
 


### PR DESCRIPTION
Ref: #2708

The `Doctrine\ORM\Mapping\ClassMetadataInfo` class is deprecated in ORM 2.x and removed entirely in 3.0, with `Doctrine\ORM\Mapping\ClassMetadata` being the replacement.  `Doctrine\ORM\Mapping\ClassMetadata` exists in 2.x as a subclass of `Doctrine\ORM\Mapping\ClassMetadataInfo`, so no version conditional behaviors are really needed here, therefore, this PR just adds both ORM classes to some existing doc block types and assertions (I'm aware there are other places using the deprecated `ClassMetadataInfo` class but the changes here just unblocked being able to run a number of tests locally on ORM 3.0 for now).