### PR TITLE
feat: allow symfony 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "doctrine/event-manager": "^1.2 || ^2.0",
         "doctrine/persistence": "^2.2 || ^3.0",
         "psr/cache": "^1 || ^2 || ^3",
-        "symfony/cache": "^5.4 || ^6.0",
+        "symfony/cache": "^5.4 || ^6.0 || ^7.0",
         "symfony/deprecation-contracts": "^2.1 || ^3.0"
     },
     "require-dev": {
@@ -64,9 +64,9 @@
         "phpstan/phpstan-phpunit": "^1.0",
         "phpunit/phpunit": "^9.6",
         "rector/rector": "^0.18",
-        "symfony/console": "^5.4 || ^6.0",
+        "symfony/console": "^5.4 || ^6.0 || ^7.0",
         "symfony/phpunit-bridge": "^6.0",
-        "symfony/yaml": "^5.4 || ^6.0"
+        "symfony/yaml": "^5.4 || ^6.0 || ^7.0"
     },
     "conflict": {
         "doctrine/dbal": "<2.13.1 || ^3.0 <3.2",


### PR DESCRIPTION
Test-Runs will probably not cover a test for 7.0.x-dev

I guess the best idea is to wait until a stable releae of 7.0 and rerun ci.