### PR TITLE
Introduce the Revisionable extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ a release.
 ---
 
 ## [Unreleased]
+### Added
+- Introduced the `Revisionable` extension as a modern replacement to the `Loggable` extension (#2825)
+
 ### Changed
 - All: Removed the dollar sign from the generated cache ID for extension metadata to ensure only characters mandated by [PSR-6](https://www.php-fig.org/psr/psr-6/#definitions) are used, improving compatibility with caching implementations with strict character requirements (#2978)
 
@@ -48,7 +51,6 @@ a release.
 - SoftDeleteable: Resolved a bug where a soft-deleted object isn't remove from the ObjectManager (#2930)
 
 ### Added
-- Introduced the `Revisionable` extension as a modern replacement to the `Loggable` extension (#2825)
 - IP address provider for use with extensions with IP address references (#2928)
 
 ## [3.19.0] - 2025-02-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ a release.
 - SoftDeleteable: Resolved a bug where a soft-deleted object isn't remove from the ObjectManager (#2930)
 
 ### Added
+- Introduced the `Revisionable` extension as a modern replacement to the `Loggable` extension (#2825)
 - IP address provider for use with extensions with IP address references (#2928)
 
 ## [3.19.0] - 2025-02-24

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         "gedmo",
         "sluggable",
         "loggable",
+        "revisionable",
         "odm",
         "orm",
         "translatable",

--- a/doc/annotations.md
+++ b/doc/annotations.md
@@ -14,6 +14,7 @@ extension, refer to the extension's documentation page.
 - [Loggable Extension](#loggable-extension)
 - [Reference Integrity Extension](#reference-integrity-extension)
 - [References Extension](#references-extension)
+- [Revisionable Extension](#revisionable-extension)
 - [Sluggable Extension](#sluggable-extension)
 - [Soft Deleteable Extension](#soft-deleteable-extension)
 - [Sortable Extension](#sortable-extension)
@@ -492,6 +493,79 @@ class Article
     {
         $this->comments = new ArrayCollection();
     }
+}
+```
+
+### Revisionable Extension
+
+The below annotations are used to configure the [Revisionable extension](./revisionable.md).
+
+#### `@Gedmo\Mapping\Annotation\Revisionable`
+
+The `Revisionable` annotation is a class annotation used to identify objects which can have changes logged,
+all revisionable objects **MUST** have this annotation.
+
+Required Attributes:
+
+- **revisionClass** - A custom model class implementing `Gedmo\Revisionable\RevisionInterface` to use for logging changes;
+  defaults to `Gedmo\Revisionable\Entity\Revision` for Doctrine ORM users or
+  `Gedmo\Revisionable\Document\Revision` for Doctrine MongoDB ODM users
+
+Example:
+
+```php
+<?php
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * @ORM\Entity
+ * @Gedmo\Revisionable(revisionClass="App\Entity\ArticleRevision")
+ */
+class Article {}
+```
+
+#### `@Gedmo\Mapping\Annotation\Versioned`
+
+The `Versioned` annotation is a property annotation used to identify properties whose changes should be logged.
+This annotation can be set for properties with a single value (i.e. a scalar type or an object such as
+`DateTimeInterface`), but not for collections. Versioned fields can be restored to an earlier version.
+
+Example:
+
+```php
+<?php
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * @ORM\Entity
+ * @Gedmo\Revisionable
+ */
+class Comment
+{
+    /**
+    * @ORM\Id
+    * @ORM\GeneratedValue
+    * @ORM\Column(type="integer")
+    */
+    public ?int $id = null;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="App\Entity\Article", inversedBy="comments")
+     * @Gedmo\Versioned
+     */
+    public ?Article $article = null;
+
+    /**
+     * @ORM\Column(type="string")
+     * @Gedmo\Versioned
+     */
+    public ?string $body = null;
 }
 ```
 

--- a/doc/annotations.md
+++ b/doc/annotations.md
@@ -527,11 +527,11 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Article {}
 ```
 
-#### `@Gedmo\Mapping\Annotation\Versioned`
+#### `@Gedmo\Mapping\Annotation\KeepRevisions`
 
-The `Versioned` annotation is a property annotation used to identify properties whose changes should be logged.
+The `KeepRevisions` annotation is a property annotation used to identify properties whose changes should be logged.
 This annotation can be set for properties with a single value (i.e. a scalar type or an object such as
-`DateTimeInterface`), but not for collections. Versioned fields can be restored to an earlier version.
+`DateTimeInterface`), but not for collections. Fields with revisions can be restored to an earlier version.
 
 Example:
 
@@ -557,13 +557,13 @@ class Comment
 
     /**
      * @ORM\ManyToOne(targetEntity="App\Entity\Article", inversedBy="comments")
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     public ?Article $article = null;
 
     /**
      * @ORM\Column(type="string")
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     public ?string $body = null;
 }

--- a/doc/attributes.md
+++ b/doc/attributes.md
@@ -14,6 +14,7 @@ For more detailed usage of each extension, refer to the extension's documentatio
 - [Loggable Extension](#loggable-extension)
 - [Reference Integrity Extension](#reference-integrity-extension)
 - [References Extension](#references-extension)
+- [Revisionable Extension](#revisionable-extension)
 - [Sluggable Extension](#sluggable-extension)
 - [Soft Deleteable Extension](#soft-deleteable-extension)
 - [Sortable Extension](#sortable-extension)
@@ -437,6 +438,70 @@ class Article
     {
         $this->comments = new ArrayCollection();
     }
+}
+```
+
+### Revisionable Extension
+
+The below attributes are used to configure the [Revisionable extension](./revisionable.md).
+
+#### `#[Gedmo\Mapping\Annotation\Revisionable]`
+
+The `Revisionable` attribute is a class attribute used to identify objects which can have changes logged,
+all revisionable objects **MUST** have this attribute.
+
+Required Parameters:
+
+- **revisionClass** - A custom model class implementing `Gedmo\Revisionable\RevisionInterface` to use for logging changes;
+  defaults to `Gedmo\Revisionable\Entity\Revision` for Doctrine ORM users or
+  `Gedmo\Revisionable\Document\Revision` for Doctrine MongoDB ODM users
+
+Example:
+
+```php
+<?php
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+#[ORM\Entity]
+#[Gedmo\Revisionable(revisionClass: ArticleRevision::class)]
+class Article {}
+```
+
+#### `#[Gedmo\Mapping\Annotation\Versioned]`
+
+The `Versioned` attribute is a property attribute used to identify properties whose changes should be logged.
+This attribute can be set for properties with a single value (i.e. a scalar type or an object such as
+`DateTimeInterface`), but not for collections. Versioned fields can be restored to an earlier version.
+
+Example:
+
+```php
+<?php
+namespace App\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+#[ORM\Entity]
+#[Gedmo\Revisionable]
+class Comment
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    public ?int $id = null;
+
+    #[ORM\ManyToOne(targetEntity: Article::class, inversedBy: 'comments')]
+    #[Gedmo\Versioned]
+    public ?Article $article = null;
+
+    #[ORM\Column(type: Types::STRING)]
+    #[Gedmo\Versioned]
+    public ?string $body = null;
 }
 ```
 

--- a/doc/attributes.md
+++ b/doc/attributes.md
@@ -470,11 +470,11 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Article {}
 ```
 
-#### `#[Gedmo\Mapping\Annotation\Versioned]`
+#### `#[Gedmo\Mapping\Annotation\KeepRevisions]`
 
-The `Versioned` attribute is a property attribute used to identify properties whose changes should be logged.
+The `KeepRevisions` attribute is a property attribute used to identify properties whose changes should be logged.
 This attribute can be set for properties with a single value (i.e. a scalar type or an object such as
-`DateTimeInterface`), but not for collections. Versioned fields can be restored to an earlier version.
+`DateTimeInterface`), but not for collections. Fields with revisions can be restored to an earlier version.
 
 Example:
 
@@ -496,11 +496,11 @@ class Comment
     public ?int $id = null;
 
     #[ORM\ManyToOne(targetEntity: Article::class, inversedBy: 'comments')]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     public ?Article $article = null;
 
     #[ORM\Column(type: Types::STRING)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     public ?string $body = null;
 }
 ```

--- a/doc/frameworks/laminas.md
+++ b/doc/frameworks/laminas.md
@@ -44,6 +44,7 @@ use Gedmo\Blameable\BlameableListener;
 use Gedmo\IpTraceable\IpTraceableListener;
 use Gedmo\Loggable\LoggableListener;
 use Gedmo\Mapping\Driver\AttributeReader;
+use Gedmo\Revisionable\RevisionableListener;
 use Gedmo\Sluggable\SluggableListener;
 use Gedmo\SoftDeleteable\SoftDeleteableListener;
 use Gedmo\Sortable\SortableListener;
@@ -77,6 +78,14 @@ return [
             },
             'gedmo.listener.loggable' => function (ContainerInterface $container, string $requestedName): LoggableListener {
                 $listener = new LoggableListener();
+
+                // This call configures the listener to use the attribute driver service created above; if using annotations, you will need to provide the appropriate service instead
+                $listener->setAnnotationReader($container->get('gedmo.mapping.driver.attribute'));
+
+                return $listener;
+            },
+            'gedmo.listener.revisionable' => function (ContainerInterface $container, string $requestedName): RevisionableListener {
+                $listener = new RevisionableListener();
 
                 // This call configures the listener to use the attribute driver service created above; if using annotations, you will need to provide the appropriate service instead
                 $listener->setAnnotationReader($container->get('gedmo.mapping.driver.attribute'));
@@ -141,6 +150,7 @@ return [
                     'gedmo.listener.blameable',
                     'gedmo.listener.ip_traceable',
                     'gedmo.listener.loggable',
+                    'gedmo.listener.revisionable',
                     'gedmo.listener.sluggable',
                     'gedmo.listener.soft_deleteable',
                     'gedmo.listener.sortable',
@@ -232,8 +242,8 @@ return [
 
 ## Registering Mapping Configuration
 
-When using the [Loggable](../loggable.md), [Translatable](../translatable.md), or [Tree](../tree.md) extensions, you will
-need to register the mappings for these extensions to your object managers.
+When using the [Loggable](../loggable.md), [Revisionable](../revisionable.md), [Translatable](../translatable.md),
+or [Tree](../tree.md) extensions, you will need to register the mappings for these extensions to your object managers.
 
 > [!NOTE]
 > These extensions only provide mappings through annotations or attributes, with support for annotations being deprecated. If using annotations, you will need to ensure the [`doctrine/annotations`](https://www.doctrine-project.org/projects/annotations.html) library is installed and configured.
@@ -258,6 +268,7 @@ return [
                 'class' => AttributeDriver::class, // If your application is using annotations, use the AnnotationDriver class instead
                 'paths' => [
                     '/path/to/vendor/gedmo/doctrine-extensions/src/Loggable/Document',
+                    '/path/to/vendor/gedmo/doctrine-extensions/src/Revisionable/Document',
                     '/path/to/vendor/gedmo/doctrine-extensions/src/Translatable/Document',
                 ],
             ],
@@ -288,6 +299,7 @@ return [
                 'class' => AttributeDriver::class, // If your application is using annotations, use the AnnotationDriver class instead
                 'paths' => [
                     '/path/to/vendor/gedmo/doctrine-extensions/src/Loggable/Entity',
+                    '/path/to/vendor/gedmo/doctrine-extensions/src/Revisionable/Entity',
                     '/path/to/vendor/gedmo/doctrine-extensions/src/Translatable/Entity',
                     '/path/to/vendor/gedmo/doctrine-extensions/src/Tree/Entity',
                 ],
@@ -310,6 +322,8 @@ $ vendor/bin/doctrine-module orm:info
 
  [OK]   Gedmo\Loggable\Entity\LogEntry
  [OK]   Gedmo\Loggable\Entity\MappedSuperclass\AbstractLogEntry
+ [OK]   Gedmo\Revisionable\Entity\Revision
+ [OK]   Gedmo\Revisionable\Entity\MappedSuperclass\AbstractRevision
  [OK]   Gedmo\Translatable\Entity\Translation
  [OK]   Gedmo\Translatable\Entity\MappedSuperclass\AbstractTranslation
  [OK]   Gedmo\Translatable\Entity\MappedSuperclass\AbstractPersonalTranslation
@@ -374,9 +388,9 @@ return [
 
 ## Configuring Extensions via Event Listeners
 
-When using the [Blameable](../blameable.md), [IP Traceable](../ip_traceable.md), [Loggable](../loggable.md), or
-[Translatable](../translatable.md) extensions, to work correctly, they require extra information that must be set
-at runtime.
+When using the [Blameable](../blameable.md), [IP Traceable](../ip_traceable.md), [Loggable](../loggable.md),
+[Revisionable](../revisionable.md), or [Translatable](../translatable.md) extensions, to work correctly,
+they require extra information that must be set at runtime.
 
 **Help Improve This Documentation**
 

--- a/doc/loggable.md
+++ b/doc/loggable.md
@@ -2,8 +2,11 @@
 
 The **Loggable** behavior adds support for logging changes to and restoring prior versions of your Doctrine objects.
 
+> [!IMPORTANT]
+> The Loggable extension is **NOT** compatible with `doctrine/dbal` >=4.0. If your project needs this extension, you will need to use the latest `doctrine/dbal` 3.x release.
+
 > [!NOTE]
-> The Loggable extension is NOT compatible with `doctrine/dbal` 4.0 or later
+> We recommend that new projects use the [Revisionable](./revisionable.md) extension instead of the Loggable extension.
 
 ## Index
 

--- a/doc/revisionable.md
+++ b/doc/revisionable.md
@@ -114,7 +114,7 @@ class Article
     public bool $published = false;
 
     #[ORM\Column(type: Types::STRING)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     public ?string $title = null;
 }
 ```
@@ -134,7 +134,7 @@ class Article
         <field name="published" type="boolean"/>
 
         <field name="title" type="string">
-            <gedmo:versioned/>
+            <gedmo:keep-revisions/>
         </field>
 
         <gedmo:revisionable/>
@@ -174,7 +174,7 @@ class Article
 
     /**
      * @ORM\Column(type="string")
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     public ?string $title = null;
 }

--- a/doc/revisionable.md
+++ b/doc/revisionable.md
@@ -1,0 +1,286 @@
+# Revisionable Behavior Extension for Doctrine
+
+The **Revisionable** behavior adds support for logging changes to and restoring prior versions of your Doctrine objects.
+
+## Index
+
+- [Differences Between Loggable and Revisionable](#differences-between-loggable-and-revisionable)
+- [Getting Started](#getting-started)
+- [Configuring Revisionable Objects](#configuring-revisionable-objects)
+- [Customizing The Revision Model](#customizing-the-revision-model)
+- [Object Repositories](#object-repositories)
+    - [Fetching a Model's Revisions](#fetching-a-models-revisions)
+    - [Revert a Model to a Previous Version](#revert-a-model-to-a-previous-version)
+
+## Differences Between Loggable and Revisionable
+
+The revisionable extension is a modern implementation of the loggable extension, and while largely similar, there are
+some underlying differences in the out-of-the-box features in each extension.
+
+### JSON Field Storage
+
+When using the revisionable extension with the Doctrine DBAL and ORM, the default `Revision` entity stores its data in
+a JSON column, whereas the loggable extension uses an array column (which under the hood is transformed to a serialized
+array). The array column type was deprecated in DBAL 3.x and removed in 4.0 in favor of the JSON column type, which requires
+a data migration since the two field types are not directly compatible.
+
+For those using the Doctrine MongoDB ODM, there is no change in the underlying mapping configuration.
+
+### Normalized Data Array
+
+The loggable extension would store the changes as provided by the underlying model. This would result in PHP objects
+(such as the core `DateTimeImmutable` class) being saved in the serialized payload. The revisionable extension saves
+normalized values using the `Type::convertToDatabaseValue()` APIs from each supported object manager. As a side effect,
+this also means that when reverting models to an older state, the `Type::convertToPHPValue()` APIs are used to restore
+values.
+
+As a practical example, this is the payload saved to a `LogEntry` when using the DBAL:
+
+```shell
+a:4:{s:5:"title";s:5:"Title";s:9:"publishAt";O:17:"DateTimeImmutable":3:{s:4:"date";s:26:"2024-06-24 23:00:00.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:3:"UTC";}s:11:"author.name";s:8:"John Doe";s:12:"author.email";s:12:"john@doe.com";}
+```
+
+And this is the equivalent value when saving a `Revision`:
+
+```json
+{
+	"title": "Title",
+	"publishAt": "2024-06-24 23:00:00",
+	"author.name": "John Doe",
+	"author.email": "john@doe.com"
+}
+```
+
+## Getting Started
+
+The revisionable behavior can be added to a supported Doctrine object manager by registering its event subscriber
+when creating the manager.
+
+```php
+use Gedmo\Revisionable\RevisionableListener;
+
+$listener = new RevisionableListener();
+
+// The $om is either an instance of the ORM's entity manager or the MongoDB ODM's document manager
+$om->getEventManager()->addEventSubscriber($listener);
+```
+
+Then, once your application has it available (i.e. after validating the authentication for your user during an HTTP request),
+you can set a reference to the user who performed actions on a revisionable model.
+
+The user reference can be set through either an [actor provider service](./utils/actor-provider.md) or by calling the
+listener's `setUsername` method with a resolved user.
+
+> [!TIP]
+> When an actor provider is given to the extension, any data set with the `setUsername` method will be ignored.
+
+```php
+// The $provider must be an implementation of Gedmo\Tool\ActorProviderInterface
+$listener->setActorProvider($provider);
+
+// The $user can be either an object or a string
+$listener->setUsername($user);
+```
+
+## Configuring Revisionable Objects
+
+The revisionable extension can be configured with [annotations](./annotations.md#revisionable-extension),
+[attributes](./attributes.md#revisionable-extension), or XML configuration (matching the mapping of
+your domain models). The full configuration for annotations and attributes can be reviewed in
+the linked documentation.
+
+The below examples show the simplest and default configuration for the extension, logging changes for defined fields.
+
+### Attribute Configuration
+
+```php
+<?php
+namespace App\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+#[ORM\Entity]
+#[Gedmo\Revisionable]
+class Article
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    public ?int $id = null;
+
+    #[ORM\Column(type: Types::BOOLEAN)]
+    public bool $published = false;
+
+    #[ORM\Column(type: Types::STRING)]
+    #[Gedmo\Versioned]
+    public ?string $title = null;
+}
+```
+
+### XML Configuration
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:gedmo="http://gediminasm.org/schemas/orm/doctrine-extensions-mapping">
+
+    <entity name="App\Model\Article" table="articles">
+        <id name="id" type="integer" column="id">
+            <generator strategy="AUTO"/>
+        </id>
+
+        <field name="published" type="boolean"/>
+
+        <field name="title" type="string">
+            <gedmo:versioned/>
+        </field>
+
+        <gedmo:revisionable/>
+    </entity>
+</doctrine-mapping>
+```
+
+### Annotation Configuration
+
+> [!NOTE]
+> Support for annotations is deprecated and will be removed in 4.0.
+
+```php
+<?php
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * @ORM\Entity
+ * @Gedmo\Revisionable
+ */
+class Article
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    public ?int $id = null;
+
+    /**
+     * @ORM\Column(type="boolean")
+     */
+    public bool $published = false;
+
+    /**
+     * @ORM\Column(type="string")
+     * @Gedmo\Versioned
+     */
+    public ?string $title = null;
+}
+```
+
+## Customizing The Revision Model
+
+When configuring revisionable models, you are able to specify a custom model to be used for the revisions for objects
+of that type using the `revisionClass` parameter:
+
+### Attribute Configuration
+
+```php
+<?php
+namespace App\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+#[ORM\Entity]
+#[Gedmo\Revisionable(revisionClass: ArticleRevision::class)]
+class Article
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    public ?int $id = null;
+}
+```
+
+### XML Configuration
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:gedmo="http://gediminasm.org/schemas/orm/doctrine-extensions-mapping">
+
+    <entity name="App\Model\Article" table="articles">
+        <id name="id" type="integer" column="id">
+            <generator strategy="AUTO"/>
+        </id>
+
+        <gedmo:revisionable revision-class="App\Model\ArticleRevision"/>
+    </entity>
+</doctrine-mapping>
+```
+
+A custom model must implement `Gedmo\Revisionable\RevisionInterface`. For convenience, we recommend extending from
+`Gedmo\Revisionable\Entity\MappedSuperClass\AbstractRevision` for Doctrine ORM users or
+`Gedmo\Revisionable\Document\MappedSuperClass\AbstractRevision` for Doctrine MongoDB ODM users, which provides a default
+mapping configuration for each object manager.
+
+## Object Repositories
+
+The revisionable extension includes a `Doctrine\Persistence\ObjectRepository` implementation for each supported object manager
+that provides out-of-the-box features for all revision models. When creating custom models, you are welcome to extend
+from either `Gedmo\Revisionable\Entity\Repository\RevisionRepository` for Doctrine ORM users or
+`Gedmo\Revisionable\Document\Repository\RevisionRepository` for Doctrine MongoDB ODM users to provide these features.
+
+### Fetching a Model's Revisions
+
+The repository classes provide a `getRevisions` method which allows fetching the list of revisions for a given model.
+
+```php
+use App\Entity\Article;
+use Doctrine\ORM\EntityManagerInterface;
+use Gedmo\Revisionable\Entity\Revision;
+use Gedmo\Revisionable\Entity\Repository\RevisionRepository;
+use Gedmo\Revisionable\RevisionableListener;
+
+/** @var EntityManagerInterface $em */
+
+// Load our revisionable model
+$article = $em->find(Article::class, 1);
+
+// Next, get the Revision repository
+/** @var RevisionRepository $repo */
+$repo = $em->getRepository(Revision::class);
+
+// Lastly, get the article's revisions
+$revisions = $repo->getRevisions($article);
+```
+
+### Revert a Model to a Previous Version
+
+The repository classes provide a `revert` method which allows reverting a model to a previous version. The repository
+will incrementally revert back to the version specified (for example, a model is currently on version 5, and you want to
+revert to version 2, it will restore the state of version 4, then version 3, and finally, version 2).
+
+```php
+use App\Entity\Article;
+use Doctrine\ORM\EntityManagerInterface;
+use Gedmo\Revisionable\Entity\Revision;
+use Gedmo\Revisionable\Entity\Repository\RevisionRepository;
+use Gedmo\Revisionable\RevisionableListener;
+
+/** @var EntityManagerInterface $em */
+
+// Load our revisionable model
+$article = $em->find(Article::class, 1);
+
+// Next, get the Revision repository
+/** @var RevisionRepository $repo */
+$repo = $em->getRepository(Revision::class);
+
+// We are now able to revert to an older version
+$repo->revert($article, 2);
+```

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -355,12 +355,6 @@ parameters:
 			path: src/References/ReferencesListener.php
 
 		-
-			message: '#^Cannot unset offset non\-empty\-string on non\-empty\-list\<non\-empty\-string\>\.$#'
-			identifier: unset.offset
-			count: 1
-			path: src/Revisionable/Document/Repository/RevisionRepository.php
-
-		-
 			message: '#^Method Gedmo\\Revisionable\\Document\\Revision\:\:createRevision\(\) should return Gedmo\\Revisionable\\Document\\Revision\<T of object\> but returns Gedmo\\Revisionable\\Document\\Revision\<object\>\.$#'
 			identifier: return.type
 			count: 1
@@ -1473,7 +1467,7 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$entity of method Gedmo\\Revisionable\\Entity\\Repository\\RevisionRepository\<Gedmo\\Tests\\Revisionable\\Fixture\\Entity\\CommentRevision\>\:\:revert\(\) expects Gedmo\\Tests\\Revisionable\\Fixture\\Entity\\CommentRevision, Gedmo\\Tests\\Revisionable\\Fixture\\Entity\\Comment given\.$#'
 			identifier: argument.type
-			count: 1
+			count: 2
 			path: tests/Gedmo/Revisionable/RevisionableEntityTest.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -355,6 +355,66 @@ parameters:
 			path: src/References/ReferencesListener.php
 
 		-
+			message: '#^Cannot unset offset non\-empty\-string on non\-empty\-list\<non\-empty\-string\>\.$#'
+			identifier: unset.offset
+			count: 1
+			path: src/Revisionable/Document/Repository/RevisionRepository.php
+
+		-
+			message: '#^Method Gedmo\\Revisionable\\Document\\Revision\:\:createRevision\(\) should return Gedmo\\Revisionable\\Document\\Revision\<T of object\> but returns Gedmo\\Revisionable\\Document\\Revision\<object\>\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Revisionable/Document/Revision.php
+
+		-
+			message: '#^Unable to resolve the template type T in call to method Doctrine\\ORM\\EntityManagerInterface\:\:getReference\(\)$#'
+			identifier: argument.templateType
+			count: 1
+			path: src/Revisionable/Entity/Repository/RevisionRepository.php
+
+		-
+			message: '#^Method Gedmo\\Revisionable\\Entity\\Revision\:\:createRevision\(\) should return Gedmo\\Revisionable\\Entity\\Revision\<T of object\> but returns Gedmo\\Revisionable\\Entity\\Revision\<object\>\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Revisionable/Entity/Revision.php
+
+		-
+			message: '#^Access to offset ''isOwningSide'' on an unknown class Doctrine\\ODM\\MongoDB\\Mapping\\AssociationFieldMapping\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/Revisionable/Mapping/Driver/Attribute.php
+
+		-
+			message: '#^Access to an undefined property Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\:\:\$associationMappings\.$#'
+			identifier: property.notFound
+			count: 1
+			path: src/Revisionable/Mapping/Driver/Xml.php
+
+		-
+			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<Gedmo\\Revisionable\\RevisionInterface\<T of object\>\>\:\:setFieldValue\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Revisionable/RevisionableListener.php
+
+		-
+			message: '#^Call to an undefined method Doctrine\\Persistence\\ObjectManager\:\:getUnitOfWork\(\)\.$#'
+			identifier: method.notFound
+			count: 4
+			path: src/Revisionable/RevisionableListener.php
+
+		-
+			message: '#^Method Gedmo\\Revisionable\\RevisionableListener\:\:getRevisionClass\(\) should return class\-string\<Gedmo\\Revisionable\\RevisionInterface\<T of object\>\> but returns class\-string\<Gedmo\\Revisionable\\RevisionInterface\<object\>\>\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Revisionable/RevisionableListener.php
+
+		-
+			message: '#^Method Gedmo\\Tool\\WrapperInterface\<Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>,object,Doctrine\\Persistence\\ObjectManager\>\:\:getIdentifier\(\) invoked with 2 parameters, 0\-1 required\.$#'
+			identifier: arguments.count
+			count: 2
+			path: src/Revisionable/RevisionableListener.php
+
+		-
 			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\:\:getFieldValue\(\)\.$#'
 			identifier: method.notFound
 			count: 1
@@ -1063,6 +1123,150 @@ parameters:
 			path: tests/Gedmo/Mapping/Fixture/Category.php
 
 		-
+			message: '#^Property Gedmo\\Tests\\Mapping\\Fixture\\Document\\EmbeddedRevisionable\:\:\$subtitle \(string\|null\) is never assigned string so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: tests/Gedmo/Mapping/Fixture/Document/EmbeddedRevisionable.php
+
+		-
+			message: '#^Property Gedmo\\Tests\\Mapping\\Fixture\\Document\\Revisionable\:\:\$id \(string\|null\) is never assigned string so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: tests/Gedmo/Mapping/Fixture/Document/Revisionable.php
+
+		-
+			message: '#^Property Gedmo\\Tests\\Mapping\\Fixture\\Document\\RevisionableWithEmbedded\:\:\$embedded \(Gedmo\\Tests\\Mapping\\Fixture\\Document\\EmbeddedRevisionable\|null\) is never assigned Gedmo\\Tests\\Mapping\\Fixture\\Document\\EmbeddedRevisionable so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: tests/Gedmo/Mapping/Fixture/Document/RevisionableWithEmbedded.php
+
+		-
+			message: '#^Property Gedmo\\Tests\\Mapping\\Fixture\\Document\\RevisionableWithEmbedded\:\:\$id \(string\|null\) is never assigned string so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: tests/Gedmo/Mapping/Fixture/Document/RevisionableWithEmbedded.php
+
+		-
+			message: '#^Property Gedmo\\Tests\\Mapping\\Fixture\\Document\\RevisionableWithEmbedded\:\:\$title \(string\|null\) is never assigned string so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: tests/Gedmo/Mapping/Fixture/Document/RevisionableWithEmbedded.php
+
+		-
+			message: '#^Property Gedmo\\Tests\\Mapping\\Fixture\\Entity\\EmbeddedRevisionable\:\:\$subtitle \(string\|null\) is never assigned string so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: tests/Gedmo/Mapping/Fixture/Entity/EmbeddedRevisionable.php
+
+		-
+			message: '#^Property Gedmo\\Tests\\Mapping\\Fixture\\Xml\\EmbeddedRevisionable\:\:\$subtitle \(string\|null\) is never assigned string so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: tests/Gedmo/Mapping/Fixture/Xml/EmbeddedRevisionable.php
+
+		-
+			message: '#^Property Gedmo\\Tests\\Mapping\\Fixture\\Xml\\Revisionable\:\:\$id \(int\|null\) is never assigned int so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: tests/Gedmo/Mapping/Fixture/Xml/Revisionable.php
+
+		-
+			message: '#^Property Gedmo\\Tests\\Mapping\\Fixture\\Xml\\RevisionableComposite\:\:\$one \(int\|null\) is never assigned int so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: tests/Gedmo/Mapping/Fixture/Xml/RevisionableComposite.php
+
+		-
+			message: '#^Property Gedmo\\Tests\\Mapping\\Fixture\\Xml\\RevisionableComposite\:\:\$two \(int\|null\) is never assigned int so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: tests/Gedmo/Mapping/Fixture/Xml/RevisionableComposite.php
+
+		-
+			message: '#^Property Gedmo\\Tests\\Mapping\\Fixture\\Xml\\RevisionableCompositeRelation\:\:\$one \(Gedmo\\Tests\\Mapping\\Fixture\\Xml\\Revisionable\|null\) is never assigned Gedmo\\Tests\\Mapping\\Fixture\\Xml\\Revisionable so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: tests/Gedmo/Mapping/Fixture/Xml/RevisionableCompositeRelation.php
+
+		-
+			message: '#^Property Gedmo\\Tests\\Mapping\\Fixture\\Xml\\RevisionableCompositeRelation\:\:\$two \(int\|null\) is never assigned int so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: tests/Gedmo/Mapping/Fixture/Xml/RevisionableCompositeRelation.php
+
+		-
+			message: '#^Property Gedmo\\Tests\\Mapping\\Fixture\\Xml\\RevisionableWithEmbedded\:\:\$embedded \(Gedmo\\Tests\\Mapping\\Fixture\\Xml\\Embedded\|null\) is never assigned Gedmo\\Tests\\Mapping\\Fixture\\Xml\\Embedded so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: tests/Gedmo/Mapping/Fixture/Xml/RevisionableWithEmbedded.php
+
+		-
+			message: '#^Property Gedmo\\Tests\\Mapping\\Fixture\\Xml\\RevisionableWithEmbedded\:\:\$id \(int\|null\) is never assigned int so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: tests/Gedmo/Mapping/Fixture/Xml/RevisionableWithEmbedded.php
+
+		-
+			message: '#^Property Gedmo\\Tests\\Mapping\\Fixture\\Xml\\RevisionableWithEmbedded\:\:\$title \(string\|null\) is never assigned string so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: tests/Gedmo/Mapping/Fixture/Xml/RevisionableWithEmbedded.php
+
+		-
+			message: '#^Property Gedmo\\Tests\\Mapping\\Fixture\\Yaml\\EmbeddedRevisionable\:\:\$subtitle \(string\|null\) is never assigned string so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: tests/Gedmo/Mapping/Fixture/Yaml/EmbeddedRevisionable.php
+
+		-
+			message: '#^Property Gedmo\\Tests\\Mapping\\Fixture\\Yaml\\Revisionable\:\:\$id \(int\|null\) is never assigned int so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: tests/Gedmo/Mapping/Fixture/Yaml/Revisionable.php
+
+		-
+			message: '#^Property Gedmo\\Tests\\Mapping\\Fixture\\Yaml\\RevisionableComposite\:\:\$one \(int\|null\) is never assigned int so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: tests/Gedmo/Mapping/Fixture/Yaml/RevisionableComposite.php
+
+		-
+			message: '#^Property Gedmo\\Tests\\Mapping\\Fixture\\Yaml\\RevisionableComposite\:\:\$two \(int\|null\) is never assigned int so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: tests/Gedmo/Mapping/Fixture/Yaml/RevisionableComposite.php
+
+		-
+			message: '#^Property Gedmo\\Tests\\Mapping\\Fixture\\Yaml\\RevisionableCompositeRelation\:\:\$one \(Gedmo\\Tests\\Mapping\\Fixture\\Yaml\\Revisionable\|null\) is never assigned Gedmo\\Tests\\Mapping\\Fixture\\Yaml\\Revisionable so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: tests/Gedmo/Mapping/Fixture/Yaml/RevisionableCompositeRelation.php
+
+		-
+			message: '#^Property Gedmo\\Tests\\Mapping\\Fixture\\Yaml\\RevisionableCompositeRelation\:\:\$two \(int\|null\) is never assigned int so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: tests/Gedmo/Mapping/Fixture/Yaml/RevisionableCompositeRelation.php
+
+		-
+			message: '#^Property Gedmo\\Tests\\Mapping\\Fixture\\Yaml\\RevisionableWithEmbedded\:\:\$embedded \(Gedmo\\Tests\\Mapping\\Fixture\\Yaml\\Embedded\|null\) is never assigned Gedmo\\Tests\\Mapping\\Fixture\\Yaml\\Embedded so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: tests/Gedmo/Mapping/Fixture/Yaml/RevisionableWithEmbedded.php
+
+		-
+			message: '#^Property Gedmo\\Tests\\Mapping\\Fixture\\Yaml\\RevisionableWithEmbedded\:\:\$id \(int\|null\) is never assigned int so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: tests/Gedmo/Mapping/Fixture/Yaml/RevisionableWithEmbedded.php
+
+		-
+			message: '#^Property Gedmo\\Tests\\Mapping\\Fixture\\Yaml\\RevisionableWithEmbedded\:\:\$title \(string\|null\) is never assigned string so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: tests/Gedmo/Mapping/Fixture/Yaml/RevisionableWithEmbedded.php
+
+		-
 			message: '#^Instantiated class Doctrine\\ORM\\Mapping\\Driver\\AnnotationDriver not found\.$#'
 			identifier: class.notFound
 			count: 2
@@ -1211,6 +1415,66 @@ parameters:
 			identifier: class.notFound
 			count: 1
 			path: tests/Gedmo/Mapping/Xml/TranslatableMappingTest.php
+
+		-
+			message: '#^Property Gedmo\\Tests\\Revisionable\\Fixture\\Document\\Address\:\:\$id \(string\|null\) is never assigned string so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: tests/Gedmo/Revisionable/Fixture/Document/Address.php
+
+		-
+			message: '#^Property Gedmo\\Tests\\Revisionable\\Fixture\\Document\\Article\:\:\$id \(string\|null\) is never assigned string so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: tests/Gedmo/Revisionable/Fixture/Document/Article.php
+
+		-
+			message: '#^Property Gedmo\\Tests\\Revisionable\\Fixture\\Document\\Comment\:\:\$id \(string\|null\) is never assigned string so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: tests/Gedmo/Revisionable/Fixture/Document/Comment.php
+
+		-
+			message: '#^Method Gedmo\\Tests\\Revisionable\\Fixture\\Document\\CommentRevision\:\:createRevision\(\) should return Gedmo\\Tests\\Revisionable\\Fixture\\Document\\CommentRevision\<T of Gedmo\\Tests\\Revisionable\\Fixture\\Document\\Comment\> but returns Gedmo\\Tests\\Revisionable\\Fixture\\Document\\CommentRevision\<Gedmo\\Tests\\Revisionable\\Fixture\\Document\\Comment\>\.$#'
+			identifier: return.type
+			count: 1
+			path: tests/Gedmo/Revisionable/Fixture/Document/CommentRevision.php
+
+		-
+			message: '#^Property Gedmo\\Tests\\Revisionable\\Fixture\\Document\\RelatedArticle\:\:\$id \(string\|null\) is never assigned string so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: tests/Gedmo/Revisionable/Fixture/Document/RelatedArticle.php
+
+		-
+			message: '#^Method Gedmo\\Tests\\Revisionable\\Fixture\\Entity\\CommentRevision\:\:createRevision\(\) should return Gedmo\\Tests\\Revisionable\\Fixture\\Entity\\CommentRevision\<T of Gedmo\\Tests\\Revisionable\\Fixture\\Entity\\Comment\> but returns Gedmo\\Tests\\Revisionable\\Fixture\\Entity\\CommentRevision\<Gedmo\\Tests\\Revisionable\\Fixture\\Entity\\Comment\>\.$#'
+			identifier: return.type
+			count: 1
+			path: tests/Gedmo/Revisionable/Fixture/Entity/CommentRevision.php
+
+		-
+			message: '#^Call to an undefined method Doctrine\\ORM\\EntityRepository\<Gedmo\\Revisionable\\Document\\Revision\>\:\:getRevisions\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: tests/Gedmo/Revisionable/RevisionableDocumentTest.php
+
+		-
+			message: '#^Parameter \#1 \$entity of method Gedmo\\Revisionable\\Entity\\Repository\\RevisionRepository\<Gedmo\\Revisionable\\Entity\\Revision\>\:\:getRevisions\(\) expects Gedmo\\Revisionable\\Entity\\Revision, Gedmo\\Tests\\Revisionable\\Fixture\\Entity\\Address given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/Gedmo/Revisionable/RevisionableEntityTest.php
+
+		-
+			message: '#^Parameter \#1 \$entity of method Gedmo\\Revisionable\\Entity\\Repository\\RevisionRepository\<Gedmo\\Tests\\Revisionable\\Fixture\\Entity\\CommentRevision\>\:\:getRevisions\(\) expects Gedmo\\Tests\\Revisionable\\Fixture\\Entity\\CommentRevision, Gedmo\\Tests\\Revisionable\\Fixture\\Entity\\Comment given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/Gedmo/Revisionable/RevisionableEntityTest.php
+
+		-
+			message: '#^Parameter \#1 \$entity of method Gedmo\\Revisionable\\Entity\\Repository\\RevisionRepository\<Gedmo\\Tests\\Revisionable\\Fixture\\Entity\\CommentRevision\>\:\:revert\(\) expects Gedmo\\Tests\\Revisionable\\Fixture\\Entity\\CommentRevision, Gedmo\\Tests\\Revisionable\\Fixture\\Entity\\Comment given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/Gedmo/Revisionable/RevisionableEntityTest.php
 
 		-
 			message: '#^Method Gedmo\\Tests\\Sluggable\\Fixture\\Doctrine\\FakeFilter\:\:addFilterConstraint\(\) has parameter \$targetTableAlias with no type specified\.$#'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -44,6 +44,9 @@
         <testsuite name="Loggable Extension">
             <directory suffix="Test.php">./tests/Gedmo/Loggable/</directory>
         </testsuite>
+        <testsuite name="Revisionable Extension">
+            <directory suffix="Test.php">./tests/Gedmo/Revisionable/</directory>
+        </testsuite>
         <testsuite name="Sortable Extension">
             <directory suffix="Test.php">./tests/Gedmo/Sortable/</directory>
         </testsuite>

--- a/schemas/orm/doctrine-extensions-mapping-2-2.xsd
+++ b/schemas/orm/doctrine-extensions-mapping-2-2.xsd
@@ -27,6 +27,7 @@
   <xs:element name="tree-closure" type="gedmo:tree-closure"/>
   <xs:element name="tree-path" type="gedmo:tree-path"/>
   <xs:element name="loggable" type="gedmo:loggable"/>
+  <xs:element name="revisionable" type="gedmo:revisionable"/>
   <xs:element name="soft-deleteable" type="gedmo:soft-deleteable"/>
   <xs:element name="uploadable" type="gedmo:uploadable"/>
   <xs:element name="reference" type="gedmo:reference"/>
@@ -90,6 +91,10 @@
 
   <xs:complexType name="loggable">
     <xs:attribute name="log-entry-class" type="xs:string" use="optional" />
+  </xs:complexType>
+
+  <xs:complexType name="revisionable">
+    <xs:attribute name="revision-class" type="xs:string" use="optional" />
   </xs:complexType>
 
   <xs:complexType name="slug">

--- a/schemas/orm/doctrine-extensions-mapping-2-2.xsd
+++ b/schemas/orm/doctrine-extensions-mapping-2-2.xsd
@@ -38,6 +38,7 @@
   <xs:element name="blameable" type="gedmo:blameable"/>
   <xs:element name="ip-traceable" type="gedmo:ip-traceable"/>
   <xs:element name="versioned" type="gedmo:emptyType"/>
+  <xs:element name="keep-revisions" type="gedmo:emptyType"/>
   <xs:element name="tree-left" type="gedmo:emptyType"/>
   <xs:element name="tree-right" type="gedmo:emptyType"/>
   <xs:element name="tree-level" type="gedmo:emptyType"/>

--- a/src/DoctrineExtensions.php
+++ b/src/DoctrineExtensions.php
@@ -41,6 +41,7 @@ final class DoctrineExtensions
         $paths = [
             __DIR__.'/Translatable/Entity',
             __DIR__.'/Loggable/Entity',
+            __DIR__.'/Revisionable/Entity',
             __DIR__.'/Tree/Entity',
         ];
 
@@ -62,6 +63,7 @@ final class DoctrineExtensions
         $paths = [
             __DIR__.'/Translatable/Entity/MappedSuperclass',
             __DIR__.'/Loggable/Entity/MappedSuperclass',
+            __DIR__.'/Revisionable/Entity/MappedSuperclass',
             __DIR__.'/Tree/Entity/MappedSuperclass',
         ];
 
@@ -83,6 +85,7 @@ final class DoctrineExtensions
         $paths = [
             __DIR__.'/Translatable/Document',
             __DIR__.'/Loggable/Document',
+            __DIR__.'/Revisionable/Document',
         ];
 
         if (\PHP_VERSION_ID >= 80000) {
@@ -103,6 +106,7 @@ final class DoctrineExtensions
         $paths = [
             __DIR__.'/Translatable/Document/MappedSuperclass',
             __DIR__.'/Loggable/Document/MappedSuperclass',
+            __DIR__.'/Revisionable/Document/MappedSuperclass',
         ];
 
         if (\PHP_VERSION_ID >= 80000) {

--- a/src/Loggable/Document/Repository/LogEntryRepository.php
+++ b/src/Loggable/Document/Repository/LogEntryRepository.php
@@ -143,14 +143,7 @@ class LogEntryRepository extends DocumentRepository
                 $value = $value ? $this->dm->getReference($mapping['targetDocument'], $value) : null;
             }
             $wrapped->setPropertyValue($field, $value);
-            unset($fields[$field]);
         }
-
-        /*
-        if (count($fields)) {
-            throw new \Gedmo\Exception\UnexpectedValueException('Cound not fully revert the document to version: '.$version);
-        }
-        */
     }
 
     /**

--- a/src/Loggable/Entity/Repository/LogEntryRepository.php
+++ b/src/Loggable/Entity/Repository/LogEntryRepository.php
@@ -136,10 +136,6 @@ class LogEntryRepository extends EntityRepository
         if (!$logsFound) {
             throw new UnexpectedValueException('Could not find any log entries under version: '.$version);
         }
-
-        /*if (count($fields)) {
-            throw new \Gedmo\Exception\UnexpectedValueException('Could not fully revert the entity to version: '.$version);
-        }*/
     }
 
     /**

--- a/src/Mapping/Annotation/KeepRevisions.php
+++ b/src/Mapping/Annotation/KeepRevisions.php
@@ -13,7 +13,7 @@ use Doctrine\Common\Annotations\Annotation;
 use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 
 /**
- * Versioned annotation for use with the Loggable extension
+ * Versioned annotation for use with the Revisionable extension
  *
  * @Annotation
  *
@@ -24,6 +24,6 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
-final class Versioned implements GedmoAnnotation
+final class KeepRevisions implements GedmoAnnotation
 {
 }

--- a/src/Mapping/Annotation/Revisionable.php
+++ b/src/Mapping/Annotation/Revisionable.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Mapping\Annotation;
+
+use Doctrine\Common\Annotations\Annotation;
+use Doctrine\Deprecations\Deprecation;
+use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
+use Gedmo\Revisionable\RevisionInterface;
+
+/**
+ * Revisionable annotation for the revisionable behavioral extension
+ *
+ * @phpstan-template T of RevisionInterface
+ *
+ * @Annotation
+ *
+ * @NamedArgumentConstructor
+ *
+ * @Target("CLASS")
+ *
+ * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class Revisionable implements GedmoAnnotation
+{
+    use ForwardCompatibilityTrait;
+
+    /**
+     * @phpstan-var class-string<T>|null
+     */
+    public ?string $revisionClass;
+
+    /**
+     * @param array<string, mixed> $data
+     *
+     * @phpstan-param class-string<T>|null $revisionClass
+     */
+    public function __construct(array $data = [], ?string $revisionClass = null)
+    {
+        if ([] !== $data) {
+            Deprecation::trigger(
+                'gedmo/doctrine-extensions',
+                'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2357',
+                'Passing an array as first argument to "%s()" is deprecated. Use named arguments instead.',
+                __METHOD__
+            );
+
+            $args = func_get_args();
+
+            $this->revisionClass = $this->getAttributeValue($data, 'revisionClass', $args, 1, $revisionClass);
+
+            return;
+        }
+
+        $this->revisionClass = $revisionClass;
+    }
+}

--- a/src/Mapping/Annotation/Versioned.php
+++ b/src/Mapping/Annotation/Versioned.php
@@ -13,7 +13,7 @@ use Doctrine\Common\Annotations\Annotation;
 use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 
 /**
- * Versioned annotation for Loggable behavioral extension
+ * Versioned annotation for use with the Loggable and Revisionable extensions
  *
  * @Annotation
  *

--- a/src/Revisionable/Document/MappedSuperclass/AbstractRevision.php
+++ b/src/Revisionable/Document/MappedSuperclass/AbstractRevision.php
@@ -1,0 +1,199 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Revisionable\Document\MappedSuperclass;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Types\Type;
+use Gedmo\Revisionable\Revisionable;
+use Gedmo\Revisionable\RevisionInterface;
+
+/**
+ * Base class defining a revision with all mapping configuration for the Doctrine MongoDB ODM.
+ *
+ * @template T of Revisionable|object
+ *
+ * @template-implements RevisionInterface<T>
+ *
+ * @ODM\MappedSuperclass
+ */
+#[ODM\MappedSuperclass]
+abstract class AbstractRevision implements RevisionInterface
+{
+    /**
+     * @ODM\Id(name="id")
+     */
+    #[ODM\Id(name: 'id')]
+    protected ?string $id = null;
+
+    /**
+     * @var self::ACTION_CREATE|self::ACTION_UPDATE|self::ACTION_REMOVE
+     *
+     * @ODM\Field(name="action", type="string")
+     */
+    #[ODM\Field(name: 'action', type: Type::STRING)]
+    protected string $action = self::ACTION_CREATE;
+
+    /**
+     * @var positive-int
+     *
+     * @ODM\Field(name="version", type="int")
+     */
+    #[ODM\Field(name: 'version', type: Type::INT)]
+    protected int $version = 1;
+
+    /**
+     * @var non-empty-string|null
+     *
+     * @ODM\Field(name="revisionable_id", type="string", nullable=true)
+     */
+    #[ODM\Field(name: 'revisionable_id', type: Type::STRING, nullable: true)]
+    protected ?string $revisionableId = null;
+
+    /**
+     * @var class-string<T>|null
+     *
+     * @ODM\Field(name="revisionable_class", type="string")
+     */
+    #[ODM\Field(name: 'revisionable_class', type: Type::STRING)]
+    protected ?string $revisionableClass = null;
+
+    /**
+     * @ODM\Field(name="logged_at", type="date_immutable")
+     */
+    #[ODM\Field(name: 'logged_at', type: Type::DATE_IMMUTABLE)]
+    protected \DateTimeImmutable $loggedAt;
+
+    /**
+     * @var non-empty-string|null
+     *
+     * @ODM\Field(name="username", type="string", nullable=true)
+     */
+    #[ODM\Field(name: 'username', type: Type::STRING, nullable: true)]
+    protected ?string $username = null;
+
+    /**
+     * @var array<string, mixed>
+     *
+     * @ODM\Field(name="data", type="hash")
+     */
+    #[ODM\Field(name: 'data', type: Type::HASH)]
+    protected array $data = [];
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param self::ACTION_CREATE|self::ACTION_UPDATE|self::ACTION_REMOVE $action
+     */
+    public function setAction(string $action): void
+    {
+        $this->action = $action;
+    }
+
+    /**
+     * @return self::ACTION_CREATE|self::ACTION_UPDATE|self::ACTION_REMOVE
+     */
+    public function getAction(): string
+    {
+        return $this->action;
+    }
+
+    /**
+     * @param positive-int $version
+     */
+    public function setVersion(int $version): void
+    {
+        $this->version = $version;
+    }
+
+    /**
+     * @return positive-int
+     */
+    public function getVersion(): int
+    {
+        return $this->version;
+    }
+
+    /**
+     * @param non-empty-string $revisionableId
+     */
+    public function setRevisionableId(string $revisionableId): void
+    {
+        $this->revisionableId = $revisionableId;
+    }
+
+    /**
+     * @return non-empty-string|null
+     */
+    public function getRevisionableId(): ?string
+    {
+        return $this->revisionableId;
+    }
+
+    /**
+     * @param class-string<T> $revisionableClass
+     */
+    public function setRevisionableClass(string $revisionableClass): void
+    {
+        $this->revisionableClass = $revisionableClass;
+    }
+
+    /**
+     * @return class-string<T>|null
+     */
+    public function getRevisionableClass(): ?string
+    {
+        return $this->revisionableClass;
+    }
+
+    public function setLoggedAt(\DateTimeImmutable $loggedAt): void
+    {
+        $this->loggedAt = $loggedAt;
+    }
+
+    public function getLoggedAt(): \DateTimeImmutable
+    {
+        return $this->loggedAt;
+    }
+
+    /**
+     * @param non-empty-string|null $username
+     */
+    public function setUsername(?string $username): void
+    {
+        $this->username = $username;
+    }
+
+    /**
+     * @return non-empty-string|null
+     */
+    public function getUsername(): ?string
+    {
+        return $this->username;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function setData(array $data): void
+    {
+        $this->data = $data;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getData(): array
+    {
+        return $this->data;
+    }
+}

--- a/src/Revisionable/Document/Repository/RevisionRepository.php
+++ b/src/Revisionable/Document/Repository/RevisionRepository.php
@@ -124,13 +124,15 @@ class RevisionRepository extends DocumentRepository
             $mapping = $documentMeta->getFieldMapping($field);
 
             // Fill the embedded document
-            if ($documentWrapper->isEmbeddedAssociation($field) && null !== $value) {
-                assert(class_exists($mapping['targetDocument']));
+            if ($documentWrapper->isEmbeddedAssociation($field)) {
+                if (null !== $value) {
+                    assert(class_exists($mapping['targetDocument']));
 
-                $embeddedMetadata = $this->getDocumentManager()->getClassMetadata($mapping['targetDocument']);
-                $document = $embeddedMetadata->newInstance();
-                $this->fillDocument($document, $value);
-                $value = $document;
+                    $embeddedMetadata = $this->getDocumentManager()->getClassMetadata($mapping['targetDocument']);
+                    $document = $embeddedMetadata->newInstance();
+                    $this->fillDocument($document, $value);
+                    $value = $document;
+                }
             } elseif ($documentMeta->isSingleValuedAssociation($field)) {
                 assert(class_exists($mapping['targetDocument']));
 

--- a/src/Revisionable/Document/Repository/RevisionRepository.php
+++ b/src/Revisionable/Document/Repository/RevisionRepository.php
@@ -124,15 +124,13 @@ class RevisionRepository extends DocumentRepository
             $mapping = $documentMeta->getFieldMapping($field);
 
             // Fill the embedded document
-            if ($documentWrapper->isEmbeddedAssociation($field)) {
-                if (!empty($value)) {
-                    assert(class_exists($mapping['targetDocument']));
+            if ($documentWrapper->isEmbeddedAssociation($field) && null !== $value) {
+                assert(class_exists($mapping['targetDocument']));
 
-                    $embeddedMetadata = $this->getDocumentManager()->getClassMetadata($mapping['targetDocument']);
-                    $document = $embeddedMetadata->newInstance();
-                    $this->fillDocument($document, $value);
-                    $value = $document;
-                }
+                $embeddedMetadata = $this->getDocumentManager()->getClassMetadata($mapping['targetDocument']);
+                $document = $embeddedMetadata->newInstance();
+                $this->fillDocument($document, $value);
+                $value = $document;
             } elseif ($documentMeta->isSingleValuedAssociation($field)) {
                 assert(class_exists($mapping['targetDocument']));
 

--- a/src/Revisionable/Document/Repository/RevisionRepository.php
+++ b/src/Revisionable/Document/Repository/RevisionRepository.php
@@ -114,7 +114,7 @@ class RevisionRepository extends DocumentRepository
         assert($documentMeta instanceof ClassMetadata);
 
         $config = $this->getListener()->getConfiguration($this->getDocumentManager(), $documentMeta->getName());
-        $fields = $config['versioned'];
+        $fields = $config['versionedFields'];
 
         foreach ($data as $field => $value) {
             if (!in_array($field, $fields, true)) {

--- a/src/Revisionable/Document/Repository/RevisionRepository.php
+++ b/src/Revisionable/Document/Repository/RevisionRepository.php
@@ -142,14 +142,12 @@ class RevisionRepository extends DocumentRepository
             }
 
             $documentWrapper->setPropertyValue($field, $value);
-            unset($fields[$field]);
+            unset($fields[array_search($field, $fields, true)]);
         }
 
-        /*
         if (count($fields)) {
-            throw new UnexpectedValueException(sprintf('Could not fully revert document %s to version %d.', $documentMetadata->getName(), $version));
+            throw new UnexpectedValueException(sprintf('Could not fully revert document %s.', $documentMeta->getName()));
         }
-        */
     }
 
     /**

--- a/src/Revisionable/Document/Repository/RevisionRepository.php
+++ b/src/Revisionable/Document/Repository/RevisionRepository.php
@@ -1,0 +1,182 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Revisionable\Document\Repository;
+
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
+use Gedmo\Exception\RuntimeException;
+use Gedmo\Exception\UnexpectedValueException;
+use Gedmo\Revisionable\Document\MappedSuperclass\AbstractRevision;
+use Gedmo\Revisionable\Revisionable;
+use Gedmo\Revisionable\RevisionableListener;
+use Gedmo\Tool\Wrapper\MongoDocumentWrapper;
+
+/**
+ * The RevisionRepository has some useful functions to interact with revisions.
+ *
+ * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ *
+ * @template T of Revisionable|object
+ *
+ * @template-extends DocumentRepository<AbstractRevision<T>>
+ */
+class RevisionRepository extends DocumentRepository
+{
+    /**
+     * The revisionable listener associated with the document manager for the {@see AbstractRevision} document.
+     *
+     * @var RevisionableListener<T>|false|null
+     */
+    private $listener = false;
+
+    /**
+     * Loads all revisions for the given document
+     *
+     * @param T $document
+     *
+     * @return list<AbstractRevision<T>>
+     */
+    public function getRevisions(object $document): array
+    {
+        $documentWrapper = new MongoDocumentWrapper($document, $this->getDocumentManager());
+
+        $documentId = (string) $documentWrapper->getIdentifier(false, true);
+        $documentClass = $documentWrapper->getMetadata()->getName();
+
+        $qb = $this->createQueryBuilder();
+        $qb->field('revisionableId')->equals($documentId);
+        $qb->field('revisionableClass')->equals($documentClass);
+        $qb->sort('version', 'DESC');
+
+        return $qb->getQuery()->getIterator()->toArray();
+    }
+
+    /**
+     * Reverts the given document to the requested version, restoring all versioned fields to the state of that revision.
+     *
+     * Callers to this method will need to persist and flush changes to the document.
+     *
+     * @param T            $document
+     * @param positive-int $version
+     *
+     * @throws UnexpectedValueException
+     */
+    public function revert(object $document, int $version = 1): void
+    {
+        $documentWrapper = new MongoDocumentWrapper($document, $this->getDocumentManager());
+
+        $documentMetadata = $documentWrapper->getMetadata();
+        $documentId = (string) $documentWrapper->getIdentifier(false, true);
+        $documentClass = $documentMetadata->getName();
+
+        $qb = $this->createQueryBuilder();
+        $qb->field('revisionableId')->equals($documentId);
+        $qb->field('revisionableClass')->equals($documentClass);
+        $qb->field('version')->lte($version);
+        $qb->sort('version', 'ASC');
+
+        $revisions = $qb->getQuery()->getIterator()->toArray();
+
+        if ([] === $revisions) {
+            throw new UnexpectedValueException(sprintf('Could not find any revisions for version %d of document %s.', $version, $documentClass));
+        }
+
+        $data = [[]];
+
+        while ($revision = array_shift($revisions)) {
+            $data[] = $revision->getData();
+        }
+
+        $data = array_merge(...$data);
+
+        $this->fillDocument($document, $data);
+    }
+
+    /**
+     * Fills a document's versioned fields with the given data
+     *
+     * @param T                    $document
+     * @param array<string, mixed> $data
+     */
+    protected function fillDocument(object $document, array $data): void
+    {
+        $documentWrapper = new MongoDocumentWrapper($document, $this->getDocumentManager());
+
+        $documentMeta = $documentWrapper->getMetadata();
+
+        assert($documentMeta instanceof ClassMetadata);
+
+        $config = $this->getListener()->getConfiguration($this->getDocumentManager(), $documentMeta->getName());
+        $fields = $config['versioned'];
+
+        foreach ($data as $field => $value) {
+            if (!in_array($field, $fields, true)) {
+                continue;
+            }
+
+            $mapping = $documentMeta->getFieldMapping($field);
+
+            // Fill the embedded document
+            if ($documentWrapper->isEmbeddedAssociation($field)) {
+                if (!empty($value)) {
+                    assert(class_exists($mapping['targetDocument']));
+
+                    $embeddedMetadata = $this->getDocumentManager()->getClassMetadata($mapping['targetDocument']);
+                    $document = $embeddedMetadata->newInstance();
+                    $this->fillDocument($document, $value);
+                    $value = $document;
+                }
+            } elseif ($documentMeta->isSingleValuedAssociation($field)) {
+                assert(class_exists($mapping['targetDocument']));
+
+                $value = $value ? $this->getDocumentManager()->getReference($mapping['targetDocument'], $value) : null;
+            } else {
+                $value = $value ? $documentWrapper->convertToPHPValue($value, $documentMeta->getTypeOfField($field)) : null;
+            }
+
+            $documentWrapper->setPropertyValue($field, $value);
+            unset($fields[$field]);
+        }
+
+        /*
+        if (count($fields)) {
+            throw new UnexpectedValueException(sprintf('Could not fully revert document %s to version %d.', $documentMetadata->getName(), $version));
+        }
+        */
+    }
+
+    /**
+     * Get the revisionable listener associated with the document manager for the {@see AbstractRevision} document.
+     *
+     * @throws RuntimeException if the listener is not found
+     *
+     * @return RevisionableListener<T>
+     */
+    private function getListener(): RevisionableListener
+    {
+        if ($this->listener instanceof RevisionableListener) {
+            return $this->listener;
+        }
+
+        if (false === $this->listener) {
+            foreach ($this->getDocumentManager()->getEventManager()->getAllListeners() as $listeners) {
+                foreach ($listeners as $listener) {
+                    if ($listener instanceof RevisionableListener) {
+                        return $this->listener = $listener;
+                    }
+                }
+            }
+
+            $this->listener = null;
+        }
+
+        throw new RuntimeException('The revisionable listener was not registered to the document manager.');
+    }
+}

--- a/src/Revisionable/Document/Revision.php
+++ b/src/Revisionable/Document/Revision.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Revisionable\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Gedmo\Revisionable\Document\MappedSuperclass\AbstractRevision;
+use Gedmo\Revisionable\Document\Repository\RevisionRepository;
+use Gedmo\Revisionable\Revisionable;
+
+/**
+ * Default concrete revision implementation for the Doctrine MongoDB ODM.
+ *
+ * @ODM\Document(repositoryClass="Gedmo\Revisionable\Document\Repository\RevisionRepository")
+ * @ODM\Index(keys={"revisionableClass": "asc"})
+ * @ODM\Index(keys={"loggedAt": "asc"})
+ * @ODM\Index(keys={"username": "asc"})
+ * @ODM\Index(keys={"revisionableId": "asc", "revisionableClass": "asc", "version": "asc"})
+ *
+ * @template T of Revisionable|object
+ *
+ * @template-extends AbstractRevision<T>
+ */
+#[ODM\Document(repositoryClass: RevisionRepository::class)]
+#[ODM\Index(keys: ['revisionableClass' => 'asc'])]
+#[ODM\Index(keys: ['loggedAt' => 'asc'])]
+#[ODM\Index(keys: ['username' => 'asc'])]
+#[ODM\Index(keys: ['revisionableId' => 'asc', 'revisionableClass' => 'asc', 'version' => 'asc'])]
+class Revision extends AbstractRevision
+{
+    /**
+     * Named constructor to create a new revision.
+     *
+     * Implementations should handle setting the initial logged at time and version for new instances within this constructor.
+     *
+     * @param self::ACTION_CREATE|self::ACTION_UPDATE|self::ACTION_REMOVE $action
+     *
+     * @return self<T>
+     */
+    public static function createRevision(string $action): self
+    {
+        $document = new self();
+        $document->setAction($action);
+        $document->setLoggedAt(new \DateTimeImmutable());
+
+        return $document;
+    }
+}

--- a/src/Revisionable/Entity/MappedSuperclass/AbstractRevision.php
+++ b/src/Revisionable/Entity/MappedSuperclass/AbstractRevision.php
@@ -1,0 +1,203 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Revisionable\Entity\MappedSuperclass;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Revisionable\Revisionable;
+use Gedmo\Revisionable\RevisionInterface;
+
+/**
+ * Base class defining a revision with all mapping configuration for the Doctrine ORM.
+ *
+ * @template T of Revisionable|object
+ *
+ * @template-implements RevisionInterface<T>
+ *
+ * @ORM\MappedSuperclass
+ */
+#[ORM\MappedSuperclass]
+abstract class AbstractRevision implements RevisionInterface
+{
+    /**
+     * @ORM\Column(name="id", type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     */
+    #[ORM\Column(name: 'id', type: Types::INTEGER)]
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    protected ?int $id = null;
+
+    /**
+     * @var self::ACTION_CREATE|self::ACTION_UPDATE|self::ACTION_REMOVE
+     *
+     * @ORM\Column(name="action", type="string", length=8)
+     */
+    #[ORM\Column(name: 'action', type: Types::STRING, length: 8)]
+    protected string $action = self::ACTION_CREATE;
+
+    /**
+     * @var positive-int
+     *
+     * @ORM\Column(type="integer")
+     */
+    #[ORM\Column(name: 'version', type: Types::INTEGER)]
+    protected int $version = 1;
+
+    /**
+     * @var non-empty-string|null
+     *
+     * @ORM\Column(name="revisionable_id", type="string", length=64, nullable=true)
+     */
+    #[ORM\Column(name: 'revisionable_id', type: Types::STRING, length: 64, nullable: true)]
+    protected ?string $revisionableId = null;
+
+    /**
+     * @var class-string<T>|null
+     *
+     * @ORM\Column(name="revisionable_class", type="string", length=191)
+     */
+    #[ORM\Column(name: 'revisionable_class', type: Types::STRING, length: 191)]
+    protected ?string $revisionableClass = null;
+
+    /**
+     * @ORM\Column(name="logged_at", type="datetime_immutable")
+     */
+    #[ORM\Column(name: 'logged_at', type: Types::DATETIME_IMMUTABLE)]
+    protected \DateTimeImmutable $loggedAt;
+
+    /**
+     * @var non-empty-string|null
+     *
+     * @ORM\Column(name="username", length=191, nullable=true)
+     */
+    #[ORM\Column(name: 'username', length: 191, nullable: true)]
+    protected ?string $username = null;
+
+    /**
+     * @var array<string, mixed>
+     *
+     * @ORM\Column(name="data", type="json")
+     */
+    #[ORM\Column(name: 'data', type: Types::JSON)]
+    protected array $data = [];
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param self::ACTION_CREATE|self::ACTION_UPDATE|self::ACTION_REMOVE $action
+     */
+    public function setAction(string $action): void
+    {
+        $this->action = $action;
+    }
+
+    /**
+     * @return self::ACTION_CREATE|self::ACTION_UPDATE|self::ACTION_REMOVE
+     */
+    public function getAction(): string
+    {
+        return $this->action;
+    }
+
+    /**
+     * @param positive-int $version
+     */
+    public function setVersion(int $version): void
+    {
+        $this->version = $version;
+    }
+
+    /**
+     * @return positive-int
+     */
+    public function getVersion(): int
+    {
+        return $this->version;
+    }
+
+    /**
+     * @param non-empty-string $revisionableId
+     */
+    public function setRevisionableId(string $revisionableId): void
+    {
+        $this->revisionableId = $revisionableId;
+    }
+
+    /**
+     * @return non-empty-string|null
+     */
+    public function getRevisionableId(): ?string
+    {
+        return $this->revisionableId;
+    }
+
+    /**
+     * @param class-string<T> $revisionableClass
+     */
+    public function setRevisionableClass(string $revisionableClass): void
+    {
+        $this->revisionableClass = $revisionableClass;
+    }
+
+    /**
+     * @return class-string<T>|null
+     */
+    public function getRevisionableClass(): ?string
+    {
+        return $this->revisionableClass;
+    }
+
+    public function setLoggedAt(\DateTimeImmutable $loggedAt): void
+    {
+        $this->loggedAt = $loggedAt;
+    }
+
+    public function getLoggedAt(): \DateTimeImmutable
+    {
+        return $this->loggedAt;
+    }
+
+    /**
+     * @param non-empty-string|null $username
+     */
+    public function setUsername(?string $username): void
+    {
+        $this->username = $username;
+    }
+
+    /**
+     * @return non-empty-string|null
+     */
+    public function getUsername(): ?string
+    {
+        return $this->username;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function setData(array $data): void
+    {
+        $this->data = $data;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getData(): array
+    {
+        return $this->data;
+    }
+}

--- a/src/Revisionable/Entity/Repository/RevisionRepository.php
+++ b/src/Revisionable/Entity/Repository/RevisionRepository.php
@@ -88,7 +88,7 @@ class RevisionRepository extends EntityRepository
             ->setParameter('version', $version);
 
         $config = $this->getListener()->getConfiguration($this->getEntityManager(), $entityClass);
-        $fields = $config['versioned'];
+        $fields = $config['versionedFields'];
         $filled = false;
         $revisionsFound = false;
 

--- a/src/Revisionable/Entity/Repository/RevisionRepository.php
+++ b/src/Revisionable/Entity/Repository/RevisionRepository.php
@@ -1,0 +1,169 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Revisionable\Entity\Repository;
+
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Gedmo\Exception\RuntimeException;
+use Gedmo\Exception\UnexpectedValueException;
+use Gedmo\Revisionable\Entity\MappedSuperclass\AbstractRevision;
+use Gedmo\Revisionable\Revisionable;
+use Gedmo\Revisionable\RevisionableListener;
+use Gedmo\Tool\Wrapper\EntityWrapper;
+
+/**
+ * The RevisionRepository has some useful functions to interact with revisions.
+ *
+ * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ *
+ * @template T of Revisionable|object
+ *
+ * @template-extends EntityRepository<AbstractRevision<T>>
+ */
+class RevisionRepository extends EntityRepository
+{
+    /**
+     * The revisionable listener associated with the entity manager for the {@see AbstractRevision} entity.
+     *
+     * @var RevisionableListener<T>|false|null
+     */
+    private $listener = false;
+
+    /**
+     * Loads all revisions for the given entity
+     *
+     * @param T $entity
+     *
+     * @return list<AbstractRevision<T>>
+     */
+    public function getRevisions(object $entity): array
+    {
+        $entityWrapper = new EntityWrapper($entity, $this->getEntityManager());
+
+        $entityId = (string) $entityWrapper->getIdentifier(false, true);
+        $entityClass = $entityWrapper->getMetadata()->getName();
+
+        return $this->createQueryBuilder('revision')
+            ->where('revision.revisionableId = :revisionableId')
+            ->andWhere('revision.revisionableClass = :revisionableClass')
+            ->orderBy('revision.version', 'DESC')
+            ->setParameter('revisionableId', $entityId)
+            ->setParameter('revisionableClass', $entityClass)
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * Reverts the given entity to the requested version, restoring all versioned fields to the state of that revision.
+     *
+     * Callers to this method will need to persist and flush changes to the entity.
+     *
+     * @param T            $entity
+     * @param positive-int $version
+     *
+     * @throws UnexpectedValueException
+     */
+    public function revert(object $entity, int $version = 1): void
+    {
+        $entityWrapper = new EntityWrapper($entity, $this->getEntityManager());
+
+        $entityMetadata = $entityWrapper->getMetadata();
+        $entityId = (string) $entityWrapper->getIdentifier(false, true);
+        $entityClass = $entityMetadata->getName();
+
+        $qb = $this->createQueryBuilder('revision')
+            ->where('revision.revisionableId = :revisionableId')
+            ->andWhere('revision.revisionableClass = :revisionableClass')
+            ->andWhere('revision.version <= :version')
+            ->orderBy('revision.version', 'DESC')
+            ->setParameter('revisionableId', $entityId)
+            ->setParameter('revisionableClass', $entityClass)
+            ->setParameter('version', $version);
+
+        $config = $this->getListener()->getConfiguration($this->getEntityManager(), $entityClass);
+        $fields = $config['versioned'];
+        $filled = false;
+        $revisionsFound = false;
+
+        $revisions = $qb->getQuery()->toIterable();
+
+        assert($revisions instanceof \Generator);
+
+        while ((null !== $revision = $revisions->current()) && !$filled) {
+            $revisionsFound = true;
+            $revisions->next();
+            if ($data = $revision->getData()) {
+                foreach ($data as $field => $value) {
+                    if (in_array($field, $fields, true)) {
+                        $this->mapValue($entityMetadata, $field, $value);
+                        $entityWrapper->setPropertyValue($field, $value);
+                        unset($fields[array_search($field, $fields, true)]);
+                    }
+                }
+            }
+
+            $filled = [] === $fields;
+        }
+
+        if (!$revisionsFound) {
+            throw new UnexpectedValueException(sprintf('Could not find any revisions for version %d of entity %s.', $version, $entityClass));
+        }
+
+        if (count($fields)) {
+            throw new UnexpectedValueException(sprintf('Could not fully revert entity %s to version %d.', $entityClass, $version));
+        }
+    }
+
+    /**
+     * @param ClassMetadata<T> $objectMeta
+     * @param mixed            $value
+     *
+     * @return void
+     */
+    protected function mapValue(ClassMetadata $objectMeta, string $field, &$value)
+    {
+        if (!$objectMeta->isSingleValuedAssociation($field)) {
+            $value = $this->getEntityManager()->getConnection()->convertToPHPValue($value, $objectMeta->getTypeOfField($field));
+
+            return;
+        }
+
+        $mapping = $objectMeta->getAssociationMapping($field);
+        $value = $value ? $this->getEntityManager()->getReference($mapping->targetEntity ?? $mapping['targetEntity'], $value) : null;
+    }
+
+    /**
+     * Get the revisionable listener associated with the entity manager for the {@see AbstractRevision} entity.
+     *
+     * @throws RuntimeException if the listener is not found
+     *
+     * @return RevisionableListener<T>
+     */
+    private function getListener(): RevisionableListener
+    {
+        if ($this->listener instanceof RevisionableListener) {
+            return $this->listener;
+        }
+
+        if (false === $this->listener) {
+            foreach ($this->getEntityManager()->getEventManager()->getAllListeners() as $listeners) {
+                foreach ($listeners as $listener) {
+                    if ($listener instanceof RevisionableListener) {
+                        return $this->listener = $listener;
+                    }
+                }
+            }
+
+            $this->listener = null;
+        }
+
+        throw new RuntimeException('The revisionable listener was not registered to the entity manager.');
+    }
+}

--- a/src/Revisionable/Entity/Revision.php
+++ b/src/Revisionable/Entity/Revision.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Revisionable\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Revisionable\Entity\MappedSuperclass\AbstractRevision;
+use Gedmo\Revisionable\Entity\Repository\RevisionRepository;
+use Gedmo\Revisionable\Revisionable;
+
+/**
+ * Default concrete revision implementation for the Doctrine ORM.
+ *
+ * @ORM\Table(
+ *     name="revisions",
+ *     options={"row_format": "DYNAMIC"},
+ *     indexes={
+ *         @ORM\Index(name="revision_class_lookup_idx", columns={"revisionable_class"}),
+ *         @ORM\Index(name="revision_date_lookup_idx", columns={"logged_at"}),
+ *         @ORM\Index(name="revision_user_lookup_idx", columns={"username"}),
+ *         @ORM\Index(name="revision_version_lookup_idx", columns={"revisionable_id", "revisionable_class", "version"})
+ *     }
+ * )
+ * @ORM\Entity(repositoryClass="Gedmo\Revisionable\Entity\Repository\RevisionRepository")
+ *
+ * @template T of Revisionable|object
+ *
+ * @template-extends AbstractRevision<T>
+ */
+#[ORM\Entity(repositoryClass: RevisionRepository::class)]
+#[ORM\Table(name: 'revisions', options: ['row_format' => 'DYNAMIC'])]
+#[ORM\Index(name: 'revision_class_lookup_idx', columns: ['revisionable_class'])]
+#[ORM\Index(name: 'revision_date_lookup_idx', columns: ['logged_at'])]
+#[ORM\Index(name: 'revision_user_lookup_idx', columns: ['username'])]
+#[ORM\Index(name: 'revision_version_lookup_idx', columns: ['revisionable_id', 'revisionable_class', 'version'])]
+class Revision extends AbstractRevision
+{
+    /**
+     * Named constructor to create a new revision.
+     *
+     * Implementations should handle setting the initial logged at time and version for new instances within this constructor.
+     *
+     * @param self::ACTION_CREATE|self::ACTION_UPDATE|self::ACTION_REMOVE $action
+     *
+     * @return self<T>
+     */
+    public static function createRevision(string $action): self
+    {
+        $entity = new self();
+        $entity->setAction($action);
+        $entity->setLoggedAt(new \DateTimeImmutable());
+
+        return $entity;
+    }
+}

--- a/src/Revisionable/Mapping/Driver/Annotation.php
+++ b/src/Revisionable/Mapping/Driver/Annotation.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Revisionable\Mapping\Driver;
+
+use Gedmo\Mapping\Driver\AnnotationDriverInterface;
+
+/**
+ * Mapping driver for the revisionable extension which reads extended metadata from annotations on a revisionable class.
+ *
+ * @deprecated since gedmo/doctrine-extensions 3.x, will be removed in version 4.0.
+ *
+ * @internal
+ */
+class Annotation extends Attribute implements AnnotationDriverInterface
+{
+}

--- a/src/Revisionable/Mapping/Driver/Attribute.php
+++ b/src/Revisionable/Mapping/Driver/Attribute.php
@@ -95,14 +95,14 @@ class Attribute extends AbstractAnnotationDriver
                     continue;
                 }
 
-                $config['versioned'][] = $field;
+                $config['versionedFields'][] = $field;
             }
         }
 
         // Validate configuration
         if (!$meta->isMappedSuperclass && $config) {
             // The revisionable flag must be set, except for embedded models, and the versioned config should be a non-empty array
-            if (isset($config['versioned']) && !isset($config['revisionable']) && !$this->isEmbed($meta)) {
+            if (isset($config['versionedFields']) && !isset($config['revisionable']) && !$this->isEmbed($meta)) {
                 throw new InvalidMappingException(sprintf('Class "%s" has "%s" annotated fields but is missing the "%s" class annotation.', $meta->getName(), Versioned::class, Revisionable::class));
             }
         }
@@ -130,7 +130,7 @@ class Attribute extends AbstractAnnotationDriver
                     continue;
                 }
 
-                $config['versioned'][] = $embeddedField;
+                $config['versionedFields'][] = $embeddedField;
             }
         }
 

--- a/src/Revisionable/Mapping/Driver/Attribute.php
+++ b/src/Revisionable/Mapping/Driver/Attribute.php
@@ -103,7 +103,7 @@ class Attribute extends AbstractAnnotationDriver
         if (!$meta->isMappedSuperclass && $config) {
             // The revisionable flag must be set, except for embedded models, and the versioned config should be a non-empty array
             if (isset($config['versioned']) && (!$this->isEmbed($meta) && !isset($config['revisionable']))) {
-                throw new InvalidMappingException(sprintf("Class '%s' has '%s' annotated fields but is missing the '%s' class annotation.", $meta->getName(), Versioned::class, Revisionable::class));
+                throw new InvalidMappingException(sprintf('Class "%s" has "%s" annotated fields but is missing the "%s" class annotation.', $meta->getName(), Versioned::class, Revisionable::class));
             }
         }
 

--- a/src/Revisionable/Mapping/Driver/Attribute.php
+++ b/src/Revisionable/Mapping/Driver/Attribute.php
@@ -13,8 +13,8 @@ use Doctrine\ODM\MongoDB\Mapping\ClassMetadata as MongoDBDOMClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadata as ORMClassMetadata;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Gedmo\Exception\InvalidMappingException;
+use Gedmo\Mapping\Annotation\KeepRevisions;
 use Gedmo\Mapping\Annotation\Revisionable;
-use Gedmo\Mapping\Annotation\Versioned;
 use Gedmo\Mapping\Driver\AbstractAnnotationDriver;
 
 /**
@@ -60,7 +60,7 @@ class Attribute extends AbstractAnnotationDriver
         foreach ($class->getProperties() as $property) {
             $field = $property->getName();
 
-            if ($this->reader->getPropertyAnnotation($property, Versioned::class)) {
+            if ($this->reader->getPropertyAnnotation($property, KeepRevisions::class)) {
                 if ($meta->isCollectionValuedAssociation($field)) {
                     throw new InvalidMappingException(sprintf('Cannot version field %s::$%s, collection valued associations are not supported.', $meta->getName(), $field));
                 }
@@ -103,7 +103,7 @@ class Attribute extends AbstractAnnotationDriver
         if (!$meta->isMappedSuperclass && $config) {
             // The revisionable flag must be set, except for embedded models, and the versioned config should be a non-empty array
             if (isset($config['versionedFields']) && !isset($config['revisionable']) && !$this->isEmbed($meta)) {
-                throw new InvalidMappingException(sprintf('Class "%s" has "%s" annotated fields but is missing the "%s" class annotation.', $meta->getName(), Versioned::class, Revisionable::class));
+                throw new InvalidMappingException(sprintf('Class "%s" has "%s" annotated fields but is missing the "%s" class annotation.', $meta->getName(), KeepRevisions::class, Revisionable::class));
             }
         }
 
@@ -121,7 +121,7 @@ class Attribute extends AbstractAnnotationDriver
     private function inspectEmbeddedForVersioned(string $field, array $config, ORMClassMetadata $meta): array
     {
         foreach ((new \ReflectionClass($meta->embeddedClasses[$field]['class']))->getProperties() as $property) {
-            if ($this->reader->getPropertyAnnotation($property, Versioned::class)) {
+            if ($this->reader->getPropertyAnnotation($property, KeepRevisions::class)) {
                 $embeddedField = $field.'.'.$property->getName();
 
                 if (isset($meta->embeddedClasses[$embeddedField])) {

--- a/src/Revisionable/Mapping/Driver/Attribute.php
+++ b/src/Revisionable/Mapping/Driver/Attribute.php
@@ -102,7 +102,7 @@ class Attribute extends AbstractAnnotationDriver
         // Validate configuration
         if (!$meta->isMappedSuperclass && $config) {
             // The revisionable flag must be set, except for embedded models, and the versioned config should be a non-empty array
-            if (isset($config['versioned']) && (!$this->isEmbed($meta) && !isset($config['revisionable']))) {
+            if (isset($config['versioned']) && !isset($config['revisionable']) && !$this->isEmbed($meta)) {
                 throw new InvalidMappingException(sprintf('Class "%s" has "%s" annotated fields but is missing the "%s" class annotation.', $meta->getName(), Versioned::class, Revisionable::class));
             }
         }

--- a/src/Revisionable/Mapping/Driver/Attribute.php
+++ b/src/Revisionable/Mapping/Driver/Attribute.php
@@ -1,0 +1,172 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Revisionable\Mapping\Driver;
+
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata as MongoDBDOMClassMetadata;
+use Doctrine\ORM\Mapping\ClassMetadata as ORMClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
+use Gedmo\Exception\InvalidMappingException;
+use Gedmo\Mapping\Annotation\Revisionable;
+use Gedmo\Mapping\Annotation\Versioned;
+use Gedmo\Mapping\Driver\AbstractAnnotationDriver;
+
+/**
+ * Mapping driver for the revisionable extension which reads extended metadata from attributes on a revisionable class.
+ *
+ * @author Boussekeyt Jules <jules.boussekeyt@gmail.com>
+ * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ *
+ * @internal
+ */
+class Attribute extends AbstractAnnotationDriver
+{
+    public function readExtendedMetadata($meta, array &$config)
+    {
+        // Skip embedded classes for the ORM, they will be handled inline while processing classes using embeds
+        if ($meta instanceof ORMClassMetadata && $meta->isEmbeddedClass) {
+            return $config;
+        }
+
+        $class = $this->getMetaReflectionClass($meta);
+
+        // Determine if the object is revisionable by inspecting the class attributes
+        if ($annot = $this->reader->getClassAnnotation($class, Revisionable::class)) {
+            \assert($annot instanceof Revisionable);
+
+            $config['revisionable'] = true;
+
+            if ($annot->revisionClass) {
+                // Embedded models cannot have a revision class defined, their data is logged to the owning model
+                if ($this->isEmbed($meta)) {
+                    throw new InvalidMappingException(sprintf("Class '%s' is mapped as an embedded object and cannot specify the revision class property.", $meta->getName()));
+                }
+
+                if (!$cl = $this->getRelatedClassName($meta, $annot->revisionClass)) {
+                    throw new InvalidMappingException(sprintf("The revision class '%s' configured for '%s' does not exist.", $class, $meta->getName()));
+                }
+
+                $config['revisionClass'] = $cl;
+            }
+        }
+
+        // Inspect properties for versioned fields
+        foreach ($class->getProperties() as $property) {
+            $field = $property->getName();
+
+            if ($this->reader->getPropertyAnnotation($property, Versioned::class)) {
+                if ($meta->isCollectionValuedAssociation($field)) {
+                    throw new InvalidMappingException(sprintf('Cannot version field %s::$%s, collection valued associations are not supported.', $meta->getName(), $field));
+                }
+
+                // The MongoDB ODM's @EmbedMany is not supported
+                if ($meta instanceof MongoDBDOMClassMetadata && $meta->isCollectionValuedEmbed($field)) {
+                    throw new InvalidMappingException(sprintf('Cannot version field %s::$%s, an embedded many collection is not supported.', $meta->getName(), $field));
+                }
+
+                // To version a field with a relationship, it must be the owning side
+                if ($this->isRelationship($meta, $field)) {
+                    $associationMapping = $meta->associationMappings[$field];
+
+                    if (!$associationMapping['isOwningSide']) {
+                        throw new InvalidMappingException(sprintf('Cannot version field %s::$%s, it is not the owning side of the relationship.', $meta->getName(), $field));
+                    }
+                }
+
+                /*
+                 * Due to differences in the UoW's for each object manager, embedded models need to be handled differently.
+                 *
+                 * The MongoDB ODM tracks embedded documents within the UoW and the listener can recursively inspect the change set
+                 * for changes to these objects.
+                 *
+                 * The ORM inlines embedded field mappings to the root entity, so the list of versioned fields needs to be added to
+                 * the extension metadata now.
+                 */
+
+                if ($meta instanceof ORMClassMetadata && isset($meta->embeddedClasses[$field])) {
+                    $config = $this->inspectEmbeddedForVersioned($field, $config, $meta);
+
+                    continue;
+                }
+
+                $config['versioned'][] = $field;
+            }
+        }
+
+        // Validate configuration
+        if (!$meta->isMappedSuperclass && $config) {
+            // The revisionable flag must be set, except for embedded models, and the versioned config should be a non-empty array
+            if (isset($config['versioned']) && (!$this->isEmbed($meta) && !isset($config['revisionable']))) {
+                throw new InvalidMappingException(sprintf("Class '%s' has '%s' annotated fields but is missing the '%s' class annotation.", $meta->getName(), Versioned::class, Revisionable::class));
+            }
+        }
+
+        return $config;
+    }
+
+    /**
+     * Recursively searches properties of an embedded object for versioned fields.
+     *
+     * @param array<string, mixed>     $config
+     * @param ORMClassMetadata<object> $meta
+     *
+     * @return array<string, mixed>
+     */
+    private function inspectEmbeddedForVersioned(string $field, array $config, ORMClassMetadata $meta): array
+    {
+        foreach ((new \ReflectionClass($meta->embeddedClasses[$field]['class']))->getProperties() as $property) {
+            if ($this->reader->getPropertyAnnotation($property, Versioned::class)) {
+                $embeddedField = $field.'.'.$property->getName();
+
+                if (isset($meta->embeddedClasses[$embeddedField])) {
+                    $config = $this->inspectEmbeddedForVersioned($embeddedField, $config, $meta);
+
+                    continue;
+                }
+
+                $config['versioned'][] = $embeddedField;
+            }
+        }
+
+        return $config;
+    }
+
+    /**
+     * @param ClassMetadata<object> $meta
+     * @param non-empty-string      $field
+     */
+    private function isRelationship(ClassMetadata $meta, string $field): bool
+    {
+        if ($meta instanceof MongoDBDOMClassMetadata) {
+            return $meta->hasReference($field);
+        }
+
+        if ($meta instanceof ORMClassMetadata) {
+            return $meta->hasAssociation($field);
+        }
+
+        return false;
+    }
+
+    /**
+     * @param ClassMetadata<object> $meta
+     */
+    private function isEmbed(ClassMetadata $meta): bool
+    {
+        if ($meta instanceof MongoDBDOMClassMetadata) {
+            return $meta->isEmbeddedDocument;
+        }
+
+        if ($meta instanceof ORMClassMetadata) {
+            return $meta->isEmbeddedClass;
+        }
+
+        return false;
+    }
+}

--- a/src/Revisionable/Mapping/Driver/Xml.php
+++ b/src/Revisionable/Mapping/Driver/Xml.php
@@ -67,7 +67,7 @@ final class Xml extends BaseXml
         // Validate configuration
         if (!$meta->isMappedSuperclass && $config) {
             // The revisionable flag must be set, except for embedded models, and the versioned config should be a non-empty array
-            if (isset($config['versioned']) && (!$this->isEmbed($meta) && !isset($config['revisionable']))) {
+            if (isset($config['versionedFields']) && (!$this->isEmbed($meta) && !isset($config['revisionable']))) {
                 throw new InvalidMappingException(sprintf("Class '%s' has fields with the 'gedmo:versioned' element but the class does not have the 'gedmo:revisionable' element.", $meta->getName()));
             }
         }
@@ -172,7 +172,7 @@ final class Xml extends BaseXml
                 continue;
             }
 
-            $config['versioned'][] = $prepend
+            $config['versionedFields'][] = $prepend
                 ? $prepend.'.'.$field
                 : $field;
         }

--- a/src/Revisionable/Mapping/Driver/Xml.php
+++ b/src/Revisionable/Mapping/Driver/Xml.php
@@ -1,0 +1,215 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Revisionable\Mapping\Driver;
+
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata as MongoDBDOMClassMetadata;
+use Doctrine\ORM\Mapping\ClassMetadata as ORMClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
+use Gedmo\Exception\InvalidMappingException;
+use Gedmo\Mapping\Driver\Xml as BaseXml;
+
+/**
+ * Mapping driver for the revisionable extension which reads extended metadata from an XML mapping document for a revisionable class.
+ *
+ * @author Boussekeyt Jules <jules.boussekeyt@gmail.com>
+ * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ * @author Miha Vrhovnik <miha.vrhovnik@gmail.com>
+ *
+ * @internal
+ */
+class Xml extends BaseXml
+{
+    public function readExtendedMetadata($meta, array &$config)
+    {
+        // Skip embedded classes for the ORM, they will be handled inline while processing classes using embeds
+        if ($meta instanceof ORMClassMetadata && $meta->isEmbeddedClass) {
+            return $config;
+        }
+
+        $xmlDoctrine = $this->_getMapping($meta->getName());
+
+        assert($xmlDoctrine instanceof \SimpleXMLElement);
+
+        $xml = $xmlDoctrine->children(self::GEDMO_NAMESPACE_URI);
+
+        $isEmbed = $this->isEmbed($meta);
+
+        // Determine if the object is revisionable by inspecting the revisionable element if present
+        if (isset($xml->revisionable)) {
+            $data = $xml->revisionable;
+            $config['revisionable'] = true;
+
+            if ($this->_isAttributeSet($data, 'revision-class')) {
+                // Embedded models cannot have a revision class defined, their data is logged to the owning model
+                if ($isEmbed) {
+                    throw new InvalidMappingException(sprintf("Class '%s' is mapped as an embedded object and cannot specify a revision-class attribute.", $meta->getName()));
+                }
+
+                $class = $this->_getAttribute($data, 'revision-class');
+
+                if (!$cl = $this->getRelatedClassName($meta, $class)) {
+                    throw new InvalidMappingException(sprintf("The revision class '%s' configured for '%s' does not exist.", $class, $meta->getName()));
+                }
+
+                $config['revisionClass'] = $cl;
+            }
+        }
+
+        $config = $this->inspectDocument($xmlDoctrine, $config, $meta);
+
+        // Validate configuration
+        if (!$meta->isMappedSuperclass && $config) {
+            // The revisionable flag must be set, except for embedded models, and the versioned config should be a non-empty array
+            if (isset($config['versioned']) && (!$this->isEmbed($meta) && !isset($config['revisionable']))) {
+                throw new InvalidMappingException(sprintf("Class '%s' has fields with the 'gedmo:versioned' element but the class does not have the 'gedmo:revisionable' element.", $meta->getName()));
+            }
+        }
+
+        return $config;
+    }
+
+    /**
+     * Searches a document for versioned fields
+     *
+     * @param array<string, mixed>  $config
+     * @param ClassMetadata<object> $meta
+     *
+     * @return array<string, mixed>
+     */
+    private function inspectDocument(\SimpleXMLElement $xmlRoot, array $config, ClassMetadata $meta, string $prepend = ''): array
+    {
+        // Inspect for versioned fields
+        if (isset($xmlRoot->field)) {
+            $config = $this->inspectElementForVersioned($xmlRoot->field, $config, $meta, $prepend);
+        }
+
+        // Inspect for versioned embeds
+        foreach (['embedded', 'embed-one', 'embed-many'] as $embedType) {
+            if (isset($xmlRoot->$embedType)) {
+                $config = $this->inspectElementForVersioned($xmlRoot->$embedType, $config, $meta, $prepend);
+            }
+        }
+
+        // Inspect for versioned relationships
+        foreach (['many-to-one', 'one-to-one', 'reference-one'] as $relationshipType) {
+            if (isset($xmlRoot->$relationshipType)) {
+                $config = $this->inspectElementForVersioned($xmlRoot->$relationshipType, $config, $meta, $prepend);
+            }
+        }
+
+        // Inspect attribute overrides
+        if (isset($xmlRoot->{'attribute-overrides'})) {
+            foreach ($xmlRoot->{'attribute-overrides'}->{'attribute-override'} ?? [] as $overrideMapping) {
+                $config = $this->inspectElementForVersioned($overrideMapping, $config, $meta, $prepend);
+            }
+        }
+
+        return $config;
+    }
+
+    /**
+     * Searches direct child nodes of the given element for versioned fields
+     *
+     * @param array<string, mixed>  $config
+     * @param ClassMetadata<object> $meta
+     *
+     * @return array<string, mixed>
+     */
+    private function inspectElementForVersioned(\SimpleXMLElement $element, array $config, ClassMetadata $meta, string $prepend = ''): array
+    {
+        foreach ($element as $mappingDoctrine) {
+            $mapping = $mappingDoctrine->children(self::GEDMO_NAMESPACE_URI);
+
+            if (!isset($mapping->versioned)) {
+                continue;
+            }
+
+            $isRelationship = !in_array($mappingDoctrine->getName(), ['field', 'embedded', 'embed-one', 'embed-many'], true);
+
+            $field = $this->_getAttribute(
+                $mappingDoctrine,
+                $isRelationship ? 'field' : 'name'
+            );
+
+            if ($meta->isCollectionValuedAssociation($field)) {
+                throw new InvalidMappingException(sprintf('Cannot version field %s::$%s, collection valued associations are not supported.', $meta->getName(), $field));
+            }
+
+            // The MongoDB ODM's @EmbedMany is not supported
+            if ('embed-many' === $mappingDoctrine->getName()) {
+                throw new InvalidMappingException(sprintf('Cannot version field %s::$%s, an embedded many collection is not supported.', $meta->getName(), $field));
+            }
+
+            // To version a field with a relationship, it must be the owning side
+            if ($isRelationship) {
+                $associationMapping = $meta->associationMappings[$field];
+
+                if (!$associationMapping['isOwningSide']) {
+                    throw new InvalidMappingException(sprintf('Cannot version field %s::$%s, it is not the owning side of the relationship.', $meta->getName(), $field));
+                }
+            }
+
+            /*
+             * Due to differences in the UoW's for each object manager, embedded models need to be handled differently.
+             *
+             * The MongoDB ODM tracks embedded documents within the UoW and the listener can recursively inspect the change set
+             * for changes to these objects.
+             *
+             * The ORM inlines embedded field mappings to the root entity, so the list of versioned fields needs to be added to
+             * the extension metadata now.
+             */
+
+            if ($meta instanceof ORMClassMetadata && isset($meta->embeddedClasses[$field])) {
+                $config = $this->inspectEmbeddedForVersioned($field, $config, $meta);
+
+                continue;
+            }
+
+            $config['versioned'][] = $prepend
+                ? $prepend.'.'.$field
+                : $field;
+        }
+
+        return $config;
+    }
+
+    /**
+     * Recursively searches properties of an embedded object for versioned fields.
+     *
+     * @param array<string, mixed>     $config
+     * @param ORMClassMetadata<object> $meta
+     *
+     * @return array<string, mixed>
+     */
+    private function inspectEmbeddedForVersioned(string $field, array $config, ORMClassMetadata $meta): array
+    {
+        $xmlDoctrine = $this->_getMapping($meta->embeddedClasses[$field]['class']);
+
+        assert($xmlDoctrine instanceof \SimpleXMLElement);
+
+        return $this->inspectDocument($xmlDoctrine, $config, $meta, $field);
+    }
+
+    /**
+     * @param ClassMetadata<object> $meta
+     */
+    private function isEmbed(ClassMetadata $meta): bool
+    {
+        if ($meta instanceof MongoDBDOMClassMetadata) {
+            return $meta->isEmbeddedDocument;
+        }
+
+        if ($meta instanceof ORMClassMetadata) {
+            return $meta->isEmbeddedClass;
+        }
+
+        return false;
+    }
+}

--- a/src/Revisionable/Mapping/Driver/Xml.php
+++ b/src/Revisionable/Mapping/Driver/Xml.php
@@ -24,7 +24,7 @@ use Gedmo\Mapping\Driver\Xml as BaseXml;
  *
  * @internal
  */
-class Xml extends BaseXml
+final class Xml extends BaseXml
 {
     public function readExtendedMetadata($meta, array &$config)
     {

--- a/src/Revisionable/Mapping/Driver/Xml.php
+++ b/src/Revisionable/Mapping/Driver/Xml.php
@@ -68,7 +68,7 @@ final class Xml extends BaseXml
         if (!$meta->isMappedSuperclass && $config) {
             // The revisionable flag must be set, except for embedded models, and the versioned config should be a non-empty array
             if (isset($config['versionedFields']) && (!$this->isEmbed($meta) && !isset($config['revisionable']))) {
-                throw new InvalidMappingException(sprintf("Class '%s' has fields with the 'gedmo:versioned' element but the class does not have the 'gedmo:revisionable' element.", $meta->getName()));
+                throw new InvalidMappingException(sprintf("Class '%s' has fields with the 'gedmo:keep-revisions' element but the class does not have the 'gedmo:revisionable' element.", $meta->getName()));
             }
         }
 
@@ -127,7 +127,7 @@ final class Xml extends BaseXml
         foreach ($element as $mappingDoctrine) {
             $mapping = $mappingDoctrine->children(self::GEDMO_NAMESPACE_URI);
 
-            if (!isset($mapping->versioned)) {
+            if (!isset($mapping->{'keep-revisions'})) {
                 continue;
             }
 

--- a/src/Revisionable/Mapping/Driver/Yaml.php
+++ b/src/Revisionable/Mapping/Driver/Yaml.php
@@ -67,7 +67,7 @@ final class Yaml extends File
         if (!$meta->isMappedSuperclass && $config) {
             // The revisionable flag must be set, except for embedded models, and the versioned config should be a non-empty array
             if (isset($config['versionedFields']) && !isset($config['revisionable'])) {
-                throw new InvalidMappingException(sprintf("Class '%s' has fields marked as versioned but the class does not have the 'revisionable' configuration.", $meta->getName()));
+                throw new InvalidMappingException(sprintf("Class '%s' has fields marked with the 'keepRevisions' property but the class does not have the 'revisionable' configuration.", $meta->getName()));
             }
         }
 
@@ -140,7 +140,7 @@ final class Yaml extends File
                 continue;
             }
 
-            if (in_array('versioned', $fieldMapping['gedmo'], true)) {
+            if (in_array('keepRevisions', $fieldMapping['gedmo'], true)) {
                 if ($meta->isCollectionValuedAssociation($field)) {
                     throw new InvalidMappingException(sprintf('Cannot version field %s::$%s, collection valued associations are not supported.', $meta->getName(), $field));
                 }

--- a/src/Revisionable/Mapping/Driver/Yaml.php
+++ b/src/Revisionable/Mapping/Driver/Yaml.php
@@ -24,7 +24,7 @@ use Symfony\Component\Yaml\Yaml as YamlParser;
  *
  * @internal
  */
-class Yaml extends File
+final class Yaml extends File
 {
     /**
      * File extension

--- a/src/Revisionable/Mapping/Driver/Yaml.php
+++ b/src/Revisionable/Mapping/Driver/Yaml.php
@@ -66,7 +66,7 @@ final class Yaml extends File
         // Validate configuration
         if (!$meta->isMappedSuperclass && $config) {
             // The revisionable flag must be set, except for embedded models, and the versioned config should be a non-empty array
-            if (isset($config['versioned']) && !isset($config['revisionable'])) {
+            if (isset($config['versionedFields']) && !isset($config['revisionable'])) {
                 throw new InvalidMappingException(sprintf("Class '%s' has fields marked as versioned but the class does not have the 'revisionable' configuration.", $meta->getName()));
             }
         }
@@ -167,7 +167,7 @@ final class Yaml extends File
                     continue;
                 }
 
-                $config['versioned'][] = $prepend
+                $config['versionedFields'][] = $prepend
                     ? $prepend.'.'.$field
                     : $field;
             }

--- a/src/Revisionable/Mapping/Driver/Yaml.php
+++ b/src/Revisionable/Mapping/Driver/Yaml.php
@@ -1,0 +1,178 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Revisionable\Mapping\Driver;
+
+use Doctrine\ORM\Mapping\ClassMetadata as ORMClassMetadata;
+use Gedmo\Exception\InvalidMappingException;
+use Gedmo\Mapping\Driver\File;
+use Symfony\Component\Yaml\Yaml as YamlParser;
+
+/**
+ * Mapping driver for the revisionable extension which reads extended metadata from a YAML mapping document for a revisionable class.
+ *
+ * @author Boussekeyt Jules <jules.boussekeyt@gmail.com>
+ * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ *
+ * @deprecated since gedmo/doctrine-extensions 3.x, will be removed in version 4.0.
+ *
+ * @internal
+ */
+class Yaml extends File
+{
+    /**
+     * File extension
+     *
+     * @var string
+     */
+    protected $_extension = '.dcm.yml';
+
+    public function readExtendedMetadata($meta, array &$config)
+    {
+        \assert($meta instanceof ORMClassMetadata);
+
+        // Skip embedded classes, they will be handled inline while processing classes using embeds
+        if ($meta->isEmbeddedClass) {
+            return $config;
+        }
+
+        $mapping = $this->_getMapping($meta->getName());
+
+        // Determine if the object is revisionable by inspecting the object root for a Gedmo config node
+        if (isset($mapping['gedmo'])) {
+            $classMapping = $mapping['gedmo'];
+
+            if (isset($classMapping['revisionable'])) {
+                $config['revisionable'] = true;
+
+                if (isset($classMapping['revisionable']['revisionClass'])) {
+                    if (!$cl = $this->getRelatedClassName($meta, $classMapping['revisionable']['revisionClass'])) {
+                        throw new InvalidMappingException(sprintf("The revision class '%s' configured for '%s' does not exist.", $classMapping['revisionable']['revisionClass'], $meta->getName()));
+                    }
+
+                    $config['revisionClass'] = $cl;
+                }
+            }
+        }
+
+        $config = $this->inspectConfiguration($mapping, $config, $meta);
+
+        // Validate configuration
+        if (!$meta->isMappedSuperclass && $config) {
+            // The revisionable flag must be set, except for embedded models, and the versioned config should be a non-empty array
+            if (isset($config['versioned']) && !isset($config['revisionable'])) {
+                throw new InvalidMappingException(sprintf("Class '%s' has fields marked as versioned but the class does not have the 'revisionable' configuration.", $meta->getName()));
+            }
+        }
+
+        return $config;
+    }
+
+    protected function _loadMappingFile($file)
+    {
+        return YamlParser::parse(file_get_contents($file));
+    }
+
+    /**
+     * Searches a configuration array for versioned fields
+     *
+     * @param array<string, mixed>     $mapping
+     * @param array<string, mixed>     $config
+     * @param ORMClassMetadata<object> $meta
+     *
+     * @return array<string, mixed>
+     */
+    private function inspectConfiguration(array $mapping, array $config, ORMClassMetadata $meta, string $prepend = ''): array
+    {
+        // Inspect for versioned fields
+        if (isset($mapping['fields'])) {
+            $config = $this->inspectConfigurationForVersioned($mapping['fields'], $config, $meta, $prepend);
+        }
+
+        // Inspect for versioned embeds
+        if (isset($mapping['embedded'])) {
+            $config = $this->inspectConfigurationForVersioned($mapping['embedded'], $config, $meta, $prepend);
+        }
+
+        // Inspect for versioned relationships
+        foreach (['manyToOne', 'oneToOne'] as $relationshipType) {
+            if (isset($mapping[$relationshipType])) {
+                $config = $this->inspectConfigurationForVersioned($mapping[$relationshipType], $config, $meta, $prepend);
+            }
+        }
+
+        // Inspect attribute overrides
+        if (isset($mapping['attributeOverride'])) {
+            $config = $this->inspectConfigurationForVersioned($mapping['attributeOverride'], $config, $meta, $prepend);
+        }
+
+        return $config;
+    }
+
+    /**
+     * @param array<string, mixed>     $config
+     * @param ORMClassMetadata<object> $meta
+     *
+     * @return array<string, mixed>
+     */
+    private function inspectEmbeddedForVersioned(string $field, array $config, ORMClassMetadata $meta): array
+    {
+        return $this->inspectConfiguration($this->_getMapping($meta->embeddedClasses[$field]['class']), $config, $meta, $field);
+    }
+
+    /**
+     * @param array<string, array<string, array<string, mixed>>> $mapping
+     * @param array<string, mixed>                               $config
+     * @param ORMClassMetadata<object>                           $meta
+     *
+     * @return array<string, mixed>
+     */
+    private function inspectConfigurationForVersioned(array $mapping, array $config, ORMClassMetadata $meta, string $prepend = ''): array
+    {
+        foreach ($mapping as $field => $fieldMapping) {
+            if (!isset($fieldMapping['gedmo'])) {
+                continue;
+            }
+
+            if (in_array('versioned', $fieldMapping['gedmo'], true)) {
+                if ($meta->isCollectionValuedAssociation($field)) {
+                    throw new InvalidMappingException(sprintf('Cannot version field %s::$%s, collection valued associations are not supported.', $meta->getName(), $field));
+                }
+
+                // To version a field with a relationship, it must be the owning side
+                if ($meta->hasAssociation($field)) {
+                    $associationMapping = $meta->associationMappings[$field];
+
+                    if (!$associationMapping['isOwningSide']) {
+                        throw new InvalidMappingException(sprintf('Cannot version field %s::$%s, it is not the owning side of the relationship.', $meta->getName(), $field));
+                    }
+                }
+
+                /*
+                 * Due to differences in the UoW's for each object manager, embedded models need to be handled differently.
+                 *
+                 * The ORM inlines embedded field mappings to the root entity, so the list of versioned fields needs to be added to
+                 * the extension metadata now.
+                 */
+
+                if (isset($meta->embeddedClasses[$field])) {
+                    $config = $this->inspectEmbeddedForVersioned($field, $config, $meta);
+
+                    continue;
+                }
+
+                $config['versioned'][] = $prepend
+                    ? $prepend.'.'.$field
+                    : $field;
+            }
+        }
+
+        return $config;
+    }
+}

--- a/src/Revisionable/Mapping/Event/Adapter/ODM.php
+++ b/src/Revisionable/Mapping/Event/Adapter/ODM.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Revisionable\Mapping\Event\Adapter;
+
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata as MongoDBODMClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
+use Gedmo\Mapping\Event\Adapter\ODM as BaseAdapterODM;
+use Gedmo\Revisionable\Document\Revision;
+use Gedmo\Revisionable\Mapping\Event\RevisionableAdapter;
+use Gedmo\Revisionable\Revisionable;
+use Gedmo\Revisionable\RevisionInterface;
+use Gedmo\Tool\Wrapper\MongoDocumentWrapper;
+
+/**
+ * Doctrine event adapter for the Revisionable extension when using the Doctrine MongoDB ORM.
+ *
+ * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ */
+final class ODM extends BaseAdapterODM implements RevisionableAdapter
+{
+    /**
+     * Get the default object class name used to store revisions.
+     *
+     * @return class-string<RevisionInterface<Revisionable|object>>
+     */
+    public function getDefaultRevisionClass(): string
+    {
+        return Revision::class;
+    }
+
+    /**
+     * Checks whether an identifier should be generated post insert.
+     *
+     * @param ClassMetadata<object> $meta
+     */
+    public function isPostInsertGenerator(ClassMetadata $meta): bool
+    {
+        // The MongoDB ODM does not support post insert generated identifiers
+        return false;
+    }
+
+    /**
+     * Get the new version number for an object.
+     *
+     * @param ClassMetadata<object> $meta
+     *
+     * @return positive-int
+     */
+    public function getNewVersion(ClassMetadata $meta, object $object): int
+    {
+        assert($meta instanceof MongoDBODMClassMetadata);
+
+        $dm = $this->getObjectManager();
+
+        $documentWrapper = new MongoDocumentWrapper($object, $dm);
+
+        $documentMetadata = $documentWrapper->getMetadata();
+        $documentId = (string) $documentWrapper->getIdentifier(false, true);
+        $documentClass = $documentMetadata->getName();
+
+        $qb = $dm->createQueryBuilder($meta->getName());
+        $qb->select('version');
+        $qb->field('revisionableId')->equals($documentId);
+        $qb->field('revisionableClass')->equals($documentClass);
+        $qb->sort('version', 'DESC');
+        $qb->limit(1);
+
+        $q = $qb->getQuery();
+        $q->setHydrate(false);
+
+        $result = $q->getSingleResult();
+
+        if ($result) {
+            $result = (int) $result['version'] + 1;
+        }
+
+        return (int) $result;
+    }
+}

--- a/src/Revisionable/Mapping/Event/Adapter/ORM.php
+++ b/src/Revisionable/Mapping/Event/Adapter/ORM.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Revisionable\Mapping\Event\Adapter;
+
+use Doctrine\ORM\Mapping\ClassMetadata as ORMClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
+use Gedmo\Mapping\Event\Adapter\ORM as BaseAdapterORM;
+use Gedmo\Revisionable\Entity\Revision;
+use Gedmo\Revisionable\Mapping\Event\RevisionableAdapter;
+use Gedmo\Revisionable\Revisionable;
+use Gedmo\Revisionable\RevisionInterface;
+use Gedmo\Tool\Wrapper\EntityWrapper;
+
+/**
+ * Doctrine event adapter for the Revisionable extension when using the Doctrine ORM.
+ *
+ * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ */
+final class ORM extends BaseAdapterORM implements RevisionableAdapter
+{
+    /**
+     * Get the default object class name used to store revisions.
+     *
+     * @return class-string<RevisionInterface<Revisionable|object>>
+     */
+    public function getDefaultRevisionClass(): string
+    {
+        return Revision::class;
+    }
+
+    /**
+     * Checks whether an identifier should be generated post insert.
+     *
+     * @param ClassMetadata<object> $meta
+     */
+    public function isPostInsertGenerator(ClassMetadata $meta): bool
+    {
+        assert($meta instanceof ORMClassMetadata);
+
+        return $meta->idGenerator->isPostInsertGenerator();
+    }
+
+    /**
+     * Get the new version number for an object.
+     *
+     * @param ClassMetadata<object> $meta
+     *
+     * @return positive-int
+     */
+    public function getNewVersion(ClassMetadata $meta, object $object): int
+    {
+        assert($meta instanceof ORMClassMetadata);
+
+        $em = $this->getObjectManager();
+
+        $entityWrapper = new EntityWrapper($object, $em);
+
+        $entityMetadata = $entityWrapper->getMetadata();
+        $entityId = (string) $entityWrapper->getIdentifier(false, true);
+        $entityClass = $entityMetadata->getName();
+
+        $qb = $em->createQueryBuilder()
+            ->select('MAX(revision.version)')
+            ->from($meta->getName(), 'revision')
+            ->where('revision.revisionableId = :revisionableId')
+            ->andWhere('revision.revisionableClass = :revisionableClass')
+            ->setParameter('revisionableId', $entityId)
+            ->setParameter('revisionableClass', $entityClass);
+
+        $version = (int) $qb->getQuery()->getSingleScalarResult();
+
+        return $version + 1;
+    }
+}

--- a/src/Revisionable/Mapping/Event/RevisionableAdapter.php
+++ b/src/Revisionable/Mapping/Event/RevisionableAdapter.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Revisionable\Mapping\Event;
+
+use Doctrine\Persistence\Mapping\ClassMetadata;
+use Gedmo\Mapping\Event\AdapterInterface;
+use Gedmo\Revisionable\Revisionable;
+use Gedmo\Revisionable\RevisionInterface;
+
+/**
+ * Doctrine event adapter for the Revisionable extension.
+ *
+ * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ */
+interface RevisionableAdapter extends AdapterInterface
+{
+    /**
+     * Get the default object class name used to store revisions.
+     *
+     * @return class-string<RevisionInterface<Revisionable|object>>
+     */
+    public function getDefaultRevisionClass(): string;
+
+    /**
+     * Checks whether an identifier should be generated post insert.
+     *
+     * @param ClassMetadata<object> $meta
+     */
+    public function isPostInsertGenerator(ClassMetadata $meta): bool;
+
+    /**
+     * Get the new version number for an object.
+     *
+     * @param ClassMetadata<object> $meta
+     *
+     * @return positive-int
+     */
+    public function getNewVersion(ClassMetadata $meta, object $object): int;
+}

--- a/src/Revisionable/RevisionInterface.php
+++ b/src/Revisionable/RevisionInterface.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Revisionable;
+
+/**
+ * Interface defining a revision model.
+ *
+ * @template T of Revisionable|object
+ *
+ * @author Javier Spagnoletti <phansys@gmail.com>
+ */
+interface RevisionInterface
+{
+    public const ACTION_CREATE = 'create';
+
+    public const ACTION_UPDATE = 'update';
+
+    public const ACTION_REMOVE = 'remove';
+
+    /**
+     * Named constructor to create a new revision.
+     *
+     * Implementations should handle setting the initial logged at time and version for new instances within this constructor.
+     *
+     * @param self::ACTION_CREATE|self::ACTION_UPDATE|self::ACTION_REMOVE $action
+     *
+     * @return RevisionInterface<T>
+     */
+    public static function createRevision(string $action): self;
+
+    /**
+     * @param self::ACTION_CREATE|self::ACTION_UPDATE|self::ACTION_REMOVE $action
+     */
+    public function setAction(string $action): void;
+
+    /**
+     * @return self::ACTION_CREATE|self::ACTION_UPDATE|self::ACTION_REMOVE
+     */
+    public function getAction(): string;
+
+    /**
+     * @param positive-int $version
+     */
+    public function setVersion(int $version): void;
+
+    /**
+     * @return positive-int
+     */
+    public function getVersion(): int;
+
+    /**
+     * @param non-empty-string $revisionableId
+     */
+    public function setRevisionableId(string $revisionableId): void;
+
+    /**
+     * @return non-empty-string|null
+     */
+    public function getRevisionableId(): ?string;
+
+    /**
+     * @param class-string<T> $revisionableClass
+     */
+    public function setRevisionableClass(string $revisionableClass): void;
+
+    /**
+     * @return class-string<T>|null
+     */
+    public function getRevisionableClass(): ?string;
+
+    public function setLoggedAt(\DateTimeImmutable $loggedAt): void;
+
+    public function getLoggedAt(): \DateTimeImmutable;
+
+    /**
+     * @param non-empty-string|null $username
+     */
+    public function setUsername(?string $username): void;
+
+    /**
+     * @return non-empty-string|null
+     */
+    public function getUsername(): ?string;
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function setData(array $data): void;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getData(): array;
+}

--- a/src/Revisionable/Revisionable.php
+++ b/src/Revisionable/Revisionable.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Revisionable;
+
+/**
+ * Marker interface for objects which can be identified as revisionable.
+ */
+interface Revisionable
+{
+}

--- a/src/Revisionable/RevisionableListener.php
+++ b/src/Revisionable/RevisionableListener.php
@@ -286,7 +286,7 @@ final class RevisionableListener extends MappedEventSubscriber
         $newValues = [];
 
         foreach ($ea->getObjectChangeSet($uow, $object) as $field => $changes) {
-            if (empty($config['versioned']) || !in_array($field, $config['versioned'], true)) {
+            if (!isset($config['versioned']) || !in_array($field, $config['versioned'], true)) {
                 continue;
             }
 
@@ -372,11 +372,6 @@ final class RevisionableListener extends MappedEventSubscriber
 
         if (RevisionInterface::ACTION_CREATE !== $action) {
             $version = $ea->getNewVersion($revisionMeta, $object);
-
-            if (empty($version)) {
-                // was versioned later
-                $version = 1;
-            }
         }
 
         $revision->setVersion($version);

--- a/src/Revisionable/RevisionableListener.php
+++ b/src/Revisionable/RevisionableListener.php
@@ -292,7 +292,7 @@ final class RevisionableListener extends MappedEventSubscriber
 
             $value = $changes[1];
 
-            if ($meta instanceof MongoDBODMClassMetadata && $meta->hasEmbed($field)) {
+            if ($meta instanceof MongoDBODMClassMetadata && $meta->hasEmbed($field) && null !== $value) {
                 $value = $this->getObjectChangeSetData($ea, $value, $revision);
             } elseif ($meta->isSingleValuedAssociation($field)) {
                 if ($value) {

--- a/src/Revisionable/RevisionableListener.php
+++ b/src/Revisionable/RevisionableListener.php
@@ -1,0 +1,390 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Revisionable;
+
+use Doctrine\Common\EventArgs;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata as MongoDBODMClassMetadata;
+use Doctrine\ORM\Mapping\ClassMetadata as ORMClassMetadata;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
+use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
+use Doctrine\Persistence\Event\ManagerEventArgs;
+use Doctrine\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\ObjectManager;
+use Gedmo\Exception\InvalidArgumentException;
+use Gedmo\Exception\UnexpectedValueException;
+use Gedmo\Mapping\MappedEventSubscriber;
+use Gedmo\Revisionable\Mapping\Event\RevisionableAdapter;
+use Gedmo\Tool\ActorProviderInterface;
+use Gedmo\Tool\Wrapper\AbstractWrapper;
+
+/**
+ * Revisionable listener
+ *
+ * @author Boussekeyt Jules <jules.boussekeyt@gmail.com>
+ * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ *
+ * @phpstan-type RevisionableConfiguration = array{
+ *   revisionable?: bool,
+ *   revisionClass?: class-string<RevisionInterface<T>>,
+ *   versioned?: list<non-empty-string>,
+ * }
+ *
+ * @template T of Revisionable|object
+ *
+ * @phpstan-extends MappedEventSubscriber<RevisionableConfiguration, RevisionableAdapter>
+ */
+final class RevisionableListener extends MappedEventSubscriber
+{
+    private ?ActorProviderInterface $actorProvider = null;
+
+    /**
+     * Username for identification
+     *
+     * @var non-empty-string|null
+     */
+    private ?string $username = null;
+
+    /**
+     * List of revisions which do not have the foreign key generated yet - MySQL case.
+     *
+     * These entries will be updated with new keys on postPersist event
+     *
+     * @var array<int, RevisionInterface<T>>
+     */
+    private array $pendingRevisionInserts = [];
+
+    /**
+     * For log of changed relations we use its identifiers to avoid storing serialized Proxies.
+     *
+     * These are pending relations in case it does not have an identifier yet.
+     *
+     * @var array<int, array<int, array{revision: RevisionInterface<T>, field: string}>>
+     */
+    private array $pendingRelatedObjects = [];
+
+    /**
+     * Set an actor provider for the user value.
+     */
+    public function setActorProvider(ActorProviderInterface $actorProvider): void
+    {
+        $this->actorProvider = $actorProvider;
+    }
+
+    /**
+     * Set the username to be used when logging revisions.
+     *
+     * If an actor provider is also provided, it will take precedence over this value.
+     *
+     * @param non-empty-string|object $username
+     *
+     * @throws InvalidArgumentException Invalid username
+     */
+    public function setUsername($username): void
+    {
+        if (is_string($username)) {
+            $this->username = $username;
+
+            return;
+        }
+
+        if (!is_object($username)) {
+            throw new InvalidArgumentException('The username must be a string or an object implementing Stringable or with a getUserIdentifier or getUsername method.');
+        }
+
+        if (method_exists($username, 'getUserIdentifier')) {
+            $this->username = (string) $username->getUserIdentifier();
+
+            return;
+        }
+
+        if (method_exists($username, 'getUsername')) {
+            $this->username = (string) $username->getUsername();
+
+            return;
+        }
+
+        if (method_exists($username, '__toString')) {
+            $this->username = $username->__toString();
+
+            return;
+        }
+
+        throw new InvalidArgumentException('The username must be a string or an object implementing Stringable or with a getUserIdentifier or getUsername method.');
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getSubscribedEvents(): array
+    {
+        return [
+            'onFlush',
+            'loadClassMetadata',
+            'postPersist',
+        ];
+    }
+
+    /**
+     * Maps additional metadata for revisionable objects.
+     *
+     * @param LoadClassMetadataEventArgs<ClassMetadata<object>, ObjectManager> $eventArgs
+     */
+    public function loadClassMetadata(EventArgs $eventArgs): void
+    {
+        $this->loadMetadataForObjectClass($eventArgs->getObjectManager(), $eventArgs->getClassMetadata());
+    }
+
+    /**
+     * Checks for inserted objects to update the revision's foreign key.
+     *
+     * @param LifecycleEventArgs<ObjectManager> $args
+     */
+    public function postPersist(EventArgs $args): void
+    {
+        $ea = $this->getEventAdapter($args);
+        $object = $ea->getObject();
+        $om = $ea->getObjectManager();
+        $oid = spl_object_id($object);
+        $uow = $om->getUnitOfWork();
+
+        if ($this->pendingRevisionInserts && array_key_exists($oid, $this->pendingRevisionInserts)) {
+            $wrapped = AbstractWrapper::wrap($object, $om);
+
+            $revision = $this->pendingRevisionInserts[$oid];
+            $revisionMeta = $om->getClassMetadata(get_class($revision));
+
+            $id = $wrapped->getIdentifier(false, true);
+            $revisionMeta->setFieldValue($revision, 'revisionableId', $id);
+            $uow->scheduleExtraUpdate($revision, [
+                'revisionableId' => [null, $id],
+            ]);
+            $ea->setOriginalObjectProperty($uow, $revision, 'revisionableId', $id);
+            unset($this->pendingRevisionInserts[$oid]);
+        }
+
+        if ($this->pendingRelatedObjects && array_key_exists($oid, $this->pendingRelatedObjects)) {
+            $wrapped = AbstractWrapper::wrap($object, $om);
+            $identifiers = $wrapped->getIdentifier(false);
+
+            foreach ($this->pendingRelatedObjects[$oid] as $props) {
+                $revision = $props['revision'];
+
+                $oldData = $data = $revision->getData();
+                $data[$props['field']] = $identifiers;
+
+                $revision->setData($data);
+
+                $uow->scheduleExtraUpdate($revision, [
+                    'data' => [$oldData, $data],
+                ]);
+                $ea->setOriginalObjectProperty($uow, $revision, 'data', $data);
+            }
+            unset($this->pendingRelatedObjects[$oid]);
+        }
+    }
+
+    /**
+     * Creates revisions for revisionable objects.
+     *
+     * @param ManagerEventArgs<ObjectManager> $eventArgs
+     */
+    public function onFlush(EventArgs $eventArgs): void
+    {
+        $ea = $this->getEventAdapter($eventArgs);
+        $om = $ea->getObjectManager();
+        $uow = $om->getUnitOfWork();
+
+        foreach ($ea->getScheduledObjectInsertions($uow) as $object) {
+            $this->createRevision(RevisionInterface::ACTION_CREATE, $object, $ea);
+        }
+
+        foreach ($ea->getScheduledObjectUpdates($uow) as $object) {
+            $this->createRevision(RevisionInterface::ACTION_UPDATE, $object, $ea);
+        }
+
+        foreach ($ea->getScheduledObjectDeletions($uow) as $object) {
+            $this->createRevision(RevisionInterface::ACTION_REMOVE, $object, $ea);
+        }
+    }
+
+    protected function getNamespace(): string
+    {
+        return __NAMESPACE__;
+    }
+
+    /**
+     * Get the {@see RevisionInterface} class name to use when creating revisions for the provided class.
+     *
+     * @param class-string $class
+     *
+     * @return class-string<RevisionInterface<T>>
+     */
+    private function getRevisionClass(RevisionableAdapter $ea, string $class): string
+    {
+        return $this->getConfiguration($ea->getObjectManager(), $class)['revisionClass'] ?? $ea->getDefaultRevisionClass();
+    }
+
+    /**
+     * Retrieve the username to use for the log entry.
+     *
+     * This method will try to fetch a username from the actor provider first, falling back to the {@see $this->username}
+     * property if the provider is not set or does not provide a value.
+     *
+     * @throws UnexpectedValueException if the actor provider provides an unsupported username value
+     *
+     * @return non-empty-string|null
+     */
+    private function getUsername(): ?string
+    {
+        if ($this->actorProvider instanceof ActorProviderInterface) {
+            $actor = $this->actorProvider->getActor();
+
+            if (is_string($actor) || null === $actor) {
+                return $actor;
+            }
+
+            if (method_exists($actor, 'getUserIdentifier')) {
+                return (string) $actor->getUserIdentifier();
+            }
+
+            if (method_exists($actor, 'getUsername')) {
+                return (string) $actor->getUsername();
+            }
+
+            if (method_exists($actor, '__toString')) {
+                return $actor->__toString();
+            }
+
+            throw new UnexpectedValueException(\sprintf('The revisionable extension requires the actor provider to return a string or an object implementing the "getUserIdentifier()", "getUsername()", or "__toString()" methods. "%s" cannot be used as an actor.', get_class($actor)));
+        }
+
+        return $this->username;
+    }
+
+    /**
+     * Provides the changed data for an object to store in a revision.
+     *
+     * @param T                    $object
+     * @param RevisionInterface<T> $revision
+     *
+     * @return array<string, mixed>
+     */
+    private function getObjectChangeSetData(RevisionableAdapter $ea, object $object, RevisionInterface $revision): array
+    {
+        $om = $ea->getObjectManager();
+        $wrapped = AbstractWrapper::wrap($object, $om);
+        $meta = $wrapped->getMetadata();
+        $config = $this->getConfiguration($om, $meta->getName());
+        $uow = $om->getUnitOfWork();
+        $newValues = [];
+
+        foreach ($ea->getObjectChangeSet($uow, $object) as $field => $changes) {
+            if (empty($config['versioned']) || !in_array($field, $config['versioned'], true)) {
+                continue;
+            }
+
+            $value = $changes[1];
+
+            if ($meta instanceof MongoDBODMClassMetadata && $meta->hasEmbed($field)) {
+                $value = $this->getObjectChangeSetData($ea, $value, $revision);
+            } elseif ($meta->isSingleValuedAssociation($field)) {
+                if ($value) {
+                    $oid = spl_object_id($value);
+                    $wrappedAssoc = AbstractWrapper::wrap($value, $om);
+                    $value = $wrappedAssoc->getIdentifier(false);
+
+                    if (!is_array($value) && !$value) {
+                        $this->pendingRelatedObjects[$oid][] = [
+                            'revision' => $revision,
+                            'field' => $field,
+                        ];
+                    }
+                }
+            } else {
+                $value = $wrapped->convertToDatabaseValue($value, $meta->getTypeOfField($field));
+            }
+
+            $newValues[$field] = $value;
+        }
+
+        return $newValues;
+    }
+
+    /**
+     * Create a new {@see RevisionInterface} instance
+     *
+     * @param RevisionInterface::ACTION_CREATE|RevisionInterface::ACTION_UPDATE|RevisionInterface::ACTION_REMOVE $action
+     * @param T                                                                                                  $object
+     *
+     * @return RevisionInterface<T>|null
+     */
+    private function createRevision(string $action, object $object, RevisionableAdapter $ea): ?RevisionInterface
+    {
+        $om = $ea->getObjectManager();
+        $wrapped = AbstractWrapper::wrap($object, $om);
+        $meta = $wrapped->getMetadata();
+
+        // Exclude embedded documents
+        if ($meta instanceof MongoDBODMClassMetadata && $meta->isEmbeddedDocument) {
+            return null;
+        }
+
+        $config = $this->getConfiguration($om, $meta->getName());
+
+        if ([] === $config) {
+            return null;
+        }
+
+        $revisionClass = $this->getRevisionClass($ea, $meta->getName());
+        $revisionMeta = $om->getClassMetadata($revisionClass);
+
+        $revision = $revisionClass::createRevision($action);
+        $revision->setUsername($this->getUsername());
+        $revision->setRevisionableClass($meta->getName());
+
+        // check for the availability of the primary key
+        if (RevisionInterface::ACTION_CREATE === $action && ($ea->isPostInsertGenerator($meta) || ($meta instanceof ORMClassMetadata && $meta->isIdentifierComposite))) {
+            $this->pendingRevisionInserts[spl_object_id($object)] = $revision;
+        } else {
+            $revision->setRevisionableId($wrapped->getIdentifier(false, true));
+        }
+
+        $newValues = [];
+
+        if (RevisionInterface::ACTION_REMOVE !== $action && isset($config['versioned'])) {
+            $newValues = $this->getObjectChangeSetData($ea, $object, $revision);
+            $revision->setData($newValues);
+        }
+
+        // Don't create a revision if there's nothing to log on update
+        if (RevisionInterface::ACTION_UPDATE === $action && [] === $newValues) {
+            return null;
+        }
+
+        $version = 1;
+
+        if (RevisionInterface::ACTION_CREATE !== $action) {
+            $version = $ea->getNewVersion($revisionMeta, $object);
+
+            if (empty($version)) {
+                // was versioned later
+                $version = 1;
+            }
+        }
+
+        $revision->setVersion($version);
+
+        $om->persist($revision);
+
+        $om->getUnitOfWork()->computeChangeSet($revisionMeta, $revision);
+
+        return $revision;
+    }
+}

--- a/src/Revisionable/RevisionableListener.php
+++ b/src/Revisionable/RevisionableListener.php
@@ -33,7 +33,7 @@ use Gedmo\Tool\Wrapper\AbstractWrapper;
  * @phpstan-type RevisionableConfiguration = array{
  *   revisionable?: bool,
  *   revisionClass?: class-string<RevisionInterface<T>>,
- *   versioned?: list<non-empty-string>,
+ *   versionedFields?: list<non-empty-string>,
  * }
  *
  * @template T of Revisionable|object
@@ -286,7 +286,7 @@ final class RevisionableListener extends MappedEventSubscriber
         $newValues = [];
 
         foreach ($ea->getObjectChangeSet($uow, $object) as $field => $changes) {
-            if (!isset($config['versioned']) || !in_array($field, $config['versioned'], true)) {
+            if (!isset($config['versionedFields']) || !in_array($field, $config['versionedFields'], true)) {
                 continue;
             }
 
@@ -358,7 +358,7 @@ final class RevisionableListener extends MappedEventSubscriber
 
         $newValues = [];
 
-        if (RevisionInterface::ACTION_REMOVE !== $action && isset($config['versioned'])) {
+        if (RevisionInterface::ACTION_REMOVE !== $action && isset($config['versionedFields'])) {
             $newValues = $this->getObjectChangeSetData($ea, $object, $revision);
             $revision->setData($newValues);
         }

--- a/src/Tool/Wrapper/EntityWrapper.php
+++ b/src/Tool/Wrapper/EntityWrapper.php
@@ -111,6 +111,30 @@ class EntityWrapper extends AbstractWrapper
     }
 
     /**
+     * Converts a given value to its database representation.
+     *
+     * @param mixed $value
+     *
+     * @return mixed
+     */
+    public function convertToDatabaseValue($value, string $type)
+    {
+        return $this->om->getConnection()->convertToDatabaseValue($value, $type);
+    }
+
+    /**
+     * Converts a given value to its PHP representation.
+     *
+     * @param mixed $value
+     *
+     * @return mixed
+     */
+    public function convertToPHPValue($value, string $type)
+    {
+        return $this->om->getConnection()->convertToPHPValue($value, $type);
+    }
+
+    /**
      * Initialize the entity if it is proxy
      * required when is detached or not initialized
      *

--- a/src/Tool/Wrapper/MongoDocumentWrapper.php
+++ b/src/Tool/Wrapper/MongoDocumentWrapper.php
@@ -11,6 +11,7 @@ namespace Gedmo\Tool\Wrapper;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Types\Type;
 use ProxyManager\Proxy\GhostObjectInterface;
 
 /**
@@ -96,6 +97,30 @@ class MongoDocumentWrapper extends AbstractWrapper
     public function isEmbeddedAssociation($field)
     {
         return $this->getMetadata()->isSingleValuedEmbed($field);
+    }
+
+    /**
+     * Converts a given value to its database representation.
+     *
+     * @param mixed $value
+     *
+     * @return mixed
+     */
+    public function convertToDatabaseValue($value, string $type)
+    {
+        return Type::getType($type)->convertToDatabaseValue($value);
+    }
+
+    /**
+     * Converts a given value to its PHP representation.
+     *
+     * @param mixed $value
+     *
+     * @return mixed
+     */
+    public function convertToPHPValue($value, string $type)
+    {
+        return Type::getType($type)->convertToPHPValue($value);
     }
 
     /**

--- a/src/Tool/WrapperInterface.php
+++ b/src/Tool/WrapperInterface.php
@@ -20,6 +20,9 @@ use Doctrine\Persistence\ObjectManager;
  * @template-covariant TObjectManager of ObjectManager
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ *
+ * @method mixed convertToDatabaseValue(mixed $value, string $type)
+ * @method mixed convertToPHPValue(mixed $value, string $type)
  */
 interface WrapperInterface
 {

--- a/tests/Gedmo/Mapping/Driver/Xml/Gedmo.Tests.Mapping.Fixture.Xml.EmbeddedRevisionable.dcm.xml
+++ b/tests/Gedmo/Mapping/Driver/Xml/Gedmo.Tests.Mapping.Fixture.Xml.EmbeddedRevisionable.dcm.xml
@@ -2,7 +2,7 @@
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:gedmo="http://gediminasm.org/schemas/orm/doctrine-extensions-mapping">
     <embeddable name="Gedmo\Tests\Mapping\Fixture\Xml\EmbeddedRevisionable">
         <field name="subtitle" type="string" length="191">
-            <gedmo:versioned/>
+            <gedmo:keep-revisions/>
         </field>
     </embeddable>
 </doctrine-mapping>

--- a/tests/Gedmo/Mapping/Driver/Xml/Gedmo.Tests.Mapping.Fixture.Xml.EmbeddedRevisionable.dcm.xml
+++ b/tests/Gedmo/Mapping/Driver/Xml/Gedmo.Tests.Mapping.Fixture.Xml.EmbeddedRevisionable.dcm.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:gedmo="http://gediminasm.org/schemas/orm/doctrine-extensions-mapping">
+    <embeddable name="Gedmo\Tests\Mapping\Fixture\Xml\EmbeddedRevisionable">
+        <field name="subtitle" type="string" length="191">
+            <gedmo:versioned/>
+        </field>
+    </embeddable>
+</doctrine-mapping>

--- a/tests/Gedmo/Mapping/Driver/Xml/Gedmo.Tests.Mapping.Fixture.Xml.Revisionable.dcm.xml
+++ b/tests/Gedmo/Mapping/Driver/Xml/Gedmo.Tests.Mapping.Fixture.Xml.Revisionable.dcm.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:gedmo="http://gediminasm.org/schemas/orm/doctrine-extensions-mapping">
+    <entity name="Gedmo\Tests\Mapping\Fixture\Xml\Revisionable" table="revisionable">
+        <id name="id" type="integer" column="id">
+            <generator strategy="AUTO"/>
+        </id>
+        <field name="title" type="string" length="64">
+            <gedmo:versioned/>
+        </field>
+        <gedmo:revisionable/>
+    </entity>
+</doctrine-mapping>

--- a/tests/Gedmo/Mapping/Driver/Xml/Gedmo.Tests.Mapping.Fixture.Xml.Revisionable.dcm.xml
+++ b/tests/Gedmo/Mapping/Driver/Xml/Gedmo.Tests.Mapping.Fixture.Xml.Revisionable.dcm.xml
@@ -5,7 +5,7 @@
             <generator strategy="AUTO"/>
         </id>
         <field name="title" type="string" length="64">
-            <gedmo:versioned/>
+            <gedmo:keep-revisions/>
         </field>
         <gedmo:revisionable/>
     </entity>

--- a/tests/Gedmo/Mapping/Driver/Xml/Gedmo.Tests.Mapping.Fixture.Xml.RevisionableComposite.dcm.xml
+++ b/tests/Gedmo/Mapping/Driver/Xml/Gedmo.Tests.Mapping.Fixture.Xml.RevisionableComposite.dcm.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:gedmo="http://gediminasm.org/schemas/orm/doctrine-extensions-mapping">
+    <entity name="Gedmo\Tests\Mapping\Fixture\Xml\RevisionableComposite" table="revisionable_with_composite">
+        <id name="one" type="integer" column="one"/>
+        <id name="two" type="integer" column="two"/>
+        <field name="title" type="string" length="64">
+            <gedmo:versioned/>
+        </field>
+        <gedmo:revisionable revision-class="Gedmo\Revisionable\Entity\Revision"/>
+    </entity>
+</doctrine-mapping>

--- a/tests/Gedmo/Mapping/Driver/Xml/Gedmo.Tests.Mapping.Fixture.Xml.RevisionableComposite.dcm.xml
+++ b/tests/Gedmo/Mapping/Driver/Xml/Gedmo.Tests.Mapping.Fixture.Xml.RevisionableComposite.dcm.xml
@@ -4,7 +4,7 @@
         <id name="one" type="integer" column="one"/>
         <id name="two" type="integer" column="two"/>
         <field name="title" type="string" length="64">
-            <gedmo:versioned/>
+            <gedmo:keep-revisions/>
         </field>
         <gedmo:revisionable revision-class="Gedmo\Revisionable\Entity\Revision"/>
     </entity>

--- a/tests/Gedmo/Mapping/Driver/Xml/Gedmo.Tests.Mapping.Fixture.Xml.RevisionableCompositeRelation.dcm.xml
+++ b/tests/Gedmo/Mapping/Driver/Xml/Gedmo.Tests.Mapping.Fixture.Xml.RevisionableCompositeRelation.dcm.xml
@@ -4,7 +4,7 @@
         <id name="one" association-key="true"/>
         <id name="two" type="integer" column="two"/>
         <field name="title" type="string" length="64">
-            <gedmo:versioned/>
+            <gedmo:keep-revisions/>
         </field>
         <many-to-one field="one" target-entity="Gedmo\Tests\Mapping\Fixture\Xml\Revisionable"/>
         <gedmo:revisionable/>

--- a/tests/Gedmo/Mapping/Driver/Xml/Gedmo.Tests.Mapping.Fixture.Xml.RevisionableCompositeRelation.dcm.xml
+++ b/tests/Gedmo/Mapping/Driver/Xml/Gedmo.Tests.Mapping.Fixture.Xml.RevisionableCompositeRelation.dcm.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:gedmo="http://gediminasm.org/schemas/orm/doctrine-extensions-mapping">
+    <entity name="Gedmo\Tests\Mapping\Fixture\Xml\RevisionableCompositeRelation" table="revisionable_with_composite_relation">
+        <id name="one" association-key="true"/>
+        <id name="two" type="integer" column="two"/>
+        <field name="title" type="string" length="64">
+            <gedmo:versioned/>
+        </field>
+        <many-to-one field="one" target-entity="Gedmo\Tests\Mapping\Fixture\Xml\Revisionable"/>
+        <gedmo:revisionable/>
+    </entity>
+</doctrine-mapping>

--- a/tests/Gedmo/Mapping/Driver/Xml/Gedmo.Tests.Mapping.Fixture.Xml.RevisionableWithEmbedded.dcm.xml
+++ b/tests/Gedmo/Mapping/Driver/Xml/Gedmo.Tests.Mapping.Fixture.Xml.RevisionableWithEmbedded.dcm.xml
@@ -5,10 +5,10 @@
             <generator strategy="AUTO"/>
         </id>
         <embedded name="embedded" class="Gedmo\Tests\Mapping\Fixture\Xml\EmbeddedRevisionable">
-            <gedmo:versioned/>
+            <gedmo:keep-revisions/>
         </embedded>
         <field name="title" type="string" length="64">
-            <gedmo:versioned/>
+            <gedmo:keep-revisions/>
         </field>
         <gedmo:revisionable revision-class="Gedmo\Revisionable\Entity\Revision"/>
     </entity>

--- a/tests/Gedmo/Mapping/Driver/Xml/Gedmo.Tests.Mapping.Fixture.Xml.RevisionableWithEmbedded.dcm.xml
+++ b/tests/Gedmo/Mapping/Driver/Xml/Gedmo.Tests.Mapping.Fixture.Xml.RevisionableWithEmbedded.dcm.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:gedmo="http://gediminasm.org/schemas/orm/doctrine-extensions-mapping">
+    <entity name="Gedmo\Tests\Mapping\Fixture\Xml\RevisionableWithEmbedded" table="revisionable_with_embedded">
+        <id name="id" type="integer" column="id">
+            <generator strategy="AUTO"/>
+        </id>
+        <embedded name="embedded" class="Gedmo\Tests\Mapping\Fixture\Xml\EmbeddedRevisionable">
+            <gedmo:versioned/>
+        </embedded>
+        <field name="title" type="string" length="64">
+            <gedmo:versioned/>
+        </field>
+        <gedmo:revisionable revision-class="Gedmo\Revisionable\Entity\Revision"/>
+    </entity>
+</doctrine-mapping>

--- a/tests/Gedmo/Mapping/Driver/Yaml/Gedmo.Tests.Mapping.Fixture.Yaml.EmbeddedRevisionable.dcm.yml
+++ b/tests/Gedmo/Mapping/Driver/Yaml/Gedmo.Tests.Mapping.Fixture.Yaml.EmbeddedRevisionable.dcm.yml
@@ -1,0 +1,8 @@
+---
+Gedmo\Tests\Mapping\Fixture\Yaml\EmbeddedRevisionable:
+  type: embeddable
+  fields:
+    subtitle:
+      type: string
+      gedmo:
+        - versioned

--- a/tests/Gedmo/Mapping/Driver/Yaml/Gedmo.Tests.Mapping.Fixture.Yaml.EmbeddedRevisionable.dcm.yml
+++ b/tests/Gedmo/Mapping/Driver/Yaml/Gedmo.Tests.Mapping.Fixture.Yaml.EmbeddedRevisionable.dcm.yml
@@ -5,4 +5,4 @@ Gedmo\Tests\Mapping\Fixture\Yaml\EmbeddedRevisionable:
     subtitle:
       type: string
       gedmo:
-        - versioned
+        - keepRevisions

--- a/tests/Gedmo/Mapping/Driver/Yaml/Gedmo.Tests.Mapping.Fixture.Yaml.Revisionable.dcm.yml
+++ b/tests/Gedmo/Mapping/Driver/Yaml/Gedmo.Tests.Mapping.Fixture.Yaml.Revisionable.dcm.yml
@@ -1,0 +1,17 @@
+---
+Gedmo\Tests\Mapping\Fixture\Yaml\Revisionable:
+  type: entity
+  table: revisionable
+  gedmo:
+    revisionable: true
+  id:
+    id:
+      type: integer
+      generator:
+        strategy: AUTO
+  fields:
+    title:
+      type: string
+      length: 64
+      gedmo:
+        - versioned

--- a/tests/Gedmo/Mapping/Driver/Yaml/Gedmo.Tests.Mapping.Fixture.Yaml.Revisionable.dcm.yml
+++ b/tests/Gedmo/Mapping/Driver/Yaml/Gedmo.Tests.Mapping.Fixture.Yaml.Revisionable.dcm.yml
@@ -14,4 +14,4 @@ Gedmo\Tests\Mapping\Fixture\Yaml\Revisionable:
       type: string
       length: 64
       gedmo:
-        - versioned
+        - keepRevisions

--- a/tests/Gedmo/Mapping/Driver/Yaml/Gedmo.Tests.Mapping.Fixture.Yaml.RevisionableComposite.dcm.yml
+++ b/tests/Gedmo/Mapping/Driver/Yaml/Gedmo.Tests.Mapping.Fixture.Yaml.RevisionableComposite.dcm.yml
@@ -1,0 +1,18 @@
+---
+Gedmo\Tests\Mapping\Fixture\Yaml\RevisionableComposite:
+  type: entity
+  table: revisionable_with_composite
+  gedmo:
+    revisionable:
+      revisionClass: Gedmo\Revisionable\Entity\Revision
+  id:
+    one:
+      type: integer
+    two:
+      type: integer
+  fields:
+    title:
+      type: string
+      length: 64
+      gedmo:
+        - versioned

--- a/tests/Gedmo/Mapping/Driver/Yaml/Gedmo.Tests.Mapping.Fixture.Yaml.RevisionableComposite.dcm.yml
+++ b/tests/Gedmo/Mapping/Driver/Yaml/Gedmo.Tests.Mapping.Fixture.Yaml.RevisionableComposite.dcm.yml
@@ -15,4 +15,4 @@ Gedmo\Tests\Mapping\Fixture\Yaml\RevisionableComposite:
       type: string
       length: 64
       gedmo:
-        - versioned
+        - keepRevisions

--- a/tests/Gedmo/Mapping/Driver/Yaml/Gedmo.Tests.Mapping.Fixture.Yaml.RevisionableCompositeRelation.dcm.yml
+++ b/tests/Gedmo/Mapping/Driver/Yaml/Gedmo.Tests.Mapping.Fixture.Yaml.RevisionableCompositeRelation.dcm.yml
@@ -1,0 +1,20 @@
+---
+Gedmo\Tests\Mapping\Fixture\Yaml\RevisionableCompositeRelation:
+  type: entity
+  table: revisionable_with_composite_relation
+  gedmo:
+    revisionable: true
+  id:
+    one:
+      associationKey: true
+    two:
+      type: integer
+  fields:
+    title:
+      type: string
+      length: 64
+      gedmo:
+        - versioned
+  manyToOne:
+    one:
+      targetEntity: Revisionable

--- a/tests/Gedmo/Mapping/Driver/Yaml/Gedmo.Tests.Mapping.Fixture.Yaml.RevisionableCompositeRelation.dcm.yml
+++ b/tests/Gedmo/Mapping/Driver/Yaml/Gedmo.Tests.Mapping.Fixture.Yaml.RevisionableCompositeRelation.dcm.yml
@@ -14,7 +14,7 @@ Gedmo\Tests\Mapping\Fixture\Yaml\RevisionableCompositeRelation:
       type: string
       length: 64
       gedmo:
-        - versioned
+        - keepRevisions
   manyToOne:
     one:
       targetEntity: Revisionable

--- a/tests/Gedmo/Mapping/Driver/Yaml/Gedmo.Tests.Mapping.Fixture.Yaml.RevisionableWithEmbedded.dcm.yml
+++ b/tests/Gedmo/Mapping/Driver/Yaml/Gedmo.Tests.Mapping.Fixture.Yaml.RevisionableWithEmbedded.dcm.yml
@@ -1,0 +1,23 @@
+---
+Gedmo\Tests\Mapping\Fixture\Yaml\RevisionableWithEmbedded:
+  type: entity
+  table: revisionable_with_embedded
+  gedmo:
+    revisionable:
+      revisionClass: Gedmo\Revisionable\Entity\Revision
+  id:
+    id:
+      type: integer
+      generator:
+        strategy: AUTO
+  fields:
+    title:
+      type: string
+      length: 64
+      gedmo:
+        - versioned
+  embedded:
+    embedded:
+      class: Gedmo\Tests\Mapping\Fixture\Yaml\EmbeddedRevisionable
+      gedmo:
+        - versioned

--- a/tests/Gedmo/Mapping/Driver/Yaml/Gedmo.Tests.Mapping.Fixture.Yaml.RevisionableWithEmbedded.dcm.yml
+++ b/tests/Gedmo/Mapping/Driver/Yaml/Gedmo.Tests.Mapping.Fixture.Yaml.RevisionableWithEmbedded.dcm.yml
@@ -15,9 +15,9 @@ Gedmo\Tests\Mapping\Fixture\Yaml\RevisionableWithEmbedded:
       type: string
       length: 64
       gedmo:
-        - versioned
+        - keepRevisions
   embedded:
     embedded:
       class: Gedmo\Tests\Mapping\Fixture\Yaml\EmbeddedRevisionable
       gedmo:
-        - versioned
+        - keepRevisions

--- a/tests/Gedmo/Mapping/Fixture/Document/EmbeddedRevisionable.php
+++ b/tests/Gedmo/Mapping/Fixture/Document/EmbeddedRevisionable.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Mapping\Fixture\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Types\Type;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * @author Fabian Sabau <fabian.sabau@socialbit.de>
+ *
+ * @ODM\EmbeddedDocument
+ */
+#[ODM\EmbeddedDocument]
+class EmbeddedRevisionable
+{
+    /**
+     * @ODM\Field(type="string")
+     *
+     * @Gedmo\Versioned
+     */
+    #[ODM\Field(type: Type::STRING)]
+    #[Gedmo\Versioned]
+    private ?string $subtitle = null;
+}

--- a/tests/Gedmo/Mapping/Fixture/Document/EmbeddedRevisionable.php
+++ b/tests/Gedmo/Mapping/Fixture/Document/EmbeddedRevisionable.php
@@ -26,9 +26,9 @@ class EmbeddedRevisionable
     /**
      * @ODM\Field(type="string")
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ODM\Field(type: Type::STRING)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?string $subtitle = null;
 }

--- a/tests/Gedmo/Mapping/Fixture/Document/Revisionable.php
+++ b/tests/Gedmo/Mapping/Fixture/Document/Revisionable.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Mapping\Fixture\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Types\Type;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * @ODM\Document(collection="revisionables")
+ *
+ * @Gedmo\Revisionable
+ */
+#[ODM\Document(collection: 'revisionables')]
+#[Gedmo\Revisionable]
+class Revisionable
+{
+    /**
+     * @ODM\Id
+     */
+    #[ODM\Id]
+    private ?string $id = null;
+
+    /**
+     * @ODM\Field(type="string")
+     *
+     * @Gedmo\Versioned
+     */
+    #[ODM\Field(type: Type::STRING)]
+    #[Gedmo\Versioned]
+    private ?string $title = null;
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+}

--- a/tests/Gedmo/Mapping/Fixture/Document/Revisionable.php
+++ b/tests/Gedmo/Mapping/Fixture/Document/Revisionable.php
@@ -31,10 +31,10 @@ class Revisionable
     /**
      * @ODM\Field(type="string")
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ODM\Field(type: Type::STRING)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?string $title = null;
 
     public function getId(): ?string

--- a/tests/Gedmo/Mapping/Fixture/Document/RevisionableWithEmbedded.php
+++ b/tests/Gedmo/Mapping/Fixture/Document/RevisionableWithEmbedded.php
@@ -34,18 +34,18 @@ class RevisionableWithEmbedded
     /**
      * @ODM\Field(type="string")
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ODM\Field(type: Type::STRING)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?string $title = null;
 
     /**
      * @ODM\EmbedOne(targetDocument="Gedmo\Tests\Mapping\Fixture\Document\EmbeddedRevisionable")
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ODM\EmbedOne(targetDocument: EmbeddedRevisionable::class)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?EmbeddedRevisionable $embedded = null;
 }

--- a/tests/Gedmo/Mapping/Fixture/Document/RevisionableWithEmbedded.php
+++ b/tests/Gedmo/Mapping/Fixture/Document/RevisionableWithEmbedded.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Mapping\Fixture\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Types\Type;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Gedmo\Revisionable\Document\Revision;
+
+/**
+ * @ODM\Document(collection="revisionables_with_embedded")
+ *
+ * @Gedmo\Revisionable(revisionClass="Gedmo\Revisionable\Document\Revision")
+ */
+#[ODM\Document(collection: 'revisionables_with_embedded')]
+#[Gedmo\Revisionable(revisionClass: Revision::class)]
+class RevisionableWithEmbedded
+{
+    /**
+     * @ODM\Id
+     */
+    #[ODM\Id]
+    private ?string $id = null;
+
+    /**
+     * @ODM\Field(type="string")
+     *
+     * @Gedmo\Versioned
+     */
+    #[ODM\Field(type: Type::STRING)]
+    #[Gedmo\Versioned]
+    private ?string $title = null;
+
+    /**
+     * @ODM\EmbedOne(targetDocument="Gedmo\Tests\Mapping\Fixture\Document\EmbeddedRevisionable")
+     *
+     * @Gedmo\Versioned
+     */
+    #[ODM\EmbedOne(targetDocument: EmbeddedRevisionable::class)]
+    #[Gedmo\Versioned]
+    private ?EmbeddedRevisionable $embedded = null;
+}

--- a/tests/Gedmo/Mapping/Fixture/Entity/EmbeddedRevisionable.php
+++ b/tests/Gedmo/Mapping/Fixture/Entity/EmbeddedRevisionable.php
@@ -26,9 +26,9 @@ class EmbeddedRevisionable
     /**
      * @ORM\Column(type="string")
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ORM\Column(type: Types::STRING)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?string $subtitle = null;
 }

--- a/tests/Gedmo/Mapping/Fixture/Entity/EmbeddedRevisionable.php
+++ b/tests/Gedmo/Mapping/Fixture/Entity/EmbeddedRevisionable.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Mapping\Fixture\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * @author Fabian Sabau <fabian.sabau@socialbit.de>
+ *
+ * @ORM\Embeddable
+ */
+#[ORM\Embeddable]
+class EmbeddedRevisionable
+{
+    /**
+     * @ORM\Column(type="string")
+     *
+     * @Gedmo\Versioned
+     */
+    #[ORM\Column(type: Types::STRING)]
+    #[Gedmo\Versioned]
+    private ?string $subtitle = null;
+}

--- a/tests/Gedmo/Mapping/Fixture/Entity/Revisionable.php
+++ b/tests/Gedmo/Mapping/Fixture/Entity/Revisionable.php
@@ -35,10 +35,10 @@ class Revisionable
     /**
      * @ORM\Column(name="title", type="string", length=64)
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?string $title = null;
 
     public function getId(): ?int

--- a/tests/Gedmo/Mapping/Fixture/Entity/Revisionable.php
+++ b/tests/Gedmo/Mapping/Fixture/Entity/Revisionable.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Mapping\Fixture\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * @ORM\Entity
+ *
+ * @Gedmo\Revisionable
+ */
+#[ORM\Entity]
+#[Gedmo\Revisionable]
+class Revisionable
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    private ?int $id = null;
+
+    /**
+     * @ORM\Column(name="title", type="string", length=64)
+     *
+     * @Gedmo\Versioned
+     */
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
+    #[Gedmo\Versioned]
+    private ?string $title = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+}

--- a/tests/Gedmo/Mapping/Fixture/Entity/RevisionableComposite.php
+++ b/tests/Gedmo/Mapping/Fixture/Entity/RevisionableComposite.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Mapping\Fixture\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Gedmo\Revisionable\Entity\Revision;
+
+/**
+ * @ORM\Entity
+ *
+ * @Gedmo\Revisionable(revisionClass="Gedmo\Revisionable\Entity\Revision")
+ */
+#[ORM\Entity]
+#[Gedmo\Revisionable(revisionClass: Revision::class)]
+class RevisionableComposite
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     */
+    #[ORM\Id]
+    #[ORM\Column(type: Types::INTEGER)]
+    private ?int $one = null;
+
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     */
+    #[ORM\Id]
+    #[ORM\Column(type: Types::INTEGER)]
+    private ?int $two = null;
+
+    /**
+     * @ORM\Column(name="title", type="string", length=64)
+     *
+     * @Gedmo\Versioned
+     */
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
+    #[Gedmo\Versioned]
+    private ?string $title = null;
+
+    public function getOne(): ?int
+    {
+        return $this->one;
+    }
+
+    public function getTwo(): ?int
+    {
+        return $this->two;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+}

--- a/tests/Gedmo/Mapping/Fixture/Entity/RevisionableComposite.php
+++ b/tests/Gedmo/Mapping/Fixture/Entity/RevisionableComposite.php
@@ -42,10 +42,10 @@ class RevisionableComposite
     /**
      * @ORM\Column(name="title", type="string", length=64)
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?string $title = null;
 
     public function getOne(): ?int

--- a/tests/Gedmo/Mapping/Fixture/Entity/RevisionableCompositeRelation.php
+++ b/tests/Gedmo/Mapping/Fixture/Entity/RevisionableCompositeRelation.php
@@ -41,10 +41,10 @@ class RevisionableCompositeRelation
     /**
      * @ORM\Column(name="title", type="string", length=64)
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?string $title = null;
 
     public function getOne(): ?Revisionable

--- a/tests/Gedmo/Mapping/Fixture/Entity/RevisionableCompositeRelation.php
+++ b/tests/Gedmo/Mapping/Fixture/Entity/RevisionableCompositeRelation.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Mapping\Fixture\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * @ORM\Entity
+ *
+ * @Gedmo\Revisionable
+ */
+#[ORM\Entity]
+#[Gedmo\Revisionable]
+class RevisionableCompositeRelation
+{
+    /**
+     * @ORM\Id
+     * @ORM\ManyToOne(targetEntity="Revisionable")
+     */
+    #[ORM\Id]
+    #[ORM\ManyToOne(targetEntity: Revisionable::class)]
+    private ?Revisionable $one = null;
+
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     */
+    #[ORM\Id]
+    #[ORM\Column(type: Types::INTEGER)]
+    private ?int $two = null;
+
+    /**
+     * @ORM\Column(name="title", type="string", length=64)
+     *
+     * @Gedmo\Versioned
+     */
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
+    #[Gedmo\Versioned]
+    private ?string $title = null;
+
+    public function getOne(): ?Revisionable
+    {
+        return $this->one;
+    }
+
+    public function getTwo(): ?int
+    {
+        return $this->two;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+}

--- a/tests/Gedmo/Mapping/Fixture/Entity/RevisionableWithEmbedded.php
+++ b/tests/Gedmo/Mapping/Fixture/Entity/RevisionableWithEmbedded.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Mapping\Fixture\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Gedmo\Revisionable\Entity\Revision;
+
+/**
+ * @ORM\Entity
+ *
+ * @Gedmo\Revisionable(revisionClass="Gedmo\Revisionable\Entity\Revision")
+ */
+#[ORM\Entity]
+#[Gedmo\Revisionable(revisionClass: Revision::class)]
+class RevisionableWithEmbedded
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    private ?int $id = null;
+
+    /**
+     * @ORM\Column(name="title", type="string", length=64)
+     *
+     * @Gedmo\Versioned
+     */
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
+    #[Gedmo\Versioned]
+    private ?string $title = null;
+
+    /**
+     * @ORM\Embedded(class="Gedmo\Tests\Mapping\Fixture\Entity\EmbeddedRevisionable")
+     *
+     * @Gedmo\Versioned
+     */
+    #[ORM\Embedded(class: EmbeddedRevisionable::class)]
+    #[Gedmo\Versioned]
+    private ?EmbeddedRevisionable $embedded = null;
+}

--- a/tests/Gedmo/Mapping/Fixture/Entity/RevisionableWithEmbedded.php
+++ b/tests/Gedmo/Mapping/Fixture/Entity/RevisionableWithEmbedded.php
@@ -38,18 +38,18 @@ class RevisionableWithEmbedded
     /**
      * @ORM\Column(name="title", type="string", length=64)
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?string $title = null;
 
     /**
      * @ORM\Embedded(class="Gedmo\Tests\Mapping\Fixture\Entity\EmbeddedRevisionable")
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ORM\Embedded(class: EmbeddedRevisionable::class)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?EmbeddedRevisionable $embedded = null;
 }

--- a/tests/Gedmo/Mapping/Fixture/Xml/EmbeddedRevisionable.php
+++ b/tests/Gedmo/Mapping/Fixture/Xml/EmbeddedRevisionable.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Mapping\Fixture\Xml;
+
+/**
+ * @author Fabian Sabau <fabian.sabau@socialbit.de>
+ */
+class EmbeddedRevisionable
+{
+    private ?string $subtitle = null;
+}

--- a/tests/Gedmo/Mapping/Fixture/Xml/Revisionable.php
+++ b/tests/Gedmo/Mapping/Fixture/Xml/Revisionable.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Mapping\Fixture\Xml;
+
+class Revisionable
+{
+    private ?int $id = null;
+
+    private ?string $title = null;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+}

--- a/tests/Gedmo/Mapping/Fixture/Xml/RevisionableComposite.php
+++ b/tests/Gedmo/Mapping/Fixture/Xml/RevisionableComposite.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Mapping\Fixture\Xml;
+
+class RevisionableComposite
+{
+    private ?int $one = null;
+
+    private ?int $two = null;
+
+    private ?string $title = null;
+
+    public function getOne(): int
+    {
+        return $this->one;
+    }
+
+    public function getTwo(): int
+    {
+        return $this->two;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+}

--- a/tests/Gedmo/Mapping/Fixture/Xml/RevisionableCompositeRelation.php
+++ b/tests/Gedmo/Mapping/Fixture/Xml/RevisionableCompositeRelation.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Mapping\Fixture\Xml;
+
+class RevisionableCompositeRelation
+{
+    private ?Revisionable $one = null;
+
+    private ?int $two = null;
+
+    private ?string $title = null;
+
+    public function getOne(): ?Revisionable
+    {
+        return $this->one;
+    }
+
+    public function getTwo(): ?int
+    {
+        return $this->two;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+}

--- a/tests/Gedmo/Mapping/Fixture/Xml/RevisionableWithEmbedded.php
+++ b/tests/Gedmo/Mapping/Fixture/Xml/RevisionableWithEmbedded.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Mapping\Fixture\Xml;
+
+class RevisionableWithEmbedded
+{
+    private ?int $id = null;
+
+    private ?string $title = null;
+
+    private ?Embedded $embedded = null;
+}

--- a/tests/Gedmo/Mapping/Fixture/Yaml/EmbeddedRevisionable.php
+++ b/tests/Gedmo/Mapping/Fixture/Yaml/EmbeddedRevisionable.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Mapping\Fixture\Yaml;
+
+/**
+ * @author Fabian Sabau <fabian.sabau@socialbit.de>
+ */
+class EmbeddedRevisionable
+{
+    private ?string $subtitle = null;
+}

--- a/tests/Gedmo/Mapping/Fixture/Yaml/Revisionable.php
+++ b/tests/Gedmo/Mapping/Fixture/Yaml/Revisionable.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Mapping\Fixture\Yaml;
+
+class Revisionable
+{
+    private ?int $id = null;
+
+    private ?string $title = null;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+}

--- a/tests/Gedmo/Mapping/Fixture/Yaml/RevisionableComposite.php
+++ b/tests/Gedmo/Mapping/Fixture/Yaml/RevisionableComposite.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Mapping\Fixture\Yaml;
+
+class RevisionableComposite
+{
+    private ?int $one = null;
+
+    private ?int $two = null;
+
+    private ?string $title = null;
+
+    public function getOne(): int
+    {
+        return $this->one;
+    }
+
+    public function getTwo(): int
+    {
+        return $this->two;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+}

--- a/tests/Gedmo/Mapping/Fixture/Yaml/RevisionableCompositeRelation.php
+++ b/tests/Gedmo/Mapping/Fixture/Yaml/RevisionableCompositeRelation.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Mapping\Fixture\Yaml;
+
+class RevisionableCompositeRelation
+{
+    private ?Revisionable $one = null;
+
+    private ?int $two = null;
+
+    private ?string $title = null;
+
+    public function getOne(): ?Revisionable
+    {
+        return $this->one;
+    }
+
+    public function getTwo(): ?int
+    {
+        return $this->two;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+}

--- a/tests/Gedmo/Mapping/Fixture/Yaml/RevisionableWithEmbedded.php
+++ b/tests/Gedmo/Mapping/Fixture/Yaml/RevisionableWithEmbedded.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Mapping\Fixture\Yaml;
+
+class RevisionableWithEmbedded
+{
+    private ?int $id = null;
+
+    private ?string $title = null;
+
+    private ?Embedded $embedded = null;
+}

--- a/tests/Gedmo/Mapping/Mock/EventSubscriberCustomMock.php
+++ b/tests/Gedmo/Mapping/Mock/EventSubscriberCustomMock.php
@@ -15,9 +15,7 @@ use Doctrine\Common\EventArgs;
 use Gedmo\Mapping\Event\AdapterInterface;
 use Gedmo\Mapping\MappedEventSubscriber;
 
-/**
- * @phpstan-extends MappedEventSubscriber<array, AdapterInterface>
- */
+/** @phpstan-extends MappedEventSubscriber<array, AdapterInterface> */
 final class EventSubscriberCustomMock extends MappedEventSubscriber
 {
     public function getAdapter(EventArgs $args): AdapterInterface

--- a/tests/Gedmo/Mapping/Mock/EventSubscriberMock.php
+++ b/tests/Gedmo/Mapping/Mock/EventSubscriberMock.php
@@ -15,9 +15,7 @@ use Doctrine\Common\EventArgs;
 use Gedmo\Mapping\Event\AdapterInterface;
 use Gedmo\Mapping\MappedEventSubscriber;
 
-/**
- * @phpstan-extends MappedEventSubscriber<array, AdapterInterface>
- */
+/** @phpstan-extends MappedEventSubscriber<array, AdapterInterface> */
 final class EventSubscriberMock extends MappedEventSubscriber
 {
     public function getAdapter(EventArgs $args): AdapterInterface

--- a/tests/Gedmo/Mapping/Mock/Extension/Encoder/EncoderListener.php
+++ b/tests/Gedmo/Mapping/Mock/Extension/Encoder/EncoderListener.php
@@ -15,13 +15,10 @@ use Doctrine\Common\EventArgs;
 use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\ObjectManager;
-use Gedmo\Mapping\Event\AdapterInterface;
 use Gedmo\Mapping\Event\AdapterInterface as EventAdapterInterface;
 use Gedmo\Mapping\MappedEventSubscriber;
 
-/**
- * @phpstan-extends MappedEventSubscriber<array, AdapterInterface>
- */
+/** @phpstan-extends MappedEventSubscriber<array, EventAdapterInterface> */
 class EncoderListener extends MappedEventSubscriber
 {
     public function getSubscribedEvents(): array

--- a/tests/Gedmo/Mapping/MongoDBODMMappingTestCase.php
+++ b/tests/Gedmo/Mapping/MongoDBODMMappingTestCase.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Mapping;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\EventManager;
+use Doctrine\ODM\MongoDB\Configuration;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
+use Doctrine\ODM\MongoDB\Mapping\Driver\AttributeDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
+use MongoDB\Client;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+abstract class MongoDBODMMappingTestCase extends TestCase
+{
+    protected CacheItemPoolInterface $cache;
+
+    protected DocumentManager $dm;
+
+    protected function setUp(): void
+    {
+        $this->cache = new ArrayAdapter();
+        $this->dm = $this->getBasicDocumentManager();
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->dm->getDocumentDatabases() as $documentDatabase) {
+            $documentDatabase->drop();
+        }
+    }
+
+    final protected function getBasicConfiguration(): Configuration
+    {
+        $config = new Configuration();
+        $config->setProxyDir(TESTS_TEMP_DIR);
+        $config->setHydratorDir(TESTS_TEMP_DIR);
+        $config->setProxyNamespace('Proxy');
+        $config->setHydratorNamespace('Hydrator');
+        $config->setDefaultDB('gedmo_extensions_test');
+        $config->setAutoGenerateProxyClasses(Configuration::AUTOGENERATE_EVAL);
+        $config->setAutoGenerateHydratorClasses(Configuration::AUTOGENERATE_EVAL);
+        $config->setMetadataCache(new ArrayAdapter());
+
+        return $config;
+    }
+
+    final protected function getBasicDocumentManager(?Configuration $config = null, ?Client $client = null, ?EventManager $evm = null): DocumentManager
+    {
+        if (null === $config) {
+            $config = $this->getBasicConfiguration();
+            $config->setMetadataDriverImpl($this->createChainedMappingDriver());
+        }
+
+        $client = new Client($_ENV['MONGODB_SERVER'], [], ['typeMap' => DocumentManager::CLIENT_TYPEMAP]);
+
+        return DocumentManager::create($client, $config, $evm);
+    }
+
+    final protected function createChainedMappingDriver(): MappingDriverChain
+    {
+        $chain = new MappingDriverChain();
+
+        if (PHP_VERSION_ID >= 80000 && class_exists(AttributeDriver::class)) {
+            $chain->addDriver(new AttributeDriver([]), 'Gedmo\Tests\Mapping\Fixture');
+        } elseif (class_exists(AnnotationDriver::class) && class_exists(AnnotationReader::class)) {
+            $chain->addDriver(new AnnotationDriver(new AnnotationReader()), 'Gedmo\Tests\Mapping\Fixture');
+        }
+
+        return $chain;
+    }
+}

--- a/tests/Gedmo/Mapping/RevisionableMongoDBODMMappingTest.php
+++ b/tests/Gedmo/Mapping/RevisionableMongoDBODMMappingTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Mapping;
+
+use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
+use Doctrine\ODM\MongoDB\Mapping\Driver\AttributeDriver;
+use Gedmo\Mapping\ExtensionMetadataFactory;
+use Gedmo\Revisionable\Document\Revision;
+use Gedmo\Revisionable\RevisionableListener;
+use Gedmo\Tests\Mapping\Fixture\Document\EmbeddedRevisionable as AnnotatedEmbeddedRevisionable;
+use Gedmo\Tests\Mapping\Fixture\Document\Revisionable as AnnotatedRevisionable;
+use Gedmo\Tests\Mapping\Fixture\Document\RevisionableWithEmbedded as AnnotatedRevisionableWithEmbedded;
+
+/**
+ * These are mapping tests for the revisionable extension
+ *
+ * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ *
+ * @requires extension mongodb
+ */
+final class RevisionableMongoDBODMMappingTest extends MongoDBODMMappingTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $listener = new RevisionableListener();
+        $listener->setCacheItemPool($this->cache);
+
+        $this->dm->getEventManager()->addEventSubscriber($listener);
+    }
+
+    /**
+     * @return \Generator<string, array{class-string}>
+     */
+    public static function dataRevisionableObject(): \Generator
+    {
+        if (PHP_VERSION_ID >= 80000 && class_exists(AttributeDriver::class)) {
+            yield 'Model with attributes' => [AnnotatedRevisionable::class];
+        } elseif (class_exists(AnnotationDriver::class)) {
+            yield 'Model with annotations' => [AnnotatedRevisionable::class];
+        }
+    }
+
+    /**
+     * @param class-string $className
+     *
+     * @dataProvider dataRevisionableObject
+     */
+    public function testRevisionableMapping(string $className): void
+    {
+        // Force metadata class loading.
+        $this->dm->getClassMetadata($className);
+        $cacheId = ExtensionMetadataFactory::getCacheId($className, 'Gedmo\Revisionable');
+        $config = $this->cache->getItem($cacheId)->get();
+
+        static::assertArrayNotHasKey('revisionableClass', $config);
+        static::assertArrayHasKey('revisionable', $config);
+        static::assertTrue($config['revisionable']);
+
+        static::assertArrayHasKey('versioned', $config);
+        static::assertCount(1, $config['versioned']);
+        static::assertContains('title', $config['versioned']);
+    }
+
+    /**
+     * @return \Generator<string, array{class-string, class-string}>
+     */
+    public static function dataRevisionableObjectWithEmbedded(): \Generator
+    {
+        if (PHP_VERSION_ID >= 80000 && class_exists(AttributeDriver::class)) {
+            yield 'Model with attributes' => [AnnotatedRevisionableWithEmbedded::class, AnnotatedEmbeddedRevisionable::class];
+        } elseif (class_exists(AnnotationDriver::class)) {
+            yield 'Model with annotations' => [AnnotatedRevisionableWithEmbedded::class, AnnotatedEmbeddedRevisionable::class];
+        }
+    }
+
+    /**
+     * @param class-string $className
+     * @param class-string $embeddedClassName
+     *
+     * @dataProvider dataRevisionableObjectWithEmbedded
+     */
+    public function testRevisionableWithEmbedded(string $className, string $embeddedClassName): void
+    {
+        // Force metadata class loading.
+        $this->dm->getClassMetadata($className);
+        $this->dm->getClassMetadata($embeddedClassName);
+
+        /*
+         * Inspect the base class
+         */
+
+        $cacheId = ExtensionMetadataFactory::getCacheId($className, 'Gedmo\Revisionable');
+        $config = $this->cache->getItem($cacheId)->get();
+
+        static::assertArrayHasKey('revisionable', $config);
+        static::assertTrue($config['revisionable']);
+        static::assertArrayHasKey('revisionClass', $config);
+        static::assertSame(Revision::class, $config['revisionClass']);
+
+        static::assertArrayHasKey('versioned', $config);
+        static::assertCount(2, $config['versioned']);
+        static::assertContains('title', $config['versioned']);
+        static::assertContains('embedded', $config['versioned']);
+
+        /*
+         * Inspect the embedded class
+         */
+
+        $cacheId = ExtensionMetadataFactory::getCacheId($embeddedClassName, 'Gedmo\Revisionable');
+        $config = $this->cache->getItem($cacheId)->get();
+
+        static::assertArrayHasKey('versioned', $config);
+        static::assertCount(1, $config['versioned']);
+        static::assertContains('subtitle', $config['versioned']);
+    }
+}

--- a/tests/Gedmo/Mapping/RevisionableMongoDBODMMappingTest.php
+++ b/tests/Gedmo/Mapping/RevisionableMongoDBODMMappingTest.php
@@ -67,9 +67,9 @@ final class RevisionableMongoDBODMMappingTest extends MongoDBODMMappingTestCase
         static::assertArrayHasKey('revisionable', $config);
         static::assertTrue($config['revisionable']);
 
-        static::assertArrayHasKey('versioned', $config);
-        static::assertCount(1, $config['versioned']);
-        static::assertContains('title', $config['versioned']);
+        static::assertArrayHasKey('versionedFields', $config);
+        static::assertCount(1, $config['versionedFields']);
+        static::assertContains('title', $config['versionedFields']);
     }
 
     /**
@@ -108,10 +108,10 @@ final class RevisionableMongoDBODMMappingTest extends MongoDBODMMappingTestCase
         static::assertArrayHasKey('revisionClass', $config);
         static::assertSame(Revision::class, $config['revisionClass']);
 
-        static::assertArrayHasKey('versioned', $config);
-        static::assertCount(2, $config['versioned']);
-        static::assertContains('title', $config['versioned']);
-        static::assertContains('embedded', $config['versioned']);
+        static::assertArrayHasKey('versionedFields', $config);
+        static::assertCount(2, $config['versionedFields']);
+        static::assertContains('title', $config['versionedFields']);
+        static::assertContains('embedded', $config['versionedFields']);
 
         /*
          * Inspect the embedded class
@@ -120,8 +120,8 @@ final class RevisionableMongoDBODMMappingTest extends MongoDBODMMappingTestCase
         $cacheId = ExtensionMetadataFactory::getCacheId($embeddedClassName, 'Gedmo\Revisionable');
         $config = $this->cache->getItem($cacheId)->get();
 
-        static::assertArrayHasKey('versioned', $config);
-        static::assertCount(1, $config['versioned']);
-        static::assertContains('subtitle', $config['versioned']);
+        static::assertArrayHasKey('versionedFields', $config);
+        static::assertCount(1, $config['versionedFields']);
+        static::assertContains('subtitle', $config['versionedFields']);
     }
 }

--- a/tests/Gedmo/Mapping/RevisionableORMMappingTest.php
+++ b/tests/Gedmo/Mapping/RevisionableORMMappingTest.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Mapping;
+
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+use Doctrine\ORM\Mapping\Driver\YamlDriver;
+use Gedmo\Mapping\ExtensionMetadataFactory;
+use Gedmo\Revisionable\Entity\Revision;
+use Gedmo\Revisionable\RevisionableListener;
+use Gedmo\Tests\Mapping\Fixture\Entity\Revisionable as AnnotatedRevisionable;
+use Gedmo\Tests\Mapping\Fixture\Entity\RevisionableComposite as AnnotatedRevisionableComposite;
+use Gedmo\Tests\Mapping\Fixture\Entity\RevisionableCompositeRelation as AnnotatedRevisionableCompositeRelation;
+use Gedmo\Tests\Mapping\Fixture\Entity\RevisionableWithEmbedded as AnnotatedRevisionableWithEmbedded;
+use Gedmo\Tests\Mapping\Fixture\Xml\Revisionable as XmlRevisionable;
+use Gedmo\Tests\Mapping\Fixture\Xml\RevisionableComposite as XmlRevisionableComposite;
+use Gedmo\Tests\Mapping\Fixture\Xml\RevisionableCompositeRelation as XmlRevisionableCompositeRelation;
+use Gedmo\Tests\Mapping\Fixture\Xml\RevisionableWithEmbedded as XmlRevisionableWithEmbedded;
+use Gedmo\Tests\Mapping\Fixture\Yaml\Revisionable as YamlRevisionable;
+use Gedmo\Tests\Mapping\Fixture\Yaml\RevisionableComposite as YamlRevisionableComposite;
+use Gedmo\Tests\Mapping\Fixture\Yaml\RevisionableCompositeRelation as YamlRevisionableCompositeRelation;
+use Gedmo\Tests\Mapping\Fixture\Yaml\RevisionableWithEmbedded as YamlRevisionableWithEmbedded;
+
+/**
+ * These are mapping tests for the revisionable extension
+ *
+ * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ */
+final class RevisionableORMMappingTest extends ORMMappingTestCase
+{
+    private EntityManager $em;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $listener = new RevisionableListener();
+        $listener->setCacheItemPool($this->cache);
+
+        $this->em = $this->getBasicEntityManager();
+        $this->em->getEventManager()->addEventSubscriber($listener);
+    }
+
+    /**
+     * @return \Generator<string, array{class-string}>
+     */
+    public static function dataRevisionableObject(): \Generator
+    {
+        yield 'Model with XML mapping' => [XmlRevisionable::class];
+
+        if (PHP_VERSION_ID >= 80000) {
+            yield 'Model with attributes' => [AnnotatedRevisionable::class];
+        } elseif (class_exists(AnnotationDriver::class)) {
+            yield 'Model with annotations' => [AnnotatedRevisionable::class];
+        }
+
+        if (class_exists(YamlDriver::class)) {
+            yield 'Model with YAML mapping' => [YamlRevisionable::class];
+        }
+    }
+
+    /**
+     * @param class-string $className
+     *
+     * @dataProvider dataRevisionableObject
+     */
+    public function testRevisionableMapping(string $className): void
+    {
+        // Force metadata class loading.
+        $this->em->getClassMetadata($className);
+        $cacheId = ExtensionMetadataFactory::getCacheId($className, 'Gedmo\Revisionable');
+        $config = $this->cache->getItem($cacheId)->get();
+
+        static::assertArrayNotHasKey('revisionableClass', $config);
+        static::assertArrayHasKey('revisionable', $config);
+        static::assertTrue($config['revisionable']);
+
+        static::assertArrayHasKey('versioned', $config);
+        static::assertCount(1, $config['versioned']);
+        static::assertContains('title', $config['versioned']);
+    }
+
+    /**
+     * @return \Generator<string, array{class-string}>
+     */
+    public static function dataRevisionableObjectWithCompositeKey(): \Generator
+    {
+        yield 'Model with XML mapping' => [XmlRevisionableComposite::class];
+
+        if (PHP_VERSION_ID >= 80000) {
+            yield 'Model with attributes' => [AnnotatedRevisionableComposite::class];
+        } elseif (class_exists(AnnotationDriver::class)) {
+            yield 'Model with annotations' => [AnnotatedRevisionableComposite::class];
+        }
+
+        if (class_exists(YamlDriver::class)) {
+            yield 'Model with YAML mapping' => [YamlRevisionableComposite::class];
+        }
+    }
+
+    /**
+     * @param class-string $className
+     *
+     * @dataProvider dataRevisionableObjectWithCompositeKey
+     */
+    public function testRevisionableCompositeMapping(string $className): void
+    {
+        $meta = $this->em->getClassMetadata($className);
+
+        static::assertIsArray($meta->identifier);
+        static::assertCount(2, $meta->identifier);
+
+        $cacheId = ExtensionMetadataFactory::getCacheId($className, 'Gedmo\Revisionable');
+        $config = $this->cache->getItem($cacheId)->get();
+
+        static::assertArrayHasKey('revisionable', $config);
+        static::assertTrue($config['revisionable']);
+        static::assertArrayHasKey('revisionClass', $config);
+        static::assertSame(Revision::class, $config['revisionClass']);
+
+        static::assertArrayHasKey('versioned', $config);
+        static::assertCount(1, $config['versioned']);
+        static::assertContains('title', $config['versioned']);
+    }
+
+    /**
+     * @return \Generator<string, array{class-string}>
+     */
+    public static function dataRevisionableObjectWithCompositeKeyAndRelation(): \Generator
+    {
+        yield 'Model with XML mapping' => [XmlRevisionableCompositeRelation::class];
+
+        if (PHP_VERSION_ID >= 80000) {
+            yield 'Model with attributes' => [AnnotatedRevisionableCompositeRelation::class];
+        } elseif (class_exists(AnnotationDriver::class)) {
+            yield 'Model with annotations' => [AnnotatedRevisionableCompositeRelation::class];
+        }
+
+        if (class_exists(YamlDriver::class)) {
+            yield 'Model with YAML mapping' => [YamlRevisionableCompositeRelation::class];
+        }
+    }
+
+    /**
+     * @param class-string $className
+     *
+     * @dataProvider dataRevisionableObjectWithCompositeKeyAndRelation
+     */
+    public function testRevisionableCompositeRelationMapping(string $className): void
+    {
+        $meta = $this->em->getClassMetadata($className);
+
+        static::assertIsArray($meta->identifier);
+        static::assertCount(2, $meta->identifier);
+
+        $cacheId = ExtensionMetadataFactory::getCacheId($className, 'Gedmo\Revisionable');
+        $config = $this->cache->getItem($cacheId)->get();
+
+        static::assertArrayHasKey('revisionable', $config);
+        static::assertTrue($config['revisionable']);
+        static::assertArrayNotHasKey('revisionClass', $config);
+
+        static::assertArrayHasKey('versioned', $config);
+        static::assertCount(1, $config['versioned']);
+        static::assertContains('title', $config['versioned']);
+    }
+
+    /**
+     * @return \Generator<string, array{class-string}>
+     */
+    public static function dataRevisionableObjectWithEmbedded(): \Generator
+    {
+        yield 'Model with XML mapping' => [XmlRevisionableWithEmbedded::class];
+
+        if (PHP_VERSION_ID >= 80000) {
+            yield 'Model with attributes' => [AnnotatedRevisionableWithEmbedded::class];
+        } elseif (class_exists(AnnotationDriver::class)) {
+            yield 'Model with annotations' => [AnnotatedRevisionableWithEmbedded::class];
+        }
+
+        if (class_exists(YamlDriver::class)) {
+            yield 'Model with YAML mapping' => [YamlRevisionableWithEmbedded::class];
+        }
+    }
+
+    /**
+     * @param class-string $className
+     *
+     * @dataProvider dataRevisionableObjectWithEmbedded
+     */
+    public function testRevisionableWithEmbedded(string $className): void
+    {
+        // Force metadata class loading.
+        $this->em->getClassMetadata($className);
+        $cacheId = ExtensionMetadataFactory::getCacheId($className, 'Gedmo\Revisionable');
+        $config = $this->cache->getItem($cacheId)->get();
+
+        static::assertArrayHasKey('revisionable', $config);
+        static::assertTrue($config['revisionable']);
+        static::assertArrayHasKey('revisionClass', $config);
+        static::assertSame(Revision::class, $config['revisionClass']);
+
+        static::assertArrayHasKey('versioned', $config);
+        static::assertCount(2, $config['versioned']);
+        static::assertContains('title', $config['versioned']);
+        static::assertContains('embedded.subtitle', $config['versioned']);
+    }
+}

--- a/tests/Gedmo/Mapping/RevisionableORMMappingTest.php
+++ b/tests/Gedmo/Mapping/RevisionableORMMappingTest.php
@@ -84,9 +84,9 @@ final class RevisionableORMMappingTest extends ORMMappingTestCase
         static::assertArrayHasKey('revisionable', $config);
         static::assertTrue($config['revisionable']);
 
-        static::assertArrayHasKey('versioned', $config);
-        static::assertCount(1, $config['versioned']);
-        static::assertContains('title', $config['versioned']);
+        static::assertArrayHasKey('versionedFields', $config);
+        static::assertCount(1, $config['versionedFields']);
+        static::assertContains('title', $config['versionedFields']);
     }
 
     /**
@@ -127,9 +127,9 @@ final class RevisionableORMMappingTest extends ORMMappingTestCase
         static::assertArrayHasKey('revisionClass', $config);
         static::assertSame(Revision::class, $config['revisionClass']);
 
-        static::assertArrayHasKey('versioned', $config);
-        static::assertCount(1, $config['versioned']);
-        static::assertContains('title', $config['versioned']);
+        static::assertArrayHasKey('versionedFields', $config);
+        static::assertCount(1, $config['versionedFields']);
+        static::assertContains('title', $config['versionedFields']);
     }
 
     /**
@@ -169,9 +169,9 @@ final class RevisionableORMMappingTest extends ORMMappingTestCase
         static::assertTrue($config['revisionable']);
         static::assertArrayNotHasKey('revisionClass', $config);
 
-        static::assertArrayHasKey('versioned', $config);
-        static::assertCount(1, $config['versioned']);
-        static::assertContains('title', $config['versioned']);
+        static::assertArrayHasKey('versionedFields', $config);
+        static::assertCount(1, $config['versionedFields']);
+        static::assertContains('title', $config['versionedFields']);
     }
 
     /**
@@ -209,9 +209,9 @@ final class RevisionableORMMappingTest extends ORMMappingTestCase
         static::assertArrayHasKey('revisionClass', $config);
         static::assertSame(Revision::class, $config['revisionClass']);
 
-        static::assertArrayHasKey('versioned', $config);
-        static::assertCount(2, $config['versioned']);
-        static::assertContains('title', $config['versioned']);
-        static::assertContains('embedded.subtitle', $config['versioned']);
+        static::assertArrayHasKey('versionedFields', $config);
+        static::assertCount(2, $config['versionedFields']);
+        static::assertContains('title', $config['versionedFields']);
+        static::assertContains('embedded.subtitle', $config['versionedFields']);
     }
 }

--- a/tests/Gedmo/Revisionable/Fixture/Document/Address.php
+++ b/tests/Gedmo/Revisionable/Fixture/Document/Address.php
@@ -36,28 +36,28 @@ class Address implements Revisionable
     /**
      * @ODM\Field(type="string")
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ODM\Field(type: Type::STRING)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?string $street = null;
 
     /**
      * @ODM\Field(type="string")
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ODM\Field(type: Type::STRING)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?string $city = null;
 
     /**
      * @ODM\EmbedOne(targetDocument="Gedmo\Tests\Revisionable\Fixture\Document\Geo")
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ODM\EmbedOne(targetDocument: Geo::class)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?Geo $geo = null;
 
     public function getId(): ?string

--- a/tests/Gedmo/Revisionable/Fixture/Document/Address.php
+++ b/tests/Gedmo/Revisionable/Fixture/Document/Address.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Revisionable\Fixture\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Types\Type;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Gedmo\Revisionable\Revisionable;
+
+/**
+ * @author Fabian Sabau <fabian.sabau@socialbit.de>
+ *
+ * @ODM\Document(collection="addresses")
+ *
+ * @Gedmo\Revisionable
+ */
+#[ODM\Document(collection: 'addresses')]
+#[Gedmo\Revisionable]
+class Address implements Revisionable
+{
+    /**
+     * @ODM\Id
+     */
+    #[ODM\Id]
+    private ?string $id = null;
+
+    /**
+     * @ODM\Field(type="string")
+     *
+     * @Gedmo\Versioned
+     */
+    #[ODM\Field(type: Type::STRING)]
+    #[Gedmo\Versioned]
+    private ?string $street = null;
+
+    /**
+     * @ODM\Field(type="string")
+     *
+     * @Gedmo\Versioned
+     */
+    #[ODM\Field(type: Type::STRING)]
+    #[Gedmo\Versioned]
+    private ?string $city = null;
+
+    /**
+     * @ODM\EmbedOne(targetDocument="Gedmo\Tests\Revisionable\Fixture\Document\Geo")
+     *
+     * @Gedmo\Versioned
+     */
+    #[ODM\EmbedOne(targetDocument: Geo::class)]
+    #[Gedmo\Versioned]
+    private ?Geo $geo = null;
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    public function getStreet(): ?string
+    {
+        return $this->street;
+    }
+
+    public function setStreet(?string $street): self
+    {
+        $this->street = $street;
+
+        return $this;
+    }
+
+    public function getCity(): ?string
+    {
+        return $this->city;
+    }
+
+    public function setCity(?string $city): self
+    {
+        $this->city = $city;
+
+        return $this;
+    }
+
+    public function getGeo(): ?Geo
+    {
+        return $this->geo;
+    }
+
+    public function setGeo(?Geo $geo): self
+    {
+        $this->geo = $geo;
+
+        return $this;
+    }
+}

--- a/tests/Gedmo/Revisionable/Fixture/Document/Article.php
+++ b/tests/Gedmo/Revisionable/Fixture/Document/Article.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Revisionable\Fixture\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Types\Type;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Gedmo\Revisionable\Revisionable;
+
+/**
+ * @ODM\Document(collection="articles")
+ *
+ * @Gedmo\Revisionable
+ */
+#[ODM\Document(collection: 'articles')]
+#[Gedmo\Revisionable]
+class Article implements Revisionable
+{
+    /**
+     * @ODM\Id
+     */
+    #[ODM\Id]
+    private ?string $id = null;
+
+    /**
+     * @ODM\Field(type="string")
+     *
+     * @Gedmo\Versioned
+     */
+    #[ODM\Field(type: Type::STRING)]
+    #[Gedmo\Versioned]
+    private ?string $title = null;
+
+    /**
+     * @ODM\Field(type="date_immutable")
+     *
+     * @Gedmo\Versioned
+     */
+    #[ODM\Field(type: Type::DATE_IMMUTABLE)]
+    #[Gedmo\Versioned]
+    private ?\DateTimeImmutable $publishAt = null;
+
+    /**
+     * @ODM\EmbedOne(targetDocument="Gedmo\Tests\Revisionable\Fixture\Document\Author")
+     *
+     * @Gedmo\Versioned
+     */
+    #[ODM\EmbedOne(targetDocument: Author::class)]
+    #[Gedmo\Versioned]
+    private ?Author $author = null;
+
+    public function __toString()
+    {
+        return $this->title;
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    public function setTitle(?string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setPublishAt(?\DateTimeImmutable $publishAt): void
+    {
+        $this->publishAt = $publishAt;
+    }
+
+    public function getPublishAt(): ?\DateTimeImmutable
+    {
+        return $this->publishAt;
+    }
+
+    public function setAuthor(?Author $author): void
+    {
+        $this->author = $author;
+    }
+
+    public function getAuthor(): ?Author
+    {
+        return $this->author;
+    }
+}

--- a/tests/Gedmo/Revisionable/Fixture/Document/Article.php
+++ b/tests/Gedmo/Revisionable/Fixture/Document/Article.php
@@ -34,28 +34,28 @@ class Article implements Revisionable
     /**
      * @ODM\Field(type="string")
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ODM\Field(type: Type::STRING)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?string $title = null;
 
     /**
      * @ODM\Field(type="date_immutable")
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ODM\Field(type: Type::DATE_IMMUTABLE)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?\DateTimeImmutable $publishAt = null;
 
     /**
      * @ODM\EmbedOne(targetDocument="Gedmo\Tests\Revisionable\Fixture\Document\Author")
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ODM\EmbedOne(targetDocument: Author::class)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?Author $author = null;
 
     public function __toString()

--- a/tests/Gedmo/Revisionable/Fixture/Document/Author.php
+++ b/tests/Gedmo/Revisionable/Fixture/Document/Author.php
@@ -25,19 +25,19 @@ class Author implements Revisionable
     /**
      * @ODM\Field(type="string")
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ODM\Field(type: Type::STRING)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?string $name = null;
 
     /**
      * @ODM\Field(type="string")
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ODM\Field(type: Type::STRING)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?string $email = null;
 
     public function __toString()

--- a/tests/Gedmo/Revisionable/Fixture/Document/Author.php
+++ b/tests/Gedmo/Revisionable/Fixture/Document/Author.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Revisionable\Fixture\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Types\Type;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Gedmo\Revisionable\Revisionable;
+
+/**
+ * @ODM\EmbeddedDocument
+ */
+#[ODM\EmbeddedDocument]
+class Author implements Revisionable
+{
+    /**
+     * @ODM\Field(type="string")
+     *
+     * @Gedmo\Versioned
+     */
+    #[ODM\Field(type: Type::STRING)]
+    #[Gedmo\Versioned]
+    private ?string $name = null;
+
+    /**
+     * @ODM\Field(type="string")
+     *
+     * @Gedmo\Versioned
+     */
+    #[ODM\Field(type: Type::STRING)]
+    #[Gedmo\Versioned]
+    private ?string $email = null;
+
+    public function __toString()
+    {
+        return (string) $this->getName();
+    }
+
+    public function setName(?string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setEmail(?string $email): void
+    {
+        $this->email = $email;
+    }
+
+    public function getEmail(): ?string
+    {
+        return $this->email;
+    }
+}

--- a/tests/Gedmo/Revisionable/Fixture/Document/Comment.php
+++ b/tests/Gedmo/Revisionable/Fixture/Document/Comment.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Revisionable\Fixture\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Types\Type;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Gedmo\Revisionable\Revisionable;
+
+/**
+ * @ODM\Document
+ *
+ * @Gedmo\Revisionable(revisionClass="Gedmo\Tests\Revisionable\Fixture\Document\CommentRevision")
+ */
+#[ODM\Document]
+#[Gedmo\Revisionable(revisionClass: CommentRevision::class)]
+class Comment implements Revisionable
+{
+    /**
+     * @ODM\Id
+     */
+    #[ODM\Id]
+    private ?string $id = null;
+
+    /**
+     * @ODM\Field(type="string")
+     *
+     * @Gedmo\Versioned
+     */
+    #[ODM\Field(type: Type::STRING)]
+    #[Gedmo\Versioned]
+    private ?string $subject = null;
+
+    /**
+     * @ODM\Field(type="string")
+     *
+     * @Gedmo\Versioned
+     */
+    #[ODM\Field(type: Type::STRING)]
+    #[Gedmo\Versioned]
+    private ?string $message = null;
+
+    /**
+     * @ODM\Field(type="date_immutable")
+     *
+     * @Gedmo\Versioned
+     */
+    #[ODM\Field(type: Type::DATE_IMMUTABLE)]
+    #[Gedmo\Versioned]
+    private ?\DateTimeImmutable $writtenAt = null;
+
+    /**
+     * @ODM\ReferenceOne(targetDocument="Gedmo\Tests\Revisionable\Fixture\Document\RelatedArticle", inversedBy="comments")
+     *
+     * @Gedmo\Versioned
+     */
+    #[ODM\ReferenceOne(targetDocument: RelatedArticle::class, inversedBy: 'comments')]
+    #[Gedmo\Versioned]
+    private ?RelatedArticle $article = null;
+
+    /**
+     * @ODM\EmbedOne(targetDocument="Gedmo\Tests\Revisionable\Fixture\Document\Author")
+     *
+     * @Gedmo\Versioned
+     */
+    #[ODM\EmbedOne(targetDocument: Author::class)]
+    #[Gedmo\Versioned]
+    private ?Author $author = null;
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    public function setSubject(?string $subject): void
+    {
+        $this->subject = $subject;
+    }
+
+    public function getSubject(): ?string
+    {
+        return $this->subject;
+    }
+
+    public function setMessage(?string $message): void
+    {
+        $this->message = $message;
+    }
+
+    public function getMessage(): ?string
+    {
+        return $this->message;
+    }
+
+    public function setWrittenAt(?\DateTimeImmutable $writtenAt): void
+    {
+        $this->writtenAt = $writtenAt;
+    }
+
+    public function getWrittenAt(): ?\DateTimeImmutable
+    {
+        return $this->writtenAt;
+    }
+
+    public function setArticle(?RelatedArticle $article): void
+    {
+        $this->article = $article;
+    }
+
+    public function getArticle(): ?RelatedArticle
+    {
+        return $this->article;
+    }
+
+    public function setAuthor(?Author $author): void
+    {
+        $this->author = $author;
+    }
+
+    public function getAuthor(): ?Author
+    {
+        return $this->author;
+    }
+}

--- a/tests/Gedmo/Revisionable/Fixture/Document/Comment.php
+++ b/tests/Gedmo/Revisionable/Fixture/Document/Comment.php
@@ -34,46 +34,46 @@ class Comment implements Revisionable
     /**
      * @ODM\Field(type="string")
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ODM\Field(type: Type::STRING)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?string $subject = null;
 
     /**
      * @ODM\Field(type="string")
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ODM\Field(type: Type::STRING)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?string $message = null;
 
     /**
      * @ODM\Field(type="date_immutable")
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ODM\Field(type: Type::DATE_IMMUTABLE)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?\DateTimeImmutable $writtenAt = null;
 
     /**
      * @ODM\ReferenceOne(targetDocument="Gedmo\Tests\Revisionable\Fixture\Document\RelatedArticle", inversedBy="comments")
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ODM\ReferenceOne(targetDocument: RelatedArticle::class, inversedBy: 'comments')]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?RelatedArticle $article = null;
 
     /**
      * @ODM\EmbedOne(targetDocument="Gedmo\Tests\Revisionable\Fixture\Document\Author")
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ODM\EmbedOne(targetDocument: Author::class)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?Author $author = null;
 
     public function getId(): ?string

--- a/tests/Gedmo/Revisionable/Fixture/Document/CommentRevision.php
+++ b/tests/Gedmo/Revisionable/Fixture/Document/CommentRevision.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Revisionable\Fixture\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Gedmo\Revisionable\Document\MappedSuperclass\AbstractRevision;
+use Gedmo\Revisionable\Document\Repository\RevisionRepository;
+
+/**
+ * @ODM\Document(
+ *     collection="comment_revisions",
+ *     repositoryClass="Gedmo\Revisionable\Document\Repository\RevisionRepository"
+ * )
+ *
+ * @template T of Comment
+ *
+ * @template-extends AbstractRevision<T>
+ */
+#[ODM\Document(collection: 'comment_revisions', repositoryClass: RevisionRepository::class)]
+class CommentRevision extends AbstractRevision
+{
+    /**
+     * Named constructor to create a new revision.
+     *
+     * Implementations should handle setting the initial logged at time and version for new instances within this constructor.
+     *
+     * @param self::ACTION_CREATE|self::ACTION_UPDATE|self::ACTION_REMOVE $action
+     *
+     * @return self<T>
+     */
+    public static function createRevision(string $action): self
+    {
+        $document = new self();
+        $document->setAction($action);
+        $document->setLoggedAt(new \DateTimeImmutable());
+
+        return $document;
+    }
+}

--- a/tests/Gedmo/Revisionable/Fixture/Document/Geo.php
+++ b/tests/Gedmo/Revisionable/Fixture/Document/Geo.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Revisionable\Fixture\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Types\Type;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * @author Fabian Sabau <fabian.sabau@socialbit.de>
+ *
+ * @ODM\EmbeddedDocument
+ */
+#[ODM\EmbeddedDocument]
+class Geo
+{
+    /**
+     * @ODM\Field(type="float")
+     *
+     * @Gedmo\Versioned
+     */
+    #[ODM\Field(type: Type::FLOAT)]
+    #[Gedmo\Versioned]
+    private float $latitude;
+
+    /**
+     * @ODM\Field(type="float")
+     *
+     * @Gedmo\Versioned
+     */
+    #[ODM\Field(type: Type::FLOAT)]
+    #[Gedmo\Versioned]
+    private float $longitude;
+
+    /**
+     * @ODM\EmbedOne(targetDocument="Gedmo\Tests\Revisionable\Fixture\Document\GeoLocation")
+     *
+     * @Gedmo\Versioned
+     */
+    #[ODM\EmbedOne(targetDocument: GeoLocation::class)]
+    #[Gedmo\Versioned]
+    private GeoLocation $geoLocation;
+
+    public function __construct(float $latitude, float $longitude, GeoLocation $geoLocation)
+    {
+        $this->latitude = $latitude;
+        $this->longitude = $longitude;
+        $this->geoLocation = $geoLocation;
+    }
+
+    public function getLatitude(): float
+    {
+        return $this->latitude;
+    }
+
+    public function setLatitude(float $latitude): void
+    {
+        $this->latitude = $latitude;
+    }
+
+    public function getLongitude(): float
+    {
+        return $this->longitude;
+    }
+
+    public function setLongitude(float $longitude): void
+    {
+        $this->longitude = $longitude;
+    }
+
+    public function getGeoLocation(): GeoLocation
+    {
+        return $this->geoLocation;
+    }
+
+    public function setGeoLocation(GeoLocation $geoLocation): void
+    {
+        $this->geoLocation = $geoLocation;
+    }
+}

--- a/tests/Gedmo/Revisionable/Fixture/Document/Geo.php
+++ b/tests/Gedmo/Revisionable/Fixture/Document/Geo.php
@@ -26,28 +26,28 @@ class Geo
     /**
      * @ODM\Field(type="float")
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ODM\Field(type: Type::FLOAT)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private float $latitude;
 
     /**
      * @ODM\Field(type="float")
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ODM\Field(type: Type::FLOAT)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private float $longitude;
 
     /**
      * @ODM\EmbedOne(targetDocument="Gedmo\Tests\Revisionable\Fixture\Document\GeoLocation")
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ODM\EmbedOne(targetDocument: GeoLocation::class)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private GeoLocation $geoLocation;
 
     public function __construct(float $latitude, float $longitude, GeoLocation $geoLocation)

--- a/tests/Gedmo/Revisionable/Fixture/Document/GeoLocation.php
+++ b/tests/Gedmo/Revisionable/Fixture/Document/GeoLocation.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Revisionable\Fixture\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Types\Type;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * @author Fabian Sabau <fabian.sabau@socialbit.de>
+ *
+ * @ODM\EmbeddedDocument
+ */
+#[ODM\EmbeddedDocument]
+class GeoLocation
+{
+    /**
+     * @ODM\Field(type="string")
+     *
+     * @Gedmo\Versioned
+     */
+    #[ODM\Field(type: Type::STRING)]
+    #[Gedmo\Versioned]
+    private string $location;
+
+    public function __construct(string $location)
+    {
+        $this->location = $location;
+    }
+
+    public function getLocation(): string
+    {
+        return $this->location;
+    }
+
+    public function setLocation(string $location): void
+    {
+        $this->location = $location;
+    }
+}

--- a/tests/Gedmo/Revisionable/Fixture/Document/GeoLocation.php
+++ b/tests/Gedmo/Revisionable/Fixture/Document/GeoLocation.php
@@ -26,10 +26,10 @@ class GeoLocation
     /**
      * @ODM\Field(type="string")
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ODM\Field(type: Type::STRING)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private string $location;
 
     public function __construct(string $location)

--- a/tests/Gedmo/Revisionable/Fixture/Document/RelatedArticle.php
+++ b/tests/Gedmo/Revisionable/Fixture/Document/RelatedArticle.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Revisionable\Fixture\Document;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Types\Type;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Gedmo\Revisionable\Revisionable;
+
+/**
+ * @ODM\Document
+ *
+ * @Gedmo\Revisionable
+ */
+#[ODM\Document]
+#[Gedmo\Revisionable]
+class RelatedArticle implements Revisionable
+{
+    /**
+     * @ODM\Id
+     */
+    #[ODM\Id]
+    private ?string $id = null;
+
+    /**
+     * @ODM\Field(type="string")
+     *
+     * @Gedmo\Versioned
+     */
+    #[ODM\Field(type: Type::STRING)]
+    #[Gedmo\Versioned]
+    private ?string $title = null;
+
+    /**
+     * @ODM\Field(type="string")
+     *
+     * @Gedmo\Versioned
+     */
+    #[ODM\Field(type: Type::STRING)]
+    #[Gedmo\Versioned]
+    private ?string $content = null;
+
+    /**
+     * @var Collection<int, Comment>
+     *
+     * @ODM\ReferenceMany(targetDocument="Gedmo\Tests\Revisionable\Fixture\Document\Comment", mappedBy="article")
+     */
+    #[ODM\ReferenceMany(targetDocument: Comment::class, mappedBy: 'article')]
+    private Collection $comments;
+
+    public function __construct()
+    {
+        $this->comments = new ArrayCollection();
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    public function setTitle(?string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setContent(?string $content): void
+    {
+        $this->content = $content;
+    }
+
+    public function getContent(): ?string
+    {
+        return $this->content;
+    }
+
+    public function addComment(Comment $comment): void
+    {
+        if (!$this->comments->contains($comment)) {
+            $this->comments[] = $comment;
+            $comment->setArticle($this);
+        }
+    }
+
+    /**
+     * @return Collection<int, Comment>
+     */
+    public function getComments(): Collection
+    {
+        return $this->comments;
+    }
+}

--- a/tests/Gedmo/Revisionable/Fixture/Document/RelatedArticle.php
+++ b/tests/Gedmo/Revisionable/Fixture/Document/RelatedArticle.php
@@ -36,19 +36,19 @@ class RelatedArticle implements Revisionable
     /**
      * @ODM\Field(type="string")
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ODM\Field(type: Type::STRING)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?string $title = null;
 
     /**
      * @ODM\Field(type="string")
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ODM\Field(type: Type::STRING)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?string $content = null;
 
     /**

--- a/tests/Gedmo/Revisionable/Fixture/Entity/Address.php
+++ b/tests/Gedmo/Revisionable/Fixture/Entity/Address.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Revisionable\Fixture\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Gedmo\Revisionable\Revisionable;
+
+/**
+ * @author Fabian Sabau <fabian.sabau@socialbit.de>
+ *
+ * @ORM\Entity
+ *
+ * @Gedmo\Revisionable
+ */
+#[ORM\Entity]
+#[Gedmo\Revisionable]
+class Address implements Revisionable
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(name="id", type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: Types::INTEGER)]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    private ?int $id = null;
+
+    /**
+     * @ORM\Column(type="string", length=191)
+     *
+     * @Gedmo\Versioned
+     */
+    #[ORM\Column(type: Types::STRING, length: 191)]
+    #[Gedmo\Versioned]
+    private ?string $street = null;
+
+    /**
+     * @ORM\Column(type="string", length=191)
+     *
+     * @Gedmo\Versioned
+     */
+    #[ORM\Column(type: Types::STRING, length: 191)]
+    #[Gedmo\Versioned]
+    private ?string $city = null;
+
+    /**
+     * @ORM\Embedded(class="Gedmo\Tests\Revisionable\Fixture\Entity\Geo")
+     *
+     * @Gedmo\Versioned
+     */
+    #[ORM\Embedded(class: Geo::class)]
+    #[Gedmo\Versioned]
+    private ?Geo $geo = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getStreet(): ?string
+    {
+        return $this->street;
+    }
+
+    public function setStreet(?string $street): self
+    {
+        $this->street = $street;
+
+        return $this;
+    }
+
+    public function getCity(): ?string
+    {
+        return $this->city;
+    }
+
+    public function setCity(?string $city): self
+    {
+        $this->city = $city;
+
+        return $this;
+    }
+
+    public function getGeo(): ?Geo
+    {
+        return $this->geo;
+    }
+
+    public function setGeo(?Geo $geo): self
+    {
+        $this->geo = $geo;
+
+        return $this;
+    }
+}

--- a/tests/Gedmo/Revisionable/Fixture/Entity/Address.php
+++ b/tests/Gedmo/Revisionable/Fixture/Entity/Address.php
@@ -40,28 +40,28 @@ class Address implements Revisionable
     /**
      * @ORM\Column(type="string", length=191)
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ORM\Column(type: Types::STRING, length: 191)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?string $street = null;
 
     /**
      * @ORM\Column(type="string", length=191)
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ORM\Column(type: Types::STRING, length: 191)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?string $city = null;
 
     /**
      * @ORM\Embedded(class="Gedmo\Tests\Revisionable\Fixture\Entity\Geo")
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ORM\Embedded(class: Geo::class)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?Geo $geo = null;
 
     public function getId(): ?int

--- a/tests/Gedmo/Revisionable/Fixture/Entity/Article.php
+++ b/tests/Gedmo/Revisionable/Fixture/Entity/Article.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Revisionable\Fixture\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Gedmo\Revisionable\Revisionable;
+
+/**
+ * @ORM\Entity
+ *
+ * @Gedmo\Revisionable
+ */
+#[ORM\Entity]
+#[Gedmo\Revisionable]
+class Article implements Revisionable
+{
+    /**
+     * @ORM\Column(name="id", type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="IDENTITY")
+     */
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: Types::INTEGER)]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    private ?int $id = null;
+
+    /**
+     * @ORM\Column(name="title", type="string", length=8)
+     *
+     * @Gedmo\Versioned
+     */
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 8)]
+    #[Gedmo\Versioned]
+    private ?string $title = null;
+
+    /**
+     * @ORM\Column(name="publish_at", type="datetime_immutable")
+     *
+     * @Gedmo\Versioned
+     */
+    #[ORM\Column(name: 'publish_at', type: Types::DATETIME_IMMUTABLE)]
+    #[Gedmo\Versioned]
+    private ?\DateTimeImmutable $publishAt = null;
+
+    /**
+     * @ORM\Embedded(class="Gedmo\Tests\Revisionable\Fixture\Entity\Author")
+     *
+     * @Gedmo\Versioned
+     */
+    #[ORM\Embedded(class: Author::class)]
+    #[Gedmo\Versioned]
+    private ?Author $author = null;
+
+    public function __toString()
+    {
+        return $this->title;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setTitle(?string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setPublishAt(?\DateTimeImmutable $publishAt): void
+    {
+        $this->publishAt = $publishAt;
+    }
+
+    public function getPublishAt(): ?\DateTimeImmutable
+    {
+        return $this->publishAt;
+    }
+
+    public function setAuthor(?Author $author): void
+    {
+        $this->author = $author;
+    }
+
+    public function getAuthor(): ?Author
+    {
+        return $this->author;
+    }
+}

--- a/tests/Gedmo/Revisionable/Fixture/Entity/Article.php
+++ b/tests/Gedmo/Revisionable/Fixture/Entity/Article.php
@@ -38,28 +38,28 @@ class Article implements Revisionable
     /**
      * @ORM\Column(name="title", type="string", length=8)
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 8)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?string $title = null;
 
     /**
      * @ORM\Column(name="publish_at", type="datetime_immutable")
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ORM\Column(name: 'publish_at', type: Types::DATETIME_IMMUTABLE)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?\DateTimeImmutable $publishAt = null;
 
     /**
      * @ORM\Embedded(class="Gedmo\Tests\Revisionable\Fixture\Entity\Author")
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ORM\Embedded(class: Author::class)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?Author $author = null;
 
     public function __toString()

--- a/tests/Gedmo/Revisionable/Fixture/Entity/Author.php
+++ b/tests/Gedmo/Revisionable/Fixture/Entity/Author.php
@@ -25,19 +25,19 @@ class Author implements Revisionable
     /**
      * @ORM\Column(name="name", type="string", nullable=true)
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ORM\Column(name: 'name', type: Types::STRING, nullable: true)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?string $name = null;
 
     /**
      * @ORM\Column(name="email", type="string", nullable=true)
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ORM\Column(name: 'email', type: Types::STRING, nullable: true)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?string $email = null;
 
     public function __toString()

--- a/tests/Gedmo/Revisionable/Fixture/Entity/Author.php
+++ b/tests/Gedmo/Revisionable/Fixture/Entity/Author.php
@@ -23,20 +23,20 @@ use Gedmo\Revisionable\Revisionable;
 class Author implements Revisionable
 {
     /**
-     * @ORM\Column(name="name", type="string")
+     * @ORM\Column(name="name", type="string", nullable=true)
      *
      * @Gedmo\Versioned
      */
-    #[ORM\Column(name: 'name', type: Types::STRING)]
+    #[ORM\Column(name: 'name', type: Types::STRING, nullable: true)]
     #[Gedmo\Versioned]
     private ?string $name = null;
 
     /**
-     * @ORM\Column(name="email", type="string")
+     * @ORM\Column(name="email", type="string", nullable=true)
      *
      * @Gedmo\Versioned
      */
-    #[ORM\Column(name: 'email', type: Types::STRING)]
+    #[ORM\Column(name: 'email', type: Types::STRING, nullable: true)]
     #[Gedmo\Versioned]
     private ?string $email = null;
 

--- a/tests/Gedmo/Revisionable/Fixture/Entity/Author.php
+++ b/tests/Gedmo/Revisionable/Fixture/Entity/Author.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Revisionable\Fixture\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Gedmo\Revisionable\Revisionable;
+
+/**
+ * @ORM\Embeddable
+ */
+#[ORM\Embeddable]
+class Author implements Revisionable
+{
+    /**
+     * @ORM\Column(name="name", type="string")
+     *
+     * @Gedmo\Versioned
+     */
+    #[ORM\Column(name: 'name', type: Types::STRING)]
+    #[Gedmo\Versioned]
+    private ?string $name = null;
+
+    /**
+     * @ORM\Column(name="email", type="string")
+     *
+     * @Gedmo\Versioned
+     */
+    #[ORM\Column(name: 'email', type: Types::STRING)]
+    #[Gedmo\Versioned]
+    private ?string $email = null;
+
+    public function __toString()
+    {
+        return (string) $this->getName();
+    }
+
+    public function setName(?string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setEmail(?string $email): void
+    {
+        $this->email = $email;
+    }
+
+    public function getEmail(): ?string
+    {
+        return $this->email;
+    }
+}

--- a/tests/Gedmo/Revisionable/Fixture/Entity/Comment.php
+++ b/tests/Gedmo/Revisionable/Fixture/Entity/Comment.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Revisionable\Fixture\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Gedmo\Revisionable\Revisionable;
+
+/**
+ * @ORM\Entity
+ *
+ * @Gedmo\Revisionable(revisionClass="Gedmo\Tests\Revisionable\Fixture\Entity\CommentRevision")
+ */
+#[ORM\Entity]
+#[Gedmo\Revisionable(revisionClass: CommentRevision::class)]
+class Comment implements Revisionable
+{
+    /**
+     * @ORM\Column(name="id", type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="IDENTITY")
+     */
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: Types::INTEGER)]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    private ?int $id = null;
+
+    /**
+     * @ORM\Column(name="subject", type="string", length=128)
+     *
+     * @Gedmo\Versioned
+     */
+    #[ORM\Column(name: 'subject', type: Types::STRING, length: 128)]
+    #[Gedmo\Versioned]
+    private ?string $subject = null;
+
+    /**
+     * @ORM\Column(name="message", type="text")
+     *
+     * @Gedmo\Versioned
+     */
+    #[ORM\Column(name: 'message', type: Types::TEXT)]
+    #[Gedmo\Versioned]
+    private ?string $message = null;
+
+    /**
+     * @ORM\Column(name="written_at", type="datetime_immutable")
+     *
+     * @Gedmo\Versioned
+     */
+    #[ORM\Column(name: 'written_at', type: Types::DATETIME_IMMUTABLE)]
+    #[Gedmo\Versioned]
+    private ?\DateTimeImmutable $writtenAt = null;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="Gedmo\Tests\Revisionable\Fixture\Entity\RelatedArticle", inversedBy="comments")
+     *
+     * @Gedmo\Versioned
+     */
+    #[ORM\ManyToOne(targetEntity: RelatedArticle::class, inversedBy: 'comments')]
+    #[Gedmo\Versioned]
+    private ?RelatedArticle $article = null;
+
+    /**
+     * @ORM\Embedded(class="Gedmo\Tests\Revisionable\Fixture\Entity\Author")
+     *
+     * @Gedmo\Versioned
+     */
+    #[ORM\Embedded(class: Author::class)]
+    #[Gedmo\Versioned]
+    private ?Author $author = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setSubject(?string $subject): void
+    {
+        $this->subject = $subject;
+    }
+
+    public function getSubject(): ?string
+    {
+        return $this->subject;
+    }
+
+    public function setMessage(?string $message): void
+    {
+        $this->message = $message;
+    }
+
+    public function getMessage(): ?string
+    {
+        return $this->message;
+    }
+
+    public function setWrittenAt(?\DateTimeImmutable $writtenAt): void
+    {
+        $this->writtenAt = $writtenAt;
+    }
+
+    public function getWrittenAt(): ?\DateTimeImmutable
+    {
+        return $this->writtenAt;
+    }
+
+    public function setArticle(?RelatedArticle $article): void
+    {
+        $this->article = $article;
+    }
+
+    public function getArticle(): ?RelatedArticle
+    {
+        return $this->article;
+    }
+
+    public function setAuthor(?Author $author): void
+    {
+        $this->author = $author;
+    }
+
+    public function getAuthor(): ?Author
+    {
+        return $this->author;
+    }
+}

--- a/tests/Gedmo/Revisionable/Fixture/Entity/Comment.php
+++ b/tests/Gedmo/Revisionable/Fixture/Entity/Comment.php
@@ -38,46 +38,46 @@ class Comment implements Revisionable
     /**
      * @ORM\Column(name="subject", type="string", length=128)
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ORM\Column(name: 'subject', type: Types::STRING, length: 128)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?string $subject = null;
 
     /**
      * @ORM\Column(name="message", type="text")
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ORM\Column(name: 'message', type: Types::TEXT)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?string $message = null;
 
     /**
      * @ORM\Column(name="written_at", type="datetime_immutable")
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ORM\Column(name: 'written_at', type: Types::DATETIME_IMMUTABLE)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?\DateTimeImmutable $writtenAt = null;
 
     /**
      * @ORM\ManyToOne(targetEntity="Gedmo\Tests\Revisionable\Fixture\Entity\RelatedArticle", inversedBy="comments")
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ORM\ManyToOne(targetEntity: RelatedArticle::class, inversedBy: 'comments')]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?RelatedArticle $article = null;
 
     /**
      * @ORM\Embedded(class="Gedmo\Tests\Revisionable\Fixture\Entity\Author")
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ORM\Embedded(class: Author::class)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?Author $author = null;
 
     public function getId(): ?int

--- a/tests/Gedmo/Revisionable/Fixture/Entity/CommentRevision.php
+++ b/tests/Gedmo/Revisionable/Fixture/Entity/CommentRevision.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Revisionable\Fixture\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Revisionable\Entity\MappedSuperclass\AbstractRevision;
+use Gedmo\Revisionable\Entity\Repository\RevisionRepository;
+
+/**
+ * @ORM\Entity(repositoryClass="Gedmo\Revisionable\Entity\Repository\RevisionRepository")
+ *
+ * @template T of Comment
+ *
+ * @template-extends AbstractRevision<T>
+ */
+#[ORM\Entity(repositoryClass: RevisionRepository::class)]
+class CommentRevision extends AbstractRevision
+{
+    /**
+     * Named constructor to create a new revision.
+     *
+     * Implementations should handle setting the initial logged at time and version for new instances within this constructor.
+     *
+     * @param self::ACTION_CREATE|self::ACTION_UPDATE|self::ACTION_REMOVE $action
+     *
+     * @return self<T>
+     */
+    public static function createRevision(string $action): self
+    {
+        $entity = new self();
+        $entity->setAction($action);
+        $entity->setLoggedAt(new \DateTimeImmutable());
+
+        return $entity;
+    }
+}

--- a/tests/Gedmo/Revisionable/Fixture/Entity/Composite.php
+++ b/tests/Gedmo/Revisionable/Fixture/Entity/Composite.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Revisionable\Fixture\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * @ORM\Entity
+ *
+ * @Gedmo\Revisionable
+ */
+#[ORM\Entity]
+#[Gedmo\Revisionable]
+class Composite
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     */
+    #[ORM\Id]
+    #[ORM\Column(name: 'one', type: Types::INTEGER)]
+    private int $one;
+
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     */
+    #[ORM\Id]
+    #[ORM\Column(name: 'two', type: Types::INTEGER)]
+    private int $two;
+
+    /**
+     * @ORM\Column(length=8)
+     *
+     * @Gedmo\Versioned
+     */
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 8)]
+    #[Gedmo\Versioned]
+    private ?string $title = null;
+
+    public function __construct(int $one, int $two)
+    {
+        $this->one = $one;
+        $this->two = $two;
+    }
+
+    public function getOne(): int
+    {
+        return $this->one;
+    }
+
+    public function getTwo(): int
+    {
+        return $this->two;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+}

--- a/tests/Gedmo/Revisionable/Fixture/Entity/Composite.php
+++ b/tests/Gedmo/Revisionable/Fixture/Entity/Composite.php
@@ -41,10 +41,10 @@ class Composite
     /**
      * @ORM\Column(length=8)
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 8)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?string $title = null;
 
     public function __construct(int $one, int $two)

--- a/tests/Gedmo/Revisionable/Fixture/Entity/CompositeRelation.php
+++ b/tests/Gedmo/Revisionable/Fixture/Entity/CompositeRelation.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Revisionable\Fixture\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * @ORM\Entity
+ *
+ * @Gedmo\Revisionable
+ */
+#[ORM\Entity]
+#[Gedmo\Revisionable]
+class CompositeRelation
+{
+    /**
+     * @ORM\Id
+     * @ORM\ManyToOne(targetEntity="Article")
+     */
+    #[ORM\Id]
+    #[ORM\ManyToOne(targetEntity: Article::class)]
+    private Article $articleOne;
+
+    /**
+     * @ORM\Id
+     * @ORM\ManyToOne(targetEntity="Article")
+     */
+    #[ORM\Id]
+    #[ORM\ManyToOne(targetEntity: Article::class)]
+    private Article $articleTwo;
+
+    /**
+     * @ORM\Column(length=8)
+     *
+     * @Gedmo\Versioned
+     */
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 8)]
+    #[Gedmo\Versioned]
+    private ?string $title = null;
+
+    public function __construct(Article $articleOne, Article $articleTwo)
+    {
+        $this->articleOne = $articleOne;
+        $this->articleTwo = $articleTwo;
+    }
+
+    public function getArticleOne(): Article
+    {
+        return $this->articleOne;
+    }
+
+    public function getArticleTwo(): Article
+    {
+        return $this->articleTwo;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+}

--- a/tests/Gedmo/Revisionable/Fixture/Entity/CompositeRelation.php
+++ b/tests/Gedmo/Revisionable/Fixture/Entity/CompositeRelation.php
@@ -41,10 +41,10 @@ class CompositeRelation
     /**
      * @ORM\Column(length=8)
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 8)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?string $title = null;
 
     public function __construct(Article $articleOne, Article $articleTwo)

--- a/tests/Gedmo/Revisionable/Fixture/Entity/Geo.php
+++ b/tests/Gedmo/Revisionable/Fixture/Entity/Geo.php
@@ -28,10 +28,10 @@ class Geo
      *
      * @ORM\Column(type="decimal", precision=9, scale=6)
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ORM\Column(type: Types::DECIMAL, precision: 9, scale: 6)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private string $latitude;
 
     /**
@@ -39,19 +39,19 @@ class Geo
      *
      * @ORM\Column(type="decimal", precision=9, scale=6)
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ORM\Column(type: Types::DECIMAL, precision: 9, scale: 6)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private string $longitude;
 
     /**
      * @ORM\Embedded(class="Gedmo\Tests\Revisionable\Fixture\Entity\GeoLocation")
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ORM\Embedded(class: GeoLocation::class)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private GeoLocation $geoLocation;
 
     public function __construct(float $latitude, float $longitude, GeoLocation $geoLocation)

--- a/tests/Gedmo/Revisionable/Fixture/Entity/Geo.php
+++ b/tests/Gedmo/Revisionable/Fixture/Entity/Geo.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Revisionable\Fixture\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * @author Fabian Sabau <fabian.sabau@socialbit.de>
+ *
+ * @ORM\Embeddable
+ */
+#[ORM\Embeddable]
+class Geo
+{
+    /**
+     * @var numeric-string
+     *
+     * @ORM\Column(type="decimal", precision=9, scale=6)
+     *
+     * @Gedmo\Versioned
+     */
+    #[ORM\Column(type: Types::DECIMAL, precision: 9, scale: 6)]
+    #[Gedmo\Versioned]
+    private string $latitude;
+
+    /**
+     * @var numeric-string
+     *
+     * @ORM\Column(type="decimal", precision=9, scale=6)
+     *
+     * @Gedmo\Versioned
+     */
+    #[ORM\Column(type: Types::DECIMAL, precision: 9, scale: 6)]
+    #[Gedmo\Versioned]
+    private string $longitude;
+
+    /**
+     * @ORM\Embedded(class="Gedmo\Tests\Revisionable\Fixture\Entity\GeoLocation")
+     *
+     * @Gedmo\Versioned
+     */
+    #[ORM\Embedded(class: GeoLocation::class)]
+    #[Gedmo\Versioned]
+    private GeoLocation $geoLocation;
+
+    public function __construct(float $latitude, float $longitude, GeoLocation $geoLocation)
+    {
+        $this->latitude = $this->parseFloatToString($latitude);
+        $this->longitude = $this->parseFloatToString($longitude);
+        $this->geoLocation = $geoLocation;
+    }
+
+    public function getLatitude(): float
+    {
+        return (float) $this->latitude;
+    }
+
+    public function setLatitude(float $latitude): void
+    {
+        $this->latitude = $this->parseFloatToString($latitude);
+    }
+
+    public function getLongitude(): float
+    {
+        return (float) $this->longitude;
+    }
+
+    public function setLongitude(float $longitude): void
+    {
+        $this->longitude = $this->parseFloatToString($longitude);
+    }
+
+    public function getGeoLocation(): GeoLocation
+    {
+        return $this->geoLocation;
+    }
+
+    public function setGeoLocation(GeoLocation $geoLocation): void
+    {
+        $this->geoLocation = $geoLocation;
+    }
+
+    /**
+     * @return numeric-string
+     */
+    private function parseFloatToString(float $number): string
+    {
+        return sprintf('%.6f', $number);
+    }
+}

--- a/tests/Gedmo/Revisionable/Fixture/Entity/GeoLocation.php
+++ b/tests/Gedmo/Revisionable/Fixture/Entity/GeoLocation.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Revisionable\Fixture\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * @author Fabian Sabau <fabian.sabau@socialbit.de>
+ *
+ * @ORM\Embeddable
+ */
+#[ORM\Embeddable]
+class GeoLocation
+{
+    /**
+     * @ORM\Column(type="string")
+     *
+     * @Gedmo\Versioned
+     */
+    #[ORM\Column(type: Types::STRING)]
+    #[Gedmo\Versioned]
+    private string $location;
+
+    public function __construct(string $location)
+    {
+        $this->location = $location;
+    }
+
+    public function getLocation(): string
+    {
+        return $this->location;
+    }
+
+    public function setLocation(string $location): void
+    {
+        $this->location = $location;
+    }
+}

--- a/tests/Gedmo/Revisionable/Fixture/Entity/GeoLocation.php
+++ b/tests/Gedmo/Revisionable/Fixture/Entity/GeoLocation.php
@@ -26,10 +26,10 @@ class GeoLocation
     /**
      * @ORM\Column(type="string")
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ORM\Column(type: Types::STRING)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private string $location;
 
     public function __construct(string $location)

--- a/tests/Gedmo/Revisionable/Fixture/Entity/RelatedArticle.php
+++ b/tests/Gedmo/Revisionable/Fixture/Entity/RelatedArticle.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Revisionable\Fixture\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Gedmo\Revisionable\Revisionable;
+
+/**
+ * @ORM\Entity
+ *
+ * @Gedmo\Revisionable
+ */
+#[ORM\Entity]
+#[Gedmo\Revisionable]
+class RelatedArticle implements Revisionable
+{
+    /**
+     * @ORM\Column(name="id", type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="IDENTITY")
+     */
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: Types::INTEGER)]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    private ?int $id = null;
+
+    /**
+     * @ORM\Column(name="title", type="string", length=8)
+     *
+     * @Gedmo\Versioned
+     */
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 8)]
+    #[Gedmo\Versioned]
+    private ?string $title = null;
+
+    /**
+     * @ORM\Column(name="content", type="text")
+     *
+     * @Gedmo\Versioned
+     */
+    #[ORM\Column(name: 'content', type: Types::TEXT)]
+    #[Gedmo\Versioned]
+    private ?string $content = null;
+
+    /**
+     * @var Collection<int, Comment>
+     *
+     * @ORM\OneToMany(targetEntity="Gedmo\Tests\Revisionable\Fixture\Entity\Comment", mappedBy="article")
+     */
+    #[ORM\OneToMany(targetEntity: Comment::class, mappedBy: 'article')]
+    private Collection $comments;
+
+    public function __construct()
+    {
+        $this->comments = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setTitle(?string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setContent(?string $content): void
+    {
+        $this->content = $content;
+    }
+
+    public function getContent(): ?string
+    {
+        return $this->content;
+    }
+
+    public function addComment(Comment $comment): void
+    {
+        if (!$this->comments->contains($comment)) {
+            $this->comments[] = $comment;
+            $comment->setArticle($this);
+        }
+    }
+
+    /**
+     * @return Collection<int, Comment>
+     */
+    public function getComments(): Collection
+    {
+        return $this->comments;
+    }
+}

--- a/tests/Gedmo/Revisionable/Fixture/Entity/RelatedArticle.php
+++ b/tests/Gedmo/Revisionable/Fixture/Entity/RelatedArticle.php
@@ -40,19 +40,19 @@ class RelatedArticle implements Revisionable
     /**
      * @ORM\Column(name="title", type="string", length=8)
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ORM\Column(name: 'title', type: Types::STRING, length: 8)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?string $title = null;
 
     /**
      * @ORM\Column(name="content", type="text")
      *
-     * @Gedmo\Versioned
+     * @Gedmo\KeepRevisions
      */
     #[ORM\Column(name: 'content', type: Types::TEXT)]
-    #[Gedmo\Versioned]
+    #[Gedmo\KeepRevisions]
     private ?string $content = null;
 
     /**

--- a/tests/Gedmo/Revisionable/RevisionableDocumentTest.php
+++ b/tests/Gedmo/Revisionable/RevisionableDocumentTest.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Revisionable;
+
+use Doctrine\Common\EventManager;
+use Gedmo\Revisionable\Document\Repository\RevisionRepository;
+use Gedmo\Revisionable\Document\Revision;
+use Gedmo\Revisionable\RevisionableListener;
+use Gedmo\Revisionable\RevisionInterface;
+use Gedmo\Tests\Revisionable\Fixture\Document\Address;
+use Gedmo\Tests\Revisionable\Fixture\Document\Article;
+use Gedmo\Tests\Revisionable\Fixture\Document\Author;
+use Gedmo\Tests\Revisionable\Fixture\Document\Comment;
+use Gedmo\Tests\Revisionable\Fixture\Document\CommentRevision;
+use Gedmo\Tests\Revisionable\Fixture\Document\Geo;
+use Gedmo\Tests\Revisionable\Fixture\Document\GeoLocation;
+use Gedmo\Tests\Revisionable\Fixture\Document\RelatedArticle;
+use Gedmo\Tests\Tool\BaseTestCaseMongoODM;
+use MongoDB\BSON\UTCDateTime;
+
+/**
+ * Functional tests for the revsionable extension with the Doctrine MongoDB ODM
+ *
+ * @author Boussekeyt Jules <jules.boussekeyt@gmail.com>
+ * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ */
+final class RevisionableDocumentTest extends BaseTestCaseMongoODM
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $evm = new EventManager();
+
+        $listener = new RevisionableListener();
+        $listener->setUsername('jules');
+
+        $evm->addEventSubscriber($listener);
+
+        $this->getDefaultDocumentManager($evm);
+    }
+
+    public function testRevisionableLifecycle(): void
+    {
+        $revisionRepository = $this->dm->getRepository(Revision::class);
+
+        static::assertCount(0, $revisionRepository->findAll());
+
+        $articleRepository = $this->dm->getRepository(Article::class);
+
+        $art0 = new Article();
+        $art0->setTitle('Title');
+        $art0->setPublishAt(new \DateTimeImmutable('2024-06-24 23:00:00', new \DateTimeZone('UTC')));
+
+        $author = new Author();
+        $author->setName('John Doe');
+        $author->setEmail('john@doe.com');
+
+        $art0->setAuthor($author);
+
+        $this->dm->persist($art0);
+        $this->dm->flush();
+
+        $articleId = $art0->getId();
+
+        $revision = $revisionRepository->findOneBy(['revisionableId' => $articleId]);
+
+        static::assertNotNull($revision);
+        static::assertSame(RevisionInterface::ACTION_CREATE, $revision->getAction());
+        static::assertSame(get_class($art0), $revision->getRevisionableClass());
+        static::assertSame('jules', $revision->getUsername());
+        static::assertSame(1, $revision->getVersion());
+
+        $data = $revision->getData();
+
+        static::assertCount(3, $data);
+        static::assertArrayHasKey('title', $data);
+        static::assertSame('Title', $data['title']);
+        static::assertArrayHasKey('publishAt', $data);
+        static::assertInstanceOf(UTCDateTime::class, $data['publishAt']);
+        static::assertArrayHasKey('author', $data);
+        static::assertSame(['name' => 'John Doe', 'email' => 'john@doe.com'], $data['author']);
+
+        // test update
+        $article = $articleRepository->findOneBy(['title' => 'Title']);
+        $article->setTitle('New');
+        $this->dm->persist($article);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $revision = $revisionRepository->findOneBy(['version' => 2, 'revisionableId' => $articleId]);
+
+        static::assertSame(RevisionInterface::ACTION_UPDATE, $revision->getAction());
+
+        // test delete
+        $article = $articleRepository->findOneBy(['title' => 'New']);
+        $this->dm->remove($article);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $revision = $revisionRepository->findOneBy(['version' => 3, 'revisionableId' => $articleId]);
+
+        static::assertSame(RevisionInterface::ACTION_REMOVE, $revision->getAction());
+        static::assertEmpty($revision->getData());
+    }
+
+    public function testVersionLifecycle(): void
+    {
+        $this->populate();
+
+        $commentRevisionRepository = $this->dm->getRepository(CommentRevision::class);
+
+        $commentRepository = $this->dm->getRepository(Comment::class);
+
+        static::assertInstanceOf(RevisionRepository::class, $commentRevisionRepository);
+
+        $comment = $commentRepository->findOneBy(['message' => 'm-v5']);
+
+        static::assertSame('m-v5', $comment->getMessage());
+        static::assertSame('s-v3', $comment->getSubject());
+        static::assertSame('2024-06-24 23:30:00', $comment->getWrittenAt()->format('Y-m-d H:i:s'));
+        static::assertSame('a2-t-v1', $comment->getArticle()->getTitle());
+        static::assertSame('Jane Doe', $comment->getAuthor()->getName());
+        static::assertSame('jane@doe.com', $comment->getAuthor()->getEmail());
+
+        // test revert
+        $commentRevisionRepository->revert($comment, 3);
+
+        static::assertSame('s-v3', $comment->getSubject());
+        static::assertSame('m-v2', $comment->getMessage());
+        static::assertSame('2024-06-24 23:30:00', $comment->getWrittenAt()->format('Y-m-d H:i:s'));
+        static::assertSame('a1-t-v1', $comment->getArticle()->getTitle());
+        static::assertSame('John Doe', $comment->getAuthor()->getName());
+        static::assertSame('john@doe.com', $comment->getAuthor()->getEmail());
+
+        $this->dm->persist($comment);
+        $this->dm->flush();
+
+        // test fetch revisions
+        $revisions = $commentRevisionRepository->getRevisions($comment);
+
+        static::assertCount(6, $revisions);
+
+        $latest = array_shift($revisions);
+
+        static::assertSame(RevisionInterface::ACTION_UPDATE, $latest->getAction());
+    }
+
+    public function testLogsRevisionsOfEmbeddedDocuments(): void
+    {
+        $address = new Address();
+        $address->setCity('city-v1');
+        $address->setStreet('street-v1');
+        $address->setGeo(new Geo(1.0000, 1.0000, new GeoLocation('Online')));
+
+        $this->dm->persist($address);
+        $this->dm->flush();
+
+        $address->setGeo(new Geo(2.0000, 2.0000, new GeoLocation('Offline')));
+
+        $this->dm->persist($address);
+        $this->dm->flush();
+
+        $address->getGeo()->setLatitude(3.0000);
+        $address->getGeo()->setLongitude(3.0000);
+
+        $this->dm->persist($address);
+        $this->dm->flush();
+
+        $address->setStreet('street-v2');
+
+        $this->dm->persist($address);
+        $this->dm->flush();
+
+        $revisionRepository = $this->dm->getRepository(Revision::class);
+
+        $revisions = $revisionRepository->getRevisions($address);
+
+        static::assertCount(4, $revisions);
+        static::assertCount(1, $revisions[0]->getData());
+        static::assertCount(1, $revisions[1]->getData());
+        static::assertCount(1, $revisions[2]->getData());
+        static::assertCount(3, $revisions[3]->getData());
+    }
+
+    private function populate(): void
+    {
+        $article = new RelatedArticle();
+        $article->setTitle('a1-t-v1');
+        $article->setContent('a1-c-v1');
+
+        $author = new Author();
+        $author->setName('John Doe');
+        $author->setEmail('john@doe.com');
+
+        $comment = new Comment();
+        $comment->setArticle($article);
+        $comment->setAuthor($author);
+        $comment->setMessage('m-v1');
+        $comment->setSubject('s-v1');
+        $comment->setWrittenAt(new \DateTimeImmutable('2024-06-24 23:30:00', new \DateTimeZone('UTC')));
+
+        $this->dm->persist($article);
+        $this->dm->persist($comment);
+        $this->dm->flush();
+
+        $comment->setMessage('m-v2');
+
+        $this->dm->persist($comment);
+        $this->dm->flush();
+
+        $comment->setSubject('s-v3');
+
+        $this->dm->persist($comment);
+        $this->dm->flush();
+
+        $article2 = new RelatedArticle();
+        $article2->setTitle('a2-t-v1');
+        $article2->setContent('a2-c-v1');
+
+        $author2 = new Author();
+        $author2->setName('Jane Doe');
+        $author2->setEmail('jane@doe.com');
+
+        $comment->setAuthor($author2);
+        $comment->setArticle($article2);
+
+        $this->dm->persist($article2);
+        $this->dm->persist($comment);
+        $this->dm->flush();
+
+        $comment->setMessage('m-v5');
+
+        $this->dm->persist($comment);
+        $this->dm->flush();
+        $this->dm->clear();
+    }
+}

--- a/tests/Gedmo/Revisionable/RevisionableDocumentTest.php
+++ b/tests/Gedmo/Revisionable/RevisionableDocumentTest.php
@@ -149,6 +149,7 @@ final class RevisionableDocumentTest extends BaseTestCaseMongoODM
         static::assertSame('m-v2', $comment->getMessage());
         static::assertSame('2024-06-24 23:30:00', $comment->getWrittenAt()->format('Y-m-d H:i:s'));
         static::assertSame('a1-t-v1', $comment->getArticle()->getTitle());
+        static::assertNotNull($comment->getAuthor());
         static::assertSame('John Doe', $comment->getAuthor()->getName());
         static::assertSame('john@doe.com', $comment->getAuthor()->getEmail());
 

--- a/tests/Gedmo/Revisionable/RevisionableEntityTest.php
+++ b/tests/Gedmo/Revisionable/RevisionableEntityTest.php
@@ -1,0 +1,496 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Revisionable;
+
+use Doctrine\Common\EventManager;
+use Gedmo\Revisionable\Entity\Repository\RevisionRepository;
+use Gedmo\Revisionable\Entity\Revision;
+use Gedmo\Revisionable\Revisionable;
+use Gedmo\Revisionable\RevisionableListener;
+use Gedmo\Revisionable\RevisionInterface;
+use Gedmo\Tests\Revisionable\Fixture\Entity\Address;
+use Gedmo\Tests\Revisionable\Fixture\Entity\Article;
+use Gedmo\Tests\Revisionable\Fixture\Entity\Author;
+use Gedmo\Tests\Revisionable\Fixture\Entity\Comment;
+use Gedmo\Tests\Revisionable\Fixture\Entity\CommentRevision;
+use Gedmo\Tests\Revisionable\Fixture\Entity\Composite;
+use Gedmo\Tests\Revisionable\Fixture\Entity\CompositeRelation;
+use Gedmo\Tests\Revisionable\Fixture\Entity\Geo;
+use Gedmo\Tests\Revisionable\Fixture\Entity\GeoLocation;
+use Gedmo\Tests\Revisionable\Fixture\Entity\RelatedArticle;
+use Gedmo\Tests\TestActorProvider;
+use Gedmo\Tests\Tool\BaseTestCaseORM;
+
+/**
+ * Functional tests for the revsionable extension with the Doctrine ORM
+ *
+ * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ */
+final class RevisionableEntityTest extends BaseTestCaseORM
+{
+    /**
+     * @var RevisionableListener<Revisionable|object>
+     */
+    private RevisionableListener $listener;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $evm = new EventManager();
+
+        $this->listener = new RevisionableListener();
+        $this->listener->setUsername('jules');
+
+        $evm->addEventSubscriber($this->listener);
+
+        $this->em = $this->getDefaultMockSqliteEntityManager($evm);
+    }
+
+    public function testRevisionableLifecycle(): void
+    {
+        $revisionRepository = $this->em->getRepository(Revision::class);
+
+        static::assertCount(0, $revisionRepository->findAll());
+
+        $articleRepository = $this->em->getRepository(Article::class);
+
+        $art0 = new Article();
+        $art0->setTitle('Title');
+        $art0->setPublishAt(new \DateTimeImmutable('2024-06-24 23:00:00', new \DateTimeZone('UTC')));
+
+        $author = new Author();
+        $author->setName('John Doe');
+        $author->setEmail('john@doe.com');
+
+        $art0->setAuthor($author);
+
+        $this->em->persist($art0);
+        $this->em->flush();
+
+        $articleId = $art0->getId();
+
+        $revision = $revisionRepository->findOneBy(['revisionableId' => $articleId]);
+
+        static::assertNotNull($revision);
+        static::assertSame(RevisionInterface::ACTION_CREATE, $revision->getAction());
+        static::assertSame(get_class($art0), $revision->getRevisionableClass());
+        static::assertSame('jules', $revision->getUsername());
+        static::assertSame(1, $revision->getVersion());
+
+        $data = $revision->getData();
+
+        static::assertCount(4, $data);
+        static::assertArrayHasKey('title', $data);
+        static::assertSame('Title', $data['title']);
+        static::assertArrayHasKey('publishAt', $data);
+        static::assertSame('2024-06-24 23:00:00', $data['publishAt']);
+        static::assertArrayHasKey('author.name', $data);
+        static::assertSame('John Doe', $data['author.name']);
+        static::assertArrayHasKey('author.email', $data);
+        static::assertSame('john@doe.com', $data['author.email']);
+
+        // test update
+        $article = $articleRepository->findOneBy(['title' => 'Title']);
+        $article->setTitle('New');
+        $this->em->persist($article);
+        $this->em->flush();
+        $this->em->clear();
+
+        $revision = $revisionRepository->findOneBy(['version' => 2, 'revisionableId' => $articleId]);
+
+        static::assertSame(RevisionInterface::ACTION_UPDATE, $revision->getAction());
+
+        // test delete
+        $article = $articleRepository->findOneBy(['title' => 'New']);
+        $this->em->remove($article);
+        $this->em->flush();
+        $this->em->clear();
+
+        $revision = $revisionRepository->findOneBy(['version' => 3, 'revisionableId' => $articleId]);
+
+        static::assertSame(RevisionInterface::ACTION_REMOVE, $revision->getAction());
+        static::assertEmpty($revision->getData());
+    }
+
+    public function testRevisionableLifecycleWithActorProvider(): void
+    {
+        $this->listener->setActorProvider(new TestActorProvider('testactor'));
+
+        $revisionRepository = $this->em->getRepository(Revision::class);
+
+        static::assertCount(0, $revisionRepository->findAll());
+
+        $articleRepository = $this->em->getRepository(Article::class);
+
+        $art0 = new Article();
+        $art0->setTitle('Title');
+        $art0->setPublishAt(new \DateTimeImmutable('2024-06-24 23:00:00', new \DateTimeZone('UTC')));
+
+        $author = new Author();
+        $author->setName('John Doe');
+        $author->setEmail('john@doe.com');
+
+        $art0->setAuthor($author);
+
+        $this->em->persist($art0);
+        $this->em->flush();
+
+        $articleId = $art0->getId();
+
+        $revision = $revisionRepository->findOneBy(['revisionableId' => $articleId]);
+
+        static::assertNotNull($revision);
+        static::assertSame(RevisionInterface::ACTION_CREATE, $revision->getAction());
+        static::assertSame(get_class($art0), $revision->getRevisionableClass());
+        static::assertSame('testactor', $revision->getUsername());
+        static::assertSame(1, $revision->getVersion());
+
+        $data = $revision->getData();
+
+        static::assertCount(4, $data);
+        static::assertArrayHasKey('title', $data);
+        static::assertSame('Title', $data['title']);
+        static::assertArrayHasKey('publishAt', $data);
+        static::assertSame('2024-06-24 23:00:00', $data['publishAt']);
+        static::assertArrayHasKey('author.name', $data);
+        static::assertSame('John Doe', $data['author.name']);
+        static::assertArrayHasKey('author.email', $data);
+        static::assertSame('john@doe.com', $data['author.email']);
+
+        // test update
+        $article = $articleRepository->findOneBy(['title' => 'Title']);
+        $article->setTitle('New');
+        $this->em->persist($article);
+        $this->em->flush();
+        $this->em->clear();
+
+        $revision = $revisionRepository->findOneBy(['version' => 2, 'revisionableId' => $articleId]);
+
+        static::assertSame(RevisionInterface::ACTION_UPDATE, $revision->getAction());
+
+        // test delete
+        $article = $articleRepository->findOneBy(['title' => 'New']);
+        $this->em->remove($article);
+        $this->em->flush();
+        $this->em->clear();
+
+        $revision = $revisionRepository->findOneBy(['version' => 3, 'revisionableId' => $articleId]);
+
+        static::assertSame(RevisionInterface::ACTION_REMOVE, $revision->getAction());
+        static::assertEmpty($revision->getData());
+    }
+
+    public function testVersionLifecycle(): void
+    {
+        $this->populate();
+
+        $commentRevisionRepository = $this->em->getRepository(CommentRevision::class);
+
+        $commentRepository = $this->em->getRepository(Comment::class);
+
+        static::assertInstanceOf(RevisionRepository::class, $commentRevisionRepository);
+
+        $comment = $commentRepository->findOneBy(['message' => 'm-v5']);
+
+        static::assertNotNull($comment);
+
+        static::assertSame('m-v5', $comment->getMessage());
+        static::assertSame('s-v3', $comment->getSubject());
+        static::assertSame('2024-06-24 23:30:00', $comment->getWrittenAt()->format('Y-m-d H:i:s'));
+        static::assertSame('a2-t-v1', $comment->getArticle()->getTitle());
+        static::assertSame('Jane Doe', $comment->getAuthor()->getName());
+        static::assertSame('jane@doe.com', $comment->getAuthor()->getEmail());
+
+        // test revert
+        $commentRevisionRepository->revert($comment, 3);
+
+        static::assertSame('s-v3', $comment->getSubject());
+        static::assertSame('m-v2', $comment->getMessage());
+        static::assertSame('2024-06-24 23:30:00', $comment->getWrittenAt()->format('Y-m-d H:i:s'));
+        static::assertSame('a1-t-v1', $comment->getArticle()->getTitle());
+        static::assertSame('John Doe', $comment->getAuthor()->getName());
+        static::assertSame('john@doe.com', $comment->getAuthor()->getEmail());
+
+        $this->em->persist($comment);
+        $this->em->flush();
+
+        // test fetch revisions
+        $revisions = $commentRevisionRepository->getRevisions($comment);
+
+        static::assertCount(6, $revisions);
+
+        $latest = array_shift($revisions);
+
+        static::assertSame(RevisionInterface::ACTION_UPDATE, $latest->getAction());
+    }
+
+    public function testSupportsClonedEntities(): void
+    {
+        $art0 = new Article();
+        $art0->setTitle('Title');
+        $art0->setPublishAt(new \DateTimeImmutable('2024-06-24 23:00:00', new \DateTimeZone('UTC')));
+
+        $author = new Author();
+        $author->setName('John Doe');
+        $author->setEmail('john@doe.com');
+
+        $art0->setAuthor($author);
+
+        $this->em->persist($art0);
+        $this->em->flush();
+
+        $art1 = clone $art0;
+        $art1->setTitle('Cloned');
+
+        $this->em->persist($art1);
+        $this->em->flush();
+
+        $revisionRepository = $this->em->getRepository(Revision::class);
+
+        $revisions = $revisionRepository->findAll();
+
+        static::assertCount(2, $revisions);
+        static::assertSame(RevisionInterface::ACTION_CREATE, $revisions[0]->getAction());
+        static::assertSame(RevisionInterface::ACTION_CREATE, $revisions[1]->getAction());
+        static::assertNotSame($revisions[0]->getRevisionableId(), $revisions[1]->getRevisionableId());
+    }
+
+    public function testLogsRevisionsOfEmbeddedEntities(): void
+    {
+        $address = new Address();
+        $address->setCity('city-v1');
+        $address->setStreet('street-v1');
+        $address->setGeo(new Geo(1.0000, 1.0000, new GeoLocation('Online')));
+
+        $this->em->persist($address);
+        $this->em->flush();
+
+        $address->setGeo(new Geo(2.0000, 2.0000, new GeoLocation('Offline')));
+
+        $this->em->persist($address);
+        $this->em->flush();
+
+        $address->getGeo()->setLatitude(3.0000);
+        $address->getGeo()->setLongitude(3.0000);
+
+        $this->em->persist($address);
+        $this->em->flush();
+
+        $address->setStreet('street-v2');
+
+        $this->em->persist($address);
+        $this->em->flush();
+
+        $revisionRepository = $this->em->getRepository(Revision::class);
+
+        $revisions = $revisionRepository->getRevisions($address);
+
+        static::assertCount(4, $revisions);
+        static::assertCount(1, $revisions[0]->getData());
+        static::assertCount(2, $revisions[1]->getData());
+        static::assertCount(3, $revisions[2]->getData());
+        static::assertCount(5, $revisions[3]->getData());
+    }
+
+    public function testLogsRevisionsOfEntitiesWithCompositeIds(): void
+    {
+        $compositeIds = [1, 2];
+
+        $composite = new Composite(...$compositeIds);
+        $composite->setTitle('Title2');
+
+        $this->em->persist($composite);
+        $this->em->flush();
+
+        $compositeId = sprintf('%s %s', ...$compositeIds);
+
+        $revisionRepository = $this->em->getRepository(Revision::class);
+
+        $revision = $revisionRepository->findOneBy(['revisionableId' => $compositeId]);
+
+        static::assertNotNull($revision);
+        static::assertSame(RevisionInterface::ACTION_CREATE, $revision->getAction());
+        static::assertSame(get_class($composite), $revision->getRevisionableClass());
+        static::assertSame('jules', $revision->getUsername());
+        static::assertSame(1, $revision->getVersion());
+
+        $data = $revision->getData();
+
+        static::assertCount(1, $data);
+        static::assertArrayHasKey('title', $data);
+        static::assertSame($data['title'], 'Title2');
+
+        $compositeRepository = $this->em->getRepository(Composite::class);
+
+        // test update
+        $composite = $compositeRepository->findOneBy(['title' => 'Title2']);
+        $composite->setTitle('New');
+
+        $this->em->persist($composite);
+        $this->em->flush();
+        $this->em->clear();
+
+        $revision = $revisionRepository->findOneBy(['revisionableId' => $compositeId, 'version' => 2]);
+
+        static::assertNotNull($revision);
+        static::assertSame(RevisionInterface::ACTION_UPDATE, $revision->getAction());
+
+        // test delete
+        $composite = $compositeRepository->findOneBy(['title' => 'New']);
+        $this->em->remove($composite);
+        $this->em->flush();
+        $this->em->clear();
+
+        $revision = $revisionRepository->findOneBy(['revisionableId' => $compositeId, 'version' => 3]);
+        static::assertSame(RevisionInterface::ACTION_REMOVE, $revision->getAction());
+        static::assertEmpty($revision->getData());
+    }
+
+    public function testLogsRevisionsOfEntitiesWithCompositeIdsBasedOnRelations(): void
+    {
+        $author = new Author();
+        $author->setName('John Doe');
+        $author->setEmail('john@doe.com');
+
+        $art0 = new Article();
+        $art0->setTitle('Title0');
+        $art0->setPublishAt(new \DateTimeImmutable('2024-06-24 23:00:00', new \DateTimeZone('UTC')));
+        $art0->setAuthor($author);
+
+        $art1 = new Article();
+        $art1->setTitle('Title1');
+        $art1->setPublishAt(new \DateTimeImmutable('2024-06-24 23:00:00', new \DateTimeZone('UTC')));
+        $art1->setAuthor($author);
+
+        $composite = new CompositeRelation($art0, $art1);
+        $composite->setTitle('Title2');
+
+        $this->em->persist($art0);
+        $this->em->persist($art1);
+        $this->em->persist($composite);
+        $this->em->flush();
+
+        $compositeId = sprintf('%s %s', $art0->getId(), $art1->getId());
+
+        $revisionRepository = $this->em->getRepository(Revision::class);
+
+        $revision = $revisionRepository->findOneBy(['revisionableId' => $compositeId]);
+
+        static::assertNotNull($revision);
+        static::assertSame(RevisionInterface::ACTION_CREATE, $revision->getAction());
+        static::assertSame(get_class($composite), $revision->getRevisionableClass());
+        static::assertSame('jules', $revision->getUsername());
+        static::assertSame(1, $revision->getVersion());
+
+        $data = $revision->getData();
+
+        static::assertCount(1, $data);
+        static::assertArrayHasKey('title', $data);
+        static::assertSame($data['title'], 'Title2');
+
+        $compositeRepository = $this->em->getRepository(CompositeRelation::class);
+
+        // test update
+        $composite = $compositeRepository->findOneBy(['title' => 'Title2']);
+        $composite->setTitle('New');
+
+        $this->em->persist($composite);
+        $this->em->flush();
+        $this->em->clear();
+
+        $revision = $revisionRepository->findOneBy(['revisionableId' => $compositeId, 'version' => 2]);
+
+        static::assertNotNull($revision);
+        static::assertSame(RevisionInterface::ACTION_UPDATE, $revision->getAction());
+
+        // test delete
+        $composite = $compositeRepository->findOneBy(['title' => 'New']);
+        $this->em->remove($composite);
+        $this->em->flush();
+        $this->em->clear();
+
+        $revision = $revisionRepository->findOneBy(['revisionableId' => $compositeId, 'version' => 3]);
+        static::assertSame(RevisionInterface::ACTION_REMOVE, $revision->getAction());
+        static::assertEmpty($revision->getData());
+    }
+
+    protected function getUsedEntityFixtures(): array
+    {
+        return [
+            Address::class,
+            Article::class,
+            Author::class,
+            Comment::class,
+            CommentRevision::class,
+            Composite::class,
+            CompositeRelation::class,
+            Geo::class,
+            GeoLocation::class,
+            RelatedArticle::class,
+            Revision::class,
+        ];
+    }
+
+    private function populate(): void
+    {
+        $article = new RelatedArticle();
+        $article->setTitle('a1-t-v1');
+        $article->setContent('a1-c-v1');
+
+        $author = new Author();
+        $author->setName('John Doe');
+        $author->setEmail('john@doe.com');
+
+        $comment = new Comment();
+        $comment->setArticle($article);
+        $comment->setAuthor($author);
+        $comment->setMessage('m-v1');
+        $comment->setSubject('s-v1');
+        $comment->setWrittenAt(new \DateTimeImmutable('2024-06-24 23:30:00', new \DateTimeZone('UTC')));
+
+        $this->em->persist($article);
+        $this->em->persist($comment);
+        $this->em->flush();
+
+        $comment->setMessage('m-v2');
+
+        $this->em->persist($comment);
+        $this->em->flush();
+
+        $comment->setSubject('s-v3');
+
+        $this->em->persist($comment);
+        $this->em->flush();
+
+        $article2 = new RelatedArticle();
+        $article2->setTitle('a2-t-v1');
+        $article2->setContent('a2-c-v1');
+
+        $author2 = new Author();
+        $author2->setName('Jane Doe');
+        $author2->setEmail('jane@doe.com');
+
+        $comment->setAuthor($author2);
+        $comment->setArticle($article2);
+
+        $this->em->persist($article2);
+        $this->em->persist($comment);
+        $this->em->flush();
+
+        $comment->setMessage('m-v5');
+
+        $this->em->persist($comment);
+        $this->em->flush();
+        $this->em->clear();
+    }
+}

--- a/tests/Gedmo/Tool/BaseTestCaseMongoODM.php
+++ b/tests/Gedmo/Tool/BaseTestCaseMongoODM.php
@@ -18,6 +18,7 @@ use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
 use Doctrine\ODM\MongoDB\Mapping\Driver\AttributeDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Gedmo\Loggable\LoggableListener;
+use Gedmo\Revisionable\RevisionableListener;
 use Gedmo\Sluggable\SluggableListener;
 use Gedmo\SoftDeleteable\Filter\ODM\SoftDeleteableFilter;
 use Gedmo\SoftDeleteable\SoftDeleteableListener;
@@ -172,6 +173,7 @@ abstract class BaseTestCaseMongoODM extends TestCase
         $evm = new EventManager();
         $evm->addEventSubscriber(new SluggableListener());
         $evm->addEventSubscriber(new LoggableListener());
+        $evm->addEventSubscriber(new RevisionableListener());
         $evm->addEventSubscriber(new TranslatableListener());
         $evm->addEventSubscriber(new TimestampableListener());
         $evm->addEventSubscriber(new SoftDeleteableListener());

--- a/tests/Gedmo/Tool/BaseTestCaseOM.php
+++ b/tests/Gedmo/Tool/BaseTestCaseOM.php
@@ -29,6 +29,7 @@ use Doctrine\ORM\Repository\DefaultRepositoryFactory as DefaultRepositoryFactory
 use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Gedmo\Loggable\LoggableListener;
+use Gedmo\Revisionable\RevisionableListener;
 use Gedmo\Sluggable\SluggableListener;
 use Gedmo\SoftDeleteable\Filter\ODM\SoftDeleteableFilter;
 use Gedmo\Timestampable\TimestampableListener;
@@ -155,6 +156,7 @@ abstract class BaseTestCaseOM extends TestCase
             $this->evm->addEventSubscriber(new TreeListener());
             $this->evm->addEventSubscriber(new SluggableListener());
             $this->evm->addEventSubscriber(new LoggableListener());
+            $this->evm->addEventSubscriber(new RevisionableListener());
             $this->evm->addEventSubscriber(new TranslatableListener());
             $this->evm->addEventSubscriber(new TimestampableListener());
         }

--- a/tests/Gedmo/Tool/BaseTestCaseORM.php
+++ b/tests/Gedmo/Tool/BaseTestCaseORM.php
@@ -22,6 +22,7 @@ use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Gedmo\Loggable\LoggableListener;
+use Gedmo\Revisionable\RevisionableListener;
 use Gedmo\Sluggable\SluggableListener;
 use Gedmo\SoftDeleteable\SoftDeleteableListener;
 use Gedmo\Timestampable\TimestampableListener;
@@ -122,6 +123,7 @@ abstract class BaseTestCaseORM extends TestCase
         $evm->addEventSubscriber(new TreeListener());
         $evm->addEventSubscriber(new SluggableListener());
         $evm->addEventSubscriber(new LoggableListener());
+        $evm->addEventSubscriber(new RevisionableListener());
         $evm->addEventSubscriber(new TranslatableListener());
         $evm->addEventSubscriber(new TimestampableListener());
         $evm->addEventSubscriber(new SoftDeleteableListener());


### PR DESCRIPTION
Ref: #2502

As the issue notes, the loggable extension is incompatible with ORM 4.x due to the removal of the array field type.  The issue also has a patch for migrating to JSON, but because of the need for a data migration, it's not a patch that can be easily dropped in.  Enter the new revisionable extension.

Mostly the same thing as the loggable extension, except for changing the way the data is collected for the history object's data field.  For the ORM, the data was stored as a serialized PHP array, which while it works, is less than optimal:

```sh
a:4:{s:5:"title";s:5:"Title";s:9:"publishAt";O:17:"DateTimeImmutable":3:{s:4:"date";s:26:"2024-06-24 23:00:00.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:3:"UTC";}s:11:"author.name";s:8:"John Doe";s:12:"author.email";s:12:"john@doe.com";}
```

The new extension uses the mapping layers of the ORM and ODM to store the data in its database representation, and for the ORM, as a native JSON field:

```json
{
	"title": "Title",
	"publishAt": "2024-06-24 23:00:00",
	"author.name": "John Doe",
	"author.email": "john@doe.com"
}
```

Another benefit to introducing a new extension is that the old and new versions can live side-by-side and allows for a data migration so long as your log entry data can be unserialized back into PHP and its info mapped to a database value (https://gist.github.com/mbabker/1879a3e55feac953e23cb2f025654052 was something I quickly hacked into the example app code as a proof of concept, a full-on tool could be built out using the logic here).

There are some other extras baked into this branch which generally help improve things too, including:

- Adding templates for the config arrays in the extension listeners
- Adding new methods to the `WrapperInterface` implementations (and `@method` annotated on the interface itself to add to 4.0) to handle mapping values to PHP and database formats for each manager

Differences between the two extensions include:

- Removing the `prePersistLogEntry()` hook that existed in the loggable listener, the Doctrine event manager can be used here without needing to have an open class
- Uses a `Revisionable` attribute instead of `Loggable` at the class level, and uses a `KeepRevisions` attribute instead of the `Versioned` attribute at the property level; for migrating, you're basically looking at a handful of lines changed no matter the mapping (changing a class import and annotation/attribute when using that mapping, XML goes from `<gedmo:loggable/>` to `<gedmo:revisionable/>` and `<gedmo:versioned/>` to `<gedmo:keep-revisions/>`)
- Fully typed to the extent PHP 7.4 allows