### PR TITLE
Make the annotations package optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ a release.
 - SoftDeleteable: `Gedmo\SoftDeleteable\Event\PreSoftDeleteEventArgs` and
   `Gedmo\SoftDeleteable\Event\PostSoftDeleteEventArgs` classes.
 
+### Changed
+- Make doctrine/annotations an optional dependency.
+
 ### Deprecated
 - Do not add type-hinted parameters `Gedmo\SoftDeleteable\Event\PreSoftDeleteEventArgs` and
   `Gedmo\SoftDeleteable\Event\PostSoftDeleteEventArgs` classes to `preSoftDelete` and `postSoftDelete` events.

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,6 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "behat/transliterator": "^1.2",
-        "doctrine/annotations": "^1.13 || ^2.0",
         "doctrine/collections": "^1.2 || ^2.0",
         "doctrine/common": "^2.13 || ^3.0",
         "doctrine/event-manager": "^1.2 || ^2.0",
@@ -52,6 +51,7 @@
         "symfony/deprecation-contracts": "^2.1 || ^3.0"
     },
     "require-dev": {
+        "doctrine/annotations": "^1.13 || ^2.0",
         "doctrine/cache": "^1.11 || ^2.0",
         "doctrine/dbal": "^3.2",
         "doctrine/doctrine-bundle": "^2.3",
@@ -69,6 +69,7 @@
         "symfony/yaml": "^5.4 || ^6.0 || ^7.0"
     },
     "conflict": {
+        "doctrine/annotations": "<1.13 || >=3.0",
         "doctrine/dbal": "<3.2",
         "doctrine/mongodb-odm": "<2.3",
         "doctrine/orm": "<2.14.0 || 2.16.0 || 2.16.1",


### PR DESCRIPTION
Fix #2683

With all of the known dependencies to the Annotations package reviewed and adjusted, it should now be practical to make it an optional package.  And that's what this PR accomplishes.

It'd be hugely beneficial if folks would test this in downstream applications, especially if this package is the only reason `doctrine/annotations` gets installed in their application, to make sure the features they are using are not broken (I've done it in an app using the ORM plus the loggable and sortable extensions, but that's a very small amount of test coverage).  To apply this PR, update your `composer.json` as appropriate with this info:

```json
{
  "repositories": [
    {
      "type": "vcs",
      "url": "https://github.com/mbabker/DoctrineExtensions"
    }
  ],
  "require": {
    "gedmo/doctrine-extensions": "dev-optional-annotations as 3.15.0",
  }
}
```