### PR TITLE
Standardize runtime deprecation handling to the `doctrine/deprecations` library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,11 +44,11 @@
         "behat/transliterator": "^1.2",
         "doctrine/collections": "^1.2 || ^2.0",
         "doctrine/common": "^2.13 || ^3.0",
+        "doctrine/deprecations": "^1.0",
         "doctrine/event-manager": "^1.2 || ^2.0",
         "doctrine/persistence": "^2.2 || ^3.0",
         "psr/cache": "^1 || ^2 || ^3",
-        "symfony/cache": "^5.4 || ^6.0 || ^7.0",
-        "symfony/deprecation-contracts": "^2.1 || ^3.0"
+        "symfony/cache": "^5.4 || ^6.0 || ^7.0"
     },
     "require-dev": {
         "doctrine/annotations": "^1.13 || ^2.0",

--- a/src/DoctrineExtensions.php
+++ b/src/DoctrineExtensions.php
@@ -12,6 +12,7 @@ namespace Gedmo;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\PsrCachedReader;
 use Doctrine\Common\Annotations\Reader;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ODM\MongoDB\Mapping\Driver as DriverMongodbODM;
 use Doctrine\ORM\Mapping\Driver as DriverORM;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
@@ -120,10 +121,12 @@ final class DoctrineExtensions
      */
     public static function registerAnnotations(): void
     {
-        @trigger_error(sprintf(
+        Deprecation::trigger(
+            'gedmo/doctrine-extensions',
+            'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2558',
             '"%s()" is deprecated since gedmo/doctrine-extensions 3.11 and will be removed in version 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        );
 
         // Purposefully no-op'd, all supported versions of `doctrine/annotations` support autoloading
     }

--- a/src/Mapping/Annotation/All.php
+++ b/src/Mapping/Annotation/All.php
@@ -7,10 +7,14 @@
  * file that was distributed with this source code.
  */
 
-@trigger_error(sprintf(
+use Doctrine\Deprecations\Deprecation;
+
+Deprecation::trigger(
+    'gedmo/doctrine-extensions',
+    'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2558',
     'Requiring the file at "%s" is deprecated since gedmo/doctrine-extensions 3.11, this file will be removed in version 4.0.',
     __FILE__
-), E_USER_DEPRECATED);
+);
 
 // Contains all annotations for extensions
 // NOTE: should be included with require_once

--- a/src/Mapping/Annotation/Blameable.php
+++ b/src/Mapping/Annotation/Blameable.php
@@ -10,6 +10,7 @@
 namespace Gedmo\Mapping\Annotation;
 
 use Doctrine\Common\Annotations\Annotation;
+use Doctrine\Deprecations\Deprecation;
 use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 
 /**
@@ -42,10 +43,12 @@ final class Blameable implements GedmoAnnotation
     public function __construct(array $data = [], string $on = 'update', $field = null, $value = null)
     {
         if ([] !== $data) {
-            @trigger_error(sprintf(
+            Deprecation::trigger(
+                'gedmo/doctrine-extensions',
+                'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2375',
                 'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            );
 
             $args = func_get_args();
 

--- a/src/Mapping/Annotation/IpTraceable.php
+++ b/src/Mapping/Annotation/IpTraceable.php
@@ -10,6 +10,7 @@
 namespace Gedmo\Mapping\Annotation;
 
 use Doctrine\Common\Annotations\Annotation;
+use Doctrine\Deprecations\Deprecation;
 use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 
 /**
@@ -43,10 +44,12 @@ final class IpTraceable implements GedmoAnnotation
     public function __construct(array $data = [], string $on = 'update', $field = null, $value = null)
     {
         if ([] !== $data) {
-            @trigger_error(sprintf(
+            Deprecation::trigger(
+                'gedmo/doctrine-extensions',
+                'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2377',
                 'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            );
 
             $args = func_get_args();
 

--- a/src/Mapping/Annotation/Loggable.php
+++ b/src/Mapping/Annotation/Loggable.php
@@ -10,6 +10,7 @@
 namespace Gedmo\Mapping\Annotation;
 
 use Doctrine\Common\Annotations\Annotation;
+use Doctrine\Deprecations\Deprecation;
 use Gedmo\Loggable\LogEntryInterface;
 use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 
@@ -46,10 +47,12 @@ final class Loggable implements GedmoAnnotation
     public function __construct(array $data = [], ?string $logEntryClass = null)
     {
         if ([] !== $data) {
-            @trigger_error(sprintf(
+            Deprecation::trigger(
+                'gedmo/doctrine-extensions',
+                'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2357',
                 'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            );
 
             $args = func_get_args();
 

--- a/src/Mapping/Annotation/Reference.php
+++ b/src/Mapping/Annotation/Reference.php
@@ -10,6 +10,7 @@
 namespace Gedmo\Mapping\Annotation;
 
 use Doctrine\Common\Annotations\Annotation;
+use Doctrine\Deprecations\Deprecation;
 use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 
 /**
@@ -67,10 +68,12 @@ abstract class Reference implements GedmoAnnotation
         ?string $inversedBy = null
     ) {
         if ([] !== $data) {
-            @trigger_error(sprintf(
+            Deprecation::trigger(
+                'gedmo/doctrine-extensions',
+                'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2389',
                 'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            );
 
             $args = func_get_args();
 

--- a/src/Mapping/Annotation/ReferenceIntegrity.php
+++ b/src/Mapping/Annotation/ReferenceIntegrity.php
@@ -10,6 +10,7 @@
 namespace Gedmo\Mapping\Annotation;
 
 use Doctrine\Common\Annotations\Annotation;
+use Doctrine\Deprecations\Deprecation;
 use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 
 /**
@@ -39,10 +40,12 @@ final class ReferenceIntegrity implements GedmoAnnotation
         if (is_string($data)) {
             $value = $data;
         } elseif ([] !== $data) {
-            @trigger_error(sprintf(
+            Deprecation::trigger(
+                'gedmo/doctrine-extensions',
+                'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2389',
                 'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            );
 
             $args = func_get_args();
 

--- a/src/Mapping/Annotation/Slug.php
+++ b/src/Mapping/Annotation/Slug.php
@@ -10,6 +10,7 @@
 namespace Gedmo\Mapping\Annotation;
 
 use Doctrine\Common\Annotations\Annotation;
+use Doctrine\Deprecations\Deprecation;
 use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 
 /**
@@ -65,10 +66,12 @@ final class Slug implements GedmoAnnotation
         string $dateFormat = 'Y-m-d-H:i'
     ) {
         if ([] !== $data) {
-            @trigger_error(sprintf(
+            Deprecation::trigger(
+                'gedmo/doctrine-extensions',
+                'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2379',
                 'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            );
 
             $args = func_get_args();
 

--- a/src/Mapping/Annotation/SlugHandler.php
+++ b/src/Mapping/Annotation/SlugHandler.php
@@ -10,6 +10,7 @@
 namespace Gedmo\Mapping\Annotation;
 
 use Doctrine\Common\Annotations\Annotation;
+use Doctrine\Deprecations\Deprecation;
 use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 use Gedmo\Sluggable\Handler\SlugHandlerInterface;
 
@@ -49,10 +50,12 @@ final class SlugHandler implements GedmoAnnotation
         array $options = []
     ) {
         if ([] !== $data) {
-            @trigger_error(sprintf(
+            Deprecation::trigger(
+                'gedmo/doctrine-extensions',
+                'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2379',
                 'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            );
 
             $args = func_get_args();
 

--- a/src/Mapping/Annotation/SlugHandlerOption.php
+++ b/src/Mapping/Annotation/SlugHandlerOption.php
@@ -10,6 +10,7 @@
 namespace Gedmo\Mapping\Annotation;
 
 use Doctrine\Common\Annotations\Annotation;
+use Doctrine\Deprecations\Deprecation;
 use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 
 /**
@@ -42,10 +43,12 @@ final class SlugHandlerOption implements GedmoAnnotation
         $value = null
     ) {
         if ([] !== $data) {
-            @trigger_error(sprintf(
+            Deprecation::trigger(
+                'gedmo/doctrine-extensions',
+                'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2379',
                 'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            );
 
             $args = func_get_args();
 

--- a/src/Mapping/Annotation/SoftDeleteable.php
+++ b/src/Mapping/Annotation/SoftDeleteable.php
@@ -10,6 +10,7 @@
 namespace Gedmo\Mapping\Annotation;
 
 use Doctrine\Common\Annotations\Annotation;
+use Doctrine\Deprecations\Deprecation;
 use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 
 /**
@@ -40,10 +41,12 @@ final class SoftDeleteable implements GedmoAnnotation
     public function __construct(array $data = [], string $fieldName = 'deletedAt', bool $timeAware = false, bool $hardDelete = true)
     {
         if ([] !== $data) {
-            @trigger_error(sprintf(
+            Deprecation::trigger(
+                'gedmo/doctrine-extensions',
+                'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2374',
                 'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            );
 
             $args = func_get_args();
 

--- a/src/Mapping/Annotation/Timestampable.php
+++ b/src/Mapping/Annotation/Timestampable.php
@@ -10,6 +10,7 @@
 namespace Gedmo\Mapping\Annotation;
 
 use Doctrine\Common\Annotations\Annotation;
+use Doctrine\Deprecations\Deprecation;
 use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 
 /**
@@ -42,10 +43,12 @@ final class Timestampable implements GedmoAnnotation
     public function __construct(array $data = [], string $on = 'update', $field = null, $value = null)
     {
         if ([] !== $data) {
-            @trigger_error(sprintf(
+            Deprecation::trigger(
+                'gedmo/doctrine-extensions',
+                'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2325',
                 'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            );
 
             $args = func_get_args();
 

--- a/src/Mapping/Annotation/Translatable.php
+++ b/src/Mapping/Annotation/Translatable.php
@@ -10,6 +10,7 @@
 namespace Gedmo\Mapping\Annotation;
 
 use Doctrine\Common\Annotations\Annotation;
+use Doctrine\Deprecations\Deprecation;
 use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 
 /**
@@ -37,10 +38,12 @@ final class Translatable implements GedmoAnnotation
     public function __construct(array $data = [], ?bool $fallback = null)
     {
         if ([] !== $data) {
-            @trigger_error(sprintf(
+            Deprecation::trigger(
+                'gedmo/doctrine-extensions',
+                'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2253',
                 'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            );
 
             $args = func_get_args();
 

--- a/src/Mapping/Annotation/TranslationEntity.php
+++ b/src/Mapping/Annotation/TranslationEntity.php
@@ -10,6 +10,7 @@
 namespace Gedmo\Mapping\Annotation;
 
 use Doctrine\Common\Annotations\Annotation;
+use Doctrine\Deprecations\Deprecation;
 use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 
 /**
@@ -37,10 +38,12 @@ final class TranslationEntity implements GedmoAnnotation
     public function __construct(array $data = [], string $class = '')
     {
         if ([] !== $data) {
-            @trigger_error(sprintf(
+            Deprecation::trigger(
+                'gedmo/doctrine-extensions',
+                'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2253',
                 'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            );
 
             $args = func_get_args();
 

--- a/src/Mapping/Annotation/Tree.php
+++ b/src/Mapping/Annotation/Tree.php
@@ -10,6 +10,7 @@
 namespace Gedmo\Mapping\Annotation;
 
 use Doctrine\Common\Annotations\Annotation;
+use Doctrine\Deprecations\Deprecation;
 use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 
 /**
@@ -60,10 +61,12 @@ final class Tree implements GedmoAnnotation
         ?string $identifierMethod = null
     ) {
         if ([] !== $data) {
-            @trigger_error(sprintf(
+            Deprecation::trigger(
+                'gedmo/doctrine-extensions',
+                'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2388',
                 'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            );
 
             $args = func_get_args();
 

--- a/src/Mapping/Annotation/TreeClosure.php
+++ b/src/Mapping/Annotation/TreeClosure.php
@@ -10,6 +10,7 @@
 namespace Gedmo\Mapping\Annotation;
 
 use Doctrine\Common\Annotations\Annotation;
+use Doctrine\Deprecations\Deprecation;
 use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 use Gedmo\Tree\Entity\MappedSuperclass\AbstractClosure;
 
@@ -42,10 +43,12 @@ final class TreeClosure implements GedmoAnnotation
     public function __construct(array $data = [], string $class = '')
     {
         if ([] !== $data) {
-            @trigger_error(sprintf(
+            Deprecation::trigger(
+                'gedmo/doctrine-extensions',
+                'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2388',
                 'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            );
 
             $args = func_get_args();
 

--- a/src/Mapping/Annotation/TreeLevel.php
+++ b/src/Mapping/Annotation/TreeLevel.php
@@ -10,6 +10,7 @@
 namespace Gedmo\Mapping\Annotation;
 
 use Doctrine\Common\Annotations\Annotation;
+use Doctrine\Deprecations\Deprecation;
 use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 
 /**
@@ -41,10 +42,12 @@ final class TreeLevel implements GedmoAnnotation
         int $base = 0
     ) {
         if ([] !== $data) {
-            @trigger_error(sprintf(
+            Deprecation::trigger(
+                'gedmo/doctrine-extensions',
+                'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2388',
                 'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            );
 
             $args = func_get_args();
 

--- a/src/Mapping/Annotation/TreePath.php
+++ b/src/Mapping/Annotation/TreePath.php
@@ -10,6 +10,7 @@
 namespace Gedmo\Mapping\Annotation;
 
 use Doctrine\Common\Annotations\Annotation;
+use Doctrine\Deprecations\Deprecation;
 use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 
 /**
@@ -50,10 +51,12 @@ final class TreePath implements GedmoAnnotation
         bool $endsWithSeparator = true
     ) {
         if ([] !== $data) {
-            @trigger_error(sprintf(
+            Deprecation::trigger(
+                'gedmo/doctrine-extensions',
+                'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2388',
                 'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            );
 
             $args = func_get_args();
 

--- a/src/Mapping/Annotation/TreeRoot.php
+++ b/src/Mapping/Annotation/TreeRoot.php
@@ -10,6 +10,7 @@
 namespace Gedmo\Mapping\Annotation;
 
 use Doctrine\Common\Annotations\Annotation;
+use Doctrine\Deprecations\Deprecation;
 use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 
 /**
@@ -37,10 +38,12 @@ final class TreeRoot implements GedmoAnnotation
     public function __construct(array $data = [], ?string $identifierMethod = null)
     {
         if ([] !== $data) {
-            @trigger_error(sprintf(
+            Deprecation::trigger(
+                'gedmo/doctrine-extensions',
+                'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2388',
                 'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            );
 
             $args = func_get_args();
 

--- a/src/Mapping/Annotation/Uploadable.php
+++ b/src/Mapping/Annotation/Uploadable.php
@@ -10,6 +10,7 @@
 namespace Gedmo\Mapping\Annotation;
 
 use Doctrine\Common\Annotations\Annotation;
+use Doctrine\Deprecations\Deprecation;
 use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 use Gedmo\Uploadable\FilenameGenerator\FilenameGeneratorInterface;
 use Gedmo\Uploadable\Mapping\Validator;
@@ -74,10 +75,12 @@ final class Uploadable implements GedmoAnnotation
         string $disallowedTypes = ''
     ) {
         if ([] !== $data) {
-            @trigger_error(sprintf(
+            Deprecation::trigger(
+                'gedmo/doctrine-extensions',
+                'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2386',
                 'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            );
 
             $args = func_get_args();
 

--- a/src/Mapping/Driver/AbstractAnnotationDriver.php
+++ b/src/Mapping/Driver/AbstractAnnotationDriver.php
@@ -10,6 +10,7 @@
 namespace Gedmo\Mapping\Driver;
 
 use Doctrine\Common\Annotations\Reader;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 
@@ -47,9 +48,9 @@ abstract class AbstractAnnotationDriver implements AnnotationDriverInterface
     public function setAnnotationReader($reader)
     {
         if (!$reader instanceof Reader && !$reader instanceof AttributeReader) {
-            trigger_deprecation(
+            Deprecation::trigger(
                 'gedmo/doctrine-extensions',
-                '3.11',
+                'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2258',
                 'Passing an object not implementing "%s" or "%s" as argument 1 to "%s()" is deprecated and'
                 .' will throw an "%s" error in version 4.0. Instance of "%s" given.',
                 Reader::class,

--- a/src/Mapping/Event/Adapter/ODM.php
+++ b/src/Mapping/Event/Adapter/ODM.php
@@ -10,6 +10,7 @@
 namespace Gedmo\Mapping\Event\Adapter;
 
 use Doctrine\Common\EventArgs;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Event\LifecycleEventArgs;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
@@ -30,10 +31,12 @@ class ODM implements AdapterInterface
 
     public function __call($method, $args)
     {
-        @trigger_error(sprintf(
+        Deprecation::trigger(
+            'gedmo/doctrine-extensions',
+            'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2409',
             'Using "%s()" method is deprecated since gedmo/doctrine-extensions 3.5 and will be removed in version 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        );
 
         if (null === $this->args) {
             throw new RuntimeException('Event args must be set before calling its methods');
@@ -161,10 +164,12 @@ class ODM implements AdapterInterface
      */
     public function createLifecycleEventArgsInstance($document, $documentManager)
     {
-        @trigger_error(sprintf(
+        Deprecation::trigger(
+            'gedmo/doctrine-extensions',
+            'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2649',
             'Using "%s()" method is deprecated since gedmo/doctrine-extensions 3.15 and will be removed in version 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        );
 
         return new LifecycleEventArgs($document, $documentManager);
     }

--- a/src/Mapping/Event/Adapter/ORM.php
+++ b/src/Mapping/Event/Adapter/ORM.php
@@ -10,6 +10,7 @@
 namespace Gedmo\Mapping\Event\Adapter;
 
 use Doctrine\Common\EventArgs;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -30,10 +31,12 @@ class ORM implements AdapterInterface
 
     public function __call($method, $args)
     {
-        @trigger_error(sprintf(
+        Deprecation::trigger(
+            'gedmo/doctrine-extensions',
+            'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2409',
             'Using "%s()" method is deprecated since gedmo/doctrine-extensions 3.5 and will be removed in version 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        );
 
         if (null === $this->args) {
             throw new RuntimeException('Event args must be set before calling its methods');
@@ -96,13 +99,15 @@ class ORM implements AdapterInterface
             return $this->args->getObjectManager();
         }
 
-        @trigger_error(sprintf(
+        Deprecation::trigger(
+            'gedmo/doctrine-extensions',
+            'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2639',
             'Calling "%s()" on event args of class "%s" that does not implement "getObjectManager()" is deprecated since gedmo/doctrine-extensions 3.14'
             .' and will throw a "%s" error in version 4.0.',
             __METHOD__,
             get_class($this->args),
             \Error::class
-        ), E_USER_DEPRECATED);
+        );
 
         return $this->args->getEntityManager();
     }
@@ -120,13 +125,15 @@ class ORM implements AdapterInterface
             return $this->args->getObject();
         }
 
-        @trigger_error(sprintf(
+        Deprecation::trigger(
+            'gedmo/doctrine-extensions',
+            'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2639',
             'Calling "%s()" on event args of class "%s" that does not imeplement "getObject()" is deprecated since gedmo/doctrine-extensions 3.14'
             .' and will throw a "%s" error in version 4.0.',
             __METHOD__,
             get_class($this->args),
             \Error::class
-        ), E_USER_DEPRECATED);
+        );
 
         return $this->args->getEntity();
     }
@@ -191,10 +198,12 @@ class ORM implements AdapterInterface
      */
     public function createLifecycleEventArgsInstance($object, $entityManager)
     {
-        @trigger_error(sprintf(
+        Deprecation::trigger(
+            'gedmo/doctrine-extensions',
+            'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2649',
             'Using "%s()" method is deprecated since gedmo/doctrine-extensions 3.15 and will be removed in version 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        );
 
         if (!class_exists(LifecycleEventArgs::class)) {
             throw new \RuntimeException(sprintf('Cannot call %s() when using doctrine/orm >=3.0, use a custom lifecycle event class instead.', __METHOD__));

--- a/src/Mapping/ExtensionMetadataFactory.php
+++ b/src/Mapping/ExtensionMetadataFactory.php
@@ -11,6 +11,7 @@ namespace Gedmo\Mapping;
 
 use Doctrine\Bundle\DoctrineBundle\Mapping\MappingDriver as DoctrineBundleMappingDriver;
 use Doctrine\Common\Annotations\Reader;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata as DocumentClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadata as EntityClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataInfo as LegacyEntityClassMetadata;
@@ -75,9 +76,9 @@ class ExtensionMetadataFactory
     public function __construct(ObjectManager $objectManager, string $extensionNamespace, ?object $annotationReader = null, ?CacheItemPoolInterface $cacheItemPool = null)
     {
         if (null !== $annotationReader && !$annotationReader instanceof Reader && !$annotationReader instanceof AttributeReader) {
-            trigger_deprecation(
+            Deprecation::trigger(
                 'gedmo/doctrine-extensions',
-                '3.11',
+                'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2258',
                 'Providing an annotation reader which does not implement %s or is not an instance of %s to %s is deprecated.',
                 Reader::class,
                 AttributeReader::class,

--- a/src/Mapping/MappedEventSubscriber.php
+++ b/src/Mapping/MappedEventSubscriber.php
@@ -14,6 +14,7 @@ use Doctrine\Common\Annotations\PsrCachedReader;
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\EventArgs;
 use Doctrine\Common\EventSubscriber;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata as DocumentClassMetadata;
 use Doctrine\ORM\EntityManagerInterface;
@@ -205,9 +206,9 @@ abstract class MappedEventSubscriber implements EventSubscriber
     public function setAnnotationReader($reader)
     {
         if (!$reader instanceof Reader && !$reader instanceof AttributeReader) {
-            trigger_deprecation(
+            Deprecation::trigger(
                 'gedmo/doctrine-extensions',
-                '3.11',
+                'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2558',
                 'Providing an annotation reader which does not implement %s or is not an instance of %s to %s() is deprecated.',
                 Reader::class,
                 AttributeReader::class,

--- a/src/SoftDeleteable/SoftDeleteableListener.php
+++ b/src/SoftDeleteable/SoftDeleteableListener.php
@@ -11,6 +11,7 @@ namespace Gedmo\SoftDeleteable;
 
 use Doctrine\Common\EventArgs;
 use Doctrine\Common\EventManager;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\UnitOfWork as MongoDBUnitOfWork;
 use Doctrine\ORM\EntityManagerInterface;
@@ -156,12 +157,14 @@ class SoftDeleteableListener extends MappedEventSubscriber
                 || !$parameters[0]->getType() instanceof \ReflectionNamedType
                 || $eventClass !== $parameters[0]->getType()->getName()
             ) {
-                @trigger_error(sprintf(
+                Deprecation::trigger(
+                    'gedmo/doctrine-extensions',
+                    'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2649',
                     'Type-hinting to something different than "%s" in "%s::%s()" is deprecated.',
                     $eventClass,
                     get_class($listener),
                     $reflMethod->getName()
-                ), E_USER_DEPRECATED);
+                );
 
                 return false;
             }

--- a/src/Sortable/SortableListener.php
+++ b/src/Sortable/SortableListener.php
@@ -12,6 +12,7 @@ namespace Gedmo\Sortable;
 use Doctrine\Common\Comparable;
 use Doctrine\Common\EventArgs;
 use Doctrine\Common\Util\ClassUtils;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\ObjectManager;
@@ -271,12 +272,14 @@ class SortableListener extends MappedEventSubscriber
                                     if (is_int($matches)) {
                                         $matches = 0 === $matches;
                                     } else {
-                                        @trigger_error(sprintf(
+                                        Deprecation::trigger(
+                                            'gedmo/doctrine-extensions',
+                                            'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2542',
                                             'Support for "%s" as return type from "%s::compareTo()" is deprecated since'
                                             .' gedmo/doctrine-extensions 3.11 and will be removed in version 4.0. Return "integer" instead.',
                                             gettype($matches),
                                             Comparable::class
-                                        ), E_USER_DEPRECATED);
+                                        );
                                     }
                                 } else {
                                     $matches = $gr == $value;

--- a/src/Sortable/SortableListener.php
+++ b/src/Sortable/SortableListener.php
@@ -158,9 +158,7 @@ class SortableListener extends MappedEventSubscriber
     /**
      * Update maxPositions as needed
      *
-     * @param 
-     
-     $args
+     * @param LifecycleEventArgs $args
      *
      * @phpstan-param LifecycleEventArgs<ObjectManager> $args
      *

--- a/src/Tool/Wrapper/AbstractWrapper.php
+++ b/src/Tool/Wrapper/AbstractWrapper.php
@@ -9,6 +9,7 @@
 
 namespace Gedmo\Tool\Wrapper;
 
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata as OdmClassMetadata;
 use Doctrine\ORM\EntityManagerInterface;
@@ -79,10 +80,12 @@ abstract class AbstractWrapper implements WrapperInterface
      */
     public static function clear()
     {
-        @trigger_error(sprintf(
+        Deprecation::trigger(
+            'gedmo/doctrine-extensions',
+            'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2410',
             'Using "%s()" method is deprecated since gedmo/doctrine-extensions 3.5 and will be removed in version 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        );
     }
 
     public function getObject()
@@ -97,10 +100,12 @@ abstract class AbstractWrapper implements WrapperInterface
 
     public function populate(array $data)
     {
-        @trigger_error(sprintf(
+        Deprecation::trigger(
+            'gedmo/doctrine-extensions',
+            'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2410',
             'Using "%s()" method is deprecated since gedmo/doctrine-extensions 3.5 and will be removed in version 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        );
 
         foreach ($data as $field => $value) {
             $this->setPropertyValue($field, $value);

--- a/src/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/src/Tree/Entity/Repository/NestedTreeRepository.php
@@ -9,6 +9,7 @@
 
 namespace Gedmo\Tree\Entity\Repository;
 
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
@@ -88,13 +89,15 @@ class NestedTreeRepository extends AbstractTreeRepository
                     }
 
                     if (!$node instanceof Node) {
-                        @trigger_error(\sprintf(
+                        Deprecation::trigger(
+                            'gedmo/doctrine-extensions',
+                            'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2547',
                             'Not implementing the "%s" interface from node "%s" is deprecated since gedmo/doctrine-extensions'
                             .' 3.13 and will throw a "%s" error in version 4.0.',
                             Node::class,
                             \get_class($node),
                             \TypeError::class
-                        ), \E_USER_DEPRECATED);
+                        );
                     }
 
                     // @todo: In the next major release, remove the previous condition and uncomment the following one.

--- a/src/Tree/Strategy/ORM/Closure.php
+++ b/src/Tree/Strategy/ORM/Closure.php
@@ -10,6 +10,7 @@
 namespace Gedmo\Tree\Strategy\ORM;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata as ORMClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
@@ -98,11 +99,13 @@ class Closure implements Strategy
         $hasTheUserExplicitlyDefinedMapping = true;
 
         if (!$closureMetadata->hasAssociation('ancestor')) {
-            @trigger_error(sprintf(
+            Deprecation::trigger(
+                'gedmo/doctrine-extensions',
+                'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2390',
                 'Not adding mapping explicitly to "ancestor" property in "%s" is deprecated and will not work in'
                 .' version 4.0. You MUST explicitly set the mapping as in our docs: https://github.com/doctrine-extensions/DoctrineExtensions/blob/main/doc/tree.md#closure-table',
                 $closureMetadata->getName()
-            ), E_USER_DEPRECATED);
+            );
 
             $hasTheUserExplicitlyDefinedMapping = false;
 
@@ -134,11 +137,13 @@ class Closure implements Strategy
         }
 
         if (!$closureMetadata->hasAssociation('descendant')) {
-            @trigger_error(sprintf(
+            Deprecation::trigger(
+                'gedmo/doctrine-extensions',
+                'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2390',
                 'Not adding mapping explicitly to "descendant" property in "%s" is deprecated and will not work in'
                 .' version 4.0. You MUST explicitly set the mapping as in our docs: https://github.com/doctrine-extensions/DoctrineExtensions/blob/main/doc/tree.md#closure-table',
                 $closureMetadata->getName()
-            ), E_USER_DEPRECATED);
+            );
 
             $hasTheUserExplicitlyDefinedMapping = false;
 
@@ -170,11 +175,13 @@ class Closure implements Strategy
         }
 
         if (!$this->hasClosureTableUniqueConstraint($closureMetadata)) {
-            @trigger_error(sprintf(
+            Deprecation::trigger(
+                'gedmo/doctrine-extensions',
+                'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2390',
                 'Not adding a unique constraint explicitly to "%s" is deprecated and will not be automatically'
                 .' added in version 4.0. You SHOULD explicitly add the unique constraint as in our docs: https://github.com/doctrine-extensions/DoctrineExtensions/blob/main/doc/tree.md#closure-table',
                 $closureMetadata->getName()
-            ), E_USER_DEPRECATED);
+            );
 
             $hasTheUserExplicitlyDefinedMapping = false;
 
@@ -189,11 +196,13 @@ class Closure implements Strategy
         }
 
         if (!$this->hasClosureTableDepthIndex($closureMetadata)) {
-            @trigger_error(sprintf(
+            Deprecation::trigger(
+                'gedmo/doctrine-extensions',
+                'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2390',
                 'Not adding an index with "depth" column explicitly to "%s" is deprecated and will not be automatically'
                 .' added in version 4.0. You SHOULD explicitly add the index as in our docs: https://github.com/doctrine-extensions/DoctrineExtensions/blob/main/doc/tree.md#closure-table',
                 $closureMetadata->getName()
-            ), E_USER_DEPRECATED);
+            );
 
             $hasTheUserExplicitlyDefinedMapping = false;
 

--- a/src/Tree/Strategy/ORM/Nested.php
+++ b/src/Tree/Strategy/ORM/Nested.php
@@ -10,6 +10,7 @@
 namespace Gedmo\Tree\Strategy\ORM;
 
 use Doctrine\Common\Collections\Criteria;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Persistence\Proxy;
@@ -666,12 +667,14 @@ class Nested implements Strategy
         // @todo: Remove the following condition and assignment in the next major release and use 0 as default value for
         // the `$levelDelta` parameter.
         if (null === $levelDelta && func_num_args() >= 8) {
-            @trigger_error(sprintf(
+            Deprecation::trigger(
+                'gedmo/doctrine-extensions',
+                'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2495',
                 'Passing a type different than "int" as argument 8 to "%s()" is deprecated since gedmo/doctrine-extensions'.
                 ' 3.9 and will throw a "%s" error in version 4.0.',
                 __METHOD__,
                 \TypeError::class
-            ), E_USER_DEPRECATED);
+            );
         }
         $levelDelta ??= 0;
 

--- a/src/Uploadable/Event/UploadableBaseEventArgs.php
+++ b/src/Uploadable/Event/UploadableBaseEventArgs.php
@@ -10,6 +10,7 @@
 namespace Gedmo\Uploadable\Event;
 
 use Doctrine\Common\EventArgs;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ObjectManager;
 use Gedmo\Uploadable\FileInfo\FileInfoInterface;
@@ -92,10 +93,12 @@ abstract class UploadableBaseEventArgs extends EventArgs
      */
     public function getEntityManager()
     {
-        @trigger_error(sprintf(
+        Deprecation::trigger(
+            'gedmo/doctrine-extensions',
+            'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2639',
             '"%s()" is deprecated since gedmo/doctrine-extensions 3.14 and will be removed in version 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        );
 
         return $this->em;
     }
@@ -117,10 +120,12 @@ abstract class UploadableBaseEventArgs extends EventArgs
      */
     public function getEntity()
     {
-        @trigger_error(sprintf(
+        Deprecation::trigger(
+            'gedmo/doctrine-extensions',
+            'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2639',
             '"%s()" is deprecated since gedmo/doctrine-extensions 3.14 and will be removed in version 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        );
 
         return $this->entity;
     }

--- a/tests/Gedmo/Mapping/Annotation/AnnotationArgumentsTest.php
+++ b/tests/Gedmo/Mapping/Annotation/AnnotationArgumentsTest.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
 
 namespace Gedmo\Tests\Mapping\Annotation;
 
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Gedmo\Mapping\Annotation\Annotation;
 use Gedmo\Mapping\Annotation\Blameable;
 use PHPUnit\Framework\TestCase;
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 /**
  * Remove this class when support for array based attributes in annotation classes is removed.
@@ -23,7 +23,7 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
  */
 final class AnnotationArgumentsTest extends TestCase
 {
-    use ExpectDeprecationTrait;
+    use VerifyDeprecations;
 
     /**
      * @param array<string, mixed> $expected
@@ -33,10 +33,10 @@ final class AnnotationArgumentsTest extends TestCase
      *
      * @param class-string<Annotation> $class
      */
-    public function testArguments(array $expected, string $class, array $args, ?string $expectedDeprecation = null): void
+    public function testArguments(array $expected, string $class, array $args, ?string $expectedDeprecationIdentifier = null): void
     {
-        if (null !== $expectedDeprecation) {
-            $this->expectDeprecation($expectedDeprecation);
+        if (null !== $expectedDeprecationIdentifier) {
+            $this->expectDeprecationWithIdentifier($expectedDeprecationIdentifier);
         }
 
         $annotation = new $class(...$args);
@@ -58,17 +58,17 @@ final class AnnotationArgumentsTest extends TestCase
         yield 'args_with_data' => [
             ['on' => 'delete', 'field' => 'some'],
             Blameable::class, [['on' => 'change', 'field' => 'id'], 'delete', 'some'],
-            'Passing an array as first argument to "Gedmo\Mapping\Annotation\%s::__construct()" is deprecated. Use named arguments instead.',
+            'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2375',
         ];
         yield 'data_without_args' => [
             ['on' => 'change', 'field' => 'id'],
             Blameable::class, [['on' => 'change', 'field' => 'id']],
-            'Passing an array as first argument to "Gedmo\Mapping\Annotation\%s::__construct()" is deprecated. Use named arguments instead.',
+            'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2375',
         ];
         yield 'default_values_with_args_and_data' => [
             ['on' => 'update', 'field' => null, 'value' => null],
             Blameable::class, [['on' => 'change'], 'update'],
-            'Passing an array as first argument to "Gedmo\Mapping\Annotation\%s::__construct()" is deprecated. Use named arguments instead.',
+            'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2375',
         ];
     }
 }


### PR DESCRIPTION
I've added some deprecations using Symfony's `trigger_deprecation()` function, others have done it with straight-up `@trigger_error()` calls.  This PR makes the runtime handling consistent and uses Doctrine's deprecations library to do so.

Why Doctrine's package?  It's a bit more feature-rich than just using one of the `trigger_*()` function calls with inbuilt support for a logger or ignoring select deprecations directly through its API compared to needing to hook into PHP's own error handling mechanism to deal with `E_USER_DEPRECATED` errors, and for package maintainers, it gives a way to selectively emit the runtime deprecation through its `Deprecation::triggerIfCalledFromOutside()` to avoid spamming unfixable deprecations from package internal code paths as well as providing its own PHPUnit integration for verify whether deprecations are emitted.

Plus, in recent Symfony versions, Doctrine's deprecation library is enabled by default in the FrameworkBundle and PHPUnit Bridge, so the tooling is already treated as a first-class citizen there.