### PR TITLE
Move phpunit.xml.dist to root directory

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -88,7 +88,7 @@ jobs:
           dependency-versions: "${{ matrix.deps }}"
 
       - name: "Run PHPUnit"
-        run: "vendor/bin/phpunit -c tests --coverage-clover coverage.xml"
+        run: "vendor/bin/phpunit --coverage-clover coverage.xml"
 
       - name: "Upload coverage file"
         uses: "actions/upload-artifact@v4"

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@ bin
 vendor
 composer.lock
 phpstan.neon
-tests/.phpunit.result.cache
+.phpunit.result.cache
 tests/phpunit.xml

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ To set up and run the tests, follow these steps:
 - From the project root, run `docker compose up -d` to start containers in daemon mode
 - Enter the container via `docker compose exec php bash` (you are now in the root directory: `/var/www`)
 - Install Composer dependencies via `composer install`
-- Run the tests: `vendor/bin/phpunit -c tests/`
+- Run the tests: `vendor/bin/phpunit`
 
 ### Running the Example
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,7 @@
     convertWarningsToExceptions="true"
     processIsolation="false"
     stopOnFailure="false"
-    bootstrap="./bootstrap.php"
+    bootstrap="./tests/bootstrap.php"
     xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
 >
     <coverage>
@@ -18,52 +18,52 @@
     </coverage>
     <testsuites>
         <testsuite name="Translatable Extension">
-            <directory suffix="Test.php">./Gedmo/Translatable/</directory>
+            <directory suffix="Test.php">./tests/Gedmo/Translatable/</directory>
         </testsuite>
         <testsuite name="Sluggable Extension">
-            <directory suffix="Test.php">./Gedmo/Sluggable/</directory>
+            <directory suffix="Test.php">./tests/Gedmo/Sluggable/</directory>
         </testsuite>
         <testsuite name="Sortable Extension">
-            <directory suffix="Test.php">./Gedmo/Sortable/</directory>
+            <directory suffix="Test.php">./tests/Gedmo/Sortable/</directory>
         </testsuite>
         <testsuite name="Tree Extension">
-            <directory suffix="Test.php">./Gedmo/Tree/</directory>
+            <directory suffix="Test.php">./tests/Gedmo/Tree/</directory>
         </testsuite>
         <testsuite name="Timestampable Extension">
-            <directory suffix="Test.php">./Gedmo/Timestampable/</directory>
+            <directory suffix="Test.php">./tests/Gedmo/Timestampable/</directory>
         </testsuite>
         <testsuite name="Blameable Extension">
-            <directory suffix="Test.php">./Gedmo/Blameable/</directory>
+            <directory suffix="Test.php">./tests/Gedmo/Blameable/</directory>
         </testsuite>
         <testsuite name="IpTraceable Extension">
-            <directory suffix="Test.php">./Gedmo/IpTraceable/</directory>
+            <directory suffix="Test.php">./tests/Gedmo/IpTraceable/</directory>
         </testsuite>
         <testsuite name="Mapping Extension">
-            <directory suffix="Test.php">./Gedmo/Mapping/</directory>
+            <directory suffix="Test.php">./tests/Gedmo/Mapping/</directory>
         </testsuite>
         <testsuite name="Loggable Extension">
-            <directory suffix="Test.php">./Gedmo/Loggable/</directory>
+            <directory suffix="Test.php">./tests/Gedmo/Loggable/</directory>
         </testsuite>
         <testsuite name="Sortable Extension">
-            <directory suffix="Test.php">./Gedmo/Sortable/</directory>
+            <directory suffix="Test.php">./tests/Gedmo/Sortable/</directory>
         </testsuite>
         <testsuite name="Object wrappers">
-            <directory suffix="Test.php">./Gedmo/Wrapper/</directory>
+            <directory suffix="Test.php">./tests/Gedmo/Wrapper/</directory>
         </testsuite>
         <testsuite name="Translator extension">
-            <directory suffix="Test.php">./Gedmo/Translator/</directory>
+            <directory suffix="Test.php">./tests/Gedmo/Translator/</directory>
         </testsuite>
         <testsuite name="SoftDeleteable Extension">
-            <directory suffix="Test.php">./Gedmo/SoftDeleteable/</directory>
+            <directory suffix="Test.php">./tests/Gedmo/SoftDeleteable/</directory>
         </testsuite>
         <testsuite name="Uploadable Extension">
-            <directory suffix="Test.php">./Gedmo/Uploadable/</directory>
+            <directory suffix="Test.php">./tests/Gedmo/Uploadable/</directory>
         </testsuite>
         <testsuite name="ReferenceIntegrity Extension">
-            <directory suffix="Test.php">./Gedmo/ReferenceIntegrity/</directory>
+            <directory suffix="Test.php">./tests/Gedmo/ReferenceIntegrity/</directory>
         </testsuite>
         <testsuite name="References Extension">
-            <directory suffix="Test.php">./Gedmo/References/</directory>
+            <directory suffix="Test.php">./tests/Gedmo/References/</directory>
         </testsuite>
     </testsuites>
     <php>


### PR DESCRIPTION
That way we don't need to specify where the configuration file is.