### PR TITLE
[Tree] Allow multiple order critieria in reorder and reorderAll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,9 @@ a release.
 - Make doctrine/annotations an optional dependency.
 - Remove `@internal` annotation from `Gedmo\Mapping\Driver\AttributeReader`.
 
+## Changed
+- Allow string[] as `$sortByField` and `$direction` parameter in  `\Gedmo\Tree\Entity\Repository\NestedTreeRepository::reorder` and `\Gedmo\Tree\Entity\Repository\NestedTreeRepository::reorderAll`
+
 ### Deprecated
 - Do not add type-hinted parameters `Gedmo\SoftDeleteable\Event\PreSoftDeleteEventArgs` and
   `Gedmo\SoftDeleteable\Event\PostSoftDeleteEventArgs` classes to `preSoftDelete` and `postSoftDelete` events.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ a release.
 ### Deprecated
 - Sluggable: Annotation-specific mapping parameters (#2837)
 
+### Changed
+- Allow `string[]` as `$sortByField` and `$direction` parameter in  `\Gedmo\Tree\Entity\Repository\NestedTreeRepository::reorder()` and `\Gedmo\Tree\Entity\Repository\NestedTreeRepository::reorderAll()`
+
+
 ### Fixed
 - Fix regression with `doctrine/dbal` >= 4.0 that caused MariaDB to improperly attempt LONGTEXT casting in `TranslationWalker` (issue #2887)
 - Tree: allow usage of UuidV4 as path source with the materialized path strategy
@@ -66,9 +70,6 @@ a release.
 ### Changed
 - Make doctrine/annotations an optional dependency.
 - Remove `@internal` annotation from `Gedmo\Mapping\Driver\AttributeReader`.
-
-## Changed
-- Allow string[] as `$sortByField` and `$direction` parameter in  `\Gedmo\Tree\Entity\Repository\NestedTreeRepository::reorder` and `\Gedmo\Tree\Entity\Repository\NestedTreeRepository::reorderAll`
 
 ### Deprecated
 - Do not add type-hinted parameters `Gedmo\SoftDeleteable\Event\PreSoftDeleteEventArgs` and

--- a/src/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/src/Tree/Entity/Repository/NestedTreeRepository.php
@@ -801,11 +801,11 @@ class NestedTreeRepository extends AbstractTreeRepository
      * Reorders $node's child nodes,
      * according to the $sortByField and $direction specified
      *
-     * @param object|null $node        node from which to start reordering the tree; null will reorder everything
-     * @param string      $sortByField field name to sort by
-     * @param string      $direction   sort direction : "ASC" or "DESC"
-     * @param bool        $verify      true to verify tree first
-     * @param bool        $recursive   true to also reorder further descendants, not just the direct children
+     * @param object|null          $node        node from which to start reordering the tree; null will reorder everything
+     * @param string|string[]|null $sortByField Field name or array of fields names to sort by
+     * @param string|string[]      $direction   Sort order ('asc'|'desc'|'ASC'|'DESC'). If $sortByField is an array, this may also be an array with matching number of elements
+     * @param bool                 $verify      true to verify tree first
+     * @param bool                 $recursive   true to also reorder further descendants, not just the direct children
      *
      * @return void
      */
@@ -836,9 +836,9 @@ class NestedTreeRepository extends AbstractTreeRepository
     /**
      * Reorders all nodes in the tree according to the $sortByField and $direction specified.
      *
-     * @param string $sortByField field name to sort by
-     * @param string $direction   sort direction : "ASC" or "DESC"
-     * @param bool   $verify      true to verify tree first
+     * @param string|string[]|null $sortByField Field name or array of fields names to sort by
+     * @param string|string[]      $direction   Sort order ('asc'|'desc'|'ASC'|'DESC'). If $sortByField is an array, this may also be an array with matching number of elements
+     * @param bool                 $verify      true to verify tree first
      *
      * @return void
      */

--- a/tests/Gedmo/Tree/NestedTreeRootRepositoryTest.php
+++ b/tests/Gedmo/Tree/NestedTreeRootRepositoryTest.php
@@ -418,6 +418,31 @@ final class NestedTreeRootRepositoryTest extends BaseTestCaseORM
         static::assertSame(9, $node->getLeft());
         static::assertSame(10, $node->getRight());
 
+        // reorder (multiple order critieria)
+
+        $node = $repo->findOneBy(['title' => 'Vegitables']);
+        $repo->reorder($node, ['level', 'title'], ['ASC', 'DESC'], false, false);
+
+        $node = $repo->findOneBy(['title' => 'Cabbages']);
+
+        static::assertSame(9, $node->getLeft());
+        static::assertSame(10, $node->getRight());
+
+        $node = $repo->findOneBy(['title' => 'Carrots']);
+
+        static::assertSame(7, $node->getLeft());
+        static::assertSame(8, $node->getRight());
+
+        $node = $repo->findOneBy(['title' => 'Onions']);
+
+        static::assertSame(5, $node->getLeft());
+        static::assertSame(6, $node->getRight());
+
+        $node = $repo->findOneBy(['title' => 'Potatoes']);
+
+        static::assertSame(3, $node->getLeft());
+        static::assertSame(4, $node->getRight());
+
         // reorder
 
         $node = $repo->findOneBy(['title' => 'Food']);


### PR DESCRIPTION
The functions `\Gedmo\Tree\Entity\Repository\NestedTreeRepository::reorder` and `\Gedmo\Tree\Entity\Repository\NestedTreeRepository::reorderAll` both take the parameters `$sortByField` and `$direction` with the type `?string`. By allowing string arrays as well, the functions allow reordering with multiple order criteria (e.g. sort by category and date).