### PR TITLE
chore: bump github actions for "ramsey/composer-install" 2 => 3

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -22,7 +22,7 @@ jobs:
           php-version: "8.1"
 
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v2"
+        uses: "ramsey/composer-install@v3"
         with:
           dependency-versions: "highest"
 
@@ -45,7 +45,7 @@ jobs:
           tools: "composer:v2"
 
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v2"
+        uses: "ramsey/composer-install@v3"
         with:
           dependency-versions: "highest"
           composer-options: "--prefer-dist --prefer-stable"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -54,7 +54,7 @@ jobs:
         run: "composer remove --dev --no-update friendsofphp/php-cs-fixer"
 
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v2"
+        uses: "ramsey/composer-install@v3"
         with:
           dependency-versions: "${{ matrix.deps }}"
 
@@ -83,7 +83,7 @@ jobs:
           extensions: mongodb
 
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v2"
+        uses: "ramsey/composer-install@v3"
         with:
           dependency-versions: "highest"
 

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -25,7 +25,7 @@ jobs:
           tools: composer:v2
 
       - name: Install Composer dependencies (highest)
-        uses: ramsey/composer-install@v2
+        uses: ramsey/composer-install@v3
         with:
           dependency-versions: highest
           composer-options: --prefer-dist --prefer-stable --no-interaction --no-progress


### PR DESCRIPTION
will fix ci deprecations for node 16.