### PR TITLE
Another round of mapping refactoring in tests for cross-version compatibility

### DIFF
--- a/tests/Gedmo/Mapping/Driver/Xml/Gedmo.Tests.Mapping.Fixture.Xml.User.dcm.xml
+++ b/tests/Gedmo/Mapping/Driver/Xml/Gedmo.Tests.Mapping.Fixture.Xml.User.dcm.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:gedmo="http://gediminasm.org/schemas/orm/doctrine-extensions-mapping">
+    <entity name="Gedmo\Tests\Mapping\Fixture\Xml\User" table="users">
+        <indexes>
+            <index name="search_idx" columns="username"/>
+        </indexes>
+        <id name="id" type="integer" column="id">
+            <generator strategy="IDENTITY"/>
+        </id>
+        <field name="password" type="string" column="password" length="32">
+            <gedmo:translatable/>
+        </field>
+        <field name="username" type="string" column="username" length="128">
+            <gedmo:translatable/>
+        </field>
+        <field name="company" type="string" column="company" length="128" nullable="true">
+            <gedmo:translatable fallback="true"/>
+        </field>
+        <gedmo:translation entity="Gedmo\Tests\Translatable\Fixture\PersonTranslation" locale="localeField"/>
+    </entity>
+</doctrine-mapping>

--- a/tests/Gedmo/Mapping/ExtensionORMTest.php
+++ b/tests/Gedmo/Mapping/ExtensionORMTest.php
@@ -58,6 +58,7 @@ final class ExtensionORMTest extends BaseTestCaseORM
         $user = new User();
         $user->setName('encode me');
         $user->setPassword('secret');
+        $user->setUsername('some_username');
         $this->em->persist($user);
         $this->em->flush();
 

--- a/tests/Gedmo/Mapping/Fixture/User.php
+++ b/tests/Gedmo/Mapping/Fixture/User.php
@@ -13,14 +13,24 @@ namespace Gedmo\Tests\Mapping\Fixture;
 
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
 use Gedmo\Tests\Mapping\Mock\Extension\Encoder\Mapping as Ext;
+use Gedmo\Tests\Translatable\Fixture\PersonTranslation;
 
 /**
- * @ORM\Table(name="test_users")
+ * @ORM\Table(name="users")
+ * @ORM\Table(
+ *     name="users",
+ *     indexes={@ORM\Index(name="search_idx", columns={"username"})}
+ * )
  * @ORM\Entity
+ *
+ * @Gedmo\TranslationEntity(class="Gedmo\Tests\Translatable\Fixture\PersonTranslation")
  */
-#[ORM\Table(name: 'test_users')]
+#[ORM\Table(name: 'users')]
 #[ORM\Entity]
+#[ORM\Index(columns: ['username'], name: 'search_idx')]
+#[Gedmo\TranslationEntity(class: PersonTranslation::class)]
 class User
 {
     /**
@@ -48,10 +58,39 @@ class User
      * @Ext\Encode(type="md5")
      *
      * @ORM\Column(length=32)
+     *
+     * @Gedmo\Translatable
      */
     #[Ext\Encode(type: 'md5')]
     #[ORM\Column(length: 32)]
+    #[Gedmo\Translatable]
     private ?string $password = null;
+
+    /**
+     * @ORM\Column(length=128)
+     *
+     * @Gedmo\Translatable
+     */
+    #[ORM\Column(length: 128)]
+    #[Gedmo\Translatable]
+    private ?string $username = null;
+
+    /**
+     * @ORM\Column(length=128, nullable=true)
+     *
+     * @Gedmo\Translatable(fallback=true)
+     */
+    #[ORM\Column(length: 128, nullable: true)]
+    #[Gedmo\Translatable(fallback: true)]
+    private ?string $company = null;
+
+    /**
+     * @var string
+     *
+     * @Gedmo\Locale
+     */
+    #[Gedmo\Locale]
+    private $localeField;
 
     public function setName(?string $name): void
     {
@@ -71,5 +110,25 @@ class User
     public function getPassword(): ?string
     {
         return $this->password;
+    }
+
+    public function setUsername(string $username): void
+    {
+        $this->username = $username;
+    }
+
+    public function getUsername(): string
+    {
+        return $this->username;
+    }
+
+    public function setCompany(string $company): void
+    {
+        $this->company = $company;
+    }
+
+    public function getCompany(): string
+    {
+        return $this->company;
     }
 }

--- a/tests/Gedmo/Mapping/Fixture/Xml/User.php
+++ b/tests/Gedmo/Mapping/Fixture/Xml/User.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Mapping\Fixture\Xml;
+
+class User
+{
+    /**
+     * @var int
+     */
+    private $id;
+
+    private ?string $password = null;
+
+    private ?string $username = null;
+
+    private ?string $company = null;
+
+    /**
+     * @var string
+     */
+    private $localeField;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function setPassword(string $password): void
+    {
+        $this->password = $password;
+    }
+
+    public function getPassword(): string
+    {
+        return $this->password;
+    }
+
+    public function setUsername(string $username): void
+    {
+        $this->username = $username;
+    }
+
+    public function getUsername(): string
+    {
+        return $this->username;
+    }
+
+    public function setCompany(string $company): void
+    {
+        $this->company = $company;
+    }
+
+    public function getCompany(): string
+    {
+        return $this->company;
+    }
+}

--- a/tests/Gedmo/Mapping/LoggableORMMappingTest.php
+++ b/tests/Gedmo/Mapping/LoggableORMMappingTest.php
@@ -13,7 +13,6 @@ namespace Gedmo\Tests\Mapping;
 
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
-use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
 use Gedmo\Loggable\Entity\LogEntry;
 use Gedmo\Loggable\LoggableListener;
@@ -58,7 +57,7 @@ final class LoggableORMMappingTest extends ORMMappingTestCase
      */
     public static function dataLoggableObject(): \Generator
     {
-        if (PHP_VERSION_ID >= 80000 && class_exists(AttributeDriver::class)) {
+        if (PHP_VERSION_ID >= 80000) {
             yield 'Model with attributes' => [AnnotatedLoggable::class];
         }
 
@@ -120,7 +119,7 @@ final class LoggableORMMappingTest extends ORMMappingTestCase
     {
         yield 'Model with XML mapping' => [XmlLoggableComposite::class];
 
-        if (PHP_VERSION_ID >= 80000 && class_exists(AttributeDriver::class)) {
+        if (PHP_VERSION_ID >= 80000) {
             yield 'Model with attributes' => [AnnotatedLoggableComposite::class];
         }
 
@@ -165,7 +164,7 @@ final class LoggableORMMappingTest extends ORMMappingTestCase
     {
         yield 'Model with XML mapping' => [XmlLoggableCompositeRelation::class];
 
-        if (PHP_VERSION_ID >= 80000 && class_exists(AttributeDriver::class)) {
+        if (PHP_VERSION_ID >= 80000) {
             yield 'Model with attributes' => [AnnotatedLoggableCompositeRelation::class];
         }
 
@@ -213,7 +212,7 @@ final class LoggableORMMappingTest extends ORMMappingTestCase
      */
     public static function dataLoggableObjectWithEmbedded(): \Generator
     {
-        if (PHP_VERSION_ID >= 80000 && class_exists(AttributeDriver::class)) {
+        if (PHP_VERSION_ID >= 80000) {
             yield 'Model with attributes' => [AnnotatedLoggableWithEmbedded::class];
         }
 

--- a/tests/Gedmo/Mapping/MappingEventSubscriberTest.php
+++ b/tests/Gedmo/Mapping/MappingEventSubscriberTest.php
@@ -12,8 +12,6 @@ declare(strict_types=1);
 namespace Gedmo\Tests\Mapping;
 
 use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\Common\EventManager;
-use Doctrine\DBAL\DriverManager;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
@@ -24,7 +22,6 @@ use Gedmo\Tests\Mapping\Fixture\Sluggable;
 use Gedmo\Tests\Mapping\Fixture\SuperClassExtension;
 use Gedmo\Tests\Mapping\Mock\Extension\Encoder\EncoderListener;
 use Psr\Cache\CacheItemPoolInterface;
-use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 final class MappingEventSubscriberTest extends ORMMappingTestCase
 {
@@ -36,18 +33,13 @@ final class MappingEventSubscriberTest extends ORMMappingTestCase
 
         $config = $this->getBasicConfiguration();
 
-        if (PHP_VERSION_ID >= 80000 && class_exists(AttributeDriver::class)) {
+        if (PHP_VERSION_ID >= 80000) {
             $config->setMetadataDriverImpl(new AttributeDriver([]));
         } else {
             $config->setMetadataDriverImpl(new AnnotationDriver(new AnnotationReader()));
         }
 
-        $conn = [
-            'driver' => 'pdo_sqlite',
-            'memory' => true,
-        ];
-
-        $this->em = new EntityManager(DriverManager::getConnection($conn, $config), $config, new EventManager());
+        $this->em = $this->getBasicEntityManager($config);
     }
 
     public function testGetMetadataFactoryCacheFromDoctrineForSluggable(): void
@@ -95,20 +87,13 @@ final class MappingEventSubscriberTest extends ORMMappingTestCase
         // Create new configuration to use new array cache
         $config = $this->getBasicConfiguration();
 
-        if (PHP_VERSION_ID >= 80000 && class_exists(AttributeDriver::class)) {
+        if (PHP_VERSION_ID >= 80000) {
             $config->setMetadataDriverImpl(new AttributeDriver([]));
         } else {
             $config->setMetadataDriverImpl(new AnnotationDriver(new AnnotationReader()));
         }
 
-        $config->setMetadataCache(new ArrayAdapter());
-
-        $conn = [
-            'driver' => 'pdo_sqlite',
-            'memory' => true,
-        ];
-
-        $this->em = new EntityManager(DriverManager::getConnection($conn, $config), $config, new EventManager());
+        $this->em = $this->getBasicEntityManager($config);
 
         $config = $subscriber->getExtensionMetadataFactory($this->em)->getExtensionMetadata($classMetadata);
 

--- a/tests/Gedmo/Mapping/MappingTest.php
+++ b/tests/Gedmo/Mapping/MappingTest.php
@@ -45,9 +45,8 @@ final class MappingTest extends TestCase
         $config = new Configuration();
         $config->setProxyDir(TESTS_TEMP_DIR);
         $config->setProxyNamespace('Gedmo\Mapping\Proxy');
-        // $this->markTestSkipped('Skipping according to a bug in annotation reader creation.');
 
-        if (PHP_VERSION_ID >= 80000 && class_exists(AttributeDriver::class)) {
+        if (PHP_VERSION_ID >= 80000) {
             $config->setMetadataDriverImpl(new AttributeDriver([]));
         } else {
             $config->setMetadataDriverImpl(new AnnotationDriver($_ENV['annotation_reader']));

--- a/tests/Gedmo/Mapping/MultiManagerMappingTest.php
+++ b/tests/Gedmo/Mapping/MultiManagerMappingTest.php
@@ -15,10 +15,12 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
-use Doctrine\ORM\Mapping\Driver\YamlDriver;
+use Doctrine\ORM\Mapping\Driver\AttributeDriver;
+use Doctrine\ORM\Mapping\Driver\XmlDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
-use Gedmo\Tests\Mapping\Fixture\Yaml\User;
-use Gedmo\Tests\Sluggable\Fixture\Document\Article;
+use Gedmo\Tests\Mapping\Fixture\Xml\User;
+use Gedmo\Tests\Sluggable\Fixture\Article as ArticleEntity;
+use Gedmo\Tests\Sluggable\Fixture\Document\Article as ArticleDocument;
 use Gedmo\Tests\Tool\BaseTestCaseOM;
 use Gedmo\Tests\Translatable\Fixture\PersonTranslation;
 
@@ -38,44 +40,53 @@ final class MultiManagerMappingTest extends BaseTestCaseOM
     protected function setUp(): void
     {
         parent::setUp();
-        // EM with standard annotation mapping
+
+        // EM with standard annotation/attribute mapping
         $this->em1 = $this->getDefaultMockSqliteEntityManager([
-            \Gedmo\Tests\Sluggable\Fixture\Article::class,
+            ArticleEntity::class,
         ]);
-        // EM with yaml and annotation mapping
-        $reader = new AnnotationReader();
-        $annotationDriver = new AnnotationDriver($reader);
 
-        $reader = new AnnotationReader();
-        $annotationDriver2 = new AnnotationDriver($reader);
+        // EM with XML and annotation/attribute mapping
+        if (PHP_VERSION_ID >= 80000) {
+            $annotationDriver = new AttributeDriver([]);
 
-        $yamlDriver = new YamlDriver(__DIR__.'/Driver/Yaml');
+            $annotationDriver2 = new AttributeDriver([]);
+        } else {
+            $reader = new AnnotationReader();
+            $annotationDriver = new AnnotationDriver($reader);
+
+            $reader = new AnnotationReader();
+            $annotationDriver2 = new AnnotationDriver($reader);
+        }
+
+        $xmlDriver = new XmlDriver(__DIR__.'/Driver/Xml');
 
         $chain = new MappingDriverChain();
         $chain->addDriver($annotationDriver, 'Gedmo\Tests\Translatable\Fixture');
-        $chain->addDriver($yamlDriver, 'Gedmo\Tests\Mapping\Fixture\Yaml');
+        $chain->addDriver($xmlDriver, 'Gedmo\Tests\Mapping\Fixture\Xml');
         $chain->addDriver($annotationDriver2, 'Gedmo\Translatable');
 
         $this->em2 = $this->getDefaultMockSqliteEntityManager([
             PersonTranslation::class,
             User::class,
         ], $chain);
-        // DM with standard annotation mapping
+
+        // DM with standard annotation/attribute mapping
         $this->dm1 = $this->getMockDocumentManager('gedmo_extensions_test');
     }
 
     public function testTwoDifferentManagers(): void
     {
         // Force metadata class loading.
-        $this->dm1->getClassMetadata(Article::class);
-        $dmArticle = new Article();
+        $this->dm1->getClassMetadata(ArticleDocument::class);
+        $dmArticle = new ArticleDocument();
         $dmArticle->setCode('code');
         $dmArticle->setTitle('title');
         $this->dm1->persist($dmArticle);
         $this->dm1->flush();
 
         static::assertSame('title-code', $dmArticle->getSlug());
-        $em1Article = new \Gedmo\Tests\Sluggable\Fixture\Article();
+        $em1Article = new ArticleEntity();
         $em1Article->setCode('code');
         $em1Article->setTitle('title');
         $this->em1->persist($em1Article);
@@ -86,7 +97,7 @@ final class MultiManagerMappingTest extends BaseTestCaseOM
 
     public function testTwoSameManagers(): void
     {
-        $em1Article = new \Gedmo\Tests\Sluggable\Fixture\Article();
+        $em1Article = new ArticleEntity();
         $em1Article->setCode('code');
         $em1Article->setTitle('title');
         $this->em1->persist($em1Article);

--- a/tests/Gedmo/Mapping/ORMMappingTestCase.php
+++ b/tests/Gedmo/Mapping/ORMMappingTestCase.php
@@ -74,7 +74,7 @@ abstract class ORMMappingTestCase extends TestCase
             $chain->addDriver(new YamlDriver(__DIR__.'/Driver/Yaml'), 'Gedmo\Tests\Mapping\Fixture\Yaml');
         }
 
-        if (PHP_VERSION_ID >= 80000 && class_exists(AttributeDriver::class)) {
+        if (PHP_VERSION_ID >= 80000) {
             $chain->addDriver(new AttributeDriver([]), 'Gedmo\Tests\Mapping\Fixture');
         }
 

--- a/tests/Gedmo/Mapping/SluggableMappingTest.php
+++ b/tests/Gedmo/Mapping/SluggableMappingTest.php
@@ -13,7 +13,6 @@ namespace Gedmo\Tests\Mapping;
 
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
-use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
 use Gedmo\Mapping\ExtensionMetadataFactory;
 use Gedmo\Sluggable\Handler\RelativeSlugHandler;
@@ -50,7 +49,7 @@ final class SluggableMappingTest extends ORMMappingTestCase
     {
         yield 'Model with XML mapping' => [XmlSluggable::class];
 
-        if (PHP_VERSION_ID >= 80000 && class_exists(AttributeDriver::class)) {
+        if (PHP_VERSION_ID >= 80000) {
             yield 'Model with attributes' => [AnnotatedSluggable::class];
         }
 

--- a/tests/Gedmo/Mapping/SoftDeleteableMappingTest.php
+++ b/tests/Gedmo/Mapping/SoftDeleteableMappingTest.php
@@ -13,7 +13,6 @@ namespace Gedmo\Tests\Mapping;
 
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
-use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
 use Gedmo\Mapping\ExtensionMetadataFactory;
 use Gedmo\SoftDeleteable\SoftDeleteableListener;
@@ -49,7 +48,7 @@ final class SoftDeleteableMappingTest extends ORMMappingTestCase
     {
         yield 'Model with XML mapping' => [XmlSoftDeleteable::class];
 
-        if (PHP_VERSION_ID >= 80000 && class_exists(AttributeDriver::class)) {
+        if (PHP_VERSION_ID >= 80000) {
             yield 'Model with attributes' => [AnnotatedSoftDeleteable::class];
         }
 

--- a/tests/Gedmo/Mapping/SortableMappingTest.php
+++ b/tests/Gedmo/Mapping/SortableMappingTest.php
@@ -13,7 +13,6 @@ namespace Gedmo\Tests\Mapping;
 
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
-use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
 use Gedmo\Mapping\ExtensionMetadataFactory;
 use Gedmo\Sortable\SortableListener;
@@ -43,14 +42,12 @@ final class SortableMappingTest extends ORMMappingTestCase
 
     /**
      * @return \Generator<string, array{class-string}>
-     *
-     * @note the XML fixture has a different mapping from the other configs, so it is tested separately
      */
     public static function dataSortableObject(): \Generator
     {
         yield 'Model with XML mapping' => [XmlSortable::class];
 
-        if (PHP_VERSION_ID >= 80000 && class_exists(AttributeDriver::class)) {
+        if (PHP_VERSION_ID >= 80000) {
             yield 'Model with attributes' => [AnnotatedSortable::class];
         }
 

--- a/tests/Gedmo/Mapping/TimestampableMappingTest.php
+++ b/tests/Gedmo/Mapping/TimestampableMappingTest.php
@@ -13,7 +13,6 @@ namespace Gedmo\Tests\Mapping;
 
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
-use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
 use Gedmo\Mapping\ExtensionMetadataFactory;
 use Gedmo\Tests\Mapping\Fixture\Category as AnnotatedCategory;
@@ -48,7 +47,7 @@ final class TimestampableMappingTest extends ORMMappingTestCase
      */
     public static function dataTimestampableObject(): \Generator
     {
-        if (PHP_VERSION_ID >= 80000 && class_exists(AttributeDriver::class)) {
+        if (PHP_VERSION_ID >= 80000) {
             yield 'Model with attributes' => [AnnotatedCategory::class];
         }
 

--- a/tests/Gedmo/Mapping/TreeMappingTest.php
+++ b/tests/Gedmo/Mapping/TreeMappingTest.php
@@ -12,8 +12,6 @@ declare(strict_types=1);
 namespace Gedmo\Tests\Mapping;
 
 use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\Common\EventManager;
-use Doctrine\DBAL\DriverManager;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
@@ -52,7 +50,7 @@ final class TreeMappingTest extends ORMMappingTestCase
         // TODO - The ORM's YAML mapping is deprecated and removed in 3.0
         $chain->addDriver(new YamlDriver(__DIR__.'/Driver/Yaml'), 'Gedmo\Tests\Mapping\Fixture\Yaml');
 
-        if (PHP_VERSION_ID >= 80000 && class_exists(AttributeDriver::class)) {
+        if (PHP_VERSION_ID >= 80000) {
             $annotationOrAttributeDriver = new AttributeDriver([]);
         } else {
             $annotationOrAttributeDriver = new AnnotationDriver(new AnnotationReader());
@@ -63,17 +61,11 @@ final class TreeMappingTest extends ORMMappingTestCase
 
         $config->setMetadataDriverImpl($chain);
 
-        $conn = [
-            'driver' => 'pdo_sqlite',
-            'memory' => true,
-        ];
-
         $this->listener = new TreeListener();
         $this->listener->setCacheItemPool($this->cache);
-        $evm = new EventManager();
-        $evm->addEventSubscriber($this->listener);
-        $connection = DriverManager::getConnection($conn, $config);
-        $this->em = new EntityManager($connection, $config, $evm);
+
+        $this->em = $this->getBasicEntityManager($config);
+        $this->em->getEventManager()->addEventSubscriber($this->listener);
     }
 
     /**

--- a/tests/Gedmo/Mapping/UploadableMappingTest.php
+++ b/tests/Gedmo/Mapping/UploadableMappingTest.php
@@ -13,7 +13,6 @@ namespace Gedmo\Tests\Mapping;
 
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
-use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
 use Gedmo\Mapping\ExtensionMetadataFactory;
 use Gedmo\Tests\Mapping\Fixture\Uploadable as AnnotatedUploadable;
@@ -53,7 +52,7 @@ final class UploadableMappingTest extends ORMMappingTestCase
     {
         yield 'Model with XML mapping' => [XmlUploadable::class];
 
-        if (PHP_VERSION_ID >= 80000 && class_exists(AttributeDriver::class)) {
+        if (PHP_VERSION_ID >= 80000) {
             yield 'Model with attributes' => [AnnotatedUploadable::class];
         }
 

--- a/tests/Gedmo/Mapping/Xml/ClosureTreeMappingTest.php
+++ b/tests/Gedmo/Mapping/Xml/ClosureTreeMappingTest.php
@@ -15,6 +15,7 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\EventManager;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Gedmo\Tests\Mapping\Fixture\ClosureTreeClosure;
@@ -37,8 +38,11 @@ final class ClosureTreeMappingTest extends BaseTestCaseOM
     {
         parent::setUp();
 
-        $reader = new AnnotationReader();
-        $annotationDriver = new AnnotationDriver($reader);
+        if (PHP_VERSION_ID >= 80000) {
+            $annotationDriver = new AttributeDriver([]);
+        } else {
+            $annotationDriver = new AnnotationDriver(new AnnotationReader());
+        }
 
         $xmlDriver = new XmlDriver(__DIR__.'/../Driver/Xml');
 

--- a/tests/Gedmo/Mapping/Xml/MaterializedPathTreeMappingTest.php
+++ b/tests/Gedmo/Mapping/Xml/MaterializedPathTreeMappingTest.php
@@ -15,6 +15,7 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\EventManager;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Gedmo\Tests\Mapping\Fixture\Xml\MaterializedPathTree;
@@ -37,8 +38,11 @@ final class MaterializedPathTreeMappingTest extends BaseTestCaseOM
     {
         parent::setUp();
 
-        $reader = new AnnotationReader();
-        $annotationDriver = new AnnotationDriver($reader);
+        if (PHP_VERSION_ID >= 80000) {
+            $annotationDriver = new AttributeDriver([]);
+        } else {
+            $annotationDriver = new AnnotationDriver(new AnnotationReader());
+        }
 
         $xmlDriver = new XmlDriver(__DIR__.'/../Driver/Xml');
 

--- a/tests/Gedmo/Mapping/Xml/ReferencesMappingTest.php
+++ b/tests/Gedmo/Mapping/Xml/ReferencesMappingTest.php
@@ -15,6 +15,7 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\EventManager;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Gedmo\References\ReferencesListener;
@@ -34,8 +35,11 @@ final class ReferencesMappingTest extends BaseTestCaseOM
     {
         parent::setUp();
 
-        $reader = new AnnotationReader();
-        $annotationDriver = new AnnotationDriver($reader);
+        if (PHP_VERSION_ID >= 80000) {
+            $annotationDriver = new AttributeDriver([]);
+        } else {
+            $annotationDriver = new AnnotationDriver(new AnnotationReader());
+        }
 
         $xmlDriver = new XmlDriver(__DIR__.'/../Driver/Xml');
 

--- a/tests/Gedmo/Mapping/Xml/TranslatableMappingTest.php
+++ b/tests/Gedmo/Mapping/Xml/TranslatableMappingTest.php
@@ -15,6 +15,7 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\EventManager;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Gedmo\Tests\Mapping\Fixture\Xml\Translatable;
@@ -38,8 +39,11 @@ final class TranslatableMappingTest extends BaseTestCaseOM
     {
         parent::setUp();
 
-        $reader = new AnnotationReader();
-        $annotationDriver = new AnnotationDriver($reader);
+        if (PHP_VERSION_ID >= 80000) {
+            $annotationDriver = new AttributeDriver([]);
+        } else {
+            $annotationDriver = new AnnotationDriver(new AnnotationReader());
+        }
 
         $xmlDriver = new XmlDriver(__DIR__.'/../Driver/Xml');
 

--- a/tests/Gedmo/Sluggable/Fixture/Issue116/Country.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue116/Country.php
@@ -11,23 +11,53 @@ declare(strict_types=1);
 
 namespace Gedmo\Tests\Sluggable\Fixture\Issue116;
 
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="sta_country")
+ */
+#[ORM\Entity]
+#[ORM\Table(name: 'sta_country')]
 class Country
 {
     /**
      * @var int|null
+     *
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
      */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     /**
      * @var string|null
+     *
+     * @ORM\Column(type="string", length=10, nullable=true)
      */
+    #[ORM\Column(type: Types::STRING, length: 10, nullable: true)]
     private $languageCode;
 
+    /**
+     * @ORM\Column(type="string", length=50)
+     */
+    #[ORM\Column(type: Types::STRING, length: 50)]
     private ?string $originalName = null;
 
     /**
      * @var string|null
+     *
+     * @ORM\Column(type="string", length=50)
+     *
+     * @Gedmo\Slug(separator="-", fields={"originalName"})
      */
+    #[ORM\Column(type: Types::STRING, length: 50)]
+    #[Gedmo\Slug(separator: '-', fields: ['originalName'])]
     private $alias;
 
     public function getId(): ?int

--- a/tests/Gedmo/Sluggable/Issue/Issue116Test.php
+++ b/tests/Gedmo/Sluggable/Issue/Issue116Test.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Gedmo\Tests\Sluggable\Issue;
 
 use Doctrine\Common\EventManager;
+use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
@@ -52,10 +53,15 @@ final class Issue116Test extends BaseTestCaseORM
     protected function getMetadataDriverImplementation(): MappingDriver
     {
         $chain = new MappingDriverChain();
-        $chain->addDriver(
-            new YamlDriver([__DIR__.'/../Fixture/Issue116/Mapping']),
-            'Gedmo\Tests\Sluggable\Fixture\Issue116'
-        );
+
+        if (PHP_VERSION_ID >= 80000) {
+            $chain->addDriver(new AttributeDriver([]), 'Gedmo\Tests\Sluggable\Fixture\Issue116');
+        } else {
+            $chain->addDriver(
+                new YamlDriver([__DIR__.'/../Fixture/Issue116/Mapping']),
+                'Gedmo\Tests\Sluggable\Fixture\Issue116'
+            );
+        }
 
         return $chain;
     }


### PR DESCRIPTION
Ref: #2708

We don't need to check for class presence on the ORM's attribute driver, we're well past the version that was introduced as a minimum requirement.  Other than that, just some more fixture generation/synchronization and adjusting test setup to always use attributes on PHP 8 instead of hard requiring the annotation driver.