### PR TITLE
Add an internal trait to allow cross-version compatibility for ORM hydrators

### DIFF
--- a/src/Tool/ORM/Hydration/HydratorCompat.php
+++ b/src/Tool/ORM/Hydration/HydratorCompat.php
@@ -1,0 +1,131 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tool\ORM\Hydration;
+
+use Doctrine\ORM\Internal\Hydration\AbstractHydrator;
+
+// The methods we need the compat bridge for are protected, so we're using a public method for this check
+if ((new \ReflectionClass(AbstractHydrator::class))->getMethod('onClear')->hasReturnType()) {
+    // ORM 3.x
+    /**
+     * Helper trait to address compatibility issues between ORM 2.x and 3.x.
+     *
+     * @mixin AbstractHydrator
+     *
+     * @internal
+     */
+    trait HydratorCompat
+    {
+        /**
+         * Executes one-time preparation tasks, once each time hydration is started
+         * through {@link hydrateAll} or {@link toIterable()}.
+         */
+        protected function prepare(): void
+        {
+            $this->doPrepareWithCompat();
+        }
+
+        protected function doPrepareWithCompat(): void
+        {
+            parent::prepare();
+        }
+
+        /**
+         * Executes one-time cleanup tasks at the end of a hydration that was initiated
+         * through {@link hydrateAll} or {@link toIterable()}.
+         */
+        protected function cleanup(): void
+        {
+            $this->doCleanupWithCompat();
+        }
+
+        protected function doCleanupWithCompat(): void
+        {
+            parent::cleanup();
+        }
+
+        /**
+         * Hydrates all rows from the current statement instance at once.
+         */
+        protected function hydrateAllData(): mixed
+        {
+            return $this->doHydrateAllData();
+        }
+
+        /**
+         * @return mixed[]
+         */
+        protected function doHydrateAllData()
+        {
+            return parent::hydrateAllData();
+        }
+    }
+} else {
+    // ORM 2.x
+    /**
+     * Helper trait to address compatibility issues between ORM 2.x and 3.x.
+     *
+     * @mixin AbstractHydrator
+     *
+     * @internal
+     */
+    trait HydratorCompat
+    {
+        /**
+         * Executes one-time preparation tasks, once each time hydration is started
+         * through {@link hydrateAll} or {@link toIterable()}.
+         *
+         * @return void
+         */
+        protected function prepare()
+        {
+            $this->doPrepareWithCompat();
+        }
+
+        protected function doPrepareWithCompat(): void
+        {
+            parent::prepare();
+        }
+
+        /**
+         * Executes one-time cleanup tasks at the end of a hydration that was initiated
+         * through {@link hydrateAll} or {@link toIterable()}.
+         *
+         * @return void
+         */
+        protected function cleanup()
+        {
+            $this->doCleanupWithCompat();
+        }
+
+        protected function doCleanupWithCompat(): void
+        {
+            parent::cleanup();
+        }
+
+        /**
+         * Hydrates all rows from the current statement instance at once.
+         *
+         * @return mixed[]
+         */
+        protected function hydrateAllData()
+        {
+            return $this->doHydrateAllData();
+        }
+
+        /**
+         * @return mixed[]
+         */
+        protected function doHydrateAllData()
+        {
+            return parent::hydrateAllData();
+        }
+    }
+}

--- a/src/Translatable/Hydrator/ORM/ObjectHydrator.php
+++ b/src/Translatable/Hydrator/ORM/ObjectHydrator.php
@@ -12,6 +12,7 @@ namespace Gedmo\Translatable\Hydrator\ORM;
 use Doctrine\ORM\Internal\Hydration\ObjectHydrator as BaseObjectHydrator;
 use Gedmo\Exception\RuntimeException;
 use Gedmo\Tool\ORM\Hydration\EntityManagerRetriever;
+use Gedmo\Tool\ORM\Hydration\HydratorCompat;
 use Gedmo\Translatable\TranslatableListener;
 
 /**
@@ -27,21 +28,17 @@ use Gedmo\Translatable\TranslatableListener;
 class ObjectHydrator extends BaseObjectHydrator
 {
     use EntityManagerRetriever;
+    use HydratorCompat;
 
     /**
      * State of skipOnLoad for listener between hydrations
      *
      * @see ObjectHydrator::prepare()
      * @see ObjectHydrator::cleanup()
-     *
-     * @var bool|null
      */
-    private $savedSkipOnLoad;
+    private ?bool $savedSkipOnLoad = null;
 
-    /**
-     * @return void
-     */
-    protected function prepare()
+    protected function doPrepareWithCompat(): void
     {
         $listener = $this->getTranslatableListener();
         $this->savedSkipOnLoad = $listener->isSkipOnLoad();
@@ -49,10 +46,7 @@ class ObjectHydrator extends BaseObjectHydrator
         parent::prepare();
     }
 
-    /**
-     * @return void
-     */
-    protected function cleanup()
+    protected function doCleanupWithCompat(): void
     {
         parent::cleanup();
         $listener = $this->getTranslatableListener();

--- a/src/Translatable/Hydrator/ORM/SimpleObjectHydrator.php
+++ b/src/Translatable/Hydrator/ORM/SimpleObjectHydrator.php
@@ -12,6 +12,7 @@ namespace Gedmo\Translatable\Hydrator\ORM;
 use Doctrine\ORM\Internal\Hydration\SimpleObjectHydrator as BaseSimpleObjectHydrator;
 use Gedmo\Exception\RuntimeException;
 use Gedmo\Tool\ORM\Hydration\EntityManagerRetriever;
+use Gedmo\Tool\ORM\Hydration\HydratorCompat;
 use Gedmo\Translatable\TranslatableListener;
 
 /**
@@ -27,21 +28,17 @@ use Gedmo\Translatable\TranslatableListener;
 class SimpleObjectHydrator extends BaseSimpleObjectHydrator
 {
     use EntityManagerRetriever;
+    use HydratorCompat;
 
     /**
      * State of skipOnLoad for listener between hydrations
      *
      * @see SimpleObjectHydrator::prepare()
      * @see SimpleObjectHydrator::cleanup()
-     *
-     * @var bool|null
      */
-    private $savedSkipOnLoad;
+    private ?bool $savedSkipOnLoad = null;
 
-    /**
-     * @return void
-     */
-    protected function prepare()
+    protected function doPrepareWithCompat(): void
     {
         $listener = $this->getTranslatableListener();
         $this->savedSkipOnLoad = $listener->isSkipOnLoad();
@@ -49,10 +46,7 @@ class SimpleObjectHydrator extends BaseSimpleObjectHydrator
         parent::prepare();
     }
 
-    /**
-     * @return void
-     */
-    protected function cleanup()
+    protected function doCleanupWithCompat(): void
     {
         parent::cleanup();
         $listener = $this->getTranslatableListener();

--- a/src/Tree/Hydrator/ORM/TreeObjectHydrator.php
+++ b/src/Tree/Hydrator/ORM/TreeObjectHydrator.php
@@ -15,6 +15,7 @@ use Doctrine\ORM\Internal\Hydration\ObjectHydrator;
 use Doctrine\ORM\PersistentCollection;
 use Gedmo\Exception\InvalidMappingException;
 use Gedmo\Tool\ORM\Hydration\EntityManagerRetriever;
+use Gedmo\Tool\ORM\Hydration\HydratorCompat;
 use Gedmo\Tree\TreeListener;
 
 /**
@@ -27,6 +28,7 @@ use Gedmo\Tree\TreeListener;
 class TreeObjectHydrator extends ObjectHydrator
 {
     use EntityManagerRetriever;
+    use HydratorCompat;
 
     /**
      * @var array<string, mixed>
@@ -66,7 +68,7 @@ class TreeObjectHydrator extends ObjectHydrator
      *
      * @return array<int, object>
      */
-    protected function hydrateAllData()
+    protected function doHydrateAllData()
     {
         $data = parent::hydrateAllData();
 


### PR DESCRIPTION
Ref: #2708

Similar to #2758 this adds a trait to help with cross-version compatibility, this time for the ORM hydrators and their changed signatures.  Flat-out adding return types would be treated as a B/C break, so that can't be done cleanly until a 4.0 release, so this trait helps to cover those changes in an easily replaced way when the bridge is no longer needed.