### PR TITLE
Use custom lifecycle event classes for the soft-deleteable lifecycle events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,14 @@ a release.
 - Dropped support for PHP < 7.4
 - Dropped support for Symfony < 5.4
 - Dropped support for doctrine/dbal < 3.2
+- ⚠️ [B/C Break] The `Gedmo\SoftDeleteable\SoftDeletableListener` dispatches events using the new `Gedmo\SoftDeleteable\Event\PreSoftDeleteEventArgs`
+  and `Gedmo\SoftDeleteable\Event\PostSoftDeleteEventArgs` classes, which directly extend from `Doctrine\Persistence\Event\LifecycleEventArgs`; previously,
+  each object manager's own lifecycle event args class was used.
 
 ### Deprecated
 - Calling `Gedmo\Mapping\Event\Adapter\ORM::getObjectManager()` and `getObject()` on EventArgs that do not implement `getObjectManager()` and `getObject()` (such as old EventArgs implementing `getEntityManager()` and `getEntity()`) 
-- Calling `Gedmo\Uploadable\Event\UploadableBaseEventArgs::getEntityManager()` and `getEntity()`. Call `getObjectManager()` and `getObject()` instead. 
+- Calling `Gedmo\Uploadable\Event\UploadableBaseEventArgs::getEntityManager()` and `getEntity()`. Call `getObjectManager()` and `getObject()` instead.
+- The `createLifecycleEventArgsInstance()` method on `Gedmo\Mapping\Event\AdapterInterface` implementations is deprecated, use your own subclass of `Doctrine\Persistence\Event\LifecycleEventArgs` as needed.
 
 ## [3.13.0] - 2023-09-06
 ### Fixed

--- a/src/Mapping/Event/Adapter/ODM.php
+++ b/src/Mapping/Event/Adapter/ODM.php
@@ -156,9 +156,16 @@ class ODM implements AdapterInterface
      * @param DocumentManager $documentManager
      *
      * @return LifecycleEventArgs
+     *
+     * @deprecated to be removed in 4.0, use custom lifecycle event classes instead
      */
     public function createLifecycleEventArgsInstance($document, $documentManager)
     {
+        @trigger_error(sprintf(
+            'Using "%s()" method is deprecated since gedmo/doctrine-extensions 3.14 and will be removed in version 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         return new LifecycleEventArgs($document, $documentManager);
     }
 }

--- a/src/Mapping/Event/Adapter/ORM.php
+++ b/src/Mapping/Event/Adapter/ORM.php
@@ -186,9 +186,20 @@ class ORM implements AdapterInterface
      * @param EntityManagerInterface $entityManager
      *
      * @return LifecycleEventArgs
+     *
+     * @deprecated Use custom lifecycle event classes instead
      */
     public function createLifecycleEventArgsInstance($document, $entityManager)
     {
+        @trigger_error(sprintf(
+            'Using "%s()" method is deprecated since gedmo/doctrine-extensions 3.14 and will be removed in version 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
+        if (!class_exists(LifecycleEventArgs::class)) {
+            throw new \RuntimeException(sprintf('Cannot call %s() when using doctrine/orm >=3.0, use a custom lifecycle event class instead.', __METHOD__));
+        }
+
         return new LifecycleEventArgs($document, $entityManager);
     }
 }

--- a/src/SoftDeleteable/Event/PostSoftDeleteEventArgs.php
+++ b/src/SoftDeleteable/Event/PostSoftDeleteEventArgs.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\SoftDeleteable\Event;
+
+use Doctrine\Persistence\Event\LifecycleEventArgs;
+use Doctrine\Persistence\ObjectManager;
+
+/**
+ * Post soft-delete lifecycle event
+ *
+ * @extends LifecycleEventArgs<ObjectManager>
+ */
+final class PostSoftDeleteEventArgs extends LifecycleEventArgs
+{
+}

--- a/src/SoftDeleteable/Event/PreSoftDeleteEventArgs.php
+++ b/src/SoftDeleteable/Event/PreSoftDeleteEventArgs.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\SoftDeleteable\Event;
+
+use Doctrine\Persistence\Event\LifecycleEventArgs;
+use Doctrine\Persistence\ObjectManager;
+
+/**
+ * Pre soft-delete lifecycle event
+ *
+ * @extends LifecycleEventArgs<ObjectManager>
+ */
+final class PreSoftDeleteEventArgs extends LifecycleEventArgs
+{
+}

--- a/src/SoftDeleteable/SoftDeleteableListener.php
+++ b/src/SoftDeleteable/SoftDeleteableListener.php
@@ -17,6 +17,8 @@ use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\ObjectManager;
 use Gedmo\Mapping\MappedEventSubscriber;
+use Gedmo\SoftDeleteable\Event\PostSoftDeleteEventArgs;
+use Gedmo\SoftDeleteable\Event\PreSoftDeleteEventArgs;
 
 /**
  * SoftDeleteable listener
@@ -83,7 +85,7 @@ class SoftDeleteableListener extends MappedEventSubscriber
 
                 $evm->dispatchEvent(
                     self::PRE_SOFT_DELETE,
-                    $ea->createLifecycleEventArgsInstance($object, $om)
+                    new PreSoftDeleteEventArgs($object, $om)
                 );
 
                 $reflProp->setValue($object, $date);
@@ -100,7 +102,7 @@ class SoftDeleteableListener extends MappedEventSubscriber
 
                 $evm->dispatchEvent(
                     self::POST_SOFT_DELETE,
-                    $ea->createLifecycleEventArgsInstance($object, $om)
+                    new PostSoftDeleteEventArgs($object, $om)
                 );
             }
         }


### PR DESCRIPTION
Ref: #2708

In ORM 3.0, the `Doctrine\ORM\Event\LifecycleEventArgs` class is removed and the ORM's lifecycle event classes directly extend `Doctrine\Persistence\Event\LifecycleEventArgs`.  This makes the ORM's implementation of `Gedmo\Mapping\Event\AdapterInterface::createLifecycleEventArgsInstance()` unusable on 3.0 since it no longer has its own lifecycle event args subclass.

Currently, the only use of this method inside the package is for the soft-deleteable extension's events.

My solution to this ORM deprecation comes with a minor B/C break; instead of dispatching the events with manager-specific event classes, the events are now dispatched with custom subclasses of `Doctrine\Persistence\Event\LifecycleEventArgs` for both supported managers.  The B/C break here is that event listeners which typehint against `Doctrine\ODM\MongoDB\Event\LifecycleEventArgs` and `Doctrine\ORM\Event\LifecycleEventArgs` will be broken because the class inheritance chain is changed.  This would also deprecate the implementations of `Gedmo\Mapping\Event\AdapterInterface::createLifecycleEventArgsInstance()` (currently soft-required through `@method` annotations).

There is an alternative solution that only has a B/C break for ORM users; changing this method to always use the `Doctrine\Persistence\Event\LifecycleEventArgs` class while the ODM adapter still uses its manager-specific subclass.

But because of the ORM 3.0 class removal, there will have to be a B/C break at some point, and I figured this would be the best alternative going forward.