### PR TITLE
Added the "forceUseAttributeReader" option, which allows you to use AttributeReader automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ a release.
 
 ### Added
 - IP address provider for use with extensions with IP address references (#2928)
+- Mapping Driver: Added option `forceUseAttributeReader`, force the use of AttributeReader for Gedmo attributes ( ignore default XML driver for all  namespaces) (#2613)
 
 ## [3.19.0] - 2025-02-24
 ### Added

--- a/src/Mapping/MappedEventSubscriber.php
+++ b/src/Mapping/MappedEventSubscriber.php
@@ -99,10 +99,20 @@ abstract class MappedEventSubscriber implements EventSubscriber
 
     private ?ClockInterface $clock = null;
 
+    /**
+     * Ignore doctrine driver class and force  use attribute reader for gedmo properties
+     * @var bool
+     */
+    private $forceUseAttributeReader = false;
+
     public function __construct()
     {
         $parts = explode('\\', $this->getNamespace());
         $this->name = end($parts);
+    }
+
+    public  function setForceUseAttributeReader(bool $forceUseAttributeReader) {
+        $this->forceUseAttributeReader = $forceUseAttributeReader;
     }
 
     /**
@@ -166,7 +176,8 @@ abstract class MappedEventSubscriber implements EventSubscriber
                 $objectManager,
                 $this->getNamespace(),
                 $this->annotationReader,
-                $this->getCacheItemPool($objectManager)
+                $this->getCacheItemPool($objectManager),
+                $this->forceUseAttributeReader
             );
         }
 

--- a/tests/Gedmo/Mapping/Driver/Xml/Gedmo.Tests.Mapping.Fixture.Xml.SeparateDoctrineMapping.dcm.xml
+++ b/tests/Gedmo/Mapping/Driver/Xml/Gedmo.Tests.Mapping.Fixture.Xml.SeparateDoctrineMapping.dcm.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" >
+    <entity name="Gedmo\Tests\Mapping\Fixture\Xml\SeparateDoctrineMapping" table="separate_doctrine_mapping">
+        <id name="id" type="integer" column="id">
+            <generator strategy="AUTO"/>
+        </id>
+        <field name="title" type="string"/>
+        <field name="created" type="datetime"/>
+        <field name="updated" type="datetime"/>
+    </entity>
+</doctrine-mapping>

--- a/tests/Gedmo/Mapping/Fixture/Xml/SeparateDoctrineMapping.php
+++ b/tests/Gedmo/Mapping/Fixture/Xml/SeparateDoctrineMapping.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Mapping\Fixture\Xml;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+class SeparateDoctrineMapping
+{
+    /**
+     * @var int
+     */
+    private $id;
+
+    private $title;
+
+    /**
+     * @var \DateTime
+     */
+    #[Gedmo\Timestampable(on: 'create')]
+    private $created;
+    /**
+     * @var \DateTime
+     */
+    #[Gedmo\Timestampable(on: 'update')]
+    private $updated;
+}

--- a/tests/Gedmo/Mapping/SeparateWithDoctrineDriverMappingTest.php
+++ b/tests/Gedmo/Mapping/SeparateWithDoctrineDriverMappingTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Mapping;
+
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+use Doctrine\ORM\Mapping\Driver\YamlDriver;
+use Gedmo\Tests\Mapping\Fixture\Category;
+use Gedmo\Tests\Mapping\Fixture\Xml\SeparateDoctrineMapping;
+use Gedmo\Tests\Mapping\Fixture\Xml\Timestampable;
+use Gedmo\Tests\Mapping\ORMMappingTestCase;
+use Gedmo\Timestampable\TimestampableListener;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * These are mapping tests for timestampable extension
+ *
+ * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ */
+final class SeparateWithDoctrineDriverMappingTest extends ORMMappingTestCase
+{
+    private EntityManager $em;
+    private EntityManager $emWithForceAttr;
+    /**
+     * @var CacheItemPoolInterface
+     */
+    protected $cacheWithForceAttr;
+
+    protected function setUp(): void
+    {
+        if (PHP_VERSION_ID < 80000) {
+            self::markTestSkipped('Test requires PHP 8.');
+        }
+
+        parent::setUp();
+
+        // Base Configuration without forceUseAttributeReader option
+        $listener = new TimestampableListener();
+        $listener->setCacheItemPool($this->cache);
+
+        $this->em = $this->getBasicEntityManager();
+        $this->em->getEventManager()->addEventSubscriber($listener);
+
+
+        // Configuration with forceUseAttributeReader option
+        $this->cacheWithForceAttr = new ArrayAdapter();
+        $listener = new TimestampableListener();
+        $listener->setCacheItemPool($this->cacheWithForceAttr);
+        $listener->setForceUseAttributeReader(true);
+        $this->emWithForceAttr = $this->getBasicEntityManager();
+        $this->emWithForceAttr->getEventManager()->addEventSubscriber($listener);
+
+
+    }
+
+
+    /**
+     * @return \Generator<string, array{class-string}>
+     *
+     * @note the XML fixture has a different mapping from the other configs, so it is tested separately
+     */
+    public static function dataTimestampableObject(): \Generator
+    {
+        yield 'Model with separated doctrine(XML Driver), gedmo(Attribute Driver)' => [SeparateDoctrineMapping::class, false, true];
+        yield 'Model without attributes (XML Driver only)' => [Timestampable::class, false, false];
+        yield 'Model with attributes (Attribute Driver only)' => [Category::class, true, true];
+
+    }
+
+    /**
+     * @param class-string $className
+     *
+     * @dataProvider dataTimestampableObject
+     */
+    public function testForceGedmoInAttributeDriverMapping(string $className, bool $doctrineMappingInAttributes, bool $gedmoMappingInAttributes): void
+    {
+        // This entityManager configured to enforce the use of attributes for gedmo.
+        $em = $this->emWithForceAttr;
+        $cache = $this->cacheWithForceAttr;
+        $em->getClassMetadata($className);
+
+        $this->em->getClassMetadata($className);
+        $cacheId = ExtensionMetadataFactory::getCacheId($className, 'Gedmo\Timestampable');
+        $config = $cache->getItem($cacheId)->get();
+
+        if($gedmoMappingInAttributes) {
+            static::assertArrayHasKey('create', $config);
+            static::assertSame('created', $config['create'][0]);
+            static::assertArrayHasKey('update', $config);
+            static::assertSame('updated', $config['update'][0]);
+        }else{
+            static::assertArrayNotHasKey('create', $config);
+            static::assertArrayNotHasKey('update', $config);
+        }
+    }
+    /**
+     * @param class-string $className
+     *
+     * @dataProvider dataTimestampableObject
+     */
+    public function testStandardWayMapping(string $className, bool $doctrineMappingInAttributes, bool $gedmoMappingInAttributes): void
+    {
+        $em = $this->em;
+        $cache = $this->cache;
+        $em->getClassMetadata($className);
+
+        $this->em->getClassMetadata($className);
+        $cacheId = ExtensionMetadataFactory::getCacheId($className, 'Gedmo\Timestampable');
+        $config = $cache->getItem($cacheId)->get();
+
+        if($gedmoMappingInAttributes && !$doctrineMappingInAttributes) {
+            // example: doctrine use XmlDriver, Gedmo - use AttributeDriver,
+            // Gedmo attributes - unreadable
+            static::assertArrayNotHasKey('create', $config);
+            static::assertArrayNotHasKey('update', $config);
+        }else{
+            static::assertArrayHasKey('create', $config);
+            static::assertSame('created', $config['create'][0]);
+            static::assertArrayHasKey('update', $config);
+            static::assertSame('updated', $config['update'][0]);
+        }
+
+    }
+
+}


### PR DESCRIPTION
Closes https://github.com/doctrine-extensions/DoctrineExtensions/issues/2613 and https://github.com/doctrine-extensions/DoctrineExtensions/issues/2318

Added "forceUseAttributeReader" option to force use of the attribute reader for Gedmo attributes. Even if the project for Entity is in different NS, the XML driver is used.

By setting this option, Gedmo will only use the attribute reader to retrieve Gedmo meta information with entity settings. This does not affect the operation of Doctrine in any way.
The revision allows you to remove the Gedmo mapping from XML files in projects that use an ORM description in XML format.

Because Doctrine now prohibits placing third-party descriptions in XML files that do not comply with the doctrine schema.

The change with this modification is separated from the other [MR](https://github.com/doctrine-extensions/DoctrineExtensions/pull/2657), where 2 solutions were proposed.

Some projects (Symfony) will also require changes similar to those in the StofDoctrineExtensionsBundle (PR: https://github.com/stof/StofDoctrineExtensionsBundle/pull/458 )

