### PR TITLE
Remove custom vendor bin directory

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -27,7 +27,7 @@ jobs:
           dependency-versions: "highest"
 
       - name: "Run PHP-CS-Fixer"
-        run: "bin/php-cs-fixer fix --ansi --verbose --diff --dry-run"
+        run: "vendor/bin/php-cs-fixer fix --ansi --verbose --diff --dry-run"
 
   rector:
     name: "Rector"
@@ -51,7 +51,7 @@ jobs:
           composer-options: "--prefer-dist --prefer-stable"
 
       - name: Rector
-        run: "bin/rector --no-progress-bar --dry-run"
+        run: "vendor/bin/rector --no-progress-bar --dry-run"
 
   composer:
     name: Composer

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -70,7 +70,7 @@ jobs:
           dependency-versions: "${{ matrix.deps }}"
 
       - name: "Run PHPUnit"
-        run: "bin/phpunit -c tests --coverage-clover coverage.xml"
+        run: "vendor/bin/phpunit -c tests --coverage-clover coverage.xml"
 
       - name: "Upload coverage file"
         uses: "actions/upload-artifact@v3"

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -31,4 +31,4 @@ jobs:
           composer-options: --prefer-dist --prefer-stable --no-interaction --no-progress
 
       - name: PHPStan
-        run: bin/phpstan --memory-limit=1G analyse --error-format=github
+        run: vendor/bin/phpstan --memory-limit=1G analyse --error-format=github

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ To set up and run the tests, follow these steps:
 - From the project root, run `docker compose up -d` to start containers in daemon mode
 - Enter the container via `docker compose exec php bash` (you are now in the root directory: `/var/www`)
 - Install Composer dependencies via `composer install`
-- Run the tests: `bin/phpunit -c tests/`
+- Run the tests: `vendor/bin/phpunit -c tests/`
 
 ### Running the Example
 

--- a/composer.json
+++ b/composer.json
@@ -89,7 +89,6 @@
         }
     },
     "config": {
-        "bin-dir": "bin",
         "sort-packages": true
     },
     "extra": {


### PR DESCRIPTION
I'm not if there was a reason why it was added in https://github.com/doctrine-extensions/DoctrineExtensions/commit/4e9bbd54ebb22bb004b2ec71b1b0ce3ed5b992d0, but this simplifies (using the common `vendor/bin` path) executing commands locally.

PS: We could also move `phpunit.xml.dist` from `tests` to the root directory.