### PR TITLE
Document expected EventArgs subtypes in listeners

### DIFF
--- a/src/AbstractTrackingListener.php
+++ b/src/AbstractTrackingListener.php
@@ -14,7 +14,9 @@ use Doctrine\DBAL\Types\Type;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Types\Type as TypeODM;
 use Doctrine\ORM\UnitOfWork;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
+use Doctrine\Persistence\Event\ManagerEventArgs;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\NotifyPropertyChanged;
 use Doctrine\Persistence\ObjectManager;
@@ -59,6 +61,10 @@ abstract class AbstractTrackingListener extends MappedEventSubscriber
 
     /**
      * Processes object updates when the manager is flushed.
+     *
+     * @param ManagerEventArgs $args
+     *
+     * @phpstan-param ManagerEventArgs<ObjectManager> $args
      *
      * @return void
      */
@@ -161,6 +167,10 @@ abstract class AbstractTrackingListener extends MappedEventSubscriber
 
     /**
      * Processes updates when an object is persisted in the manager.
+     *
+     * @param LifecycleEventArgs $args
+     *
+     * @phpstan-param LifecycleEventArgs<ObjectManager> $args
      *
      * @return void
      */

--- a/src/Loggable/LoggableListener.php
+++ b/src/Loggable/LoggableListener.php
@@ -11,7 +11,9 @@ namespace Gedmo\Loggable;
 
 use Doctrine\Common\EventArgs;
 use Doctrine\ORM\Mapping\ClassMetadata as ORMClassMetadata;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
+use Doctrine\Persistence\Event\ManagerEventArgs;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\ObjectManager;
 use Gedmo\Exception\InvalidArgumentException;
@@ -140,6 +142,10 @@ class LoggableListener extends MappedEventSubscriber
      * Checks for inserted object to update its logEntry
      * foreign key
      *
+     * @param LifecycleEventArgs $args
+     *
+     * @phpstan-param LifecycleEventArgs<ObjectManager> $args
+     *
      * @return void
      */
     public function postPersist(EventArgs $args)
@@ -186,6 +192,10 @@ class LoggableListener extends MappedEventSubscriber
     /**
      * Looks for loggable objects being inserted or updated
      * for further processing
+     *
+     * @param ManagerEventArgs $eventArgs
+     *
+     * @phpstan-param ManagerEventArgs<ObjectManager> $eventArgs
      *
      * @return void
      */

--- a/src/ReferenceIntegrity/ReferenceIntegrityListener.php
+++ b/src/ReferenceIntegrity/ReferenceIntegrityListener.php
@@ -10,6 +10,7 @@
 namespace Gedmo\ReferenceIntegrity;
 
 use Doctrine\Common\EventArgs;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\ObjectManager;
@@ -55,6 +56,10 @@ class ReferenceIntegrityListener extends MappedEventSubscriber
     /**
      * Looks for referenced objects being removed
      * to nullify the relation or throw an exception
+     *
+     * @param LifecycleEventArgs $args
+     *
+     * @phpstan-param LifecycleEventArgs<ObjectManager> $args
      *
      * @return void
      */

--- a/src/References/ReferencesListener.php
+++ b/src/References/ReferencesListener.php
@@ -11,6 +11,7 @@ namespace Gedmo\References;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\EventArgs;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\ObjectManager;
@@ -74,6 +75,10 @@ class ReferencesListener extends MappedEventSubscriber
     }
 
     /**
+     * @param LifecycleEventArgs $eventArgs
+     *
+     * @phpstan-param LifecycleEventArgs<ObjectManager> $eventArgs
+     *
      * @return void
      */
     public function postLoad(EventArgs $eventArgs)
@@ -140,6 +145,10 @@ class ReferencesListener extends MappedEventSubscriber
     }
 
     /**
+     * @param LifecycleEventArgs $eventArgs
+     *
+     * @phpstan-param LifecycleEventArgs<ObjectManager> $eventArgs
+     *
      * @return void
      */
     public function prePersist(EventArgs $eventArgs)
@@ -148,6 +157,10 @@ class ReferencesListener extends MappedEventSubscriber
     }
 
     /**
+     * @param LifecycleEventArgs $eventArgs
+     *
+     * @phpstan-param LifecycleEventArgs<ObjectManager> $eventArgs
+     *
      * @return void
      */
     public function preUpdate(EventArgs $eventArgs)
@@ -190,6 +203,10 @@ class ReferencesListener extends MappedEventSubscriber
     }
 
     /**
+     * @param LifecycleEventArgs $eventArgs
+     *
+     * @phpstan-param LifecycleEventArgs<ObjectManager> $eventArgs
+     *
      * @return void
      */
     public function updateManyEmbedReferences(EventArgs $eventArgs)
@@ -237,6 +254,11 @@ class ReferencesListener extends MappedEventSubscriber
         return __NAMESPACE__;
     }
 
+    /**
+     * @param LifecycleEventArgs $eventArgs
+     *
+     * @phpstan-param LifecycleEventArgs<ObjectManager> $eventArgs
+     */
     private function updateReferences(EventArgs $eventArgs): void
     {
         $ea = $this->getEventAdapter($eventArgs);

--- a/src/Sluggable/SluggableListener.php
+++ b/src/Sluggable/SluggableListener.php
@@ -10,7 +10,9 @@
 namespace Gedmo\Sluggable;
 
 use Doctrine\Common\EventArgs;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
+use Doctrine\Persistence\Event\ManagerEventArgs;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\ObjectManager;
 use Gedmo\Exception\InvalidArgumentException;
@@ -239,6 +241,10 @@ class SluggableListener extends MappedEventSubscriber
     /**
      * Allows identifier fields to be slugged as usual
      *
+     * @param LifecycleEventArgs $args
+     *
+     * @phpstan-param LifecycleEventArgs<ObjectManager> $args
+     *
      * @return void
      */
     public function prePersist(EventArgs $args)
@@ -260,6 +266,10 @@ class SluggableListener extends MappedEventSubscriber
     /**
      * Generate slug on objects being updated during flush
      * if they require changing
+     *
+     * @param ManagerEventArgs $args
+     *
+     * @phpstan-param ManagerEventArgs<ObjectManager> $args
      *
      * @return void
      */

--- a/src/SoftDeleteable/SoftDeleteableListener.php
+++ b/src/SoftDeleteable/SoftDeleteableListener.php
@@ -15,6 +15,7 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\UnitOfWork as MongoDBUnitOfWork;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
+use Doctrine\Persistence\Event\ManagerEventArgs;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\ObjectManager;
 use Gedmo\Mapping\MappedEventSubscriber;
@@ -59,6 +60,10 @@ class SoftDeleteableListener extends MappedEventSubscriber
     /**
      * If it's a SoftDeleteable object, update the "deletedAt" field
      * and skip the removal of the object
+     *
+     * @param ManagerEventArgs $args
+     *
+     * @phpstan-param ManagerEventArgs<ObjectManager> $args
      *
      * @return void
      */

--- a/src/Sortable/SortableListener.php
+++ b/src/Sortable/SortableListener.php
@@ -12,7 +12,9 @@ namespace Gedmo\Sortable;
 use Doctrine\Common\Comparable;
 use Doctrine\Common\EventArgs;
 use Doctrine\Common\Util\ClassUtils;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
+use Doctrine\Persistence\Event\ManagerEventArgs;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\ObjectManager;
 use Gedmo\Mapping\MappedEventSubscriber;
@@ -107,6 +109,10 @@ class SortableListener extends MappedEventSubscriber
      * The synchronization of the objects in memory is done in postFlush. This
      * ensures that the positions have been successfully persisted to database.
      *
+     * @param ManagerEventArgs $args
+     *
+     * @phpstan-param ManagerEventArgs<ObjectManager> $args
+     *
      * @return void
      */
     public function onFlush(EventArgs $args)
@@ -151,6 +157,10 @@ class SortableListener extends MappedEventSubscriber
     /**
      * Update maxPositions as needed
      *
+     * @param LifecycleEventArgs $args
+     *
+     * @phpstan-param LifecycleEventArgs<ObjectManager> $args
+     *
      * @return void
      */
     public function prePersist(EventArgs $args)
@@ -175,6 +185,10 @@ class SortableListener extends MappedEventSubscriber
     }
 
     /**
+     * @param LifecycleEventArgs $args
+     *
+     * @phpstan-param LifecycleEventArgs<ObjectManager> $args
+     *
      * @return void
      */
     public function postPersist(EventArgs $args)
@@ -185,6 +199,10 @@ class SortableListener extends MappedEventSubscriber
     }
 
     /**
+     * @param LifecycleEventArgs $args
+     *
+     * @phpstan-param LifecycleEventArgs<ObjectManager> $args
+     *
      * @return void
      */
     public function preUpdate(EventArgs $args)
@@ -195,6 +213,10 @@ class SortableListener extends MappedEventSubscriber
     }
 
     /**
+     * @param LifecycleEventArgs $args
+     *
+     * @phpstan-param LifecycleEventArgs<ObjectManager> $args
+     *
      * @return void
      */
     public function postRemove(EventArgs $args)
@@ -206,6 +228,10 @@ class SortableListener extends MappedEventSubscriber
 
     /**
      * Sync objects in memory
+     *
+     * @param ManagerEventArgs $args
+     *
+     * @phpstan-param ManagerEventArgs<ObjectManager> $args
      *
      * @return void
      */

--- a/src/Translatable/TranslatableListener.php
+++ b/src/Translatable/TranslatableListener.php
@@ -12,7 +12,9 @@ namespace Gedmo\Translatable;
 use Doctrine\Common\EventArgs;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ORM\ORMInvalidArgumentException;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
+use Doctrine\Persistence\Event\ManagerEventArgs;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\ObjectManager;
 use Gedmo\Exception\InvalidArgumentException;
@@ -372,6 +374,10 @@ class TranslatableListener extends MappedEventSubscriber
      * This has to be done in the preFlush because, when an entity has been loaded
      * in a different locale, no changes will be detected.
      *
+     * @param ManagerEventArgs $args
+     *
+     * @phpstan-param ManagerEventArgs<ObjectManager> $args
+     *
      * @return void
      */
     public function preFlush(EventArgs $args)
@@ -408,6 +414,10 @@ class TranslatableListener extends MappedEventSubscriber
     /**
      * Looks for translatable objects being inserted or updated
      * for further processing
+     *
+     * @param ManagerEventArgs $args
+     *
+     * @phpstan-param ManagerEventArgs<ObjectManager> $args
      *
      * @return void
      */
@@ -449,6 +459,10 @@ class TranslatableListener extends MappedEventSubscriber
      * Checks for inserted object to update their translation
      * foreign keys
      *
+     * @param LifecycleEventArgs $args
+     *
+     * @phpstan-param LifecycleEventArgs<ObjectManager> $args
+     *
      * @return void
      */
     public function postPersist(EventArgs $args)
@@ -481,6 +495,10 @@ class TranslatableListener extends MappedEventSubscriber
     /**
      * After object is loaded, listener updates the translations
      * by currently used locale
+     *
+     * @param ManagerEventArgs $args
+     *
+     * @phpstan-param ManagerEventArgs<ObjectManager> $args
      *
      * @return void
      */

--- a/src/Tree/TreeListener.php
+++ b/src/Tree/TreeListener.php
@@ -12,7 +12,9 @@ namespace Gedmo\Tree;
 use Doctrine\Common\EventArgs;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
+use Doctrine\Persistence\Event\ManagerEventArgs;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\ObjectManager;
 use Gedmo\Exception\InvalidArgumentException;
@@ -140,6 +142,10 @@ class TreeListener extends MappedEventSubscriber
      * Looks for Tree objects being updated
      * for further processing
      *
+     * @param ManagerEventArgs $args
+     *
+     * @phpstan-param ManagerEventArgs<ObjectManager> $args
+     *
      * @return void
      */
     public function onFlush(EventArgs $args)
@@ -182,6 +188,10 @@ class TreeListener extends MappedEventSubscriber
     /**
      * Updates tree on Node removal
      *
+     * @param LifecycleEventArgs $args
+     *
+     * @phpstan-param LifecycleEventArgs<ObjectManager> $args
+     *
      * @return void
      */
     public function preRemove(EventArgs $args)
@@ -199,6 +209,10 @@ class TreeListener extends MappedEventSubscriber
     /**
      * Checks for persisted Nodes
      *
+     * @param LifecycleEventArgs $args
+     *
+     * @phpstan-param LifecycleEventArgs<ObjectManager> $args
+     *
      * @return void
      */
     public function prePersist(EventArgs $args)
@@ -215,6 +229,10 @@ class TreeListener extends MappedEventSubscriber
 
     /**
      * Checks for updated Nodes
+     *
+     * @param LifecycleEventArgs $args
+     *
+     * @phpstan-param LifecycleEventArgs<ObjectManager> $args
      *
      * @return void
      */
@@ -234,6 +252,10 @@ class TreeListener extends MappedEventSubscriber
      * Checks for pending Nodes to fully synchronize
      * the tree
      *
+     * @param LifecycleEventArgs $args
+     *
+     * @phpstan-param LifecycleEventArgs<ObjectManager> $args
+     *
      * @return void
      */
     public function postPersist(EventArgs $args)
@@ -251,6 +273,10 @@ class TreeListener extends MappedEventSubscriber
     /**
      * Checks for pending Nodes to fully synchronize
      * the tree
+     *
+     * @param LifecycleEventArgs $args
+     *
+     * @phpstan-param LifecycleEventArgs<ObjectManager> $args
      *
      * @return void
      */
@@ -270,6 +296,10 @@ class TreeListener extends MappedEventSubscriber
      * Checks for pending Nodes to fully synchronize
      * the tree
      *
+     * @param LifecycleEventArgs $args
+     *
+     * @phpstan-param LifecycleEventArgs<ObjectManager> $args
+     *
      * @return void
      */
     public function postRemove(EventArgs $args)
@@ -285,7 +315,7 @@ class TreeListener extends MappedEventSubscriber
     }
 
     /**
-     * Mapps additional metadata
+     * Maps additional metadata
      *
      * @param LoadClassMetadataEventArgs $eventArgs
      *

--- a/src/Uploadable/UploadableListener.php
+++ b/src/Uploadable/UploadableListener.php
@@ -12,7 +12,9 @@ namespace Gedmo\Uploadable;
 use Doctrine\Common\EventArgs;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
+use Doctrine\Persistence\Event\ManagerEventArgs;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\NotifyPropertyChanged;
 use Doctrine\Persistence\ObjectManager;
@@ -113,6 +115,10 @@ class UploadableListener extends MappedEventSubscriber
      * doctrine thinks the entity has no changes, which produces that the "onFlush" event gets never called.
      * Here we mark the entity as dirty, so the "onFlush" event gets called, and the file is processed.
      *
+     * @param ManagerEventArgs $args
+     *
+     * @phpstan-param ManagerEventArgs<ObjectManager> $args
+     *
      * @return void
      */
     public function preFlush(EventArgs $args)
@@ -151,6 +157,10 @@ class UploadableListener extends MappedEventSubscriber
     /**
      * Handle file-uploading depending on the action
      * being done with objects
+     *
+     * @param ManagerEventArgs $args
+     *
+     * @phpstan-param ManagerEventArgs<ObjectManager> $args
      *
      * @return void
      */

--- a/src/Uploadable/UploadableListener.php
+++ b/src/Uploadable/UploadableListener.php
@@ -12,7 +12,6 @@ namespace Gedmo\Uploadable;
 use Doctrine\Common\EventArgs;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
 use Doctrine\Persistence\Event\ManagerEventArgs;
 use Doctrine\Persistence\Mapping\ClassMetadata;


### PR DESCRIPTION
The event listeners really aren't expected to receive the base `Doctrine\Common\EventArgs` object, it misses information that almost every listener needs (all of them expect an object manager, and many also are lifecycle event listeners expecting an object).  Since changing the type declarations in the signatures would be a B/C break, this PR adds the expected subtype through `@param` annotations.  Bouncing this off the ORM and MongoDB ODM, it looks like the intent is that all of the event sub-classes end up being a child of either `Doctrine\Persistence\Event\LifecycleEventArgs` or `Doctrine\Persistence\Event\ManagerEventArgs` so that is the information provided.

There's still a lot of missing type safety or sanity checks (i.e. always assuming `$event->getObjectManager()->getUnitOfWork()` will exist since that's not a part of the root object manager interface, but it's there for the managers that are supported here), but it's a small step in the right direction.