### PR TITLE
Removed explicit default options for PHPStan 6

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -517,12 +517,12 @@ parameters:
 
 		-
 			message: "#^Method Gedmo\\\\Uploadable\\\\Event\\\\UploadableBaseEventArgs\\:\\:__construct\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
-			count: 2
+			count: 1
 			path: src/Uploadable/Event/UploadableBaseEventArgs.php
 
 		-
 			message: "#^Method Gedmo\\\\Uploadable\\\\Event\\\\UploadableBaseEventArgs\\:\\:getExtensionConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 2
+			count: 1
 			path: src/Uploadable/Event/UploadableBaseEventArgs.php
 
 		-
@@ -532,7 +532,7 @@ parameters:
 
 		-
 			message: "#^Property Gedmo\\\\Uploadable\\\\Event\\\\UploadableBaseEventArgs\\:\\:\\$config type has no value type specified in iterable type array\\.$#"
-			count: 2
+			count: 1
 			path: src/Uploadable/Event/UploadableBaseEventArgs.php
 
 		-
@@ -542,7 +542,7 @@ parameters:
 
 		-
 			message: "#^Property Gedmo\\\\Uploadable\\\\Event\\\\UploadableBaseEventArgs\\:\\:\\$extensionConfiguration type has no value type specified in iterable type array\\.$#"
-			count: 2
+			count: 1
 			path: src/Uploadable/Event/UploadableBaseEventArgs.php
 
 		-

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -11,8 +11,6 @@ parameters:
     bootstrapFiles:
         - tests/bootstrap.php
     treatPhpDocTypesAsCertain: false
-    checkMissingVarTagTypehint: true
-    checkMissingTypehints: true
     ignoreErrors:
         - '#^Property Gedmo\\Tests\\.+\\Fixture\\[^:]+::\$\w+ is never written, only read\.$#'
         - '#^Property Gedmo\\Tests\\.+\\Fixture\\[^:]+::\$\w+ is never read, only written\.$#'
@@ -21,11 +19,3 @@ parameters:
         - '#^Method Gedmo\\Uploadable\\Mapping\\Validator::validateConfiguration\(\) with return type void returns array<string, mixed> but should not return anything\.$#'
         - '#^Result of static method Gedmo\\Uploadable\\Mapping\\Validator::validateConfiguration\(\) \(void\) is used\.$#'
         - '#^Result of method Gedmo\\Mapping\\Driver::readExtendedMetadata\(\) \(void\) is used\.$#'
-
-rules:
-    - PHPStan\Rules\Constants\MissingClassConstantTypehintRule
-    - PHPStan\Rules\Functions\MissingFunctionParameterTypehintRule
-    - PHPStan\Rules\Functions\MissingFunctionReturnTypehintRule
-    - PHPStan\Rules\Methods\MissingMethodParameterTypehintRule
-    - PHPStan\Rules\Methods\MissingMethodReturnTypehintRule
-    - PHPStan\Rules\Properties\MissingPropertyTypehintRule


### PR DESCRIPTION
These options are in https://github.com/phpstan/phpstan-src/blob/a849f06ff5195c95d0c03ef14dffc65986fe92a2/conf/config.level6.neon by default.

I don't know why it shows now less errors 🤷‍♂️ 