### PR TITLE
Run tests without `doctrine/annotations` installed

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -78,7 +78,7 @@ jobs:
       - name: "Upload coverage file"
         uses: "actions/upload-artifact@v4"
         with:
-          name: "${{ github.job }}-${{ matrix.php-version }}-${{ matrix.deps }}-coverage"
+          name: "${{ github.job }}-${{ matrix.php-version }}-${{ matrix.deps }}-${{ matrix.no-annotations == true && 'no-annotations' || 'with-annotations' }}-coverage"
           path: "coverage.xml"
 
   lint-doctrine-xml-schema:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,6 +21,7 @@ jobs:
           - 27017:27017
 
     strategy:
+      fail-fast: false
       matrix:
         php-version:
           - "7.4"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   phpunit:
-    name: "PHPUnit ${{ matrix.php-version }} (${{ matrix.deps }})"
+    name: "PHPUnit ${{ matrix.php-version }} (${{ matrix.deps }})${{ matrix.no-annotations == true && ' - Without Annotations' || '' }}"
     runs-on: "ubuntu-20.04"
 
     services:
@@ -30,11 +30,19 @@ jobs:
           - "8.3"
         deps:
           - "highest"
+        no-annotations:
+          - false
         include:
           - deps: "lowest"
             php-version: "7.4"
           - deps: "highest"
             php-version: "8.3"
+          - deps: "highest"
+            php-version: "7.4"
+            no-annotations: true
+          - deps: "highest"
+            php-version: "8.3"
+            no-annotations: true
 
     steps:
       - name: "Checkout"
@@ -52,6 +60,11 @@ jobs:
       # Remove PHP-CS-Fixer to avoid conflicting dependency ranges (i.e. doctrine/annotations)
       - name: "Remove PHP-CS-Fixer"
         run: "composer remove --dev --no-update friendsofphp/php-cs-fixer"
+
+      # Remove doctrine/annotations if configured to do so
+      - name: "Remove doctrine/annotations"
+        if: "${{ matrix.no-annotations }}"
+        run: "composer remove --dev --no-update doctrine/annotations"
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v3"

--- a/tests/Gedmo/Mapping/Fixture/Unmapped/Timestampable.php
+++ b/tests/Gedmo/Mapping/Fixture/Unmapped/Timestampable.php
@@ -25,5 +25,6 @@ class Timestampable
      *
      * @Tmsp(on="create")
      */
+    #[Tmsp(on: 'create')]
     private $created;
 }

--- a/tests/Gedmo/Mapping/LoggableORMMappingTest.php
+++ b/tests/Gedmo/Mapping/LoggableORMMappingTest.php
@@ -59,9 +59,7 @@ final class LoggableORMMappingTest extends ORMMappingTestCase
     {
         if (PHP_VERSION_ID >= 80000) {
             yield 'Model with attributes' => [AnnotatedLoggable::class];
-        }
-
-        if (class_exists(AnnotationDriver::class)) {
+        } elseif (class_exists(AnnotationDriver::class)) {
             yield 'Model with annotations' => [AnnotatedLoggable::class];
         }
 
@@ -121,9 +119,7 @@ final class LoggableORMMappingTest extends ORMMappingTestCase
 
         if (PHP_VERSION_ID >= 80000) {
             yield 'Model with attributes' => [AnnotatedLoggableComposite::class];
-        }
-
-        if (class_exists(AnnotationDriver::class)) {
+        } elseif (class_exists(AnnotationDriver::class)) {
             yield 'Model with annotations' => [AnnotatedLoggableComposite::class];
         }
 
@@ -166,9 +162,7 @@ final class LoggableORMMappingTest extends ORMMappingTestCase
 
         if (PHP_VERSION_ID >= 80000) {
             yield 'Model with attributes' => [AnnotatedLoggableCompositeRelation::class];
-        }
-
-        if (class_exists(AnnotationDriver::class)) {
+        } elseif (class_exists(AnnotationDriver::class)) {
             yield 'Model with annotations' => [AnnotatedLoggableCompositeRelation::class];
         }
 
@@ -214,9 +208,7 @@ final class LoggableORMMappingTest extends ORMMappingTestCase
     {
         if (PHP_VERSION_ID >= 80000) {
             yield 'Model with attributes' => [AnnotatedLoggableWithEmbedded::class];
-        }
-
-        if (class_exists(AnnotationDriver::class)) {
+        } elseif (class_exists(AnnotationDriver::class)) {
             yield 'Model with annotations' => [AnnotatedLoggableWithEmbedded::class];
         }
     }

--- a/tests/Gedmo/Mapping/MetadataFactory/CustomDriverTest.php
+++ b/tests/Gedmo/Mapping/MetadataFactory/CustomDriverTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Gedmo\Tests\Mapping\MetadataFactory;
 
+use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\ORM\Configuration;
@@ -19,6 +20,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
+use Gedmo\Mapping\Driver\AttributeReader;
 use Gedmo\Tests\Mapping\Fixture\Unmapped\Timestampable;
 use Gedmo\Timestampable\TimestampableListener;
 use PHPUnit\Framework\TestCase;
@@ -48,7 +50,13 @@ final class CustomDriverTest extends TestCase
 
         $evm = new EventManager();
         $this->timestampable = new TimestampableListener();
-        $this->timestampable->setAnnotationReader($_ENV['annotation_reader']);
+
+        if (PHP_VERSION >= 80000) {
+            $this->timestampable->setAnnotationReader(new AttributeReader());
+        } elseif (class_exists(AnnotationReader::class)) {
+            $this->timestampable->setAnnotationReader($_ENV['annotation_reader']);
+        }
+
         $evm->addEventSubscriber($this->timestampable);
         $connection = DriverManager::getConnection($conn, $config);
         $this->em = new EntityManager($connection, $config, $evm);

--- a/tests/Gedmo/Mapping/ORMMappingTestCase.php
+++ b/tests/Gedmo/Mapping/ORMMappingTestCase.php
@@ -78,7 +78,7 @@ abstract class ORMMappingTestCase extends TestCase
             $chain->addDriver(new AttributeDriver([]), 'Gedmo\Tests\Mapping\Fixture');
         }
 
-        if (class_exists(AnnotationDriver::class)) {
+        if (class_exists(AnnotationDriver::class) && class_exists(AnnotationReader::class)) {
             $chain->addDriver(new AnnotationDriver(new AnnotationReader()), 'Gedmo\Tests\Mapping\Fixture');
         }
 

--- a/tests/Gedmo/Mapping/ORMMappingTestCase.php
+++ b/tests/Gedmo/Mapping/ORMMappingTestCase.php
@@ -76,9 +76,7 @@ abstract class ORMMappingTestCase extends TestCase
 
         if (PHP_VERSION_ID >= 80000) {
             $chain->addDriver(new AttributeDriver([]), 'Gedmo\Tests\Mapping\Fixture');
-        }
-
-        if (class_exists(AnnotationDriver::class) && class_exists(AnnotationReader::class)) {
+        } elseif (class_exists(AnnotationDriver::class) && class_exists(AnnotationReader::class)) {
             $chain->addDriver(new AnnotationDriver(new AnnotationReader()), 'Gedmo\Tests\Mapping\Fixture');
         }
 

--- a/tests/Gedmo/Mapping/SluggableMappingTest.php
+++ b/tests/Gedmo/Mapping/SluggableMappingTest.php
@@ -51,9 +51,7 @@ final class SluggableMappingTest extends ORMMappingTestCase
 
         if (PHP_VERSION_ID >= 80000) {
             yield 'Model with attributes' => [AnnotatedSluggable::class];
-        }
-
-        if (class_exists(AnnotationDriver::class)) {
+        } elseif (class_exists(AnnotationDriver::class)) {
             yield 'Model with annotations' => [AnnotatedSluggable::class];
         }
     }

--- a/tests/Gedmo/Mapping/SoftDeleteableMappingTest.php
+++ b/tests/Gedmo/Mapping/SoftDeleteableMappingTest.php
@@ -50,9 +50,7 @@ final class SoftDeleteableMappingTest extends ORMMappingTestCase
 
         if (PHP_VERSION_ID >= 80000) {
             yield 'Model with attributes' => [AnnotatedSoftDeleteable::class];
-        }
-
-        if (class_exists(AnnotationDriver::class)) {
+        } elseif (class_exists(AnnotationDriver::class)) {
             yield 'Model with annotations' => [AnnotatedSoftDeleteable::class];
         }
 

--- a/tests/Gedmo/Mapping/SortableMappingTest.php
+++ b/tests/Gedmo/Mapping/SortableMappingTest.php
@@ -49,9 +49,7 @@ final class SortableMappingTest extends ORMMappingTestCase
 
         if (PHP_VERSION_ID >= 80000) {
             yield 'Model with attributes' => [AnnotatedSortable::class];
-        }
-
-        if (class_exists(AnnotationDriver::class)) {
+        } elseif (class_exists(AnnotationDriver::class)) {
             yield 'Model with annotations' => [AnnotatedSortable::class];
         }
 

--- a/tests/Gedmo/Mapping/TimestampableMappingTest.php
+++ b/tests/Gedmo/Mapping/TimestampableMappingTest.php
@@ -49,9 +49,7 @@ final class TimestampableMappingTest extends ORMMappingTestCase
     {
         if (PHP_VERSION_ID >= 80000) {
             yield 'Model with attributes' => [AnnotatedCategory::class];
-        }
-
-        if (class_exists(AnnotationDriver::class)) {
+        } elseif (class_exists(AnnotationDriver::class)) {
             yield 'Model with annotations' => [AnnotatedCategory::class];
         }
 

--- a/tests/Gedmo/Mapping/TranslatableMappingTest.php
+++ b/tests/Gedmo/Mapping/TranslatableMappingTest.php
@@ -51,9 +51,7 @@ final class TranslatableMappingTest extends ORMMappingTestCase
 
         if (PHP_VERSION_ID >= 80000) {
             yield 'Model with attributes' => [AnnotatedUser::class];
-        }
-
-        if (class_exists(AnnotationDriver::class)) {
+        } elseif (class_exists(AnnotationDriver::class)) {
             yield 'Model with annotations' => [AnnotatedUser::class];
         }
 

--- a/tests/Gedmo/Mapping/UploadableMappingTest.php
+++ b/tests/Gedmo/Mapping/UploadableMappingTest.php
@@ -54,9 +54,7 @@ final class UploadableMappingTest extends ORMMappingTestCase
 
         if (PHP_VERSION_ID >= 80000) {
             yield 'Model with attributes' => [AnnotatedUploadable::class];
-        }
-
-        if (class_exists(AnnotationDriver::class)) {
+        } elseif (class_exists(AnnotationDriver::class)) {
             yield 'Model with annotations' => [AnnotatedUploadable::class];
         }
 

--- a/tests/Gedmo/Timestampable/AttributeChangeTest.php
+++ b/tests/Gedmo/Timestampable/AttributeChangeTest.php
@@ -25,6 +25,8 @@ use Gedmo\Tests\Tool\BaseTestCaseORM;
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  *
  * @requires PHP >= 8.0
+ *
+ * @todo This test requires {@see ChangeTest} to have been run first to load the {@see TimestampableListenerStub}
  */
 final class AttributeChangeTest extends BaseTestCaseORM
 {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -29,8 +29,8 @@ define('TESTS_TEMP_DIR', sys_get_temp_dir().'/doctrine-extension-tests');
 
 require dirname(__DIR__).'/vendor/autoload.php';
 
-$reader = new AnnotationReader();
-$reader = new PsrCachedReader($reader, new ArrayAdapter());
-$_ENV['annotation_reader'] = $reader;
+if (class_exists(AnnotationReader::class)) {
+    $_ENV['annotation_reader'] = new PsrCachedReader(new AnnotationReader(), new ArrayAdapter());
+}
 
 Type::addType('uuid', UuidType::class);


### PR DESCRIPTION
MongoDB ODM 2.7 dropped the hard dependency, so let's do a smoke test build without the annotations package installed here and see what happens...