### PR TITLE
Fix PHPUnit config to restore Codecov support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 bin
 vendor
 composer.lock
+coverage.xml
 phpstan.neon
 .phpunit.result.cache
-tests/phpunit.xml
+phpunit.xml

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,11 +9,11 @@
     processIsolation="false"
     stopOnFailure="false"
     bootstrap="./tests/bootstrap.php"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
 >
     <coverage>
         <include>
-            <directory>../src</directory>
+            <directory>./src</directory>
         </include>
     </coverage>
     <testsuites>


### PR DESCRIPTION
After #2818 it looks like Codecov hasn't been working because the coverage config was looking for the wrong source path.  That's been fixed.  A couple other minor QoL improvements:

- Updates `.gitignore` to ignore a `phpunit.xml` at root instead of inside the tests folder, making local edits easier (don't have to add the `-c tests/phpunit.xml` config anymore to not use the dist file)
- Adds the code coverage to `.gitignore` (generally won't be there, but doesn't hurt since I copied the command out of the GHA config to make sure it actually generated a coverage file)
- Updates the PHPUnit config to use the XSD from the local install instead of a URL, as this regularly falls out-of-date