### PR TITLE
Make the annotation/attribute reader optional in the extension metadata factory

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -26,6 +26,7 @@ return static function (RectorConfig $rectorConfig): void {
 
     $rectorConfig->skip([
         TypedPropertyFromAssignsRector::class => [
+            __DIR__.'/src/Mapping/MappedEventSubscriber.php', // Rector is trying to set a type on the $annotationReader property which requires a union type, not supported on PHP 7.4
             __DIR__.'/tests/Gedmo/Wrapper/Fixture/Entity/CompositeRelation.php', // @todo: remove this when https://github.com/doctrine/orm/issues/8255 is solved
         ],
     ]);

--- a/src/Mapping/ExtensionMetadataFactory.php
+++ b/src/Mapping/ExtensionMetadataFactory.php
@@ -61,20 +61,20 @@ class ExtensionMetadataFactory
     protected $extensionNamespace;
 
     /**
-     * Custom annotation reader
+     * Metadata annotation reader
      *
-     * @var Reader|AttributeReader|object
+     * @var Reader|AttributeReader|object|null
      */
     protected $annotationReader;
 
     private ?CacheItemPoolInterface $cacheItemPool = null;
 
     /**
-     * @param Reader|AttributeReader|object $annotationReader
+     * @param Reader|AttributeReader|object|null $annotationReader
      */
-    public function __construct(ObjectManager $objectManager, string $extensionNamespace, object $annotationReader, ?CacheItemPoolInterface $cacheItemPool = null)
+    public function __construct(ObjectManager $objectManager, string $extensionNamespace, ?object $annotationReader = null, ?CacheItemPoolInterface $cacheItemPool = null)
     {
-        if (!$annotationReader instanceof Reader && !$annotationReader instanceof AttributeReader) {
+        if (null !== $annotationReader && !$annotationReader instanceof Reader && !$annotationReader instanceof AttributeReader) {
             trigger_deprecation(
                 'gedmo/doctrine-extensions',
                 '3.11',
@@ -98,7 +98,7 @@ class ExtensionMetadataFactory
      *
      * @param ClassMetadata&(DocumentClassMetadata|EntityClassMetadata|LegacyEntityClassMetadata) $meta
      *
-     * @return array<string, mixed> the metatada configuration
+     * @return array<string, mixed> the metadata configuration
      */
     public function getExtensionMetadata($meta)
     {
@@ -209,8 +209,20 @@ class ExtensionMetadataFactory
             // create driver instance
             $driverClassName = $this->extensionNamespace.'\Mapping\Driver\\'.$driverName;
             if (!class_exists($driverClassName)) {
-                $driverClassName = $this->extensionNamespace.'\Mapping\Driver\Annotation';
+                $originalDriverClassName = $driverClassName;
+
+                // try to fall back to either an annotation or attribute driver depending on the available dependencies
+                if (interface_exists(Reader::class)) {
+                    $driverClassName = $this->extensionNamespace.'\Mapping\Driver\Annotation';
+                } elseif (\PHP_VERSION_ID >= 80000) {
+                    $driverClassName = $this->extensionNamespace.'\Mapping\Driver\Attribute';
+                }
+
                 if (!class_exists($driverClassName)) {
+                    if ($originalDriverClassName !== $driverClassName) {
+                        throw new RuntimeException("Failed to create mapping driver: ({$originalDriverClassName}), the extension driver nor a fallback annotation or attribute driver could be found.");
+                    }
+
                     throw new RuntimeException("Failed to fallback to annotation driver: ({$driverClassName}), extension driver was not found.");
                 }
             }
@@ -227,14 +239,20 @@ class ExtensionMetadataFactory
                 }
             }
 
-            if ($driver instanceof AttributeDriverInterface) {
-                if ($this->annotationReader instanceof AttributeReader) {
-                    $driver->setAnnotationReader($this->annotationReader);
-                } else {
-                    $driver->setAnnotationReader(new AttributeAnnotationReader(new AttributeReader(), $this->annotationReader));
+            if ($driver instanceof AnnotationDriverInterface) {
+                if (null === $this->annotationReader) {
+                    throw new RuntimeException("Cannot use metadata driver ({$driverClassName}), an annotation or attribute reader was not provided.");
                 }
-            } elseif ($driver instanceof AnnotationDriverInterface) {
-                $driver->setAnnotationReader($this->annotationReader);
+
+                if ($driver instanceof AttributeDriverInterface) {
+                    if ($this->annotationReader instanceof AttributeReader) {
+                        $driver->setAnnotationReader($this->annotationReader);
+                    } else {
+                        $driver->setAnnotationReader(new AttributeAnnotationReader(new AttributeReader(), $this->annotationReader));
+                    }
+                } else {
+                    $driver->setAnnotationReader($this->annotationReader);
+                }
             }
         }
 


### PR DESCRIPTION
Continuing the effort toward completing #2683, this will make the annotation reader optional in `Gedmo\Mapping\ExtensionMetadataFactory`.

As this factory only needs the annotation reader when creating an annotation or attribute driver, this means it should not be a hard requirement when working with other driver mappings (i.e. XML or deprecated YAML support).  So, the factory's constructor now allows creating it without the reader and checks when it's creating drivers if the reader is needed.

The factory's `getDriver()` method also had a fallback to a default annotation driver if an extension didn't provide a driver in another format.  With that being hard coupled to `doctrine/annotations`, a similar approach to what is proposed in #2683 is used where the fallback will go to the annotation driver if `doctrine/annotations` is installed, and now it will try falling back to the attribute driver if `doctrine/annotations` is not installed and the app is running on PHP 8.

To make this work, the private state in the base `Gedmo\Mapping\MappedEventSubscriber` class now initializes the annotation reader properties to false, and either through setter injection or the internal `getDefaultAnnotationReader()` those will flip to either a reader instance or null.  The setter isn't documented to support the new internal false condition, and everything else is private, so we should be good on B/C here.

In theory, after this PR, `doctrine/annotations` could become a `require-dev` dependency as I think we've now got everything in the production code with a hard Annotations package dependency reviewed, but there's a long way to go before we could even consider a test run for this package with it fully uninstalled since so many of the tests absolutely require either annotation or YAML support.