### PR TITLE
Do not use the return of include as an entity manager

### DIFF
--- a/example/bin/console.php
+++ b/example/bin/console.php
@@ -22,8 +22,7 @@ use Symfony\Component\Console\Application;
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-/** @var EntityManager $em */
-$em = include __DIR__.'/../em.php';
+include __DIR__.'/../em.php';
 
 $entityManagerProvider = new SingleManagerProvider($em);
 


### PR DESCRIPTION
`include` returns `1` on success.

Did this ever work? Maybe a long time ago?

So I get:
```
PHP Fatal error:  Uncaught TypeError: Doctrine\ORM\Tools\Console\EntityManagerProvider\SingleManagerProvider::__construct(): Argument #1 ($entityManager) must be of type Doctrine\ORM\EntityManagerInterface, int given, called in /home/douglas/Projects/r_DoctrineExtensions/example/bin/console.php on line 28 and defined in /home/douglas/Projects/r_DoctrineExtensions/vendor/doctrine/orm/src/Tools/Console/EntityManagerProvider/SingleManagerProvider.php:18
Stack trace:
#0 /home/douglas/Projects/r_DoctrineExtensions/example/bin/console.php(28): Doctrine\ORM\Tools\Console\EntityManagerProvider\SingleManagerProvider->__construct()
#1 /home/douglas/Projects/r_DoctrineExtensions/example/bin/console(4): include('...')
#2 {main}
  thrown in /home/douglas/Projects/r_DoctrineExtensions/vendor/doctrine/orm/src/Tools/Console/EntityManagerProvider/SingleManagerProvider.php on line 18
```

easy to fix.