### PR TITLE
Add generics for the event subscriber configuration arrays and adapters

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -286,21 +286,6 @@ parameters:
 			path: src/References/ReferencesListener.php
 
 		-
-			message: "#^Call to an undefined method Gedmo\\\\Mapping\\\\Event\\\\AdapterInterface\\:\\:extractIdentifier\\(\\)\\.$#"
-			count: 2
-			path: src/References/ReferencesListener.php
-
-		-
-			message: "#^Call to an undefined method Gedmo\\\\Mapping\\\\Event\\\\AdapterInterface\\:\\:getIdentifier\\(\\)\\.$#"
-			count: 1
-			path: src/References/ReferencesListener.php
-
-		-
-			message: "#^Call to an undefined method Gedmo\\\\Mapping\\\\Event\\\\AdapterInterface\\:\\:getSingleReference\\(\\)\\.$#"
-			count: 1
-			path: src/References/ReferencesListener.php
-
-		-
 			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\<object\\>\\:\\:getReflectionProperty\\(\\)\\.$#"
 			count: 2
 			path: src/Sluggable/Handler/InversedRelativeSlugHandler.php
@@ -399,11 +384,6 @@ parameters:
 			message: "#^Method Gedmo\\\\SoftDeleteable\\\\Query\\\\TreeWalker\\\\SoftDeleteableWalker\\:\\:__construct\\(\\) has parameter \\$query with no type specified\\.$#"
 			count: 1
 			path: src/SoftDeleteable/Query/TreeWalker/SoftDeleteableWalker.php
-
-		-
-			message: "#^Call to an undefined method Gedmo\\\\Mapping\\\\Event\\\\AdapterInterface\\:\\:getDateValue\\(\\)\\.$#"
-			count: 1
-			path: src/SoftDeleteable/SoftDeleteableListener.php
 
 		-
 			message: "#^Access to offset 'inherited' on an unknown class Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\AssociationFieldMapping\\.$#"

--- a/src/AbstractTrackingListener.php
+++ b/src/AbstractTrackingListener.php
@@ -27,6 +27,11 @@ use Gedmo\Mapping\MappedEventSubscriber;
 /**
  * The AbstractTrackingListener provides generic functions for all listeners.
  *
+ * @phpstan-template TConfig of array
+ * @phpstan-template TEventAdapter of AdapterInterface
+ *
+ * @phpstan-extends MappedEventSubscriber<TConfig, TEventAdapter>
+ *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
 abstract class AbstractTrackingListener extends MappedEventSubscriber

--- a/src/Blameable/BlameableListener.php
+++ b/src/Blameable/BlameableListener.php
@@ -11,11 +11,14 @@ namespace Gedmo\Blameable;
 
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Gedmo\AbstractTrackingListener;
+use Gedmo\Blameable\Mapping\Event\BlameableAdapter;
 use Gedmo\Exception\InvalidArgumentException;
 
 /**
  * The Blameable listener handles the update of
  * dates on creation and update.
+ *
+ * @phpstan-extends AbstractTrackingListener<array, BlameableAdapter>
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  *

--- a/src/IpTraceable/IpTraceableListener.php
+++ b/src/IpTraceable/IpTraceableListener.php
@@ -12,11 +12,14 @@ namespace Gedmo\IpTraceable;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Gedmo\AbstractTrackingListener;
 use Gedmo\Exception\InvalidArgumentException;
+use Gedmo\IpTraceable\Mapping\Event\IpTraceableAdapter;
 use Gedmo\Mapping\Event\AdapterInterface;
 
 /**
  * The IpTraceable listener handles the update of
  * IPs on creation and update.
+ *
+ * @phpstan-extends AbstractTrackingListener<array, IpTraceableAdapter>
  *
  * @author Pierre-Charles Bertineau <pc.bertineau@alterphp.com>
  *

--- a/src/Loggable/LoggableListener.php
+++ b/src/Loggable/LoggableListener.php
@@ -17,7 +17,6 @@ use Doctrine\Persistence\Event\ManagerEventArgs;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\ObjectManager;
 use Gedmo\Exception\InvalidArgumentException;
-use Gedmo\Loggable\Entity\LogEntry;
 use Gedmo\Loggable\Mapping\Event\LoggableAdapter;
 use Gedmo\Mapping\MappedEventSubscriber;
 use Gedmo\Tool\Wrapper\AbstractWrapper;
@@ -35,11 +34,9 @@ use Gedmo\Tool\Wrapper\AbstractWrapper;
  *   versioned?: string[],
  * }
  *
- * @phpstan-method LoggableConfiguration getConfiguration(ObjectManager $objectManager, $class)
- *
- * @method LoggableAdapter getEventAdapter(EventArgs $args)
- *
  * @phpstan-template T of Loggable|object
+ *
+ * @phpstan-extends MappedEventSubscriber<LoggableConfiguration, LoggableAdapter>
  */
 class LoggableListener extends MappedEventSubscriber
 {

--- a/src/Mapping/MappedEventSubscriber.php
+++ b/src/Mapping/MappedEventSubscriber.php
@@ -27,9 +27,6 @@ use Gedmo\Exception\InvalidArgumentException;
 use Gedmo\Mapping\Driver\AttributeReader;
 use Gedmo\Mapping\Event\AdapterInterface;
 use Gedmo\Mapping\Event\ClockAwareAdapterInterface;
-use Gedmo\ReferenceIntegrity\Mapping\Validator as ReferenceIntegrityValidator;
-use Gedmo\Uploadable\FilenameGenerator\FilenameGeneratorInterface;
-use Gedmo\Uploadable\Mapping\Validator as MappingValidator;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Clock\ClockInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
@@ -42,6 +39,9 @@ use Symfony\Component\Cache\Adapter\ArrayAdapter;
  * It dries up some reusable code which is common for
  * all extensions who maps additional metadata through
  * extended drivers
+ *
+ * @phpstan-template TConfig of array
+ * @phpstan-template TEventAdapter of AdapterInterface
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
@@ -115,24 +115,7 @@ abstract class MappedEventSubscriber implements EventSubscriber
      *
      * @return array<string, mixed>
      *
-     * @phpstan-return array{
-     *  useObjectClass?: class-string,
-     *  referenceIntegrity?: array<string, array<string, value-of<ReferenceIntegrityValidator::INTEGRITY_ACTIONS>>>,
-     *  filePathField?: string,
-     *  uploadable?: bool,
-     *  fileNameField?: string,
-     *  allowOverwrite?: bool,
-     *  appendNumber?: bool,
-     *  maxSize?: float,
-     *  path?: string,
-     *  pathMethod?: string,
-     *  allowedTypes?: string[],
-     *  disallowedTypes?: string[],
-     *  filenameGenerator?: MappingValidator::FILENAME_GENERATOR_*|class-string<FilenameGeneratorInterface>,
-     *  fileMimeTypeField?: string,
-     *  fileSizeField?: string,
-     *  callback?: string,
-     * }
+     * @phpstan-return TConfig
      */
     public function getConfiguration(ObjectManager $objectManager, $class)
     {
@@ -273,6 +256,8 @@ abstract class MappedEventSubscriber implements EventSubscriber
      * @throws InvalidArgumentException if event is not recognized
      *
      * @return AdapterInterface
+     *
+     * @phpstan-return TEventAdapter
      */
     protected function getEventAdapter(EventArgs $args)
     {

--- a/src/ReferenceIntegrity/ReferenceIntegrityListener.php
+++ b/src/ReferenceIntegrity/ReferenceIntegrityListener.php
@@ -16,11 +16,14 @@ use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\ObjectManager;
 use Gedmo\Exception\InvalidMappingException;
 use Gedmo\Exception\ReferenceIntegrityStrictException;
+use Gedmo\Mapping\Event\AdapterInterface;
 use Gedmo\Mapping\MappedEventSubscriber;
 use Gedmo\ReferenceIntegrity\Mapping\Validator;
 
 /**
  * The ReferenceIntegrity listener handles the reference integrity on related documents
+ *
+ * @phpstan-extends MappedEventSubscriber<array, AdapterInterface>
  *
  * @author Evert Harmeling <evert.harmeling@freshheads.com>
  *

--- a/src/References/ReferencesListener.php
+++ b/src/References/ReferencesListener.php
@@ -16,6 +16,7 @@ use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\ObjectManager;
 use Gedmo\Mapping\MappedEventSubscriber;
+use Gedmo\References\Mapping\Event\ReferencesAdapter;
 
 /**
  * Listener for loading and persisting cross database references.
@@ -39,7 +40,7 @@ use Gedmo\Mapping\MappedEventSubscriber;
  *   useObjectClass?: class-string,
  * }
  *
- * @phpstan-method ReferencesConfiguration getConfiguration(ObjectManager $objectManager, $class)
+ * @phpstan-extends MappedEventSubscriber<ReferencesConfiguration, ReferencesAdapter>
  *
  * @final since gedmo/doctrine-extensions 3.11
  */

--- a/src/Sluggable/SluggableListener.php
+++ b/src/Sluggable/SluggableListener.php
@@ -65,9 +65,7 @@ use Gedmo\Sluggable\Util\Urlizer;
  *   useObjectClass?: class-string,
  * }
  *
- * @phpstan-method SluggableConfiguration getConfiguration(ObjectManager $objectManager, $class)
- *
- * @method SluggableAdapter getEventAdapter(EventArgs $args)
+ * @phpstan-extends MappedEventSubscriber<SluggableConfiguration, SluggableAdapter>
  */
 class SluggableListener extends MappedEventSubscriber
 {

--- a/src/SoftDeleteable/SoftDeleteableListener.php
+++ b/src/SoftDeleteable/SoftDeleteableListener.php
@@ -23,9 +23,12 @@ use Doctrine\Persistence\ObjectManager;
 use Gedmo\Mapping\MappedEventSubscriber;
 use Gedmo\SoftDeleteable\Event\PostSoftDeleteEventArgs;
 use Gedmo\SoftDeleteable\Event\PreSoftDeleteEventArgs;
+use Gedmo\SoftDeleteable\Mapping\Event\SoftDeleteableAdapter;
 
 /**
  * SoftDeleteable listener
+ *
+ * @phpstan-extends MappedEventSubscriber<array, SoftDeleteableAdapter>
  *
  * @author Gustavo Falco <comfortablynumb84@gmail.com>
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>

--- a/src/Sortable/SortableListener.php
+++ b/src/Sortable/SortableListener.php
@@ -47,9 +47,7 @@ use ProxyManager\Proxy\GhostObjectInterface;
  *   }>,
  * }
  *
- * @phpstan-method SortableConfiguration getConfiguration(ObjectManager $objectManager, $class)
- *
- * @method SortableAdapter getEventAdapter(EventArgs $args)
+ * @phpstan-extends MappedEventSubscriber<SortableConfiguration, SortableAdapter>
  *
  * @final since gedmo/doctrine-extensions 3.11
  */

--- a/src/Timestampable/TimestampableListener.php
+++ b/src/Timestampable/TimestampableListener.php
@@ -19,6 +19,8 @@ use Gedmo\Timestampable\Mapping\Event\TimestampableAdapter;
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  *
+ * @phpstan-extends AbstractTrackingListener<array, TimestampableAdapter>
+ *
  * @final since gedmo/doctrine-extensions 3.11
  */
 class TimestampableListener extends AbstractTrackingListener

--- a/src/Translatable/TranslatableListener.php
+++ b/src/Translatable/TranslatableListener.php
@@ -45,9 +45,7 @@ use Gedmo\Translatable\Mapping\Event\TranslatableAdapter;
  *   useObjectClass?: class-string,
  * }
  *
- * @phpstan-method TranslatableConfiguration getConfiguration(ObjectManager $objectManager, $class)
- *
- * @method TranslatableAdapter getEventAdapter(EventArgs $args)
+ * @phpstan-extends MappedEventSubscriber<TranslatableConfiguration, TranslatableAdapter>
  *
  * @final since gedmo/doctrine-extensions 3.11
  */

--- a/src/Tree/TreeListener.php
+++ b/src/Tree/TreeListener.php
@@ -52,9 +52,7 @@ use Gedmo\Tree\Mapping\Event\TreeAdapter;
  *   level_base?: int,
  * }
  *
- * @phpstan-method TreeConfiguration getConfiguration(ObjectManager $objectManager, $class)
- *
- * @method TreeAdapter getEventAdapter(EventArgs $args)
+ * @phpstan-extends MappedEventSubscriber<TreeConfiguration, TreeAdapter>
  */
 class TreeListener extends MappedEventSubscriber
 {

--- a/src/Uploadable/UploadableListener.php
+++ b/src/Uploadable/UploadableListener.php
@@ -37,6 +37,7 @@ use Gedmo\Uploadable\Event\UploadablePostFileProcessEventArgs;
 use Gedmo\Uploadable\Event\UploadablePreFileProcessEventArgs;
 use Gedmo\Uploadable\FileInfo\FileInfoArray;
 use Gedmo\Uploadable\FileInfo\FileInfoInterface;
+use Gedmo\Uploadable\FilenameGenerator\FilenameGeneratorInterface;
 use Gedmo\Uploadable\Mapping\Validator;
 use Gedmo\Uploadable\MimeType\MimeTypeGuesser;
 use Gedmo\Uploadable\MimeType\MimeTypeGuesserInterface;
@@ -46,6 +47,25 @@ use Gedmo\Uploadable\MimeType\MimeTypeGuesserInterface;
  *
  * @author Gustavo Falco <comfortablynumb84@gmail.com>
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ *
+ * @phpstan-type UploadableConfiguration = array{
+ *  filePathField?: string,
+ *  uploadable?: bool,
+ *  fileNameField?: string,
+ *  allowOverwrite?: bool,
+ *  appendNumber?: bool,
+ *  maxSize?: float,
+ *  path?: string,
+ *  pathMethod?: string,
+ *  allowedTypes?: string[],
+ *  disallowedTypes?: string[],
+ *  filenameGenerator?: Validator::FILENAME_GENERATOR_*|class-string<FilenameGeneratorInterface>,
+ *  fileMimeTypeField?: string,
+ *  fileSizeField?: string,
+ *  callback?: string,
+ * }
+ *
+ * @phpstan-extends MappedEventSubscriber<UploadableConfiguration, AdapterInterface>
  */
 class UploadableListener extends MappedEventSubscriber
 {

--- a/tests/Gedmo/Mapping/Mock/EventSubscriberCustomMock.php
+++ b/tests/Gedmo/Mapping/Mock/EventSubscriberCustomMock.php
@@ -15,6 +15,9 @@ use Doctrine\Common\EventArgs;
 use Gedmo\Mapping\Event\AdapterInterface;
 use Gedmo\Mapping\MappedEventSubscriber;
 
+/**
+ * @phpstan-extends MappedEventSubscriber<array, AdapterInterface>
+ */
 final class EventSubscriberCustomMock extends MappedEventSubscriber
 {
     public function getAdapter(EventArgs $args): AdapterInterface

--- a/tests/Gedmo/Mapping/Mock/EventSubscriberMock.php
+++ b/tests/Gedmo/Mapping/Mock/EventSubscriberMock.php
@@ -15,6 +15,9 @@ use Doctrine\Common\EventArgs;
 use Gedmo\Mapping\Event\AdapterInterface;
 use Gedmo\Mapping\MappedEventSubscriber;
 
+/**
+ * @phpstan-extends MappedEventSubscriber<array, AdapterInterface>
+ */
 final class EventSubscriberMock extends MappedEventSubscriber
 {
     public function getAdapter(EventArgs $args): AdapterInterface

--- a/tests/Gedmo/Mapping/Mock/Extension/Encoder/EncoderListener.php
+++ b/tests/Gedmo/Mapping/Mock/Extension/Encoder/EncoderListener.php
@@ -15,9 +15,13 @@ use Doctrine\Common\EventArgs;
 use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\ObjectManager;
+use Gedmo\Mapping\Event\AdapterInterface;
 use Gedmo\Mapping\Event\AdapterInterface as EventAdapterInterface;
 use Gedmo\Mapping\MappedEventSubscriber;
 
+/**
+ * @phpstan-extends MappedEventSubscriber<array, AdapterInterface>
+ */
 class EncoderListener extends MappedEventSubscriber
 {
     public function getSubscribedEvents(): array

--- a/tests/Gedmo/Timestampable/ChangeTest.php
+++ b/tests/Gedmo/Timestampable/ChangeTest.php
@@ -130,6 +130,9 @@ final class EventAdapterORMStub extends BaseAdapterORM implements TimestampableA
     }
 }
 
+/**
+ * @phpstan-extends AbstractTrackingListener<array, TimestampableAdapter>
+ */
 final class TimestampableListenerStub extends AbstractTrackingListener
 {
     /**


### PR DESCRIPTION
Extracted from #2825

There is already an attempt to document the returned configs and event adapters in the event subscribers using `@method` annotations, but this can be quirky with IDEs (`@method` is read as a virtual method as an example) and there were still some baseline PHPStan issues from the existing setup.  This PR formalizes that through generics by providing templates for the config and adapter interfaces and updating each listener to fill those in (where that info already exists, there are a few extensions where a type for the config still needs to be generated so a generic array is still specified).