### PR TITLE
Refactor some mapping tests for improved coverage and forward compat

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -571,6 +571,11 @@ parameters:
 			path: src/Uploadable/UploadableListener.php
 
 		-
+			message: "#^Class Gedmo\\\\Tests\\\\Translatable\\\\Fixture\\\\CategoryTranslation not found\\.$#"
+			count: 1
+			path: tests/Gedmo/Mapping/Fixture/Category.php
+
+		-
 			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\<T of object\\>\\:\\:mapField\\(\\)\\.$#"
 			count: 2
 			path: tests/Gedmo/Mapping/MetadataFactory/CustomDriverTest.php

--- a/tests/Gedmo/Mapping/Fixture/BaseCategory.php
+++ b/tests/Gedmo/Mapping/Fixture/BaseCategory.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Mapping\Fixture;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * @ORM\MappedSuperclass
+ */
+#[ORM\MappedSuperclass]
+class BaseCategory
+{
+    /**
+     * @ORM\Column(type="integer")
+     *
+     * @Gedmo\TreeLeft
+     */
+    #[ORM\Column(type: Types::INTEGER)]
+    #[Gedmo\TreeLeft]
+    private ?int $left = null;
+
+    /**
+     * @ORM\Column(type="integer")
+     *
+     * @Gedmo\TreeRight
+     */
+    #[ORM\Column(type: Types::INTEGER)]
+    #[Gedmo\TreeRight]
+    private ?int $right = null;
+
+    /**
+     * @ORM\Column(type="integer")
+     *
+     * @Gedmo\TreeLevel
+     */
+    #[ORM\Column(type: Types::INTEGER)]
+    #[Gedmo\TreeLevel]
+    private ?int $level = null;
+
+    /**
+     * @ORM\Column(type="integer")
+     *
+     * @Gedmo\TreeRoot
+     */
+    #[ORM\Column(type: Types::INTEGER)]
+    #[Gedmo\TreeRoot]
+    private ?int $rooted = null;
+
+    /**
+     * @ORM\Column(type="datetime")
+     *
+     * @Gedmo\Timestampable(on="create")
+     */
+    #[ORM\Column(type: Types::DATETIME_MUTABLE)]
+    #[Gedmo\Timestampable(on: 'create')]
+    private ?\DateTime $created = null;
+
+    /**
+     * @ORM\Column(type="date")
+     *
+     * @Gedmo\Timestampable(on="update")
+     */
+    #[ORM\Column(type: Types::DATE_MUTABLE)]
+    #[Gedmo\Timestampable(on: 'update')]
+    private ?\DateTime $updated = null;
+
+    public function setCreated(\DateTime $created): void
+    {
+        $this->created = $created;
+    }
+
+    /**
+     * @return \DateTime $created
+     */
+    public function getCreated(): ?\DateTime
+    {
+        return $this->created;
+    }
+
+    public function setUpdated(\DateTime $updated): void
+    {
+        $this->updated = $updated;
+    }
+
+    public function getUpdated(): ?\DateTime
+    {
+        return $this->updated;
+    }
+
+    public function setLeft(int $left): self
+    {
+        $this->left = $left;
+
+        return $this;
+    }
+
+    public function getLeft(): int
+    {
+        return $this->left;
+    }
+
+    public function setRight(int $right): self
+    {
+        $this->right = $right;
+
+        return $this;
+    }
+
+    public function getRight(): int
+    {
+        return $this->right;
+    }
+
+    public function setLevel(int $level): self
+    {
+        $this->level = $level;
+
+        return $this;
+    }
+
+    public function getLevel(): int
+    {
+        return $this->level;
+    }
+
+    public function setRooted(int $rooted): self
+    {
+        $this->rooted = $rooted;
+
+        return $this;
+    }
+
+    public function getRooted(): int
+    {
+        return $this->rooted;
+    }
+}

--- a/tests/Gedmo/Mapping/Fixture/Category.php
+++ b/tests/Gedmo/Mapping/Fixture/Category.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Mapping\Fixture;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Loggable\Entity\LogEntry;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Gedmo\Sluggable\Handler\RelativeSlugHandler;
+use Gedmo\Sluggable\Handler\TreeSlugHandler;
+use Gedmo\Tests\Translatable\Fixture\CategoryTranslation;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="categories")
+ *
+ * @Gedmo\Loggable(logEntryClass="Gedmo\Loggable\Entity\LogEntry")
+ * @Gedmo\TranslationEntity(class="Gedmo\Tests\Translatable\Fixture\CategoryTranslation")
+ * @Gedmo\Tree(type="nested")
+ */
+#[ORM\Entity]
+#[ORM\Table(name: 'categories')]
+#[Gedmo\Loggable(logEntryClass: LogEntry::class)]
+#[Gedmo\TranslationEntity(class: CategoryTranslation::class)]
+#[Gedmo\Tree(type: 'nested')]
+class Category extends BaseCategory
+{
+    /**
+     * @var int
+     *
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    private $id;
+
+    /**
+     * @ORM\Column(type="string", length=64)
+     *
+     * @Gedmo\Translatable
+     */
+    #[ORM\Column(type: Types::STRING, length: 64)]
+    #[Gedmo\Translatable]
+    private ?string $title = null;
+
+    /**
+     * @ORM\Column(type="string", length=64)
+     *
+     * @Gedmo\Slug(
+     *     fields={"title"},
+     *     style="camel",
+     *     separator="_",
+     *     handlers={
+     *       @Gedmo\SlugHandler(class="Gedmo\Sluggable\Handler\RelativeSlugHandler", options={
+     *           @Gedmo\SlugHandlerOption(name="relationField", value="parent"),
+     *           @Gedmo\SlugHandlerOption(name="relationSlugField", value="parent"),
+     *           @Gedmo\SlugHandlerOption(name="separator", value="/")
+     *       }),
+     *       @Gedmo\SlugHandler(class="Gedmo\Sluggable\Handler\TreeSlugHandler", options={
+     *           @Gedmo\SlugHandlerOption(name="parentRelationField", value="parent"),
+     *           @Gedmo\SlugHandlerOption(name="separator", value="/")
+     *       })
+     *     }
+     * )
+     */
+    #[ORM\Column(type: Types::STRING, length: 64)]
+    #[Gedmo\Slug(fields: ['title'], style: 'camel', separator: '_')]
+    #[Gedmo\SlugHandler(class: RelativeSlugHandler::class, options: ['relationField' => 'parent', 'relationSlugField' => 'slug', 'separator' => '/'])]
+    #[Gedmo\SlugHandler(class: TreeSlugHandler::class, options: ['parentRelationField' => 'parent', 'separator' => '/'])]
+    private ?string $slug = null;
+
+    /**
+     * @var Collection<int, self>
+     *
+     * @ORM\OneToMany(targetEntity="Gedmo\Tests\Mapping\Fixture\Category", mappedBy="parent")
+     */
+    #[ORM\OneToMany(targetEntity: self::class, mappedBy: 'parent')]
+    private $children;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="Gedmo\Tests\Mapping\Fixture\Category", inversedBy="children")
+     *
+     * @Gedmo\TreeParent
+     */
+    #[ORM\ManyToOne(targetEntity: self::class, inversedBy: 'children')]
+    #[Gedmo\TreeParent]
+    private ?Category $parent = null;
+
+    /**
+     * @var \DateTime
+     *
+     * @ORM\Column(type="date")
+     *
+     * @Gedmo\Timestampable(on="change", field="title", value="Test")
+     */
+    #[ORM\Column(type: Types::DATE_MUTABLE)]
+    #[Gedmo\Timestampable(on: 'change', field: 'title', value: 'Test')]
+    private $changed;
+
+    public function __construct()
+    {
+        $this->children = new ArrayCollection();
+    }
+
+    /**
+     * @return int $id
+     */
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function setSlug(string $slug): void
+    {
+        $this->slug = $slug;
+    }
+
+    /**
+     * @return string $slug
+     */
+    public function getSlug(): string
+    {
+        return $this->slug;
+    }
+
+    public function addChildren(self $children): void
+    {
+        $this->children[] = $children;
+    }
+
+    /**
+     * @return Collection<int, self> $children
+     */
+    public function getChildren()
+    {
+        return $this->children;
+    }
+
+    public function setParent(self $parent): void
+    {
+        $this->parent = $parent;
+    }
+
+    /**
+     * @return self $parent
+     */
+    public function getParent(): self
+    {
+        return $this->parent;
+    }
+}

--- a/tests/Gedmo/Mapping/Fixture/Loggable.php
+++ b/tests/Gedmo/Mapping/Fixture/Loggable.php
@@ -9,6 +9,7 @@
 
 namespace Gedmo\Tests\Mapping\Fixture;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
@@ -17,6 +18,8 @@ use Gedmo\Mapping\Annotation as Gedmo;
  *
  * @Gedmo\Loggable
  */
+#[ORM\Entity]
+#[Gedmo\Loggable]
 class Loggable
 {
     /**
@@ -26,6 +29,9 @@ class Loggable
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
      */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     /**
@@ -33,6 +39,8 @@ class Loggable
      *
      * @Gedmo\Versioned
      */
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
+    #[Gedmo\Versioned]
     private ?string $title = null;
 
     public function getId(): int

--- a/tests/Gedmo/Mapping/Fixture/LoggableComposite.php
+++ b/tests/Gedmo/Mapping/Fixture/LoggableComposite.php
@@ -9,6 +9,7 @@
 
 namespace Gedmo\Tests\Mapping\Fixture;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
@@ -17,6 +18,8 @@ use Gedmo\Mapping\Annotation as Gedmo;
  *
  * @Gedmo\Loggable
  */
+#[ORM\Entity]
+#[Gedmo\Loggable]
 class LoggableComposite
 {
     /**
@@ -25,6 +28,8 @@ class LoggableComposite
      * @ORM\Id
      * @ORM\Column(type="integer")
      */
+    #[ORM\Id]
+    #[ORM\Column(type: Types::INTEGER)]
     private $one;
 
     /**
@@ -33,6 +38,8 @@ class LoggableComposite
      * @ORM\Id
      * @ORM\Column(type="integer")
      */
+    #[ORM\Id]
+    #[ORM\Column(type: Types::INTEGER)]
     private $two;
 
     /**
@@ -40,6 +47,8 @@ class LoggableComposite
      *
      * @Gedmo\Versioned
      */
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
+    #[Gedmo\Versioned]
     private ?string $title = null;
 
     public function getOne(): int

--- a/tests/Gedmo/Mapping/Fixture/LoggableCompositeRelation.php
+++ b/tests/Gedmo/Mapping/Fixture/LoggableCompositeRelation.php
@@ -9,6 +9,7 @@
 
 namespace Gedmo\Tests\Mapping\Fixture;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
@@ -17,6 +18,8 @@ use Gedmo\Mapping\Annotation as Gedmo;
  *
  * @Gedmo\Loggable
  */
+#[ORM\Entity]
+#[Gedmo\Loggable]
 class LoggableCompositeRelation
 {
     /**
@@ -25,6 +28,8 @@ class LoggableCompositeRelation
      * @ORM\Id
      * @ORM\ManyToOne(targetEntity="Loggable")
      */
+    #[ORM\Id]
+    #[ORM\ManyToOne(targetEntity: Loggable::class)]
     private $one;
 
     /**
@@ -33,6 +38,8 @@ class LoggableCompositeRelation
      * @ORM\Id
      * @ORM\Column(type="integer")
      */
+    #[ORM\Id]
+    #[ORM\Column(type: Types::INTEGER)]
     private $two;
 
     /**
@@ -40,6 +47,8 @@ class LoggableCompositeRelation
      *
      * @Gedmo\Versioned
      */
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
+    #[Gedmo\Versioned]
     private ?string $title = null;
 
     public function getOne(): Loggable

--- a/tests/Gedmo/Mapping/Fixture/SoftDeleteable.php
+++ b/tests/Gedmo/Mapping/Fixture/SoftDeleteable.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Gedmo\Tests\Mapping\Fixture;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
@@ -19,6 +20,8 @@ use Gedmo\Mapping\Annotation as Gedmo;
  *
  * @Gedmo\SoftDeleteable(fieldName="deletedAt")
  */
+#[ORM\Entity]
+#[Gedmo\SoftDeleteable(fieldName: 'deletedAt')]
 class SoftDeleteable
 {
     /**
@@ -28,6 +31,9 @@ class SoftDeleteable
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
      */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     private ?string $title = null;
@@ -44,6 +50,7 @@ class SoftDeleteable
      *
      * @ORM\Column(name="deleted_at", type="datetime", nullable=true)
      */
+    #[ORM\Column(name: 'deleted_at', type: Types::DATETIME_MUTABLE, nullable: true)]
     private $deletedAt;
 
     public function getId(): ?int

--- a/tests/Gedmo/Mapping/LoggableORMMappingTest.php
+++ b/tests/Gedmo/Mapping/LoggableORMMappingTest.php
@@ -11,71 +11,70 @@ declare(strict_types=1);
 
 namespace Gedmo\Tests\Mapping;
 
-use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\Common\EventManager;
-use Doctrine\DBAL\DriverManager;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
-use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Gedmo\Loggable\Entity\LogEntry;
 use Gedmo\Loggable\LoggableListener;
 use Gedmo\Mapping\ExtensionMetadataFactory;
-use Gedmo\Tests\Mapping\Fixture\Yaml\Category;
-use Gedmo\Tests\Mapping\Fixture\Yaml\LoggableComposite;
-use Gedmo\Tests\Mapping\Fixture\Yaml\LoggableCompositeRelation;
+use Gedmo\Tests\Mapping\Fixture\Category as AnnotatedCategory;
+use Gedmo\Tests\Mapping\Fixture\LoggableComposite as AnnotatedLoggableComposite;
+use Gedmo\Tests\Mapping\Fixture\LoggableCompositeRelation as AnnotatedLoggableCompositeRelation;
+use Gedmo\Tests\Mapping\Fixture\Xml\LoggableComposite as XmlLoggableComposite;
+use Gedmo\Tests\Mapping\Fixture\Xml\LoggableCompositeRelation as XmlLoggableCompositeRelation;
+use Gedmo\Tests\Mapping\Fixture\Yaml\Category as YamlCategory;
+use Gedmo\Tests\Mapping\Fixture\Yaml\LoggableComposite as YamlLoggableComposite;
+use Gedmo\Tests\Mapping\Fixture\Yaml\LoggableCompositeRelation as YamlLoggableCompositeRelation;
 
 /**
- * These are mapping tests for tree extension
+ * These are mapping tests for the loggable extension
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
 final class LoggableORMMappingTest extends ORMMappingTestCase
 {
-    private const YAML_CATEGORY = Category::class;
-    private const COMPOSITE = LoggableComposite::class;
-    private const COMPOSITE_RELATION = LoggableCompositeRelation::class;
-
     private EntityManager $em;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $config = $this->getBasicConfiguration();
+        $listener = new LoggableListener();
+        $listener->setCacheItemPool($this->cache);
 
-        $chain = new MappingDriverChain();
-
-        // TODO - The ORM's YAML mapping is deprecated and removed in 3.0
-        $chain->addDriver(new YamlDriver(__DIR__.'/Driver/Yaml'), 'Gedmo\Tests\Mapping\Fixture\Yaml');
-
-        if (PHP_VERSION_ID >= 80000 && class_exists(AttributeDriver::class)) {
-            $chain->addDriver(new AttributeDriver([]), 'Gedmo\Tests\Mapping\Fixture');
-        } else {
-            $chain->addDriver(new AnnotationDriver(new AnnotationReader()), 'Gedmo\Tests\Mapping\Fixture');
-        }
-
-        $config->setMetadataDriverImpl($chain);
-
-        $conn = [
-            'driver' => 'pdo_sqlite',
-            'memory' => true,
-        ];
-
-        $evm = new EventManager();
-        $loggableListener = new LoggableListener();
-        $loggableListener->setCacheItemPool($this->cache);
-        $evm->addEventSubscriber($loggableListener);
-        $connection = DriverManager::getConnection($conn, $config);
-        $this->em = new EntityManager($connection, $config, $evm);
+        $this->em = $this->getBasicEntityManager();
+        $this->em->getEventManager()->addEventSubscriber($listener);
     }
 
-    public function testLoggableMapping(): void
+    /**
+     * @return \Generator<string, array{class-string}>
+     */
+    public static function dataLoggableObject(): \Generator
+    {
+        if (PHP_VERSION_ID >= 80000 && class_exists(AttributeDriver::class)) {
+            yield 'Model with attributes' => [AnnotatedCategory::class];
+        }
+
+        if (class_exists(AnnotationDriver::class)) {
+            yield 'Model with annotations' => [AnnotatedCategory::class];
+        }
+
+        if (class_exists(YamlDriver::class)) {
+            yield 'Model with YAML mapping' => [YamlCategory::class];
+        }
+    }
+
+    /**
+     * @param class-string $className
+     *
+     * @dataProvider dataLoggableObject
+     */
+    public function testLoggableMapping(string $className): void
     {
         // Force metadata class loading.
-        $this->em->getClassMetadata(self::YAML_CATEGORY);
-        $cacheId = ExtensionMetadataFactory::getCacheId(self::YAML_CATEGORY, 'Gedmo\Loggable');
+        $this->em->getClassMetadata($className);
+        $cacheId = ExtensionMetadataFactory::getCacheId($className, 'Gedmo\Loggable');
         $config = $this->cache->getItem($cacheId)->get();
 
         static::assertArrayHasKey('loggable', $config);
@@ -84,28 +83,78 @@ final class LoggableORMMappingTest extends ORMMappingTestCase
         static::assertSame(LogEntry::class, $config['logEntryClass']);
     }
 
-    public function testLoggableCompositeMapping(): void
+    /**
+     * @return \Generator<string, array{class-string}>
+     */
+    public static function dataLoggableObjectWithCompositeKey(): \Generator
     {
-        $meta = $this->em->getClassMetadata(self::COMPOSITE);
+        yield 'Model with XML mapping' => [XmlLoggableComposite::class];
+
+        if (PHP_VERSION_ID >= 80000 && class_exists(AttributeDriver::class)) {
+            yield 'Model with attributes' => [AnnotatedLoggableComposite::class];
+        }
+
+        if (class_exists(AnnotationDriver::class)) {
+            yield 'Model with annotations' => [AnnotatedLoggableComposite::class];
+        }
+
+        if (class_exists(YamlDriver::class)) {
+            yield 'Model with YAML mapping' => [YamlLoggableComposite::class];
+        }
+    }
+
+    /**
+     * @param class-string $className
+     *
+     * @dataProvider dataLoggableObjectWithCompositeKey
+     */
+    public function testLoggableCompositeMapping(string $className): void
+    {
+        $meta = $this->em->getClassMetadata($className);
 
         static::assertIsArray($meta->identifier);
         static::assertCount(2, $meta->identifier);
 
-        $cacheId = ExtensionMetadataFactory::getCacheId(self::COMPOSITE, 'Gedmo\Loggable');
+        $cacheId = ExtensionMetadataFactory::getCacheId($className, 'Gedmo\Loggable');
         $config = $this->cache->getItem($cacheId)->get();
 
         static::assertArrayHasKey('loggable', $config);
         static::assertTrue($config['loggable']);
     }
 
-    public function testLoggableCompositeRelationMapping(): void
+    /**
+     * @return \Generator<string, array{class-string}>
+     */
+    public static function dataLoggableObjectWithCompositeKeyAndRelation(): \Generator
     {
-        $meta = $this->em->getClassMetadata(self::COMPOSITE_RELATION);
+        yield 'Model with XML mapping' => [XmlLoggableCompositeRelation::class];
+
+        if (PHP_VERSION_ID >= 80000 && class_exists(AttributeDriver::class)) {
+            yield 'Model with attributes' => [AnnotatedLoggableCompositeRelation::class];
+        }
+
+        if (class_exists(AnnotationDriver::class)) {
+            yield 'Model with annotations' => [AnnotatedLoggableCompositeRelation::class];
+        }
+
+        if (class_exists(YamlDriver::class)) {
+            yield 'Model with YAML mapping' => [YamlLoggableCompositeRelation::class];
+        }
+    }
+
+    /**
+     * @param class-string $className
+     *
+     * @dataProvider dataLoggableObjectWithCompositeKeyAndRelation
+     */
+    public function testLoggableCompositeRelationMapping(string $className): void
+    {
+        $meta = $this->em->getClassMetadata($className);
 
         static::assertIsArray($meta->identifier);
         static::assertCount(2, $meta->identifier);
 
-        $cacheId = ExtensionMetadataFactory::getCacheId(self::COMPOSITE_RELATION, 'Gedmo\Loggable');
+        $cacheId = ExtensionMetadataFactory::getCacheId($className, 'Gedmo\Loggable');
         $config = $this->cache->getItem($cacheId)->get();
 
         static::assertArrayHasKey('loggable', $config);


### PR DESCRIPTION
Ref: #2708

Right now there are a lot of tests that rely on the deprecated annotation and YAML drivers from the ORM to actually test anything.  This means in a lot of cases the XML mapping isn't explicitly tested in a mapping case (it is incidentally covered elsewhere), nor can the tests run without the deprecated Annotations package.  This is a first step at improving some of the test cases to be able to cover XML and explicitly test attribute mapping (and while all the extension-level attribute drivers are just an extension of their respective annotation drivers, there should be coverage when working purely in the context of attributes and not using the annotations package at all).

This PR refactors the loggable, sluggable, and soft-deleteable mapping tests to conditionally test mapping drivers based on whether the underlying dependencies are available so that the tests automatically skip themselves when needed while also supporting covering all mapping options.  I'm mostly building on and re-using existing test fixtures where they exist, and adding attributes where they don't exist on annotated classes, so some stuff might not exist at all right now (i.e. there isn't an XML mapping or fixture class for the `Category` models tested with other drivers).  Following this pattern for at least the mapping tests, this will help ensure explicit coverage on all drivers while only testing drivers that the environment supports.