### PR TITLE
Update the branch alias for dev-main

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -96,7 +96,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "3.13-dev"
+            "dev-main": "3.x-dev"
         }
     },
     "scripts": {


### PR DESCRIPTION
Having the main branch aliased to an older minor version causes issues. Aliasing it only for the major version makes the maintenance easier as it does not need to be updated for each minor release.