### PR TITLE
Misc. code doc updates

### DIFF
--- a/src/Blameable/Blameable.php
+++ b/src/Blameable/Blameable.php
@@ -10,9 +10,7 @@
 namespace Gedmo\Blameable;
 
 /**
- * This interface is not necessary but can be implemented for
- * Entities which in some cases needs to be identified as
- * Blameable
+ * Marker interface for objects which can be identified as blamable.
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
@@ -21,35 +19,35 @@ interface Blameable
     // blameable expects annotations on properties
 
     /*
-     * @gedmo:Blameable(on="create")
+     * @Gedmo\Blameable(on="create")
      * fields which should be updated on insert only
      */
 
     /*
-     * @gedmo:Blameable(on="update")
+     * @Gedmo\Blameable(on="update")
      * fields which should be updated on update and insert
      */
 
     /*
-     * @gedmo:Blameable(on="change", field="field", value="value")
+     * @Gedmo\Blameable(on="change", field="field", value="value")
      * fields which should be updated on changed "property"
      * value and become equal to given "value"
      */
 
     /*
-     * @gedmo:Blameable(on="change", field="field")
+     * @Gedmo\Blameable(on="change", field="field")
      * fields which should be updated on changed "property"
      */
 
     /*
-     * @gedmo:Blameable(on="change", fields={"field1", "field2"})
+     * @Gedmo\Blameable(on="change", fields={"field1", "field2"})
      * fields which should be updated if at least one of the given fields changed
      */
 
     /*
      * example
      *
-     * @gedmo:Blameable(on="create")
+     * @Gedmo\Blameable(on="create")
      * @Column(type="string")
      * $created
      */

--- a/src/Blameable/Traits/Blameable.php
+++ b/src/Blameable/Traits/Blameable.php
@@ -10,7 +10,9 @@
 namespace Gedmo\Blameable\Traits;
 
 /**
- * Blameable Trait, usable with PHP >= 5.4
+ * Trait for blamable objects.
+ *
+ * This implementation does not provide any mapping configurations.
  *
  * @author David Buchmann <mail@davidbu.ch>
  */

--- a/src/Blameable/Traits/BlameableDocument.php
+++ b/src/Blameable/Traits/BlameableDocument.php
@@ -14,7 +14,9 @@ use Doctrine\ODM\MongoDB\Types\Type;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
- * Blameable Trait, usable with PHP >= 5.4
+ * Trait for blamable objects.
+ *
+ * This implementation provides a mapping configuration for the Doctrine MongoDB ODM.
  *
  * @author David Buchmann <mail@davidbu.ch>
  */

--- a/src/Blameable/Traits/BlameableEntity.php
+++ b/src/Blameable/Traits/BlameableEntity.php
@@ -13,7 +13,9 @@ use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
- * Blameable Trait, usable with PHP >= 5.4
+ * Trait for blamable objects.
+ *
+ * This implementation provides a mapping configuration for the Doctrine ORM.
  *
  * @author David Buchmann <mail@davidbu.ch>
  */

--- a/src/IpTraceable/IpTraceable.php
+++ b/src/IpTraceable/IpTraceable.php
@@ -10,9 +10,7 @@
 namespace Gedmo\IpTraceable;
 
 /**
- * This interface is not necessary but can be implemented for
- * Entities which in some cases needs to be identified as
- * IpTraceable
+ * Marker interface for objects which can be identified as IP traceable.
  *
  * @author Pierre-Charles Bertineau <pc.bertineau@alterphp.com>
  */
@@ -21,35 +19,35 @@ interface IpTraceable
     // ipTraceable expects annotations on properties
 
     /*
-     * @gedmo:IpTraceable(on="create")
+     * @Gedmo\IpTraceable(on="create")
      * strings which should be updated on insert only
      */
 
     /*
-     * @gedmo:IpTraceable(on="update")
+     * @Gedmo\IpTraceable(on="update")
      * strings which should be updated on update and insert
      */
 
     /*
-     * @gedmo:IpTraceable(on="change", field="field", value="value")
+     * @Gedmo\IpTraceable(on="change", field="field", value="value")
      * strings which should be updated on changed "property"
      * value and become equal to given "value"
      */
 
     /*
-     * @gedmo:IpTraceable(on="change", field="field")
+     * @Gedmo\IpTraceable(on="change", field="field")
      * strings which should be updated on changed "property"
      */
 
     /*
-     * @gedmo:IpTraceable(on="change", fields={"field1", "field2"})
+     * @Gedmo\IpTraceable(on="change", fields={"field1", "field2"})
      * strings which should be updated if at least one of the given fields changed
      */
 
     /*
      * example
      *
-     * @gedmo:IpTraceable(on="create")
+     * @Gedmo\IpTraceable(on="create")
      * @Column(type="string")
      * $created
      */

--- a/src/IpTraceable/Traits/IpTraceable.php
+++ b/src/IpTraceable/Traits/IpTraceable.php
@@ -10,7 +10,9 @@
 namespace Gedmo\IpTraceable\Traits;
 
 /**
- * IpTraceable Trait, usable with PHP >= 5.4
+ * Trait for IP traceable objects.
+ *
+ * This implementation does not provide any mapping configurations.
  *
  * @author Pierre-Charles Bertineau <pc.bertineau@alterphp.com>
  */

--- a/src/IpTraceable/Traits/IpTraceableDocument.php
+++ b/src/IpTraceable/Traits/IpTraceableDocument.php
@@ -14,7 +14,9 @@ use Doctrine\ODM\MongoDB\Types\Type;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
- * IpTraceable Trait, usable with PHP >= 5.4
+ * Trait for IP traceable objects.
+ *
+ * This implementation provides a mapping configuration for the Doctrine MongoDB ODM.
  *
  * @author Pierre-Charles Bertineau <pc.bertineau@alterphp.com>
  */

--- a/src/IpTraceable/Traits/IpTraceableEntity.php
+++ b/src/IpTraceable/Traits/IpTraceableEntity.php
@@ -13,7 +13,9 @@ use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
- * IpTraceable Trait, usable with PHP >= 5.4
+ * Trait for IP traceable objects.
+ *
+ * This implementation provides a mapping configuration for the Doctrine ORM.
  *
  * @author Pierre-Charles Bertineau <pc.bertineau@alterphp.com>
  */

--- a/src/Loggable/Loggable.php
+++ b/src/Loggable/Loggable.php
@@ -10,9 +10,7 @@
 namespace Gedmo\Loggable;
 
 /**
- * This interface is not necessary but can be implemented for
- * Domain Objects which in some cases needs to be identified as
- * Loggable
+ * Marker interface for objects which can be identified as loggable.
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
@@ -21,14 +19,14 @@ interface Loggable
     // this interface is not necessary to implement
 
     /*
-     * @gedmo:Loggable
-     * to mark the class as loggable use class annotation @gedmo:Loggable
+     * @Gedmo\Loggable
+     * to mark the class as loggable use class annotation @Gedmo\Loggable
      * this object will contain now a history
      * available options:
      *         logEntryClass="My\LogEntryObject" (optional) defaultly will use internal object class
      * example:
      *
-     * @gedmo:Loggable(logEntryClass="My\LogEntryObject")
+     * @Gedmo\Loggable(logEntryClass="My\LogEntryObject")
      * class MyEntity
      */
 }

--- a/src/ReferenceIntegrity/ReferenceIntegrity.php
+++ b/src/ReferenceIntegrity/ReferenceIntegrity.php
@@ -10,9 +10,7 @@
 namespace Gedmo\ReferenceIntegrity;
 
 /**
- * This interface is not necessary but can be implemented for
- * Entities which in some cases needs to be identified te have
- * ReferenceIntegrity checks
+ * Marker interface for objects which can be identified as requiring reference integrity checks.
  *
  * @author Evert Harmeling <evert.harmeling@freshheads.com>
  */

--- a/src/Sluggable/Sluggable.php
+++ b/src/Sluggable/Sluggable.php
@@ -10,9 +10,7 @@
 namespace Gedmo\Sluggable;
 
 /**
- * This interface is not necessary but can be implemented for
- * Entities which in some cases needs to be identified as
- * Sluggable
+ * Marker interface for objects which can be identified as sluggable.
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
@@ -21,13 +19,13 @@ interface Sluggable
     // use now annotations instead of predefined methods, this interface is not necessary
 
     /*
-     * @gedmo:Sluggable
-     * to mark the field as sluggable use property annotation @gedmo:Sluggable
+     * @Gedmo\Sluggable
+     * to mark the field as sluggable use property annotation @Gedmo\Sluggable
      * this field value will be included in built slug
      */
 
     /*
-     * @gedmo:Slug - to mark property which will hold slug use annotation @gedmo:Slug
+     * @Gedmo\Slug - to mark property which will hold slug use annotation @Gedmo\Slug
      * available options:
      *         updatable (optional, default=true) - true to update the slug on sluggable field changes, false - otherwise
      *         unique (optional, default=true) - true if slug should be unique and if identical it will be prefixed, false - otherwise
@@ -40,7 +38,7 @@ interface Sluggable
      *
      * example:
      *
-     * @gedmo:Slug(style="camel", separator="_", prefix="", suffix="", updatable=false, unique=false)
+     * @Gedmo\Slug(style="camel", separator="_", prefix="", suffix="", updatable=false, unique=false)
      * @Column(type="string", length=64)
      * $property
      */

--- a/src/SoftDeleteable/SoftDeleteable.php
+++ b/src/SoftDeleteable/SoftDeleteable.php
@@ -10,9 +10,7 @@
 namespace Gedmo\SoftDeleteable;
 
 /**
- * This interface is not necessary but can be implemented for
- * Domain Objects which in some cases needs to be identified as
- * SoftDeleteable
+ * Marker interface for objects which can be identified as soft-deletable.
  *
  * @author Gustavo Falco <comfortablynumb84@gmail.com>
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
@@ -22,12 +20,12 @@ interface SoftDeleteable
     // this interface is not necessary to implement
 
     /*
-     * @gedmo:SoftDeleteable
-     * to mark the class as SoftDeleteable use class annotation @gedmo:SoftDeleteable
+     * @Gedmo\SoftDeleteable
+     * to mark the class as SoftDeleteable use class annotation @Gedmo\SoftDeleteable
      * this object will be able to be soft deleted
      * example:
      *
-     * @gedmo:SoftDeleteable
+     * @Gedmo\SoftDeleteable
      * class MyEntity
      */
 }

--- a/src/SoftDeleteable/Traits/SoftDeleteable.php
+++ b/src/SoftDeleteable/Traits/SoftDeleteable.php
@@ -10,8 +10,9 @@
 namespace Gedmo\SoftDeleteable\Traits;
 
 /**
- * A generic trait to use on your self-deletable entities.
- * There is no mapping information defined in this trait.
+ * Trait for soft-deletable objects.
+ *
+ * This implementation does not provide any mapping configurations.
  *
  * @author Wesley van Opdorp <wesley.van.opdorp@freshheads.com>
  */

--- a/src/SoftDeleteable/Traits/SoftDeleteableDocument.php
+++ b/src/SoftDeleteable/Traits/SoftDeleteableDocument.php
@@ -13,8 +13,9 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Types\Type;
 
 /**
- * A soft deletable trait you can apply to your MongoDB entities.
- * Includes default annotation mapping.
+ * Trait for soft-deletable objects.
+ *
+ * This implementation provides a mapping configuration for the Doctrine MongoDB ODM.
  *
  * @author Wesley van Opdorp <wesley.van.opdorp@freshheads.com>
  */

--- a/src/SoftDeleteable/Traits/SoftDeleteableEntity.php
+++ b/src/SoftDeleteable/Traits/SoftDeleteableEntity.php
@@ -14,8 +14,9 @@ use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * A soft deletable trait you can apply to your Doctrine ORM entities.
- * Includes default annotation mapping.
+ * Trait for soft-deletable objects.
+ *
+ * This implementation provides a mapping configuration for the Doctrine ORM.
  *
  * @author Wesley van Opdorp <wesley.van.opdorp@freshheads.com>
  */

--- a/src/Sortable/Sortable.php
+++ b/src/Sortable/Sortable.php
@@ -10,9 +10,7 @@
 namespace Gedmo\Sortable;
 
 /**
- * This interface is not necessary but can be implemented for
- * Entities which in some cases needs to be identified as
- * Sortable
+ * Marker interface for objects which can be identified as sortable.
  *
  * @author Lukas Botsch <lukas.botsch@gmail.com>
  */
@@ -21,27 +19,27 @@ interface Sortable
     // use now annotations instead of predefined methods, this interface is not necessary
 
     /*
-     * @gedmo:SortablePosition - to mark property which will hold the item position use annotation @gedmo:SortablePosition
+     * @Gedmo\SortablePosition - to mark property which will hold the item position use annotation @Gedmo\SortablePosition
      *              This property has to be numeric. The position index can be negative and will be counted from right to left.
      *
      * example:
      *
-     * @gedmo:SortablePosition
+     * @Gedmo\SortablePosition
      * @Column(type="int")
      * $position
      *
-     * @gedmo:SortableGroup
+     * @Gedmo\SortableGroup
      * @Column(type="string", length=64)
      * $category
      *
      */
 
     /*
-     * @gedmo:SortableGroup - to group node sorting by a property use annotation @gedmo:SortableGroup on this property
+     * @Gedmo\SortableGroup - to group node sorting by a property use annotation @Gedmo\SortableGroup on this property
      *
      * example:
      *
-     * @gedmo:SortableGroup
+     * @Gedmo\SortableGroup
      * @Column(type="string", length=64)
      * $category
      */

--- a/src/Timestampable/Timestampable.php
+++ b/src/Timestampable/Timestampable.php
@@ -10,9 +10,7 @@
 namespace Gedmo\Timestampable;
 
 /**
- * This interface is not necessary but can be implemented for
- * Entities which in some cases needs to be identified as
- * Timestampable
+ * Marker interface for objects which can be identified as timestampable.
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
@@ -21,35 +19,35 @@ interface Timestampable
     // timestampable expects annotations on properties
 
     /*
-     * @gedmo:Timestampable(on="create")
+     * @Gedmo\Timestampable(on="create")
      * dates which should be updated on insert only
      */
 
     /*
-     * @gedmo:Timestampable(on="update")
+     * @Gedmo\Timestampable(on="update")
      * dates which should be updated on update and insert
      */
 
     /*
-     * @gedmo:Timestampable(on="change", field="field", value="value")
+     * @Gedmo\Timestampable(on="change", field="field", value="value")
      * dates which should be updated on changed "property"
      * value and become equal to given "value"
      */
 
     /*
-     * @gedmo:Timestampable(on="change", field="field")
+     * @Gedmo\Timestampable(on="change", field="field")
      * dates which should be updated on changed "property"
      */
 
     /*
-     * @gedmo:Timestampable(on="change", fields={"field1", "field2"})
+     * @Gedmo\Timestampable(on="change", fields={"field1", "field2"})
      * dates which should be updated if at least one of the given fields changed
      */
 
     /*
      * example
      *
-     * @gedmo:Timestampable(on="create")
+     * @Gedmo\Timestampable(on="create")
      * @Column(type="date")
      * $created
      */

--- a/src/Timestampable/Traits/Timestampable.php
+++ b/src/Timestampable/Traits/Timestampable.php
@@ -10,7 +10,9 @@
 namespace Gedmo\Timestampable\Traits;
 
 /**
- * Timestampable Trait, usable with PHP >= 5.4
+ * Trait for timestampable objects.
+ *
+ * This implementation does not provide any mapping configurations.
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */

--- a/src/Timestampable/Traits/TimestampableDocument.php
+++ b/src/Timestampable/Traits/TimestampableDocument.php
@@ -14,7 +14,9 @@ use Doctrine\ODM\MongoDB\Types\Type;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
- * Timestampable Trait, usable with PHP >= 5.4
+ * Trait for timestampable objects.
+ *
+ * This implementation provides a mapping configuration for the Doctrine MongoDB ODM.
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */

--- a/src/Timestampable/Traits/TimestampableEntity.php
+++ b/src/Timestampable/Traits/TimestampableEntity.php
@@ -14,7 +14,9 @@ use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
- * Timestampable Trait, usable with PHP >= 5.4
+ * Trait for timestampable objects.
+ *
+ * This implementation provides a mapping configuration for the Doctrine ORM.
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -21,19 +21,19 @@ interface Translatable
     // use now annotations instead of predefined methods, this interface is not necessary
 
     /*
-     * @gedmo:TranslationEntity
+     * @Gedmo\TranslationEntity
      * to specify custom translation class use
-     * class annotation @gedmo:TranslationEntity(class="your\class")
+     * class annotation @Gedmo\TranslationEntity(class="your\class")
      */
 
     /*
-     * @gedmo:Translatable
+     * @Gedmo\Translatable
      * to mark the field as translatable,
      * these fields will be translated
      */
 
     /*
-     * @gedmo:Locale OR @gedmo:Language
+     * @Gedmo\Locale OR @Gedmo\Language
      * to mark the field as locale used to override global
      * locale settings from TranslatableListener
      */

--- a/src/Tree/Node.php
+++ b/src/Tree/Node.php
@@ -10,9 +10,7 @@
 namespace Gedmo\Tree;
 
 /**
- * This interface is not necessary but can be implemented for
- * Entities which in some cases needs to be identified as
- * Tree Node
+ * Marker interface for objects which can be identified as a tree node.
  *
  * @method void  setSibling(self $node)
  * @method ?self getSibling()
@@ -24,25 +22,25 @@ interface Node
     // use now annotations instead of predefined methods, this interface is not necessary
 
     /*
-     * @gedmo:TreeLeft
-     * to mark the field as "tree left" use property annotation @gedmo:TreeLeft
+     * @Gedmo\TreeLeft
+     * to mark the field as "tree left" use property annotation @Gedmo\TreeLeft
      * it will use this field to store tree left value
      */
 
     /*
-     * @gedmo:TreeRight
-     * to mark the field as "tree right" use property annotation @gedmo:TreeRight
+     * @Gedmo\TreeRight
+     * to mark the field as "tree right" use property annotation @Gedmo\TreeRight
      * it will use this field to store tree right value
      */
 
     /*
-     * @gedmo:TreeParent
+     * @Gedmo\TreeParent
      * in every tree there should be link to parent. To identify a relation
      * as parent relation to child use @Tree:Ancestor annotation on the related property
      */
 
     /*
-     * @gedmo:TreeLevel
+     * @Gedmo\TreeLevel
      * level of node.
      */
 

--- a/src/Tree/Traits/MaterializedPath.php
+++ b/src/Tree/Traits/MaterializedPath.php
@@ -13,7 +13,9 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 
 /**
- * MaterializedPath Trait
+ * Trait for objects in a materialized path tree.
+ *
+ *  This implementation does not provide any mapping configurations.
  *
  * @author Steffen Roßkamp <steffen.rosskamp@gimmickmedia.de>
  */
@@ -23,18 +25,22 @@ trait MaterializedPath
      * @var string
      */
     protected $path;
+
     /**
      * @var self|null
      */
     protected $parent;
+
     /**
      * @var int
      */
     protected $level;
+
     /**
      * @var Collection<int, self>|self[]|null
      */
     protected $children;
+
     /**
      * @var string
      */

--- a/src/Tree/Traits/NestedSet.php
+++ b/src/Tree/Traits/NestedSet.php
@@ -10,7 +10,9 @@
 namespace Gedmo\Tree\Traits;
 
 /**
- * NestedSet Trait, usable with PHP >= 5.4
+ * Trait for objects in a nested tree.
+ *
+ * This implementation does not provide any mapping configurations.
  *
  * @author Renaat De Muynck <renaat.demuynck@gmail.com>
  */

--- a/src/Tree/Traits/NestedSetEntity.php
+++ b/src/Tree/Traits/NestedSetEntity.php
@@ -14,7 +14,9 @@ use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
- * NestedSet Trait, usable with PHP >= 5.4
+ * Trait for objects in a nested tree.
+ *
+ * This implementation provides a mapping configuration for the Doctrine ORM for entities using numeric primary keys.
  *
  * @author Renaat De Muynck <renaat.demuynck@gmail.com>
  */

--- a/src/Tree/Traits/NestedSetEntityUuid.php
+++ b/src/Tree/Traits/NestedSetEntityUuid.php
@@ -14,7 +14,9 @@ use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
- * NestedSet Trait with UUid, usable with PHP >= 5.4
+ * Trait for objects in a nested tree.
+ *
+ * This implementation provides a mapping configuration for the Doctrine ORM for entities using UUID-generated primary keys.
  *
  * @author Benjamin Lazarecki <benjamin.lazarecki@sensiolabs.com>
  */

--- a/src/Uploadable/Uploadable.php
+++ b/src/Uploadable/Uploadable.php
@@ -10,9 +10,7 @@
 namespace Gedmo\Uploadable;
 
 /**
- * This interface is not necessary but can be implemented for
- * Domain Objects which in some cases needs to be identified as
- * Uploadable
+ * Marker interface for objects which can be identified as uploadable.
  *
  * @author Gustavo Falco <comfortablynumb84@gmail.com>
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
@@ -22,12 +20,12 @@ interface Uploadable
     // this interface is not necessary to implement
 
     /*
-     * @gedmo:Uploadable
-     * to mark the class as Uploadable use class annotation @gedmo:Uploadable
+     * @Gedmo\Uploadable
+     * to mark the class as Uploadable use class annotation @Gedmo\Uploadable
      * this object will be able Uploadable
      * example:
      *
-     * @gedmo:Uploadable
+     * @Gedmo\Uploadable
      * class MyEntity
      */
 }


### PR DESCRIPTION
Just as advertised:

- Updates the trait doc blocks to remove references to PHP 5.4, we're a bit past that point 😉
- Updates the marker interface doc blocks to make it a bit more clear these are generic marker interfaces
- Updates the inline comments on the marker interfaces to stop using a very legacy annotation syntax