### PR TITLE
symfony.md - add missing use statements for DoctrineExtensionSubscriber

### DIFF
--- a/doc/symfony.md
+++ b/doc/symfony.md
@@ -273,28 +273,22 @@ Gedmo\Loggable\LoggableListener:
 namespace App\EventSubscriber;
 
 use Gedmo\Blameable\BlameableListener;
+use Gedmo\Loggable\LoggableListener;
+use Gedmo\Translatable\TranslatableListener;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 final class DoctrineExtensionSubscriber implements EventSubscriberInterface
 {
-    /**
-     * @var BlameableListener
-     */
-    private $blameableListener;
-    /**
-     * @var TokenStorageInterface
-     */
-    private $tokenStorage;
-    /**
-     * @var TranslatableListener
-     */
-    private $translatableListener;
-    /**
-     * @var LoggableListener
-     */
-    private $loggableListener;
+    private BlameableListener $blameableListener;
+
+    private TokenStorageInterface $tokenStorage;
+
+    private TranslatableListener $translatableListener;
+
+    private LoggableListener $loggableListener;
 
 
     public function __construct(
@@ -307,7 +301,7 @@ final class DoctrineExtensionSubscriber implements EventSubscriberInterface
         $this->tokenStorage = $tokenStorage;
         $this->translatableListener = $translatableListener;
         $this->loggableListener = $loggableListener;
-    }    
+    }
 
 
     public static function getSubscribedEvents(): array
@@ -319,19 +313,18 @@ final class DoctrineExtensionSubscriber implements EventSubscriberInterface
     }
     public function onKernelRequest(): void
     {
-        if ($this->tokenStorage !== null &&
+        if (
             $this->tokenStorage->getToken() !== null &&
             $this->tokenStorage->getToken()->getUser() !== null
         ) {
             $this->blameableListener->setUserValue($this->tokenStorage->getToken()->getUser());
         }
     }
-    
+
     public function onLateKernelRequest(FinishRequestEvent $event): void
     {
         $this->translatableListener->setTranslatableLocale($event->getRequest()->getLocale());
     }
-
 }
 ```
 


### PR DESCRIPTION
- added missing use statements
- upgraded the example PHP 7.4
- removed unnecessary if check