### PR TITLE
[Translatable] Ignore notInsertable columns…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ a release.
 ---
 
 ## [Unreleased]
+### Fixed
+- Translatable: Ignore notInsertable columns in postPersist hook
 
 ## [3.16.1]
 ### Fixed

--- a/src/Translatable/Mapping/Event/Adapter/ODM.php
+++ b/src/Translatable/Mapping/Event/Adapter/ODM.php
@@ -139,9 +139,15 @@ final class ODM extends BaseAdapterODM implements TranslatableAdapter
         $data = [];
 
         foreach ($meta->getReflectionProperties() as $fieldName => $reflProp) {
-            if (!$meta->isIdentifier($fieldName)) {
-                $data[$meta->getFieldMapping($fieldName)['name']] = $reflProp->getValue($translation);
+            if ($meta->isIdentifier($fieldName)) {
+                continue;
             }
+            $fieldMappings = $meta->getFieldMapping($fieldName);
+            if (($fieldMappings['notSaved'] ?? false) === true) {
+                continue;
+            }
+
+            $data[$meta->getFieldMapping($fieldName)['name']] = $reflProp->getValue($translation);
         }
 
         $insertResult = $collection->insertOne($data);

--- a/src/Translatable/Mapping/Event/Adapter/ORM.php
+++ b/src/Translatable/Mapping/Event/Adapter/ORM.php
@@ -195,11 +195,16 @@ final class ORM extends BaseAdapterORM implements TranslatableAdapter
         $data = [];
 
         foreach ($meta->getReflectionProperties() as $fieldName => $reflProp) {
-            if (!$meta->isIdentifier($fieldName)) {
-                $data[$meta->getColumnName($fieldName)] = $reflProp->getValue($translation);
+            if ($meta->isIdentifier($fieldName)) {
+                continue;
             }
-        }
+            $fieldMappings = $meta->getFieldMapping($fieldName);
+            if (($fieldMappings['notInsertable'] ?? false) === true) {
+                continue;
+            }
 
+            $data[$meta->getColumnName($fieldName)] = $reflProp->getValue($translation);
+        }
         $table = $meta->getTableName();
         if (!$em->getConnection()->insert($table, $data)) {
             throw new RuntimeException('Failed to insert new Translation record');

--- a/tests/Gedmo/Translatable/EntityTranslationCollectionTest.php
+++ b/tests/Gedmo/Translatable/EntityTranslationCollectionTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Translatable;
+
+use Doctrine\Common\EventManager;
+use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
+use Gedmo\Tests\Tool\BaseTestCaseMongoODM;
+use Gedmo\Tests\Translatable\Fixture\Document\TranslationCollection\Person;
+use Gedmo\Tests\Translatable\Fixture\Document\TranslationCollection\PersonTranslation;
+use Gedmo\Translatable\Document\Repository\TranslationRepository;
+use Gedmo\Translatable\TranslatableListener;
+
+/**
+ * These are tests for translatable behavior
+ *
+ * @author Dominik Grothaus <dominik@dodo-softworks.de>
+ */
+class EntityTranslationCollectionTest extends BaseTestCaseMongoODM
+{
+    private const PERSON = Person::class;
+    private const TRANSLATION = PersonTranslation::class;
+
+    private TranslatableListener $translatableListener;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $evm = new EventManager();
+        $this->translatableListener = new TranslatableListener();
+        $this->translatableListener->setDefaultLocale('en_US');
+        $this->translatableListener->setTranslatableLocale('en_US');
+        $evm->addEventSubscriber($this->translatableListener);
+
+        $this->getDefaultDocumentManager($evm);
+    }
+
+    public function testFixtureGeneratedTranslations(): void
+    {
+        $person = new (self::PERSON)();
+        $person->setName('name in en');
+
+        $this->dm->persist($person);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $repo = $this->dm->getRepository(self::TRANSLATION);
+        static::assertInstanceOf(TranslationRepository::class, $repo);
+
+        $translations = $repo->findTranslations($person);
+        // As Translate locale and Default locale are the same, no records should be present in translations table
+        static::assertCount(0, $translations);
+
+        // test second translations
+        $person = $this->dm->find(self::PERSON, $person->getId());
+        $this->translatableListener->setTranslatableLocale('de_DE');
+        $person->setName('name in de');
+
+        $this->dm->persist($person);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $translations = $repo->findTranslations($person);
+        // Only one translation should be present
+        static::assertCount(1, $translations);
+        static::assertArrayHasKey('de_DE', $translations);
+
+        static::assertArrayHasKey('name', $translations['de_DE']);
+        static::assertSame('name in de', $translations['de_DE']['name']);
+
+        $this->translatableListener->setTranslatableLocale('en_US');
+    }
+
+    public function testShouldPersistDefaultLocaleValue(): void
+    {
+        $this->translatableListener->setPersistDefaultLocaleTranslation(true);
+
+        $person = new (self::PERSON)();
+        $person->setName('de_DE');
+
+        /** @var TranslationRepository $translationRepository */
+        $translationRepository = $this->dm->getRepository(self::TRANSLATION);
+        $translationRepository
+            ->translate($person, 'name', 'de_DE', 'de_DE')
+            ->translate($person, 'name', 'en_US', 'en_US');
+        $this->dm->persist($person);
+        $this->dm->flush();
+
+        $this->translatableListener->setTranslatableLocale('en_US');
+
+        /** @var DocumentRepository<Person> $personRepository */
+        $personRepository = $this->dm->getRepository(self::PERSON);
+        $persons = $personRepository
+            ->createQueryBuilder()
+            ->hydrate(false)
+            ->find()
+            ->getQuery()
+            ->getIterator()
+            ->toArray()
+        ;
+        static::assertSame('en_US', $persons[0]['name']);
+
+        $trans = $translationRepository
+            ->createQueryBuilder()
+            ->hydrate(false)
+            ->find()
+            ->getQuery()
+            ->getIterator()
+            ->toArray()
+        ;
+        static::assertCount(2, $trans);
+        foreach ($trans as $item) {
+            static::assertSame($item['locale'], $item['content']);
+        }
+        $this->translatableListener->setTranslatableLocale('en_US');
+    }
+}

--- a/tests/Gedmo/Translatable/Fixture/Document/TranslationCollection/Person.php
+++ b/tests/Gedmo/Translatable/Fixture/Document/TranslationCollection/Person.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and licence information, please view the LICENCE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Translatable\Fixture\Document\TranslationCollection;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * @ODM\Document(collection="persons")
+ */
+#[ODM\Document(collection: 'persons')]
+#[Gedmo\TranslationEntity(class: PersonTranslation::class)]
+class Person
+{
+    /**
+     * @var ?string
+     * @ODM\Id
+     */
+    #[ODM\Id]
+    private ?string $id = null;
+
+    /**
+     * @Gedmo\Translatable
+     *
+     * @ODM\Field(name="name", type="string")
+     */
+    #[Gedmo\Translatable]
+    #[ODM\Field(name: 'name', type: Types::STRING)]
+    private ?string $name = null;
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    public function setName(?string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+}

--- a/tests/Gedmo/Translatable/Fixture/Document/TranslationCollection/PersonTranslation.php
+++ b/tests/Gedmo/Translatable/Fixture/Document/TranslationCollection/PersonTranslation.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Translatable\Fixture\Document\TranslationCollection;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Gedmo\Translatable\Document\MappedSuperclass\AbstractTranslation;
+use Gedmo\Translatable\Document\Repository\TranslationRepository;
+
+/**
+ * Gedmo\Translatable\Document\Translation
+ *
+ * @ODM\Document(
+ *     collection="ext_translations",
+ *     repositoryClass="Gedmo\Translatable\Document\Repository\TranslationRepository"
+ * )
+ * @ODM\UniqueIndex(name="lookup_unique_idx", keys={
+ *     "locale": "asc",
+ *     "object_class": "asc",
+ *     "foreign_key": "asc",
+ *     "field": "asc"
+ * })
+ * @ODM\Index(name="translations_lookup_idx", keys={
+ *     "locale": "asc",
+ *     "object_class": "asc",
+ *     "foreign_key": "asc"
+ * })
+ */
+#[ODM\Document(collection: 'ext_translations', repositoryClass: TranslationRepository::class)]
+#[ODM\UniqueIndex(keys: [
+    'locale' => 'asc',
+    'object_class' => 'asc',
+    'foreign_key' => 'asc',
+    'field' => 'asc',
+], name: 'lookup_unique_idx'
+)]
+#[ODM\Index(keys: [
+    'locale' => 'asc',
+    'object_class' => 'asc',
+    'foreign_key' => 'asc',
+], name: 'translations_lookup_idx'
+)]
+class PersonTranslation extends AbstractTranslation
+{
+    /**
+     * @ODM\Field(
+     *     name="full_name",
+     *     type= Types::STRING,
+     *     nullable= true,
+     *     notSaved= true,
+     * )
+     */
+    #[ODM\Field(
+        name: 'full_name',
+        type: Types::STRING,
+        nullable: true,
+        notSaved: true,
+    )]
+    protected ?string $fullName = null;
+
+    public function getFullName(): ?string
+    {
+        return $this->fullName;
+    }
+}

--- a/tests/Gedmo/Translatable/Fixture/PersonTranslation.php
+++ b/tests/Gedmo/Translatable/Fixture/PersonTranslation.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Gedmo\Tests\Translatable\Fixture;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Translatable\Entity\MappedSuperclass\AbstractTranslation;
 use Gedmo\Translatable\Entity\Repository\TranslationRepository;
@@ -33,4 +34,30 @@ use Gedmo\Translatable\Entity\Repository\TranslationRepository;
 #[ORM\UniqueConstraint(name: 'lookup_unique_idx', columns: ['locale', 'object_Class', 'foreign_key', 'field'])]
 class PersonTranslation extends AbstractTranslation
 {
+    /**
+     * @ORM\Column (
+     *     name: 'full_name',
+     *     type: Types::STRING,
+     *     length: 256,
+     *     nullable: true,
+     *     insertable: false,
+     *     updatable: false,
+     *     generated: 'ALWAYS'
+     * )
+     */
+    #[ORM\Column(
+        name: 'full_name',
+        type: Types::STRING,
+        length: 256,
+        nullable: true,
+        insertable: false,
+        updatable: false,
+        generated: 'ALWAYS'
+    )]
+    protected ?string $fullName = null;
+
+    public function getFullName(): ?string
+    {
+        return $this->fullName;
+    }
 }


### PR DESCRIPTION
in postPersist hook.

Respect the column's metadata and don't attempt to insert a column that's flagged to be not-insertable.

When a custom Translation class configures a field that is flagged as not insertable

```php
#[ORM\Column(
    insertable: false
)]
```

then don't attempt to insert the field in the postPersist hook.

While this works with MySql and MariaDB, inserting a generated column in Postgres throws an error.

```error
cannot insert a non-DEFAULT value
```