### PR TITLE
Add missing token for "codecov/codecov-action" at "upload_coverage" CI job

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -143,3 +143,4 @@ jobs:
         uses: "codecov/codecov-action@v4"
         with:
           directory: reports
+          token: "${{ secrets.CODECOV_TOKEN }}"


### PR DESCRIPTION
Closes #2852.