### PR TITLE
Change the placeholder for the sluggable extension when generating a slug for an identifier field

### DIFF
--- a/src/Sluggable/SluggableListener.php
+++ b/src/Sluggable/SluggableListener.php
@@ -257,7 +257,7 @@ class SluggableListener extends MappedEventSubscriber
         if ($config = $this->getConfiguration($om, $meta->getName())) {
             foreach ($config['slugs'] as $slugField => $options) {
                 if ($meta->isIdentifier($slugField)) {
-                    $meta->getReflectionProperty($slugField)->setValue($object, '__id__');
+                    $meta->getReflectionProperty($slugField)->setValue($object, uniqid('__sluggable_placeholder__'));
                 }
             }
         }
@@ -344,7 +344,7 @@ class SluggableListener extends MappedEventSubscriber
             $slug = $meta->getReflectionProperty($slugField)->getValue($object);
 
             // if slug should not be updated, skip it
-            if (!$options['updatable'] && !$isInsert && (!isset($changeSet[$slugField]) || '__id__' === $slug)) {
+            if (!$options['updatable'] && !$isInsert && (!isset($changeSet[$slugField]) || 0 === strpos($slug, '__sluggable_placeholder__'))) {
                 continue;
             }
             // must fetch the old slug from changeset, since $object holds the new version
@@ -352,7 +352,7 @@ class SluggableListener extends MappedEventSubscriber
             $needToChangeSlug = false;
 
             // if slug is null, regenerate it, or needs an update
-            if (null === $slug || '__id__' === $slug || !isset($changeSet[$slugField])) {
+            if (null === $slug || 0 === strpos($slug, '__sluggable_placeholder__') || !isset($changeSet[$slugField])) {
                 $slug = '';
 
                 foreach ($options['fields'] as $sluggableField) {


### PR DESCRIPTION
Ref: #2708

In https://github.com/doctrine/orm/pull/10785 (shipped in ORM 2.16.0) a check was added to the UnitOfWork to prevent ID collisions in its internal map, which was then changed to a deprecation in https://github.com/doctrine/orm/pull/10878 (shipped in ORM 2.16.1) due to its disruptiveness.  That check is back in 3.0.

This PR avoids the issue by changing the ID placeholder used by the sluggable extension when it is configured to generate slugs for an identifier field to a placeholder based on `uniqid()` and fixes the last PHPUnit error on my hack-it-together-ORM-3-support branch.