### PR TITLE
[SoftDeleteableFilter] Fix addFilterConstraint() return type is missing

### DIFF
--- a/src/SoftDeleteable/Filter/SoftDeleteableFilter.php
+++ b/src/SoftDeleteable/Filter/SoftDeleteableFilter.php
@@ -51,7 +51,7 @@ class SoftDeleteableFilter extends SQLFilter
      *
      * @return string
      */
-    public function addFilterConstraint(ClassMetadata $targetEntity, $targetTableAlias)
+    public function addFilterConstraint(ClassMetadata $targetEntity, $targetTableAlias): string
     {
         $class = $targetEntity->getName();
         if (true === ($this->disabled[$class] ?? false)) {


### PR DESCRIPTION
Resolve:
> Fatal error: Declaration of Gedmo\SoftDeleteable\Filter\SoftDeleteableFilter::addFilterConstraint(Doctrine\ORM\Mapping\ClassMetadata $targetEntity, $targetTableAlias) must be compatible with Doctrine\ORM\Query\Filter\SQLFilter::addFilterConstraint(Doctrine\ORM\Mapping\ClassMetadata $targetEntity, string $targetTableAlias): string in /var/www/html/vendor/gedmo/doctrine-extensions/src/SoftDeleteable/Filter/SoftDeleteableFilter.php on line 54

https://github.com/doctrine/orm/blob/55c4845d5734bea5579424c2c2a7c5b97dbb4c60/src/Query/Filter/SQLFilter.php#L173

As DoctrineExtensions supports `php >= 7`, but was denied in #2089 before.