### PR TITLE
Add support for providing a PSR-20 clock to event adapters which create new DateTimeInterface objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ a release.
 ### Added
 - SoftDeleteable: `Gedmo\SoftDeleteable\Event\PreSoftDeleteEventArgs` and
   `Gedmo\SoftDeleteable\Event\PostSoftDeleteEventArgs` classes.
+- Add support for injecting a `psr/clock` implementation into event adapters
+  that create new `DateTimeInterface` objects (SoftDeleteable and Timestampable)
 
 ### Changed
 - Make doctrine/annotations an optional dependency.

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
         "doctrine/event-manager": "^1.2 || ^2.0",
         "doctrine/persistence": "^2.2 || ^3.0",
         "psr/cache": "^1 || ^2 || ^3",
+        "psr/clock": "^1",
         "symfony/cache": "^5.4 || ^6.0 || ^7.0"
     },
     "require-dev": {

--- a/src/Mapping/Event/ClockAwareAdapterInterface.php
+++ b/src/Mapping/Event/ClockAwareAdapterInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Mapping\Event;
+
+use Psr\Clock\ClockInterface;
+
+/**
+ * Doctrine event adapter supporting a PSR-20 {@see ClockInterface}.
+ */
+interface ClockAwareAdapterInterface
+{
+    public function setClock(ClockInterface $clock): void;
+}

--- a/src/Mapping/MappedEventSubscriber.php
+++ b/src/Mapping/MappedEventSubscriber.php
@@ -26,10 +26,12 @@ use Doctrine\Persistence\ObjectManager;
 use Gedmo\Exception\InvalidArgumentException;
 use Gedmo\Mapping\Driver\AttributeReader;
 use Gedmo\Mapping\Event\AdapterInterface;
+use Gedmo\Mapping\Event\ClockAwareAdapterInterface;
 use Gedmo\ReferenceIntegrity\Mapping\Validator as ReferenceIntegrityValidator;
 use Gedmo\Uploadable\FilenameGenerator\FilenameGeneratorInterface;
 use Gedmo\Uploadable\Mapping\Validator as MappingValidator;
 use Psr\Cache\CacheItemPoolInterface;
+use Psr\Clock\ClockInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 /**
@@ -94,6 +96,8 @@ abstract class MappedEventSubscriber implements EventSubscriber
      * @var CacheItemPoolInterface|null
      */
     private $cacheItemPool;
+
+    private ?ClockInterface $clock = null;
 
     public function __construct()
     {
@@ -224,6 +228,11 @@ abstract class MappedEventSubscriber implements EventSubscriber
         $this->cacheItemPool = $cacheItemPool;
     }
 
+    final public function setClock(ClockInterface $clock): void
+    {
+        $this->clock = $clock;
+    }
+
     /**
      * Scans the objects for extended annotations
      * event subscribers must subscribe to loadClassMetadata event
@@ -267,6 +276,10 @@ abstract class MappedEventSubscriber implements EventSubscriber
                     $adapterClass = 'Gedmo\\Mapping\\Event\\Adapter\\'.$m[1];
                 }
                 $this->adapters[$m[1]] = new $adapterClass();
+
+                if ($this->adapters[$m[1]] instanceof ClockAwareAdapterInterface && $this->clock instanceof ClockInterface) {
+                    $this->adapters[$m[1]]->setClock($this->clock);
+                }
             }
             $this->adapters[$m[1]]->setEventArgs($args);
 

--- a/src/SoftDeleteable/Mapping/Event/Adapter/ORM.php
+++ b/src/SoftDeleteable/Mapping/Event/Adapter/ORM.php
@@ -13,7 +13,9 @@ use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Gedmo\Mapping\Event\Adapter\ORM as BaseAdapterORM;
+use Gedmo\Mapping\Event\ClockAwareAdapterInterface;
 use Gedmo\SoftDeleteable\Mapping\Event\SoftDeleteableAdapter;
+use Psr\Clock\ClockInterface;
 
 /**
  * Doctrine event adapter for ORM adapted
@@ -21,8 +23,18 @@ use Gedmo\SoftDeleteable\Mapping\Event\SoftDeleteableAdapter;
  *
  * @author David Buchmann <mail@davidbu.ch>
  */
-final class ORM extends BaseAdapterORM implements SoftDeleteableAdapter
+final class ORM extends BaseAdapterORM implements SoftDeleteableAdapter, ClockAwareAdapterInterface
 {
+    /**
+     * @var ClockInterface|null
+     */
+    private ?ClockInterface $clock = null;
+
+    public function setClock(ClockInterface $clock): void
+    {
+        $this->clock = $clock;
+    }
+
     /**
      * @param ClassMetadata $meta
      */
@@ -44,7 +56,7 @@ final class ORM extends BaseAdapterORM implements SoftDeleteableAdapter
      */
     private function getRawDateValue(array $mapping)
     {
-        $datetime = new \DateTime();
+        $datetime = $this->clock instanceof ClockInterface ? $this->clock->now() : new \DateTimeImmutable();
         $type = $mapping['type'] ?? null;
 
         if ('integer' === $type) {
@@ -52,9 +64,9 @@ final class ORM extends BaseAdapterORM implements SoftDeleteableAdapter
         }
 
         if (in_array($type, ['date_immutable', 'time_immutable', 'datetime_immutable', 'datetimetz_immutable'], true)) {
-            return \DateTimeImmutable::createFromMutable($datetime);
+            return $datetime;
         }
 
-        return $datetime;
+        return \DateTime::createFromImmutable($datetime);
     }
 }

--- a/tests/Gedmo/Clock.php
+++ b/tests/Gedmo/Clock.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests;
+
+use Psr\Clock\ClockInterface;
+
+final class Clock implements ClockInterface
+{
+    public function now(): \DateTimeImmutable
+    {
+        return new \DateTimeImmutable();
+    }
+}

--- a/tests/Gedmo/SoftDeleteable/SoftDeleteableEntityTest.php
+++ b/tests/Gedmo/SoftDeleteable/SoftDeleteableEntityTest.php
@@ -17,6 +17,7 @@ use Doctrine\ORM\Query;
 use Gedmo\SoftDeleteable\Filter\SoftDeleteableFilter;
 use Gedmo\SoftDeleteable\Query\TreeWalker\SoftDeleteableWalker;
 use Gedmo\SoftDeleteable\SoftDeleteableListener;
+use Gedmo\Tests\Clock;
 use Gedmo\Tests\SoftDeleteable\Fixture\Entity\Article;
 use Gedmo\Tests\SoftDeleteable\Fixture\Entity\Child;
 use Gedmo\Tests\SoftDeleteable\Fixture\Entity\Comment;
@@ -62,6 +63,7 @@ final class SoftDeleteableEntityTest extends BaseTestCaseORM
 
         $evm = new EventManager();
         $this->softDeleteableListener = new SoftDeleteableListener();
+        $this->softDeleteableListener->setClock(new Clock());
         $evm->addEventSubscriber($this->softDeleteableListener);
         $config = $this->getDefaultConfiguration();
         $config->addFilter(self::SOFT_DELETEABLE_FILTER_NAME, SoftDeleteableFilter::class);

--- a/tests/Gedmo/Timestampable/TimestampableTest.php
+++ b/tests/Gedmo/Timestampable/TimestampableTest.php
@@ -13,6 +13,7 @@ namespace Gedmo\Tests\Timestampable;
 
 use Doctrine\Common\EventManager;
 use Doctrine\Persistence\Proxy;
+use Gedmo\Tests\Clock;
 use Gedmo\Tests\Timestampable\Fixture\Article;
 use Gedmo\Tests\Timestampable\Fixture\Author;
 use Gedmo\Tests\Timestampable\Fixture\Comment;
@@ -35,8 +36,11 @@ final class TimestampableTest extends BaseTestCaseORM
     {
         parent::setUp();
 
+        $listener = new TimestampableListener();
+        $listener->setClock(new Clock());
+
         $evm = new EventManager();
-        $evm->addEventSubscriber(new TimestampableListener());
+        $evm->addEventSubscriber($listener);
 
         $this->getDefaultMockSqliteEntityManager($evm);
     }


### PR DESCRIPTION
Refs: #2700, stof/StofDoctrineExtensionsBundle#469

This PR adds support for injecting a PSR-20 clock into event listeners and their event adapters to replace hardcoded `new \DateTime()` calls.  Similar to supporting injection of an annotation reader or cache pool, a setter is provided to inject the clock.  Then, when creating adapters via `MappedEventSubscriber::getEventAdapter()`, if the adapter implements the new `Gedmo\Mapping\Event\ClockAwareAdapterInterface`, this factory will inject the clock to the adapter if one was provided.

Basic example:

```php
$listener = new TimestampableListener();
$listener->setClock(new Clock());

// All the rest of the usual setup logic...
```

Since the PSR-20 implementations I looked at all require PHP 8, for testing purposes, a very simple test mock is added to the test suite and used in a couple of the test cases.