### PR TITLE
LogEntryInterface::getObjectClass() @phpstan-return is missing null

### DIFF
--- a/src/Loggable/LogEntryInterface.php
+++ b/src/Loggable/LogEntryInterface.php
@@ -58,7 +58,7 @@ interface LogEntryInterface
     /**
      * @return string|null
      *
-     * @phpstan-return class-string<T>
+     * @phpstan-return class-string<T>|null
      */
     public function getObjectClass();
 


### PR DESCRIPTION
Fixes #2789.