### PR TITLE
[add-ascii-string-blameable] Allow ascii_string to validTypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ a release.
 ---
 
 ## [Unreleased]
+### Added
 - Blameable: Added UUID in allowed types list for Blameable fields in Annotation
+- Blameable: Allow ascii_string to validTypes (issue #2726)
 
 ## [3.15.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ a release.
 ### Added
 - Blameable: Added UUID in allowed types list for Blameable fields in Annotation
 - Blameable: Allow ascii_string to validTypes (issue #2726)
+- Sluggable: Allow ascii_string to validTypes
+- IpTraceable: Allow ascii_string to validTypes
 
 ## [3.15.0]
 ### Added

--- a/src/Blameable/Mapping/Driver/Annotation.php
+++ b/src/Blameable/Mapping/Driver/Annotation.php
@@ -41,6 +41,7 @@ class Annotation extends AbstractAnnotationDriver
         'int',
         'ulid',
         'uuid',
+        'ascii_string',
     ];
 
     public function readExtendedMetadata($meta, array &$config)

--- a/src/IpTraceable/Mapping/Driver/Annotation.php
+++ b/src/IpTraceable/Mapping/Driver/Annotation.php
@@ -37,6 +37,7 @@ class Annotation extends AbstractAnnotationDriver
      */
     protected $validTypes = [
         'string',
+        'ascii_string',
     ];
 
     public function readExtendedMetadata($meta, array &$config)

--- a/src/Sluggable/Mapping/Driver/Annotation.php
+++ b/src/Sluggable/Mapping/Driver/Annotation.php
@@ -61,6 +61,7 @@ class Annotation extends AbstractAnnotationDriver
         'datetimetz',
         'datetimetz_immutable',
         'citext',
+        'ascii_string',
     ];
 
     public function readExtendedMetadata($meta, array &$config)


### PR DESCRIPTION
Update Gedmo\Blameable\Mapping\Driver\Annotation::validTypes to allow ascii_string.
This is my first contribution to an open source project. Thank you in advance for guiding me through the process.