### PR TITLE
Remove the `@internal` annotation from the attribute reader

### DIFF
--- a/src/Mapping/Driver/AttributeReader.php
+++ b/src/Mapping/Driver/AttributeReader.php
@@ -13,8 +13,6 @@ use Gedmo\Mapping\Annotation\Annotation;
 
 /**
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
- *
- * @internal
  */
 final class AttributeReader
 {


### PR DESCRIPTION
`Gedmo\Mapping\Driver\AttributeReader` isn't really internal.  If you're running an application that doesn't actually use annotations (but the annotations library still gets installed because of dependencies like this one where there's still a hard coupling), the only way to actually configure this library to not use annotations is to use this `@internal` annotated class.  Which is also typehinted in a fairly decent number of public APIs.  So, let's just remove the annotation.