### PR TITLE
[Timestampable] Prevent deprecated ArrayAccess on FieldMapping in doctrine/orm 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ a release.
 ---
 
 ## [Unreleased]
+### Fixed
+- Prevent depected ArrayAccess on FieldMapping in Timestampable ORM with `doctrine/orm` 3
 
 ## [3.16.1]
 ### Fixed


### PR DESCRIPTION
During an upgrade to `doctrine/orm` 3 together with `gedmo/doctrine-extensions` 3.16.1, I noticed a lot of deprecation messages that seem to originate in this package, rather than my application code ;) 

I verified this change by applying a non-backwards compatible version to in my `vendor` directory directly, and the deprecation messages went away.

---

I introduced a small helper method to avoid code duplication around the `instanceof` check. This can be removed when support for `doctrine/orm` 2 is dropped somewhere in the future and replaced with:

```diff
-$this->getType($mapping);
+$mapping->type;
```