### PR TITLE
Bump versions in CI tools

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -19,7 +19,7 @@ jobs:
         uses: "shivammathur/setup-php@v2"
         with:
           coverage: "none"
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v2"
@@ -40,7 +40,7 @@ jobs:
       - name: "Install PHP"
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.2"
+          php-version: "8.3"
           coverage: "none"
           tools: "composer:v2"
 
@@ -65,7 +65,7 @@ jobs:
       - name: Install PHP with extensions
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
           tools: composer:v2, composer-normalize:2
         env:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -34,7 +34,7 @@ jobs:
           - deps: "lowest"
             php-version: "7.4"
           - deps: "highest"
-            php-version: "8.1"
+            php-version: "8.3"
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/qa-dockerfile.yml
+++ b/.github/workflows/qa-dockerfile.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build "php" container
-        uses: isbang/compose-action@v1.5.1
+        uses: isbang/compose-action@v2.0.0
         with:
           compose-file: "./compose.yaml"
           services: |

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -19,9 +19,9 @@ jobs:
       - name: Install PHP with extensions
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
-          extensions: mongodb-1.9.0, zip
+          extensions: mongodb, zip
           tools: composer:v2
 
       - name: Install Composer dependencies (highest)

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,7 +5,7 @@ services:
       target: php
       dockerfile: ./.docker/php/Dockerfile
       args:
-        PHP_VERSION: ${PHP_VERSION:-8.2-cli}
+        PHP_VERSION: ${PHP_VERSION:-8.3-cli}
     volumes:
       - .:/var/www
     working_dir: /var/www


### PR DESCRIPTION
Upgrades all the CI stuff.  Gist of the changes:

- Use PHP 8.3 for all analysis jobs or high builds (previously a mix of 8.1 or 8.2)
- Bump the Docker Compose config to use PHP 8.3
- Unpin the `ext/mongodb` version in the PHPStan build, latest release is G2G on the latest PHP version to my knowledge (and if it's not then we can use something more recent than 10 minor releases ago 😅)
- `isbang/compose-action` has a new major release