### PR TITLE
Doctrine\ORM\Mapping\ClassMetadata::getFieldMapping() will return an object on ORM 3 instead of an array

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -291,6 +291,21 @@ parameters:
 			path: src/Sluggable/SluggableListener.php
 
 		-
+			message: "#^Access to property \\$type on an unknown class Doctrine\\\\ORM\\\\Mapping\\\\FieldMapping\\.$#"
+			count: 1
+			path: src/SoftDeleteable/Mapping/Event/Adapter/ORM.php
+
+		-
+			message: "#^Class Doctrine\\\\ORM\\\\Mapping\\\\FieldMapping not found\\.$#"
+			count: 1
+			path: src/SoftDeleteable/Mapping/Event/Adapter/ORM.php
+
+		-
+			message: "#^Parameter \\$mapping of method Gedmo\\\\SoftDeleteable\\\\Mapping\\\\Event\\\\Adapter\\\\ORM\\:\\:getRawDateValue\\(\\) has invalid type Doctrine\\\\ORM\\\\Mapping\\\\FieldMapping\\.$#"
+			count: 1
+			path: src/SoftDeleteable/Mapping/Event/Adapter/ORM.php
+
+		-
 			message: "#^Access to an undefined property Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:\\$isMappedSuperclass\\.$#"
 			count: 1
 			path: src/SoftDeleteable/Mapping/Validator.php
@@ -354,6 +369,21 @@ parameters:
 			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:getFieldMapping\\(\\)\\.$#"
 			count: 1
 			path: src/Timestampable/Mapping/Driver/Yaml.php
+
+		-
+			message: "#^Access to property \\$type on an unknown class Doctrine\\\\ORM\\\\Mapping\\\\FieldMapping\\.$#"
+			count: 1
+			path: src/Timestampable/Mapping/Event/Adapter/ORM.php
+
+		-
+			message: "#^Class Doctrine\\\\ORM\\\\Mapping\\\\FieldMapping not found\\.$#"
+			count: 1
+			path: src/Timestampable/Mapping/Event/Adapter/ORM.php
+
+		-
+			message: "#^Parameter \\$mapping of method Gedmo\\\\Timestampable\\\\Mapping\\\\Event\\\\Adapter\\\\ORM\\:\\:getRawDateValue\\(\\) has invalid type Doctrine\\\\ORM\\\\Mapping\\\\FieldMapping\\.$#"
+			count: 1
+			path: src/Timestampable/Mapping/Event/Adapter/ORM.php
 
 		-
 			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\ObjectManager\\:\\:getUnitOfWork\\(\\)\\.$#"

--- a/src/SoftDeleteable/Mapping/Event/Adapter/ORM.php
+++ b/src/SoftDeleteable/Mapping/Event/Adapter/ORM.php
@@ -12,6 +12,7 @@ namespace Gedmo\SoftDeleteable\Mapping\Event\Adapter;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\FieldMapping;
 use Gedmo\Mapping\Event\Adapter\ORM as BaseAdapterORM;
 use Gedmo\Mapping\Event\ClockAwareAdapterInterface;
 use Gedmo\SoftDeleteable\Mapping\Event\SoftDeleteableAdapter;
@@ -50,14 +51,14 @@ final class ORM extends BaseAdapterORM implements SoftDeleteableAdapter, ClockAw
     /**
      * Generates current timestamp for the specified mapping
      *
-     * @param array<string, mixed> $mapping
+     * @param array<string, mixed>|FieldMapping $mapping
      *
      * @return \DateTimeInterface|int
      */
-    private function getRawDateValue(array $mapping)
+    private function getRawDateValue($mapping)
     {
         $datetime = $this->clock instanceof ClockInterface ? $this->clock->now() : new \DateTimeImmutable();
-        $type = $mapping['type'] ?? null;
+        $type = $mapping instanceof FieldMapping ? $mapping->type : ($mapping['type'] ?? '');
 
         if ('integer' === $type) {
             return (int) $datetime->format('U');

--- a/src/Timestampable/Mapping/Event/Adapter/ORM.php
+++ b/src/Timestampable/Mapping/Event/Adapter/ORM.php
@@ -12,6 +12,7 @@ namespace Gedmo\Timestampable\Mapping\Event\Adapter;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\FieldMapping;
 use Gedmo\Mapping\Event\Adapter\ORM as BaseAdapterORM;
 use Gedmo\Mapping\Event\ClockAwareAdapterInterface;
 use Gedmo\Timestampable\Mapping\Event\TimestampableAdapter;
@@ -50,14 +51,14 @@ final class ORM extends BaseAdapterORM implements TimestampableAdapter, ClockAwa
     /**
      * Generates current timestamp for the specified mapping
      *
-     * @param array<string, mixed> $mapping
+     * @param array<string, mixed>|FieldMapping $mapping
      *
      * @return \DateTimeInterface|int
      */
-    private function getRawDateValue(array $mapping)
+    private function getRawDateValue($mapping)
     {
         $datetime = $this->clock instanceof ClockInterface ? $this->clock->now() : new \DateTimeImmutable();
-        $type = $mapping['type'] ?? null;
+        $type = $mapping instanceof FieldMapping ? $mapping->type : ($mapping['type'] ?? '');
 
         if ('integer' === $type) {
             return (int) $datetime->format('U');

--- a/tests/Gedmo/Uploadable/Mapping/ValidatorTest.php
+++ b/tests/Gedmo/Uploadable/Mapping/ValidatorTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Gedmo\Tests\Uploadable\Mapping;
 
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\FieldMapping;
 use Gedmo\Exception\InvalidMappingException;
 use Gedmo\Exception\UploadableInvalidPathException;
 use Gedmo\Uploadable\FilenameGenerator\FilenameGeneratorSha1;
@@ -51,7 +52,13 @@ final class ValidatorTest extends TestCase
         $this->expectException(InvalidMappingException::class);
         $this->meta->expects(static::once())
             ->method('getFieldMapping')
-            ->willReturn(['type' => 'someType']);
+            ->willReturnCallback(static function (string $fieldName) {
+                if (class_exists(FieldMapping::class)) {
+                    return FieldMapping::fromMappingArray(['type' => 'someType', 'fieldName' => $fieldName, 'columnName' => $fieldName]);
+                }
+
+                return ['type' => 'someType'];
+            });
 
         Validator::validateField(
             $this->meta,
@@ -122,7 +129,13 @@ final class ValidatorTest extends TestCase
             ->willReturn(new \ReflectionClass(new FakeEntity()));
         $this->meta
             ->method('getFieldMapping')
-            ->willReturn(['type' => 'someType']);
+            ->willReturnCallback(static function (string $fieldName) {
+                if (class_exists(FieldMapping::class)) {
+                    return FieldMapping::fromMappingArray(['type' => 'someType', 'fieldName' => $fieldName, 'columnName' => $fieldName]);
+                }
+
+                return ['type' => 'someType'];
+            });
 
         $config = [
             'fileMimeTypeField' => '',
@@ -151,7 +164,13 @@ final class ValidatorTest extends TestCase
             ->willReturn(new \ReflectionClass(new FakeEntity()));
         $this->meta
             ->method('getFieldMapping')
-            ->willReturn(['type' => 'someType']);
+            ->willReturnCallback(static function (string $fieldName) {
+                if (class_exists(FieldMapping::class)) {
+                    return FieldMapping::fromMappingArray(['type' => 'someType', 'fieldName' => $fieldName, 'columnName' => $fieldName]);
+                }
+
+                return ['type' => 'someType'];
+            });
 
         $config = [
             'fileMimeTypeField' => '',
@@ -179,7 +198,13 @@ final class ValidatorTest extends TestCase
             ->willReturn(new \ReflectionClass(new FakeEntity()));
         $this->meta
             ->method('getFieldMapping')
-            ->willReturn(['type' => 'string']);
+            ->willReturnCallback(static function (string $fieldName) {
+                if (class_exists(FieldMapping::class)) {
+                    return FieldMapping::fromMappingArray(['type' => 'string', 'fieldName' => $fieldName, 'columnName' => $fieldName]);
+                }
+
+                return ['type' => 'string'];
+            });
 
         $config = [
             'fileMimeTypeField' => '',
@@ -207,7 +232,13 @@ final class ValidatorTest extends TestCase
             ->willReturn(new \ReflectionClass(new FakeEntity()));
         $this->meta
             ->method('getFieldMapping')
-            ->willReturn(['type' => 'string']);
+            ->willReturnCallback(static function (string $fieldName) {
+                if (class_exists(FieldMapping::class)) {
+                    return FieldMapping::fromMappingArray(['type' => 'string', 'fieldName' => $fieldName, 'columnName' => $fieldName]);
+                }
+
+                return ['type' => 'string'];
+            });
 
         $config = [
             'fileMimeTypeField' => '',


### PR DESCRIPTION
Ref: #2708

Cherry-picks out changes related to moving from an array to the `Doctrine\ORM\Mapping\FieldMapping` in ORM 3.0.

The compat issues are baselined into the PHPStan config for now since we know the class doesn't exist on 2.18 (which is what SA is running against) and the entire point of this diff is to be a compat layer.