### PR TITLE
Update tests to use QCNs for fixture classes

### DIFF
--- a/tests/Gedmo/Blameable/BlameableDocumentTest.php
+++ b/tests/Gedmo/Blameable/BlameableDocumentTest.php
@@ -27,8 +27,6 @@ final class BlameableDocumentTest extends BaseTestCaseMongoODM
 {
     private const TEST_USERNAME = 'testuser';
 
-    private const ARTICLE = Article::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -50,7 +48,7 @@ final class BlameableDocumentTest extends BaseTestCaseMongoODM
 
     public function testBlameable(): void
     {
-        $repo = $this->dm->getRepository(self::ARTICLE);
+        $repo = $this->dm->getRepository(Article::class);
         $article = $repo->findOneBy(['title' => 'Blameable Article']);
 
         static::assertSame(self::TEST_USERNAME, $article->getCreated());
@@ -81,7 +79,7 @@ final class BlameableDocumentTest extends BaseTestCaseMongoODM
         $this->dm->persist($sport);
         $this->dm->flush();
 
-        $repo = $this->dm->getRepository(self::ARTICLE);
+        $repo = $this->dm->getRepository(Article::class);
         $sport = $repo->findOneBy(['title' => 'sport forced']);
         static::assertSame(self::TEST_USERNAME, $sport->getCreated());
         static::assertSame(self::TEST_USERNAME, $sport->getUpdated());

--- a/tests/Gedmo/Blameable/BlameableTest.php
+++ b/tests/Gedmo/Blameable/BlameableTest.php
@@ -26,10 +26,6 @@ use Gedmo\Tests\Tool\BaseTestCaseORM;
  */
 final class BlameableTest extends BaseTestCaseORM
 {
-    private const ARTICLE = Article::class;
-    private const COMMENT = Comment::class;
-    private const TYPE = Type::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -62,12 +58,12 @@ final class BlameableTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $sport = $this->em->getRepository(self::ARTICLE)->findOneBy(['title' => 'Sport']);
+        $sport = $this->em->getRepository(Article::class)->findOneBy(['title' => 'Sport']);
         static::assertSame('testuser', $sport->getCreated());
         static::assertSame('testuser', $sport->getUpdated());
         static::assertNull($sport->getPublished());
 
-        $sportComment = $this->em->getRepository(self::COMMENT)->findOneBy(['message' => 'hello']);
+        $sportComment = $this->em->getRepository(Comment::class)->findOneBy(['message' => 'hello']);
         static::assertSame('testuser', $sportComment->getModified());
         static::assertNull($sportComment->getClosed());
 
@@ -83,7 +79,7 @@ final class BlameableTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $sportComment = $this->em->getRepository(self::COMMENT)->findOneBy(['message' => 'hello']);
+        $sportComment = $this->em->getRepository(Comment::class)->findOneBy(['message' => 'hello']);
         static::assertSame('testuser', $sportComment->getClosed());
 
         static::assertSame('testuser', $sport->getPublished());
@@ -100,7 +96,7 @@ final class BlameableTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $repo = $this->em->getRepository(self::ARTICLE);
+        $repo = $this->em->getRepository(Article::class);
         $sport = $repo->findOneBy(['title' => 'sport forced']);
         static::assertSame('myuser', $sport->getCreated());
         static::assertSame('myuser', $sport->getUpdated());
@@ -122,9 +118,9 @@ final class BlameableTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::ARTICLE,
-            self::COMMENT,
-            self::TYPE,
+            Article::class,
+            Comment::class,
+            Type::class,
         ];
     }
 }

--- a/tests/Gedmo/Blameable/BlameableUuidTest.php
+++ b/tests/Gedmo/Blameable/BlameableUuidTest.php
@@ -21,8 +21,6 @@ use Symfony\Component\Uid\UuidV6;
 
 final class BlameableUuidTest extends BaseTestCaseORM
 {
-    private const COMPANY = Company::class;
-
     private UuidV6 $uuid;
 
     protected function setUp(): void
@@ -54,7 +52,7 @@ final class BlameableUuidTest extends BaseTestCaseORM
         /**
          * @var Company $foundCompany
          */
-        $foundCompany = $this->em->getRepository(self::COMPANY)->findOneBy(['name' => 'ACME']);
+        $foundCompany = $this->em->getRepository(Company::class)->findOneBy(['name' => 'ACME']);
         $created = $foundCompany->getCreated();
         $createdUuid = $created instanceof Uuid ? $created->toRfc4122() : null;
 
@@ -64,7 +62,7 @@ final class BlameableUuidTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::COMPANY,
+            Company::class,
         ];
     }
 }

--- a/tests/Gedmo/Blameable/ChangeTest.php
+++ b/tests/Gedmo/Blameable/ChangeTest.php
@@ -23,8 +23,6 @@ use Gedmo\Tests\Tool\BaseTestCaseORM;
  */
 final class ChangeTest extends BaseTestCaseORM
 {
-    private const FIXTURE = TitledArticle::class;
-
     private BlameableListener $listener;
 
     protected function setUp(): void
@@ -49,7 +47,7 @@ final class ChangeTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $test = $this->em->getRepository(self::FIXTURE)->findOneBy(['title' => 'Test']);
+        $test = $this->em->getRepository(TitledArticle::class)->findOneBy(['title' => 'Test']);
         $test->setTitle('New Title');
         $this->em->persist($test);
         $this->em->flush();
@@ -59,7 +57,7 @@ final class ChangeTest extends BaseTestCaseORM
 
         $this->listener->setUserValue('otheruser');
 
-        $test = $this->em->getRepository(self::FIXTURE)->findOneBy(['title' => 'New Title']);
+        $test = $this->em->getRepository(TitledArticle::class)->findOneBy(['title' => 'New Title']);
         $test->setText('New Text');
         $this->em->persist($test);
         $this->em->flush();
@@ -71,7 +69,7 @@ final class ChangeTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::FIXTURE,
+            TitledArticle::class,
         ];
     }
 }

--- a/tests/Gedmo/Blameable/NoInterfaceTest.php
+++ b/tests/Gedmo/Blameable/NoInterfaceTest.php
@@ -23,8 +23,6 @@ use Gedmo\Tests\Tool\BaseTestCaseORM;
  */
 final class NoInterfaceTest extends BaseTestCaseORM
 {
-    private const FIXTURE = WithoutInterface::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -46,7 +44,7 @@ final class NoInterfaceTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $test = $this->em->getRepository(self::FIXTURE)->findOneBy(['title' => 'Test']);
+        $test = $this->em->getRepository(WithoutInterface::class)->findOneBy(['title' => 'Test']);
         static::assertSame('testuser', $test->getCreated());
         static::assertSame('testuser', $test->getUpdated());
     }
@@ -54,7 +52,7 @@ final class NoInterfaceTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::FIXTURE,
+            WithoutInterface::class,
         ];
     }
 }

--- a/tests/Gedmo/Blameable/NoUserTest.php
+++ b/tests/Gedmo/Blameable/NoUserTest.php
@@ -23,8 +23,6 @@ use Gedmo\Tests\Tool\BaseTestCaseMongoODM;
  */
 final class NoUserTest extends BaseTestCaseMongoODM
 {
-    private const ARTICLE = Article::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -47,7 +45,7 @@ final class NoUserTest extends BaseTestCaseMongoODM
         $this->dm->flush();
         $this->dm->clear();
 
-        $repo = $this->dm->getRepository(self::ARTICLE);
+        $repo = $this->dm->getRepository(Article::class);
         $sport = $repo->findOneBy(['title' => 'sport no user']);
         static::assertEmpty($sport->getCreated());
         static::assertEmpty($sport->getUpdated());

--- a/tests/Gedmo/Blameable/ProtectedPropertySupperclassTest.php
+++ b/tests/Gedmo/Blameable/ProtectedPropertySupperclassTest.php
@@ -25,9 +25,6 @@ use Gedmo\Translatable\TranslatableListener;
  */
 final class ProtectedPropertySupperclassTest extends BaseTestCaseORM
 {
-    private const SUPERCLASS = SupperClassExtension::class;
-    private const TRANSLATION = Translation::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -53,7 +50,7 @@ final class ProtectedPropertySupperclassTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $repo = $this->em->getRepository(self::TRANSLATION);
+        $repo = $this->em->getRepository(Translation::class);
         $translations = $repo->findTranslations($test);
         static::assertCount(0, $translations);
 
@@ -63,8 +60,8 @@ final class ProtectedPropertySupperclassTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::TRANSLATION,
-            self::SUPERCLASS,
+            Translation::class,
+            SupperClassExtension::class,
         ];
     }
 }

--- a/tests/Gedmo/Blameable/TraitUsageTest.php
+++ b/tests/Gedmo/Blameable/TraitUsageTest.php
@@ -23,8 +23,6 @@ use Gedmo\Tests\Tool\BaseTestCaseORM;
  */
 final class TraitUsageTest extends BaseTestCaseORM
 {
-    private const TARGET = UsingTrait::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -52,14 +50,14 @@ final class TraitUsageTest extends BaseTestCaseORM
     public function testTraitMethodthShouldReturnObject(): void
     {
         $sport = new UsingTrait();
-        static::assertInstanceOf(self::TARGET, $sport->setCreatedBy('myuser'));
-        static::assertInstanceOf(self::TARGET, $sport->setUpdatedBy('myuser'));
+        static::assertInstanceOf(UsingTrait::class, $sport->setCreatedBy('myuser'));
+        static::assertInstanceOf(UsingTrait::class, $sport->setUpdatedBy('myuser'));
     }
 
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::TARGET,
+            UsingTrait::class,
         ];
     }
 }

--- a/tests/Gedmo/IpTraceable/ChangeTest.php
+++ b/tests/Gedmo/IpTraceable/ChangeTest.php
@@ -24,7 +24,6 @@ use Gedmo\Tests\Tool\BaseTestCaseORM;
 final class ChangeTest extends BaseTestCaseORM
 {
     private const TEST_IP = '34.234.1.10';
-    private const FIXTURE = TitledArticle::class;
 
     /**
      * @var IpTraceableListener
@@ -54,7 +53,7 @@ final class ChangeTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $test = $this->em->getRepository(self::FIXTURE)->findOneBy(['title' => 'Test']);
+        $test = $this->em->getRepository(TitledArticle::class)->findOneBy(['title' => 'Test']);
         $test->setTitle('New Title');
         $this->em->persist($test);
         $this->em->flush();
@@ -64,7 +63,7 @@ final class ChangeTest extends BaseTestCaseORM
 
         $this->listener->setIpValue('127.0.0.1');
 
-        $test = $this->em->getRepository(self::FIXTURE)->findOneBy(['title' => 'New Title']);
+        $test = $this->em->getRepository(TitledArticle::class)->findOneBy(['title' => 'New Title']);
         $test->setText('New Text');
         $this->em->persist($test);
         $this->em->flush();
@@ -76,7 +75,7 @@ final class ChangeTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::FIXTURE,
+            TitledArticle::class,
         ];
     }
 }

--- a/tests/Gedmo/IpTraceable/IpTraceableDocumentTest.php
+++ b/tests/Gedmo/IpTraceable/IpTraceableDocumentTest.php
@@ -26,8 +26,6 @@ final class IpTraceableDocumentTest extends BaseTestCaseMongoODM
 {
     private const TEST_IP = '34.234.1.10';
 
-    private const ARTICLE = Article::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -44,7 +42,7 @@ final class IpTraceableDocumentTest extends BaseTestCaseMongoODM
 
     public function testIpTraceable(): void
     {
-        $repo = $this->dm->getRepository(self::ARTICLE);
+        $repo = $this->dm->getRepository(Article::class);
         $article = $repo->findOneBy(['title' => 'IpTraceable Article']);
 
         static::assertSame(self::TEST_IP, $article->getCreated());
@@ -77,7 +75,7 @@ final class IpTraceableDocumentTest extends BaseTestCaseMongoODM
         $this->dm->flush();
         $this->dm->clear();
 
-        $repo = $this->dm->getRepository(self::ARTICLE);
+        $repo = $this->dm->getRepository(Article::class);
         $sport = $repo->findOneBy(['title' => 'sport forced']);
         static::assertSame(self::TEST_IP, (string) $sport->getCreated());
         static::assertSame(self::TEST_IP, $sport->getUpdated());

--- a/tests/Gedmo/IpTraceable/IpTraceableTest.php
+++ b/tests/Gedmo/IpTraceable/IpTraceableTest.php
@@ -31,10 +31,6 @@ final class IpTraceableTest extends BaseTestCaseORM
 {
     private const TEST_IP = '34.234.1.10';
 
-    private const ARTICLE = Article::class;
-    private const COMMENT = Comment::class;
-    private const TYPE = Type::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -98,12 +94,12 @@ final class IpTraceableTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $sport = $this->em->getRepository(self::ARTICLE)->findOneBy(['title' => 'Sport']);
+        $sport = $this->em->getRepository(Article::class)->findOneBy(['title' => 'Sport']);
         static::assertSame(self::TEST_IP, $sport->getCreated());
         static::assertSame(self::TEST_IP, $sport->getUpdated());
         static::assertNull($sport->getPublished());
 
-        $sportComment = $this->em->getRepository(self::COMMENT)->findOneBy(['message' => 'hello']);
+        $sportComment = $this->em->getRepository(Comment::class)->findOneBy(['message' => 'hello']);
         static::assertSame(self::TEST_IP, $sportComment->getModified());
         static::assertNull($sportComment->getClosed());
 
@@ -119,7 +115,7 @@ final class IpTraceableTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $sportComment = $this->em->getRepository(self::COMMENT)->findOneBy(['message' => 'hello']);
+        $sportComment = $this->em->getRepository(Comment::class)->findOneBy(['message' => 'hello']);
         static::assertSame(self::TEST_IP, $sportComment->getClosed());
 
         static::assertSame(self::TEST_IP, $sport->getPublished());
@@ -136,7 +132,7 @@ final class IpTraceableTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $repo = $this->em->getRepository(self::ARTICLE);
+        $repo = $this->em->getRepository(Article::class);
         $sport = $repo->findOneBy(['title' => 'sport forced']);
         static::assertSame(self::TEST_IP, $sport->getCreated());
         static::assertSame(self::TEST_IP, $sport->getUpdated());
@@ -158,9 +154,9 @@ final class IpTraceableTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::ARTICLE,
-            self::COMMENT,
-            self::TYPE,
+            Article::class,
+            Comment::class,
+            Type::class,
         ];
     }
 }

--- a/tests/Gedmo/IpTraceable/NoInterfaceTest.php
+++ b/tests/Gedmo/IpTraceable/NoInterfaceTest.php
@@ -24,7 +24,6 @@ use Gedmo\Tests\Tool\BaseTestCaseORM;
 final class NoInterfaceTest extends BaseTestCaseORM
 {
     private const TEST_IP = '34.234.1.10';
-    private const FIXTURE = WithoutInterface::class;
 
     protected function setUp(): void
     {
@@ -47,7 +46,7 @@ final class NoInterfaceTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $test = $this->em->getRepository(self::FIXTURE)->findOneBy(['title' => 'Test']);
+        $test = $this->em->getRepository(WithoutInterface::class)->findOneBy(['title' => 'Test']);
         static::assertSame(self::TEST_IP, $test->getCreated());
         static::assertSame(self::TEST_IP, $test->getUpdated());
     }
@@ -55,7 +54,7 @@ final class NoInterfaceTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::FIXTURE,
+            WithoutInterface::class,
         ];
     }
 }

--- a/tests/Gedmo/IpTraceable/TraitUsageTest.php
+++ b/tests/Gedmo/IpTraceable/TraitUsageTest.php
@@ -24,7 +24,6 @@ use Gedmo\Tests\Tool\BaseTestCaseORM;
 final class TraitUsageTest extends BaseTestCaseORM
 {
     private const TEST_IP = '34.234.1.10';
-    private const TARGET = UsingTrait::class;
 
     protected function setUp(): void
     {
@@ -60,7 +59,7 @@ final class TraitUsageTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::TARGET,
+            UsingTrait::class,
         ];
     }
 }

--- a/tests/Gedmo/Loggable/LoggableDocumentTest.php
+++ b/tests/Gedmo/Loggable/LoggableDocumentTest.php
@@ -18,6 +18,7 @@ use Gedmo\Loggable\LoggableListener;
 use Gedmo\Tests\Loggable\Fixture\Document\Article;
 use Gedmo\Tests\Loggable\Fixture\Document\Author;
 use Gedmo\Tests\Loggable\Fixture\Document\Comment;
+use Gedmo\Tests\Loggable\Fixture\Document\Log\Comment as CommentLog;
 use Gedmo\Tests\Loggable\Fixture\Document\RelatedArticle;
 use Gedmo\Tests\Tool\BaseTestCaseMongoODM;
 
@@ -29,10 +30,6 @@ use Gedmo\Tests\Tool\BaseTestCaseMongoODM;
  */
 final class LoggableDocumentTest extends BaseTestCaseMongoODM
 {
-    private const ARTICLE = Article::class;
-    private const COMMENT = Comment::class;
-    private const COMMENT_LOG = Fixture\Document\Log\Comment::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -47,7 +44,7 @@ final class LoggableDocumentTest extends BaseTestCaseMongoODM
     public function testLogGeneration(): void
     {
         $logRepo = $this->dm->getRepository(LogEntry::class);
-        $articleRepo = $this->dm->getRepository(self::ARTICLE);
+        $articleRepo = $this->dm->getRepository(Article::class);
         static::assertCount(0, $logRepo->findAll());
 
         $art0 = new Article();
@@ -100,8 +97,8 @@ final class LoggableDocumentTest extends BaseTestCaseMongoODM
     public function testVersionControl(): void
     {
         $this->populate();
-        $commentLogRepo = $this->dm->getRepository(self::COMMENT_LOG);
-        $commentRepo = $this->dm->getRepository(self::COMMENT);
+        $commentLogRepo = $this->dm->getRepository(CommentLog::class);
+        $commentRepo = $this->dm->getRepository(Comment::class);
         static::assertInstanceOf(LogEntryRepository::class, $commentLogRepo);
 
         $comment = $commentRepo->findOneBy(['message' => 'm-v5']);

--- a/tests/Gedmo/Loggable/LoggableEntityTest.php
+++ b/tests/Gedmo/Loggable/LoggableEntityTest.php
@@ -21,6 +21,7 @@ use Gedmo\Tests\Loggable\Fixture\Entity\Composite;
 use Gedmo\Tests\Loggable\Fixture\Entity\CompositeRelation;
 use Gedmo\Tests\Loggable\Fixture\Entity\Geo;
 use Gedmo\Tests\Loggable\Fixture\Entity\GeoLocation;
+use Gedmo\Tests\Loggable\Fixture\Entity\Log\Comment as CommentLog;
 use Gedmo\Tests\Loggable\Fixture\Entity\RelatedArticle;
 use Gedmo\Tests\Tool\BaseTestCaseORM;
 
@@ -31,13 +32,6 @@ use Gedmo\Tests\Tool\BaseTestCaseORM;
  */
 abstract class LoggableEntityTest extends BaseTestCaseORM
 {
-    private const ARTICLE = Article::class;
-    private const COMMENT = Comment::class;
-    private const COMPOSITE = Composite::class;
-    private const COMPOSITE_RELATION = CompositeRelation::class;
-    private const RELATED_ARTICLE = RelatedArticle::class;
-    private const COMMENT_LOG = Fixture\Entity\Log\Comment::class;
-
     public static function setUpBeforeClass(): void
     {
         if (!class_exists(ArrayType::class)) {
@@ -69,7 +63,7 @@ abstract class LoggableEntityTest extends BaseTestCaseORM
     public function testLoggable(): void
     {
         $logRepo = $this->em->getRepository(LogEntry::class);
-        $articleRepo = $this->em->getRepository(self::ARTICLE);
+        $articleRepo = $this->em->getRepository(Article::class);
         static::assertCount(0, $logRepo->findAll());
 
         $art0 = new Article();
@@ -116,8 +110,8 @@ abstract class LoggableEntityTest extends BaseTestCaseORM
     {
         $this->populate();
         /** @var LogEntryRepository<Comment> $commentLogRepo */
-        $commentLogRepo = $this->em->getRepository(self::COMMENT_LOG);
-        $commentRepo = $this->em->getRepository(self::COMMENT);
+        $commentLogRepo = $this->em->getRepository(CommentLog::class);
+        $commentRepo = $this->em->getRepository(Comment::class);
 
         $comment = $commentRepo->find(1);
         static::assertInstanceOf(Comment::class, $comment);
@@ -158,7 +152,7 @@ abstract class LoggableEntityTest extends BaseTestCaseORM
     public function testComposite(): void
     {
         $logRepo = $this->em->getRepository(LogEntry::class);
-        $compositeRepo = $this->em->getRepository(self::COMPOSITE);
+        $compositeRepo = $this->em->getRepository(Composite::class);
         static::assertCount(0, $logRepo->findAll());
 
         $compositeIds = [1, 2];
@@ -208,7 +202,7 @@ abstract class LoggableEntityTest extends BaseTestCaseORM
     public function testCompositeRelation(): void
     {
         $logRepo = $this->em->getRepository(LogEntry::class);
-        $compositeRepo = $this->em->getRepository(self::COMPOSITE_RELATION);
+        $compositeRepo = $this->em->getRepository(CompositeRelation::class);
         static::assertCount(0, $logRepo->findAll());
 
         $art0 = new Article();
@@ -262,12 +256,12 @@ abstract class LoggableEntityTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::ARTICLE,
-            self::COMMENT,
-            self::COMMENT_LOG,
-            self::RELATED_ARTICLE,
-            self::COMPOSITE,
-            self::COMPOSITE_RELATION,
+            Article::class,
+            Comment::class,
+            CommentLog::class,
+            RelatedArticle::class,
+            Composite::class,
+            CompositeRelation::class,
             LogEntry::class,
             Address::class,
             Geo::class,

--- a/tests/Gedmo/Mapping/ExtensionODMTest.php
+++ b/tests/Gedmo/Mapping/ExtensionODMTest.php
@@ -21,8 +21,6 @@ use Gedmo\Tests\Tool\BaseTestCaseMongoODM;
 
 final class ExtensionODMTest extends BaseTestCaseMongoODM
 {
-    private const USER = User::class;
-
     private EncoderListener $encoderListener;
 
     protected function setUp(): void
@@ -38,7 +36,7 @@ final class ExtensionODMTest extends BaseTestCaseMongoODM
 
     public function testExtensionMetadata(): void
     {
-        $config = $this->encoderListener->getConfiguration($this->dm, self::USER);
+        $config = $this->encoderListener->getConfiguration($this->dm, User::class);
         static::assertArrayHasKey('encode', $config);
         static::assertCount(2, $config['encode']);
 
@@ -72,7 +70,7 @@ final class ExtensionODMTest extends BaseTestCaseMongoODM
         $getEventAdapterMethod->setAccessible(true);
 
         $loadClassMetadataEventArgs = new LoadClassMetadataEventArgs(
-            $this->dm->getClassMetadata(self::USER),
+            $this->dm->getClassMetadata(User::class),
             $this->dm
         );
         $eventAdapter = $getEventAdapterMethod->invoke(

--- a/tests/Gedmo/Mapping/ExtensionORMTest.php
+++ b/tests/Gedmo/Mapping/ExtensionORMTest.php
@@ -21,8 +21,6 @@ use Gedmo\Tests\Tool\BaseTestCaseORM;
 
 final class ExtensionORMTest extends BaseTestCaseORM
 {
-    private const USER = User::class;
-
     private EncoderListener $encoderListener;
 
     protected function setUp(): void
@@ -38,7 +36,7 @@ final class ExtensionORMTest extends BaseTestCaseORM
 
     public function testExtensionMetadata(): void
     {
-        $config = $this->encoderListener->getConfiguration($this->em, self::USER);
+        $config = $this->encoderListener->getConfiguration($this->em, User::class);
         static::assertArrayHasKey('encode', $config);
         static::assertCount(2, $config['encode']);
 
@@ -73,7 +71,7 @@ final class ExtensionORMTest extends BaseTestCaseORM
         $getEventAdapterMethod->setAccessible(true);
 
         $loadClassMetadataEventArgs = new LoadClassMetadataEventArgs(
-            $this->em->getClassMetadata(self::USER),
+            $this->em->getClassMetadata(User::class),
             $this->em
         );
         $eventAdapter = $getEventAdapterMethod->invoke(
@@ -86,7 +84,7 @@ final class ExtensionORMTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::USER,
+            User::class,
         ];
     }
 }

--- a/tests/Gedmo/Mapping/MappingTest.php
+++ b/tests/Gedmo/Mapping/MappingTest.php
@@ -33,9 +33,6 @@ use PHPUnit\Framework\TestCase;
  */
 final class MappingTest extends TestCase
 {
-    private const TEST_ENTITY_CATEGORY = BehavioralCategory::class;
-    private const TEST_ENTITY_TRANSLATION = Translation::class;
-
     private EntityManager $em;
 
     private TimestampableListener $timestampable;
@@ -68,8 +65,8 @@ final class MappingTest extends TestCase
         $schemaTool = new SchemaTool($this->em);
         $schemaTool->dropSchema([]);
         $schemaTool->createSchema([
-            $this->em->getClassMetadata(self::TEST_ENTITY_CATEGORY),
-            $this->em->getClassMetadata(self::TEST_ENTITY_TRANSLATION),
+            $this->em->getClassMetadata(BehavioralCategory::class),
+            $this->em->getClassMetadata(Translation::class),
         ]);
     }
 
@@ -82,7 +79,7 @@ final class MappingTest extends TestCase
         // assertion checks if configuration is read correctly without cache driver
         $conf = $this->timestampable->getConfiguration(
             $this->em,
-            self::TEST_ENTITY_CATEGORY
+            BehavioralCategory::class
         );
         static::assertCount(0, $conf);
     }

--- a/tests/Gedmo/Mapping/TreeMappingTest.php
+++ b/tests/Gedmo/Mapping/TreeMappingTest.php
@@ -31,10 +31,6 @@ use Gedmo\Tree\TreeListener;
  */
 final class TreeMappingTest extends ORMMappingTestCase
 {
-    private const TEST_YAML_ENTITY_CLASS = Category::class;
-    private const YAML_CLOSURE_CATEGORY = ClosureCategory::class;
-    private const YAML_MATERIALIZED_PATH_CATEGORY = MaterializedPathCategory::class;
-
     private EntityManager $em;
 
     private TreeListener $listener;
@@ -83,7 +79,7 @@ final class TreeMappingTest extends ORMMappingTestCase
      */
     public function testApcCached(): void
     {
-        $this->em->getClassMetadata(self::YAML_CLOSURE_CATEGORY);
+        $this->em->getClassMetadata(ClosureCategory::class);
         $this->em->getClassMetadata(CategoryClosureWithoutMapping::class);
 
         $meta = $this->em->getConfiguration()->getMetadataCache()->getItem(
@@ -96,9 +92,9 @@ final class TreeMappingTest extends ORMMappingTestCase
 
     public function testYamlNestedMapping(): void
     {
-        $this->em->getClassMetadata(self::TEST_YAML_ENTITY_CLASS);
+        $this->em->getClassMetadata(Category::class);
         $cacheId = ExtensionMetadataFactory::getCacheId(
-            self::TEST_YAML_ENTITY_CLASS,
+            Category::class,
             'Gedmo\Tree'
         );
         $config = $this->cache->getItem($cacheId)->get();
@@ -122,8 +118,8 @@ final class TreeMappingTest extends ORMMappingTestCase
     public function testYamlClosureMapping(): void
     {
         // Force metadata class loading.
-        $this->em->getClassMetadata(self::YAML_CLOSURE_CATEGORY);
-        $cacheId = ExtensionMetadataFactory::getCacheId(self::YAML_CLOSURE_CATEGORY, 'Gedmo\Tree');
+        $this->em->getClassMetadata(ClosureCategory::class);
+        $cacheId = ExtensionMetadataFactory::getCacheId(ClosureCategory::class, 'Gedmo\Tree');
         $config = $this->cache->getItem($cacheId)->get();
 
         static::assertArrayHasKey('parent', $config);
@@ -136,7 +132,7 @@ final class TreeMappingTest extends ORMMappingTestCase
 
     public function testYamlMaterializedPathMapping(): void
     {
-        $meta = $this->em->getClassMetadata(self::YAML_MATERIALIZED_PATH_CATEGORY);
+        $meta = $this->em->getClassMetadata(MaterializedPathCategory::class);
         $config = $this->listener->getConfiguration($this->em, $meta->getName());
 
         static::assertArrayHasKey('strategy', $config);

--- a/tests/Gedmo/ReferenceIntegrity/ReferenceIntegrityDocumentTest.php
+++ b/tests/Gedmo/ReferenceIntegrity/ReferenceIntegrityDocumentTest.php
@@ -14,8 +14,18 @@ namespace Gedmo\Tests\ReferenceIntegrity;
 use Doctrine\Common\EventManager;
 use Gedmo\Exception\ReferenceIntegrityStrictException;
 use Gedmo\ReferenceIntegrity\ReferenceIntegrityListener;
+use Gedmo\Tests\ReferenceIntegrity\Fixture\Document\ManyNullify\Article as ArticleManyNullify;
+use Gedmo\Tests\ReferenceIntegrity\Fixture\Document\ManyNullify\Type as TypeManyNullify;
+use Gedmo\Tests\ReferenceIntegrity\Fixture\Document\ManyPull\Article as ArticleManyPull;
+use Gedmo\Tests\ReferenceIntegrity\Fixture\Document\ManyPull\Type as TypeManyPull;
 use Gedmo\Tests\ReferenceIntegrity\Fixture\Document\ManyRestrict\Article;
 use Gedmo\Tests\ReferenceIntegrity\Fixture\Document\ManyRestrict\Type;
+use Gedmo\Tests\ReferenceIntegrity\Fixture\Document\OneNullify\Article as ArticleOneNullify;
+use Gedmo\Tests\ReferenceIntegrity\Fixture\Document\OneNullify\Type as TypeOneNullify;
+use Gedmo\Tests\ReferenceIntegrity\Fixture\Document\OnePull\Article as ArticleOnePull;
+use Gedmo\Tests\ReferenceIntegrity\Fixture\Document\OnePull\Type as TypeOnePull;
+use Gedmo\Tests\ReferenceIntegrity\Fixture\Document\OneRestrict\Article as ArticleOneRestrict;
+use Gedmo\Tests\ReferenceIntegrity\Fixture\Document\OneRestrict\Type as TypeOneRestrict;
 use Gedmo\Tests\Tool\BaseTestCaseMongoODM;
 
 /**
@@ -25,24 +35,6 @@ use Gedmo\Tests\Tool\BaseTestCaseMongoODM;
  */
 final class ReferenceIntegrityDocumentTest extends BaseTestCaseMongoODM
 {
-    private const TYPE_ONE_NULLIFY_CLASS = Fixture\Document\OneNullify\Type::class;
-    private const ARTICLE_ONE_NULLIFY_CLASS = Fixture\Document\OneNullify\Article::class;
-
-    private const TYPE_MANY_NULLIFY_CLASS = Fixture\Document\ManyNullify\Type::class;
-    private const ARTICLE_MANY_NULLIFY_CLASS = Fixture\Document\ManyNullify\Article::class;
-
-    private const TYPE_ONE_PULL_CLASS = Fixture\Document\OnePull\Type::class;
-    private const ARTICLE_ONE_PULL_CLASS = Fixture\Document\OnePull\Article::class;
-
-    private const TYPE_MANY_PULL_CLASS = Fixture\Document\ManyPull\Type::class;
-    private const ARTICLE_MANY_PULL_CLASS = Fixture\Document\ManyPull\Article::class;
-
-    private const TYPE_ONE_RESTRICT_CLASS = Fixture\Document\OneRestrict\Type::class;
-    private const ARTICLE_ONE_RESTRICT_CLASS = Fixture\Document\OneRestrict\Article::class;
-
-    private const TYPE_MANY_RESTRICT_CLASS = Type::class;
-    private const ARTICLE_MANY_RESTRICT_CLASS = Article::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -64,7 +56,7 @@ final class ReferenceIntegrityDocumentTest extends BaseTestCaseMongoODM
 
     public function testOneNullify(): void
     {
-        $type = $this->dm->getRepository(self::TYPE_ONE_NULLIFY_CLASS)
+        $type = $this->dm->getRepository(TypeOneNullify::class)
             ->findOneBy(['title' => 'One Nullify Type']);
 
         static::assertNotNull($type);
@@ -73,11 +65,11 @@ final class ReferenceIntegrityDocumentTest extends BaseTestCaseMongoODM
         $this->dm->remove($type);
         $this->dm->flush();
 
-        $type = $this->dm->getRepository(self::TYPE_ONE_NULLIFY_CLASS)
+        $type = $this->dm->getRepository(TypeOneNullify::class)
             ->findOneBy(['title' => 'One Nullify Type']);
         static::assertNull($type);
 
-        $article = $this->dm->getRepository(self::ARTICLE_ONE_NULLIFY_CLASS)
+        $article = $this->dm->getRepository(ArticleOneNullify::class)
             ->findOneBy(['title' => 'One Nullify Article']);
 
         static::assertNull($article->getType());
@@ -87,7 +79,7 @@ final class ReferenceIntegrityDocumentTest extends BaseTestCaseMongoODM
 
     public function testManyNullify(): void
     {
-        $type = $this->dm->getRepository(self::TYPE_MANY_NULLIFY_CLASS)
+        $type = $this->dm->getRepository(TypeManyNullify::class)
             ->findOneBy(['title' => 'Many Nullify Type']);
 
         static::assertNotNull($type);
@@ -96,11 +88,11 @@ final class ReferenceIntegrityDocumentTest extends BaseTestCaseMongoODM
         $this->dm->remove($type);
         $this->dm->flush();
 
-        $type = $this->dm->getRepository(self::TYPE_MANY_NULLIFY_CLASS)
+        $type = $this->dm->getRepository(TypeManyNullify::class)
             ->findOneBy(['title' => 'Many Nullify Type']);
         static::assertNull($type);
 
-        $article = $this->dm->getRepository(self::ARTICLE_MANY_NULLIFY_CLASS)
+        $article = $this->dm->getRepository(ArticleManyNullify::class)
             ->findOneBy(['title' => 'Many Nullify Article']);
 
         static::assertNull($article->getType());
@@ -110,9 +102,9 @@ final class ReferenceIntegrityDocumentTest extends BaseTestCaseMongoODM
 
     public function testOnePull(): void
     {
-        $type1 = $this->dm->getRepository(self::TYPE_ONE_PULL_CLASS)
+        $type1 = $this->dm->getRepository(TypeOnePull::class)
             ->findOneBy(['title' => 'One Pull Type 1']);
-        $type2 = $this->dm->getRepository(self::TYPE_ONE_PULL_CLASS)
+        $type2 = $this->dm->getRepository(TypeOnePull::class)
             ->findOneBy(['title' => 'One Pull Type 2']);
 
         static::assertNotNull($type1);
@@ -124,11 +116,11 @@ final class ReferenceIntegrityDocumentTest extends BaseTestCaseMongoODM
         $this->dm->remove($type2);
         $this->dm->flush();
 
-        $type2 = $this->dm->getRepository(self::TYPE_ONE_PULL_CLASS)
+        $type2 = $this->dm->getRepository(TypeOnePull::class)
             ->findOneBy(['title' => 'One Pull Type 2']);
         static::assertNull($type2);
 
-        $article = $this->dm->getRepository(self::ARTICLE_ONE_PULL_CLASS)
+        $article = $this->dm->getRepository(ArticleOnePull::class)
             ->findOneBy(['title' => 'One Pull Article']);
 
         $types = $article->getTypes();
@@ -140,9 +132,9 @@ final class ReferenceIntegrityDocumentTest extends BaseTestCaseMongoODM
 
     public function testManyPull(): void
     {
-        $type1 = $this->dm->getRepository(self::TYPE_ONE_PULL_CLASS)
+        $type1 = $this->dm->getRepository(TypeOnePull::class)
             ->findOneBy(['title' => 'Many Pull Type 1']);
-        $type2 = $this->dm->getRepository(self::TYPE_ONE_PULL_CLASS)
+        $type2 = $this->dm->getRepository(TypeOnePull::class)
             ->findOneBy(['title' => 'Many Pull Type 2']);
 
         static::assertNotNull($type1);
@@ -154,11 +146,11 @@ final class ReferenceIntegrityDocumentTest extends BaseTestCaseMongoODM
         $this->dm->remove($type2);
         $this->dm->flush();
 
-        $type2 = $this->dm->getRepository(self::TYPE_MANY_PULL_CLASS)
+        $type2 = $this->dm->getRepository(TypeManyPull::class)
             ->findOneBy(['title' => 'Many Pull Type 2']);
         static::assertNull($type2);
 
-        $article = $this->dm->getRepository(self::ARTICLE_MANY_PULL_CLASS)
+        $article = $this->dm->getRepository(ArticleManyPull::class)
             ->findOneBy(['title' => 'Many Pull Article']);
 
         $types = $article->getTypes();
@@ -171,7 +163,7 @@ final class ReferenceIntegrityDocumentTest extends BaseTestCaseMongoODM
     public function testOneRestrict(): void
     {
         $this->expectException(ReferenceIntegrityStrictException::class);
-        $type = $this->dm->getRepository(self::TYPE_ONE_RESTRICT_CLASS)
+        $type = $this->dm->getRepository(TypeOneRestrict::class)
             ->findOneBy(['title' => 'One Restrict Type']);
 
         static::assertNotNull($type);
@@ -184,7 +176,7 @@ final class ReferenceIntegrityDocumentTest extends BaseTestCaseMongoODM
     public function testManyRestrict(): void
     {
         $this->expectException(ReferenceIntegrityStrictException::class);
-        $type = $this->dm->getRepository(self::TYPE_MANY_RESTRICT_CLASS)
+        $type = $this->dm->getRepository(Type::class)
             ->findOneBy(['title' => 'Many Restrict Type']);
 
         static::assertNotNull($type);
@@ -196,12 +188,10 @@ final class ReferenceIntegrityDocumentTest extends BaseTestCaseMongoODM
 
     private function populateOneNullify(): void
     {
-        $typeClass = self::TYPE_ONE_NULLIFY_CLASS;
-        $type = new $typeClass();
+        $type = new TypeOneNullify();
         $type->setTitle('One Nullify Type');
 
-        $articleClass = self::ARTICLE_ONE_NULLIFY_CLASS;
-        $article = new $articleClass();
+        $article = new ArticleOneNullify();
         $article->setTitle('One Nullify Article');
         $article->setType($type);
 
@@ -214,12 +204,10 @@ final class ReferenceIntegrityDocumentTest extends BaseTestCaseMongoODM
 
     private function populateManyNullify(): void
     {
-        $typeClass = self::TYPE_MANY_NULLIFY_CLASS;
-        $type = new $typeClass();
+        $type = new TypeManyNullify();
         $type->setTitle('Many Nullify Type');
 
-        $articleClass = self::ARTICLE_MANY_NULLIFY_CLASS;
-        $article = new $articleClass();
+        $article = new ArticleManyNullify();
         $article->setTitle('Many Nullify Article');
         $article->setType($type);
 
@@ -232,15 +220,13 @@ final class ReferenceIntegrityDocumentTest extends BaseTestCaseMongoODM
 
     private function populateOnePull(): void
     {
-        $typeClass = self::TYPE_ONE_PULL_CLASS;
-        $type1 = new $typeClass();
+        $type1 = new TypeOnePull();
         $type1->setTitle('One Pull Type 1');
 
-        $type2 = new $typeClass();
+        $type2 = new TypeOnePull();
         $type2->setTitle('One Pull Type 2');
 
-        $articleClass = self::ARTICLE_ONE_PULL_CLASS;
-        $article = new $articleClass();
+        $article = new ArticleOnePull();
         $article->setTitle('One Pull Article');
         $article->addType($type1);
         $article->addType($type2);
@@ -255,15 +241,13 @@ final class ReferenceIntegrityDocumentTest extends BaseTestCaseMongoODM
 
     private function populateManyPull(): void
     {
-        $typeClass = self::TYPE_MANY_PULL_CLASS;
-        $type1 = new $typeClass();
+        $type1 = new TypeManyPull();
         $type1->setTitle('Many Pull Type 1');
 
-        $type2 = new $typeClass();
+        $type2 = new TypeManyPull();
         $type2->setTitle('Many Pull Type 2');
 
-        $articleClass = self::ARTICLE_MANY_PULL_CLASS;
-        $article = new $articleClass();
+        $article = new ArticleManyPull();
         $article->setTitle('Many Pull Article');
         $article->addType($type1);
         $article->addType($type2);
@@ -278,12 +262,10 @@ final class ReferenceIntegrityDocumentTest extends BaseTestCaseMongoODM
 
     private function populateOneRestrict(): void
     {
-        $typeClass = self::TYPE_ONE_RESTRICT_CLASS;
-        $type = new $typeClass();
+        $type = new TypeOneRestrict();
         $type->setTitle('One Restrict Type');
 
-        $articleClass = self::ARTICLE_ONE_RESTRICT_CLASS;
-        $article = new $articleClass();
+        $article = new ArticleOneRestrict();
         $article->setTitle('One Restrict Article');
         $article->setType($type);
 
@@ -296,12 +278,10 @@ final class ReferenceIntegrityDocumentTest extends BaseTestCaseMongoODM
 
     private function populateManyRestrict(): void
     {
-        $typeClass = self::TYPE_MANY_RESTRICT_CLASS;
-        $type = new $typeClass();
+        $type = new Type();
         $type->setTitle('Many Restrict Type');
 
-        $articleClass = self::ARTICLE_MANY_RESTRICT_CLASS;
-        $article = new $articleClass();
+        $article = new Article();
         $article->setTitle('Many Restrict Article');
         $article->setType($type);
 

--- a/tests/Gedmo/Sluggable/CustomTransliteratorTest.php
+++ b/tests/Gedmo/Sluggable/CustomTransliteratorTest.php
@@ -23,8 +23,6 @@ use Gedmo\Tests\Tool\BaseTestCaseORM;
  */
 final class CustomTransliteratorTest extends BaseTestCaseORM
 {
-    private const ARTICLE = Article::class;
-
     public function testStandardTransliteratorFailsOnChineseCharacters(): void
     {
         $evm = new EventManager();
@@ -33,7 +31,7 @@ final class CustomTransliteratorTest extends BaseTestCaseORM
         $this->getDefaultMockSqliteEntityManager($evm);
         $this->populate();
 
-        $repo = $this->em->getRepository(self::ARTICLE);
+        $repo = $this->em->getRepository(Article::class);
 
         $chinese = $repo->findOneBy(['code' => 'zh']);
         static::assertSame('bei-jing-zh', $chinese->getSlug());
@@ -49,7 +47,7 @@ final class CustomTransliteratorTest extends BaseTestCaseORM
         $this->getDefaultMockSqliteEntityManager($evm);
         $this->populate();
 
-        $repo = $this->em->getRepository(self::ARTICLE);
+        $repo = $this->em->getRepository(Article::class);
 
         $chinese = $repo->findOneBy(['code' => 'zh']);
         static::assertSame('bei-jing', $chinese->getSlug());
@@ -58,7 +56,7 @@ final class CustomTransliteratorTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::ARTICLE,
+            Article::class,
         ];
     }
 

--- a/tests/Gedmo/Sluggable/Handlers/BothSlugHandlerTest.php
+++ b/tests/Gedmo/Sluggable/Handlers/BothSlugHandlerTest.php
@@ -25,9 +25,6 @@ use Gedmo\Tree\TreeListener;
  */
 final class BothSlugHandlerTest extends BaseTestCaseORM
 {
-    private const OCCUPATION = Occupation::class;
-    private const PERSON = Person::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -42,7 +39,7 @@ final class BothSlugHandlerTest extends BaseTestCaseORM
     public function testSlugGeneration(): void
     {
         $this->populate();
-        $repo = $this->em->getRepository(self::PERSON);
+        $repo = $this->em->getRepository(Person::class);
 
         $herzult = $repo->findOneBy(['name' => 'Herzult']);
         static::assertSame('web/developer/php/herzult', $herzult->getSlug());
@@ -57,7 +54,7 @@ final class BothSlugHandlerTest extends BaseTestCaseORM
     public function testSlugUpdates(): void
     {
         $this->populate();
-        $repo = $this->em->getRepository(self::PERSON);
+        $repo = $this->em->getRepository(Person::class);
 
         $gedi = $repo->findOneBy(['name' => 'Gedi']);
         $gedi->setName('Upd Gedi');
@@ -66,7 +63,7 @@ final class BothSlugHandlerTest extends BaseTestCaseORM
 
         static::assertSame('web/developer/upd-gedi', $gedi->getSlug());
 
-        $artist = $this->em->getRepository(self::OCCUPATION)->findOneBy(['title' => 'Singer']);
+        $artist = $this->em->getRepository(Occupation::class)->findOneBy(['title' => 'Singer']);
         $artist->setTitle('Artist');
 
         $this->em->persist($artist);
@@ -85,8 +82,8 @@ final class BothSlugHandlerTest extends BaseTestCaseORM
     public function test1093(): void
     {
         $this->populate();
-        $personRepo = $this->em->getRepository(self::PERSON);
-        $occupationRepo = $this->em->getRepository(self::OCCUPATION);
+        $personRepo = $this->em->getRepository(Person::class);
+        $occupationRepo = $this->em->getRepository(Occupation::class);
 
         $herzult = $personRepo->findOneBy(['name' => 'Herzult']);
         static::assertSame('web/developer/php/herzult', $herzult->getSlug());
@@ -111,14 +108,14 @@ final class BothSlugHandlerTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::OCCUPATION,
-            self::PERSON,
+            Occupation::class,
+            Person::class,
         ];
     }
 
     private function populate(): void
     {
-        $repo = $this->em->getRepository(self::OCCUPATION);
+        $repo = $this->em->getRepository(Occupation::class);
 
         $web = new Occupation();
         $web->setTitle('Web');

--- a/tests/Gedmo/Sluggable/Handlers/RelativeSlugHandlerDocumentTest.php
+++ b/tests/Gedmo/Sluggable/Handlers/RelativeSlugHandlerDocumentTest.php
@@ -24,9 +24,6 @@ use Gedmo\Tests\Tool\BaseTestCaseMongoODM;
  */
 final class RelativeSlugHandlerDocumentTest extends BaseTestCaseMongoODM
 {
-    private const ARTICLE = Article::class;
-    private const SLUG = RelativeSlug::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -39,7 +36,7 @@ final class RelativeSlugHandlerDocumentTest extends BaseTestCaseMongoODM
     public function testSlugGeneration(): void
     {
         $this->populate();
-        $repo = $this->dm->getRepository(self::SLUG);
+        $repo = $this->dm->getRepository(RelativeSlug::class);
 
         $thomas = $repo->findOneBy(['title' => 'Thomas']);
         static::assertSame('sport-test/thomas', $thomas->getSlug());
@@ -57,7 +54,7 @@ final class RelativeSlugHandlerDocumentTest extends BaseTestCaseMongoODM
     public function testUpdateOperations(): void
     {
         $this->populate();
-        $repo = $this->dm->getRepository(self::SLUG);
+        $repo = $this->dm->getRepository(RelativeSlug::class);
 
         $thomas = $repo->findOneBy(['title' => 'Thomas']);
         $thomas->setTitle('Ninja');
@@ -66,7 +63,7 @@ final class RelativeSlugHandlerDocumentTest extends BaseTestCaseMongoODM
 
         static::assertSame('sport-test/ninja', $thomas->getSlug());
 
-        $sport = $this->dm->getRepository(self::ARTICLE)->findOneBy(['title' => 'Sport']);
+        $sport = $this->dm->getRepository(Article::class)->findOneBy(['title' => 'Sport']);
         $sport->setTitle('Martial Arts');
 
         $this->dm->persist($sport);
@@ -79,7 +76,7 @@ final class RelativeSlugHandlerDocumentTest extends BaseTestCaseMongoODM
         $jen = $repo->findOneBy(['title' => 'Jen']);
         static::assertSame('martial-arts-test/jen', $jen->getSlug());
 
-        $cars = $this->dm->getRepository(self::ARTICLE)->findOneBy(['title' => 'Cars']);
+        $cars = $this->dm->getRepository(Article::class)->findOneBy(['title' => 'Cars']);
         $jen->setArticle($cars);
 
         $this->dm->persist($jen);

--- a/tests/Gedmo/Sluggable/Handlers/RelativeSlugHandlerTest.php
+++ b/tests/Gedmo/Sluggable/Handlers/RelativeSlugHandlerTest.php
@@ -24,9 +24,6 @@ use Gedmo\Tests\Tool\BaseTestCaseORM;
  */
 final class RelativeSlugHandlerTest extends BaseTestCaseORM
 {
-    private const SLUG = ArticleRelativeSlug::class;
-    private const ARTICLE = Article::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -40,7 +37,7 @@ final class RelativeSlugHandlerTest extends BaseTestCaseORM
     public function testSlugGeneration(): void
     {
         $this->populate();
-        $repo = $this->em->getRepository(self::SLUG);
+        $repo = $this->em->getRepository(ArticleRelativeSlug::class);
 
         $thomas = $repo->findOneBy(['title' => 'Thomas']);
         static::assertSame('sport-test/thomas', $thomas->getSlug());
@@ -58,7 +55,7 @@ final class RelativeSlugHandlerTest extends BaseTestCaseORM
     public function testUpdateOperations(): void
     {
         $this->populate();
-        $repo = $this->em->getRepository(self::SLUG);
+        $repo = $this->em->getRepository(ArticleRelativeSlug::class);
 
         $thomas = $repo->findOneBy(['title' => 'Thomas']);
         $thomas->setTitle('Ninja');
@@ -67,7 +64,7 @@ final class RelativeSlugHandlerTest extends BaseTestCaseORM
 
         static::assertSame('sport-test/ninja', $thomas->getSlug());
 
-        $sport = $this->em->getRepository(self::ARTICLE)->findOneBy(['title' => 'Sport']);
+        $sport = $this->em->getRepository(Article::class)->findOneBy(['title' => 'Sport']);
         $sport->setTitle('Martial Arts');
 
         $this->em->persist($sport);
@@ -78,7 +75,7 @@ final class RelativeSlugHandlerTest extends BaseTestCaseORM
         $jen = $repo->findOneBy(['title' => 'Jen']);
         static::assertSame('martial-arts-test/jen', $jen->getSlug());
 
-        $cars = $this->em->getRepository(self::ARTICLE)->findOneBy(['title' => 'Cars']);
+        $cars = $this->em->getRepository(Article::class)->findOneBy(['title' => 'Cars']);
         $jen->setArticle($cars);
 
         $this->em->persist($jen);
@@ -90,8 +87,8 @@ final class RelativeSlugHandlerTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::SLUG,
-            self::ARTICLE,
+            ArticleRelativeSlug::class,
+            Article::class,
         ];
     }
 

--- a/tests/Gedmo/Sluggable/Handlers/TreeSlugHandlerDocumentTest.php
+++ b/tests/Gedmo/Sluggable/Handlers/TreeSlugHandlerDocumentTest.php
@@ -23,8 +23,6 @@ use Gedmo\Tests\Tool\BaseTestCaseMongoODM;
  */
 final class TreeSlugHandlerDocumentTest extends BaseTestCaseMongoODM
 {
-    private const SLUG = TreeSlug::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -37,7 +35,7 @@ final class TreeSlugHandlerDocumentTest extends BaseTestCaseMongoODM
     public function testSlugGeneration(): void
     {
         $this->populate();
-        $repo = $this->dm->getRepository(self::SLUG);
+        $repo = $this->dm->getRepository(TreeSlug::class);
 
         $food = $repo->findOneBy(['title' => 'Food']);
         static::assertSame('food', $food->getSlug());
@@ -55,7 +53,7 @@ final class TreeSlugHandlerDocumentTest extends BaseTestCaseMongoODM
     public function testSlugUpdates(): void
     {
         $this->populate();
-        $repo = $this->dm->getRepository(self::SLUG);
+        $repo = $this->dm->getRepository(TreeSlug::class);
 
         $fruits = $repo->findOneBy(['title' => 'Fruits']);
         $fruits->setTitle('Fructis');

--- a/tests/Gedmo/Sluggable/Handlers/TreeSlugHandlerPrefixSuffixTest.php
+++ b/tests/Gedmo/Sluggable/Handlers/TreeSlugHandlerPrefixSuffixTest.php
@@ -19,8 +19,6 @@ use Gedmo\Tree\TreeListener;
 
 final class TreeSlugHandlerPrefixSuffixTest extends BaseTestCaseORM
 {
-    private const TARGET = TreeSlugPrefixSuffix::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -57,7 +55,7 @@ final class TreeSlugHandlerPrefixSuffixTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::TARGET,
+            TreeSlugPrefixSuffix::class,
         ];
     }
 }

--- a/tests/Gedmo/Sluggable/Handlers/TreeSlugHandlerTest.php
+++ b/tests/Gedmo/Sluggable/Handlers/TreeSlugHandlerTest.php
@@ -24,8 +24,6 @@ use Gedmo\Tree\TreeListener;
  */
 final class TreeSlugHandlerTest extends BaseTestCaseORM
 {
-    private const TARGET = TreeSlug::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -40,7 +38,7 @@ final class TreeSlugHandlerTest extends BaseTestCaseORM
     public function testSlugGeneration(): void
     {
         $this->populate();
-        $repo = $this->em->getRepository(self::TARGET);
+        $repo = $this->em->getRepository(TreeSlug::class);
 
         $food = $repo->findOneBy(['title' => 'Food']);
         static::assertSame('food', $food->getSlug());
@@ -67,7 +65,7 @@ final class TreeSlugHandlerTest extends BaseTestCaseORM
     public function testSlugUpdates(): void
     {
         $this->populate();
-        $repo = $this->em->getRepository(self::TARGET);
+        $repo = $this->em->getRepository(TreeSlug::class);
 
         $fruits = $repo->findOneBy(['title' => 'Fruits']);
         $fruits->setTitle('Fructis');
@@ -97,7 +95,7 @@ final class TreeSlugHandlerTest extends BaseTestCaseORM
     public function testMoreSlugUpdates(): void
     {
         $this->populate();
-        $repo = $this->em->getRepository(self::TARGET);
+        $repo = $this->em->getRepository(TreeSlug::class);
 
         $fruits = $repo->findOneBy(['title' => 'Fruits']);
         $fruits->setTitle('Fructis');
@@ -133,13 +131,13 @@ final class TreeSlugHandlerTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::TARGET,
+            TreeSlug::class,
         ];
     }
 
     private function populate(): void
     {
-        $repo = $this->em->getRepository(self::TARGET);
+        $repo = $this->em->getRepository(TreeSlug::class);
 
         $food = new TreeSlug();
         $food->setTitle('Food');

--- a/tests/Gedmo/Sluggable/Handlers/TreeSlugHandlerUniqueTest.php
+++ b/tests/Gedmo/Sluggable/Handlers/TreeSlugHandlerUniqueTest.php
@@ -19,8 +19,6 @@ use Gedmo\Tree\TreeListener;
 
 final class TreeSlugHandlerUniqueTest extends BaseTestCaseORM
 {
-    private const TARGET = TreeSlug::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -75,7 +73,7 @@ final class TreeSlugHandlerUniqueTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::TARGET,
+            TreeSlug::class,
         ];
     }
 }

--- a/tests/Gedmo/Sluggable/Handlers/UserRelativeSlugHandlerTest.php
+++ b/tests/Gedmo/Sluggable/Handlers/UserRelativeSlugHandlerTest.php
@@ -24,9 +24,6 @@ use Gedmo\Tests\Tool\BaseTestCaseORM;
  */
 final class UserRelativeSlugHandlerTest extends BaseTestCaseORM
 {
-    private const USER = User::class;
-    private const COMPANY = Company::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -62,8 +59,8 @@ final class UserRelativeSlugHandlerTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::USER,
-            self::COMPANY,
+            User::class,
+            Company::class,
         ];
     }
 }

--- a/tests/Gedmo/Sluggable/Issue/Issue100Test.php
+++ b/tests/Gedmo/Sluggable/Issue/Issue100Test.php
@@ -25,9 +25,6 @@ use Gedmo\Translatable\TranslatableListener;
  */
 final class Issue100Test extends BaseTestCaseORM
 {
-    public const ARTICLE = Article::class;
-    public const TRANSLATION = Translation::class;
-
     private TranslatableListener $translatableListener;
 
     protected function setUp(): void
@@ -46,7 +43,7 @@ final class Issue100Test extends BaseTestCaseORM
 
     public function testShouldWorkWithTranslatableSlug(): void
     {
-        $repository = $this->em->getRepository(self::TRANSLATION);
+        $repository = $this->em->getRepository(Translation::class);
 
         /*
          * First article
@@ -99,8 +96,8 @@ final class Issue100Test extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::ARTICLE,
-            self::TRANSLATION,
+            Article::class,
+            Translation::class,
         ];
     }
 }

--- a/tests/Gedmo/Sluggable/Issue/Issue104Test.php
+++ b/tests/Gedmo/Sluggable/Issue/Issue104Test.php
@@ -25,8 +25,6 @@ use Gedmo\Tests\Tool\BaseTestCaseORM;
  */
 final class Issue104Test extends BaseTestCaseORM
 {
-    private const CAR = Car::class;
-
     public static function setUpBeforeClass(): void
     {
         if (!class_exists(AnnotationDriver::class)) {
@@ -52,7 +50,7 @@ final class Issue104Test extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::CAR,
+            Car::class,
         ];
     }
 }

--- a/tests/Gedmo/Sluggable/Issue/Issue1058Test.php
+++ b/tests/Gedmo/Sluggable/Issue/Issue1058Test.php
@@ -24,9 +24,6 @@ use Gedmo\Tests\Tool\BaseTestCaseORM;
  */
 final class Issue1058Test extends BaseTestCaseORM
 {
-    private const ARTICLE = Page::class;
-    private const USER = User::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -88,8 +85,8 @@ final class Issue1058Test extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::ARTICLE,
-            self::USER,
+            Page::class,
+            User::class,
         ];
     }
 }

--- a/tests/Gedmo/Sluggable/Issue/Issue116Test.php
+++ b/tests/Gedmo/Sluggable/Issue/Issue116Test.php
@@ -27,8 +27,6 @@ use Gedmo\Tests\Tool\BaseTestCaseORM;
  */
 final class Issue116Test extends BaseTestCaseORM
 {
-    private const TARGET = Country::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -69,7 +67,7 @@ final class Issue116Test extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::TARGET,
+            Country::class,
         ];
     }
 }

--- a/tests/Gedmo/Sluggable/Issue/Issue1177Test.php
+++ b/tests/Gedmo/Sluggable/Issue/Issue1177Test.php
@@ -23,8 +23,6 @@ use Gedmo\Tests\Tool\BaseTestCaseORM;
  */
 final class Issue1177Test extends BaseTestCaseORM
 {
-    private const ARTICLE = Article::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -67,7 +65,7 @@ final class Issue1177Test extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::ARTICLE,
+            Article::class,
         ];
     }
 }

--- a/tests/Gedmo/Sluggable/Issue/Issue1240Test.php
+++ b/tests/Gedmo/Sluggable/Issue/Issue1240Test.php
@@ -23,8 +23,6 @@ use Gedmo\Tests\Tool\BaseTestCaseORM;
  */
 final class Issue1240Test extends BaseTestCaseORM
 {
-    private const ARTICLE = Article::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -67,7 +65,7 @@ final class Issue1240Test extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::ARTICLE,
+            Article::class,
         ];
     }
 }

--- a/tests/Gedmo/Sluggable/Issue/Issue131Test.php
+++ b/tests/Gedmo/Sluggable/Issue/Issue131Test.php
@@ -23,8 +23,6 @@ use Gedmo\Tests\Tool\BaseTestCaseORM;
  */
 final class Issue131Test extends BaseTestCaseORM
 {
-    private const TARGET = Article::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -68,7 +66,7 @@ final class Issue131Test extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::TARGET,
+            Article::class,
         ];
     }
 }

--- a/tests/Gedmo/Sluggable/Issue/Issue449Test.php
+++ b/tests/Gedmo/Sluggable/Issue/Issue449Test.php
@@ -27,7 +27,6 @@ use Gedmo\Tests\Tool\BaseTestCaseORM;
  */
 final class Issue449Test extends BaseTestCaseORM
 {
-    private const TARGET = Article::class;
     private const SOFT_DELETEABLE_FILTER_NAME = 'soft-deleteable';
 
     private SoftDeleteableListener $softDeleteableListener;
@@ -80,7 +79,7 @@ final class Issue449Test extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::TARGET,
+            Article::class,
         ];
     }
 }

--- a/tests/Gedmo/Sluggable/Issue/Issue633Test.php
+++ b/tests/Gedmo/Sluggable/Issue/Issue633Test.php
@@ -23,8 +23,6 @@ use Gedmo\Tests\Tool\BaseTestCaseORM;
  */
 final class Issue633Test extends BaseTestCaseORM
 {
-    private const TARGET = Article::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -94,7 +92,7 @@ final class Issue633Test extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::TARGET,
+            Article::class,
         ];
     }
 }

--- a/tests/Gedmo/Sluggable/Issue/Issue827Test.php
+++ b/tests/Gedmo/Sluggable/Issue/Issue827Test.php
@@ -28,11 +28,6 @@ use Gedmo\Tests\Tool\BaseTestCaseORM;
  */
 final class Issue827Test extends BaseTestCaseORM
 {
-    private const ARTICLE = Article::class;
-    private const CATEGORY = Category::class;
-    private const COMMENT = Comment::class;
-    private const POST = Post::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -169,11 +164,11 @@ final class Issue827Test extends BaseTestCaseORM
         $this->em->clear();
 
         $testPost1 = $this->em->find(
-            self::POST,
+            Post::class,
             ['title' => $testPost1->getTitle(), 'slug' => $testPost1->getSlug()]
         );
         $testPost2 = $this->em->find(
-            self::POST,
+            Post::class,
             ['title' => $testPost2->getTitle(), 'slug' => $testPost2->getSlug()]
         );
 
@@ -276,10 +271,10 @@ final class Issue827Test extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::ARTICLE,
-            self::CATEGORY,
-            self::COMMENT,
-            self::POST,
+            Article::class,
+            Category::class,
+            Comment::class,
+            Post::class,
         ];
     }
 }

--- a/tests/Gedmo/Sluggable/Issue/Issue939Test.php
+++ b/tests/Gedmo/Sluggable/Issue/Issue939Test.php
@@ -24,9 +24,6 @@ use Gedmo\Tests\Tool\BaseTestCaseORM;
  */
 final class Issue939Test extends BaseTestCaseORM
 {
-    private const ARTICLE = Article::class;
-    private const CATEGORY = Category::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -57,8 +54,8 @@ final class Issue939Test extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::ARTICLE,
-            self::CATEGORY,
+            Article::class,
+            Category::class,
         ];
     }
 }

--- a/tests/Gedmo/Sluggable/SluggableConfigurationTest.php
+++ b/tests/Gedmo/Sluggable/SluggableConfigurationTest.php
@@ -24,8 +24,6 @@ use Gedmo\Tests\Tool\BaseTestCaseORM;
  */
 final class SluggableConfigurationTest extends BaseTestCaseORM
 {
-    private const ARTICLE = ConfigurationArticle::class;
-
     private ?int $articleId = null;
 
     protected function setUp(): void
@@ -41,7 +39,7 @@ final class SluggableConfigurationTest extends BaseTestCaseORM
 
     public function testInsertedNewSlug(): void
     {
-        $article = $this->em->find(self::ARTICLE, $this->articleId);
+        $article = $this->em->find(ConfigurationArticle::class, $this->articleId);
 
         static::assertInstanceOf(Sluggable::class, $article);
         static::assertSame('the-title-my-code', $article->getSlug());
@@ -78,7 +76,7 @@ final class SluggableConfigurationTest extends BaseTestCaseORM
 
     public function testNonUpdatableSlug(): void
     {
-        $article = $this->em->find(self::ARTICLE, $this->articleId);
+        $article = $this->em->find(ConfigurationArticle::class, $this->articleId);
         $article->setTitle('the title updated');
         $this->em->persist($article);
         $this->em->flush();
@@ -90,7 +88,7 @@ final class SluggableConfigurationTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::ARTICLE,
+            ConfigurationArticle::class,
         ];
     }
 

--- a/tests/Gedmo/Sluggable/SluggableDateTimeTypesTest.php
+++ b/tests/Gedmo/Sluggable/SluggableDateTimeTypesTest.php
@@ -29,13 +29,6 @@ use Gedmo\Tests\Tool\BaseTestCaseORM;
  */
 final class SluggableDateTimeTypesTest extends BaseTestCaseORM
 {
-    private const ARTICLE_DATE = ArticleDate::class;
-    private const ARTICLE_DATE_IMMUTABLE = ArticleDateImmutable::class;
-    private const ARTICLE_DATETIME = ArticleDateTime::class;
-    private const ARTICLE_DATETIME_IMMUTABLE = ArticleDateTimeImmutable::class;
-    private const ARTICLE_DATETIME_TZ = ArticleDateTimeTz::class;
-    private const ARTICLE_DATETIME_TZ_IMMUTABLE = ArticleDateTimeTzImmutable::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -106,12 +99,12 @@ final class SluggableDateTimeTypesTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::ARTICLE_DATE,
-            self::ARTICLE_DATE_IMMUTABLE,
-            self::ARTICLE_DATETIME,
-            self::ARTICLE_DATETIME_IMMUTABLE,
-            self::ARTICLE_DATETIME_TZ,
-            self::ARTICLE_DATETIME_TZ_IMMUTABLE,
+            ArticleDate::class,
+            ArticleDateImmutable::class,
+            ArticleDateTime::class,
+            ArticleDateTimeImmutable::class,
+            ArticleDateTimeTz::class,
+            ArticleDateTimeTzImmutable::class,
         ];
     }
 }

--- a/tests/Gedmo/Sluggable/SluggableDocumentTest.php
+++ b/tests/Gedmo/Sluggable/SluggableDocumentTest.php
@@ -23,8 +23,6 @@ use Gedmo\Tests\Tool\BaseTestCaseMongoODM;
  */
 final class SluggableDocumentTest extends BaseTestCaseMongoODM
 {
-    private const ARTICLE = Article::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -38,7 +36,7 @@ final class SluggableDocumentTest extends BaseTestCaseMongoODM
     public function testSlugGeneration(): void
     {
         // test insert
-        $repo = $this->dm->getRepository(self::ARTICLE);
+        $repo = $this->dm->getRepository(Article::class);
         $article = $repo->findOneBy(['title' => 'My Title']);
 
         static::assertSame('my-title-the-code', $article->getSlug());

--- a/tests/Gedmo/Sluggable/SluggableFltersTest.php
+++ b/tests/Gedmo/Sluggable/SluggableFltersTest.php
@@ -25,8 +25,6 @@ use Gedmo\Tests\Tool\BaseTestCaseORM;
  */
 final class SluggableFltersTest extends BaseTestCaseORM
 {
-    private const TARGET = Article::class;
-
     private const SOFT_DELETEABLE_FILTER_NAME = 'soft-deleteable';
     private const FAKE_FILTER_NAME = 'fake-filter';
 
@@ -68,7 +66,7 @@ final class SluggableFltersTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::TARGET,
+            Article::class,
         ];
     }
 }

--- a/tests/Gedmo/Sluggable/SluggableIdentifierTest.php
+++ b/tests/Gedmo/Sluggable/SluggableIdentifierTest.php
@@ -23,8 +23,6 @@ use Gedmo\Tests\Tool\BaseTestCaseORM;
  */
 final class SluggableIdentifierTest extends BaseTestCaseORM
 {
-    private const TARGET = Identifier::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -63,7 +61,7 @@ final class SluggableIdentifierTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::TARGET,
+            Identifier::class,
         ];
     }
 }

--- a/tests/Gedmo/Sluggable/SluggablePositionTest.php
+++ b/tests/Gedmo/Sluggable/SluggablePositionTest.php
@@ -23,8 +23,6 @@ use Gedmo\Tests\Tool\BaseTestCaseORM;
  */
 final class SluggablePositionTest extends BaseTestCaseORM
 {
-    private const POSITION = Position::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -38,8 +36,8 @@ final class SluggablePositionTest extends BaseTestCaseORM
 
     public function testPositionedSlugOrder(): void
     {
-        $meta = $this->em->getClassMetadata(self::POSITION);
-        $repo = $this->em->getRepository(self::POSITION);
+        $meta = $this->em->getClassMetadata(Position::class);
+        $repo = $this->em->getRepository(Position::class);
 
         $object = $repo->find(1);
         $slug = $meta->getReflectionProperty('slug')->getValue($object);
@@ -49,13 +47,13 @@ final class SluggablePositionTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::POSITION,
+            Position::class,
         ];
     }
 
     private function populate(): void
     {
-        $meta = $this->em->getClassMetadata(self::POSITION);
+        $meta = $this->em->getClassMetadata(Position::class);
         $object = new Position();
         $meta->getReflectionProperty('title')->setValue($object, 'title');
         $meta->getReflectionProperty('prop')->setValue($object, 'prop');

--- a/tests/Gedmo/Sluggable/SluggablePrefixSuffixTest.php
+++ b/tests/Gedmo/Sluggable/SluggablePrefixSuffixTest.php
@@ -22,11 +22,6 @@ use Gedmo\Tree\TreeListener;
 
 final class SluggablePrefixSuffixTest extends BaseTestCaseORM
 {
-    private const PREFIX = Prefix::class;
-    private const SUFFIX = Suffix::class;
-    private const SUFFIX_TREE = SuffixWithTreeHandler::class;
-    private const PREFIX_TREE = PrefixWithTreeHandler::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -106,10 +101,10 @@ final class SluggablePrefixSuffixTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::SUFFIX,
-            self::PREFIX,
-            self::SUFFIX_TREE,
-            self::PREFIX_TREE,
+            Suffix::class,
+            Prefix::class,
+            SuffixWithTreeHandler::class,
+            PrefixWithTreeHandler::class,
         ];
     }
 }

--- a/tests/Gedmo/Sluggable/TranslatableManySlugTest.php
+++ b/tests/Gedmo/Sluggable/TranslatableManySlugTest.php
@@ -27,9 +27,6 @@ use Gedmo\Translatable\TranslatableListener;
  */
 final class TranslatableManySlugTest extends BaseTestCaseORM
 {
-    private const ARTICLE = TransArticleManySlug::class;
-    private const TRANSLATION = Translation::class;
-
     private ?int $articleId = null;
 
     private TranslatableListener $translatableListener;
@@ -50,16 +47,16 @@ final class TranslatableManySlugTest extends BaseTestCaseORM
 
     public function testSlugAndTranslation(): void
     {
-        $article = $this->em->find(self::ARTICLE, $this->articleId);
+        $article = $this->em->find(TransArticleManySlug::class, $this->articleId);
         static::assertTrue($article instanceof Translatable && $article instanceof Sluggable);
         static::assertSame('the-title-my-code', $article->getSlug());
         static::assertSame('the-unique-title', $article->getUniqueSlug());
-        $repo = $this->em->getRepository(self::TRANSLATION);
+        $repo = $this->em->getRepository(Translation::class);
 
         $translations = $repo->findTranslations($article);
         static::assertCount(0, $translations);
 
-        $article = $this->em->find(self::ARTICLE, $this->articleId);
+        $article = $this->em->find(TransArticleManySlug::class, $this->articleId);
         $article->setTranslatableLocale('de_DE');
         $article->setCode('code in de');
         $article->setTitle('title in de');
@@ -68,7 +65,7 @@ final class TranslatableManySlugTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $repo = $this->em->getRepository(self::TRANSLATION);
+        $repo = $this->em->getRepository(Translation::class);
         $translations = $repo->findTranslations($article);
         static::assertCount(1, $translations);
         static::assertArrayHasKey('de_DE', $translations);
@@ -107,8 +104,8 @@ final class TranslatableManySlugTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::ARTICLE,
-            self::TRANSLATION,
+            TransArticleManySlug::class,
+            Translation::class,
         ];
     }
 

--- a/tests/Gedmo/Sluggable/TranslatableSlugTest.php
+++ b/tests/Gedmo/Sluggable/TranslatableSlugTest.php
@@ -29,11 +29,6 @@ use Gedmo\Translatable\TranslatableListener;
  */
 final class TranslatableSlugTest extends BaseTestCaseORM
 {
-    private const ARTICLE = TranslatableArticle::class;
-    private const COMMENT = Comment::class;
-    private const PAGE = Page::class;
-    private const TRANSLATION = Translation::class;
-
     private ?int $articleId = null;
 
     private TranslatableListener $translatableListener;
@@ -54,15 +49,15 @@ final class TranslatableSlugTest extends BaseTestCaseORM
 
     public function testSlugAndTranslation(): void
     {
-        $article = $this->em->find(self::ARTICLE, $this->articleId);
+        $article = $this->em->find(TranslatableArticle::class, $this->articleId);
         static::assertTrue($article instanceof Translatable && $article instanceof Sluggable);
         static::assertSame('the-title-my-code', $article->getSlug());
-        $repo = $this->em->getRepository(self::TRANSLATION);
+        $repo = $this->em->getRepository(Translation::class);
 
         $translations = $repo->findTranslations($article);
         static::assertCount(0, $translations);
 
-        $article = $this->em->find(self::ARTICLE, $this->articleId);
+        $article = $this->em->find(TranslatableArticle::class, $this->articleId);
         $article->setTranslatableLocale('de_DE');
         $article->setCode('code in de');
         $article->setTitle('title in de');
@@ -71,7 +66,7 @@ final class TranslatableSlugTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $repo = $this->em->getRepository(self::TRANSLATION);
+        $repo = $this->em->getRepository(Translation::class);
         $translations = $repo->findTranslations($article);
         static::assertCount(1, $translations);
         static::assertArrayHasKey('de_DE', $translations);
@@ -95,7 +90,7 @@ final class TranslatableSlugTest extends BaseTestCaseORM
         $a0Page = new Page();
         $a0Page->setContent('bi vv');
 
-        $article0 = $this->em->find(self::ARTICLE, $this->articleId);
+        $article0 = $this->em->find(TranslatableArticle::class, $this->articleId);
         $article0->setCode('cell');
         $article0->setTitle('xx gg');
         $a0Page->addArticle($article0);
@@ -140,10 +135,10 @@ final class TranslatableSlugTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::ARTICLE,
-            self::COMMENT,
-            self::PAGE,
-            self::TRANSLATION,
+            TranslatableArticle::class,
+            Comment::class,
+            Page::class,
+            Translation::class,
         ];
     }
 

--- a/tests/Gedmo/Sluggable/TransliterationTest.php
+++ b/tests/Gedmo/Sluggable/TransliterationTest.php
@@ -23,8 +23,6 @@ use Gedmo\Tests\Tool\BaseTestCaseORM;
  */
 final class TransliterationTest extends BaseTestCaseORM
 {
-    private const ARTICLE = Article::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -38,7 +36,7 @@ final class TransliterationTest extends BaseTestCaseORM
 
     public function testInsertedNewSlug(): void
     {
-        $repo = $this->em->getRepository(self::ARTICLE);
+        $repo = $this->em->getRepository(Article::class);
 
         $lithuanian = $repo->findOneBy(['code' => 'lt']);
         static::assertSame('transliteration-test-usage-uz-lt', $lithuanian->getSlug());
@@ -56,7 +54,7 @@ final class TransliterationTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::ARTICLE,
+            Article::class,
         ];
     }
 

--- a/tests/Gedmo/SoftDeleteable/CarbonTest.php
+++ b/tests/Gedmo/SoftDeleteable/CarbonTest.php
@@ -22,8 +22,6 @@ use Gedmo\Tests\Tool\BaseTestCaseORM;
 
 final class CarbonTest extends BaseTestCaseORM
 {
-    private const ARTICLE_CLASS = Article::class;
-    private const COMMENT_CLASS = Comment::class;
     private const SOFT_DELETEABLE_FILTER_NAME = 'soft-deleteable';
 
     private SoftDeleteableListener $softDeleteableListener;
@@ -52,8 +50,8 @@ final class CarbonTest extends BaseTestCaseORM
 
     public function testSoftDeleteable(): void
     {
-        $repo = $this->em->getRepository(self::ARTICLE_CLASS);
-        $commentRepo = $this->em->getRepository(self::COMMENT_CLASS);
+        $repo = $this->em->getRepository(Article::class);
+        $commentRepo = $this->em->getRepository(Comment::class);
 
         $comment = new Comment();
         $commentField = 'comment';
@@ -97,8 +95,8 @@ final class CarbonTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::ARTICLE_CLASS,
-            self::COMMENT_CLASS,
+            Article::class,
+            Comment::class,
         ];
     }
 }

--- a/tests/Gedmo/SoftDeleteable/SoftDeleteableDocumentTest.php
+++ b/tests/Gedmo/SoftDeleteable/SoftDeleteableDocumentTest.php
@@ -30,8 +30,6 @@ use Gedmo\Tests\Tool\BaseTestCaseMongoODM;
  */
 final class SoftDeleteableDocumentTest extends BaseTestCaseMongoODM
 {
-    private const USER_CLASS = User::class;
-    private const USER__TIME_AWARE_CLASS = UserTimeAware::class;
     private const SOFT_DELETEABLE_FILTER_NAME = 'soft-deleteable';
 
     private SoftDeleteableListener $softDeleteableListener;
@@ -52,7 +50,7 @@ final class SoftDeleteableDocumentTest extends BaseTestCaseMongoODM
 
     public function testShouldSoftlyDeleteIfColumnNameDifferFromPropertyName(): void
     {
-        $repo = $this->dm->getRepository(self::USER_CLASS);
+        $repo = $this->dm->getRepository(User::class);
 
         $newUser = new User();
 
@@ -82,9 +80,9 @@ final class SoftDeleteableDocumentTest extends BaseTestCaseMongoODM
     {
         $filter = $this->dm->getFilterCollection()->getFilter(self::SOFT_DELETEABLE_FILTER_NAME);
         static::assertInstanceOf(SoftDeleteableFilter::class, $filter);
-        $filter->disableForDocument(self::USER_CLASS);
+        $filter->disableForDocument(User::class);
 
-        $repo = $this->dm->getRepository(self::USER_CLASS);
+        $repo = $this->dm->getRepository(User::class);
 
         $newUser = new User();
         $username = 'test_user';
@@ -102,7 +100,7 @@ final class SoftDeleteableDocumentTest extends BaseTestCaseMongoODM
 
         static::assertNotNull($user->getDeletedAt());
 
-        $filter->enableForDocument(self::USER_CLASS);
+        $filter->enableForDocument(User::class);
 
         $user = $repo->findOneBy(['username' => $username]);
         static::assertNull($user);
@@ -119,9 +117,9 @@ final class SoftDeleteableDocumentTest extends BaseTestCaseMongoODM
     {
         $filter = $this->dm->getFilterCollection()->getFilter(self::SOFT_DELETEABLE_FILTER_NAME);
         static::assertInstanceOf(SoftDeleteableFilter::class, $filter);
-        $filter->disableForDocument(self::USER__TIME_AWARE_CLASS);
+        $filter->disableForDocument(UserTimeAware::class);
 
-        $repo = $this->dm->getRepository(self::USER__TIME_AWARE_CLASS);
+        $repo = $this->dm->getRepository(UserTimeAware::class);
 
         // Find entity with deletedAt date in future
         $newUser = new User();
@@ -168,7 +166,7 @@ final class SoftDeleteableDocumentTest extends BaseTestCaseMongoODM
 
     private function doTestPostSoftDeleteEventIsDispatched(): void
     {
-        $repo = $this->dm->getRepository(self::USER_CLASS);
+        $repo = $this->dm->getRepository(User::class);
 
         $newUser = new User();
         $username = 'test_user';

--- a/tests/Gedmo/SoftDeleteable/SoftDeleteableEntityTest.php
+++ b/tests/Gedmo/SoftDeleteable/SoftDeleteableEntityTest.php
@@ -43,17 +43,7 @@ use Symfony\Component\Cache\Adapter\ArrayAdapter;
  */
 final class SoftDeleteableEntityTest extends BaseTestCaseORM
 {
-    private const ARTICLE_CLASS = Article::class;
-    private const COMMENT_CLASS = Comment::class;
-    private const PAGE_CLASS = Page::class;
-    private const MEGA_PAGE_CLASS = MegaPage::class;
-    private const MODULE_CLASS = Module::class;
-    private const OTHER_ARTICLE_CLASS = OtherArticle::class;
-    private const OTHER_COMMENT_CLASS = OtherComment::class;
-    private const USER_CLASS = User::class;
-    private const MAPPED_SUPERCLASS_CHILD_CLASS = Child::class;
     private const SOFT_DELETEABLE_FILTER_NAME = 'soft-deleteable';
-    private const USER_NO_HARD_DELETE_CLASS = UserNoHardDelete::class;
 
     private SoftDeleteableListener $softDeleteableListener;
 
@@ -73,7 +63,7 @@ final class SoftDeleteableEntityTest extends BaseTestCaseORM
 
     public function testShouldBeAbleToHardDeleteSoftdeletedItems(): void
     {
-        $repo = $this->em->getRepository(self::USER_CLASS);
+        $repo = $this->em->getRepository(User::class);
 
         $newUser = new User();
         $newUser->setUsername($username = 'test_user');
@@ -93,7 +83,7 @@ final class SoftDeleteableEntityTest extends BaseTestCaseORM
 
     public function testShouldSoftlyDeleteIfColumnNameDifferFromPropertyName(): void
     {
-        $repo = $this->em->getRepository(self::USER_CLASS);
+        $repo = $this->em->getRepository(User::class);
 
         $newUser = new User();
         $username = 'test_user';
@@ -126,8 +116,8 @@ final class SoftDeleteableEntityTest extends BaseTestCaseORM
 
     public function testSoftDeleteable(): void
     {
-        $repo = $this->em->getRepository(self::ARTICLE_CLASS);
-        $commentRepo = $this->em->getRepository(self::COMMENT_CLASS);
+        $repo = $this->em->getRepository(Article::class);
+        $commentRepo = $this->em->getRepository(Comment::class);
 
         $comment = new Comment();
         $commentField = 'comment';
@@ -167,7 +157,7 @@ final class SoftDeleteableEntityTest extends BaseTestCaseORM
         static::assertIsObject($comment->getDeletedAt());
         static::assertInstanceOf(\DateTime::class, $comment->getDeletedAt());
 
-        $this->em->createQuery('UPDATE '.self::ARTICLE_CLASS.' a SET a.deletedAt = NULL')->execute();
+        $this->em->createQuery('UPDATE '.Article::class.' a SET a.deletedAt = NULL')->execute();
 
         $this->em->refresh($art);
         $this->em->refresh($comment);
@@ -175,7 +165,7 @@ final class SoftDeleteableEntityTest extends BaseTestCaseORM
         // Now we try with a DQL Delete query
         $this->em->getFilters()->enable(self::SOFT_DELETEABLE_FILTER_NAME);
         $dql = sprintf('DELETE FROM %s a WHERE a.%s = :%s',
-            self::ARTICLE_CLASS, $field, $field);
+            Article::class, $field, $field);
         $query = $this->em->createQuery($dql);
         $query->setParameter($field, $value);
         $query->setHint(
@@ -201,7 +191,7 @@ final class SoftDeleteableEntityTest extends BaseTestCaseORM
         // Inheritance tree DELETE DQL
         $this->em->getFilters()->enable(self::SOFT_DELETEABLE_FILTER_NAME);
 
-        $megaPageRepo = $this->em->getRepository(self::MEGA_PAGE_CLASS);
+        $megaPageRepo = $this->em->getRepository(MegaPage::class);
         $module = new Module();
         $module->setTitle('Module 1');
         $page = new MegaPage();
@@ -214,7 +204,7 @@ final class SoftDeleteableEntityTest extends BaseTestCaseORM
         $this->em->flush();
 
         $dql = sprintf('DELETE FROM %s p',
-            self::PAGE_CLASS);
+            Page::class);
         $query = $this->em->createQuery($dql);
         $query->setHint(
             Query::HINT_CUSTOM_OUTPUT_WALKER,
@@ -239,8 +229,8 @@ final class SoftDeleteableEntityTest extends BaseTestCaseORM
         // Test of #301
         $this->em->getFilters()->enable(self::SOFT_DELETEABLE_FILTER_NAME);
 
-        $otherArticleRepo = $this->em->getRepository(self::OTHER_ARTICLE_CLASS);
-        $otherCommentRepo = $this->em->getRepository(self::OTHER_COMMENT_CLASS);
+        $otherArticleRepo = $this->em->getRepository(OtherArticle::class);
+        $otherCommentRepo = $this->em->getRepository(OtherComment::class);
         $otherArt = new OtherArticle();
         $otherComment = new OtherComment();
         $otherArt->setTitle('Page 1');
@@ -266,7 +256,7 @@ final class SoftDeleteableEntityTest extends BaseTestCaseORM
 
         static::assertNull($foundArt);
         static::assertIsObject($foundComment);
-        static::assertInstanceOf(self::OTHER_COMMENT_CLASS, $foundComment);
+        static::assertInstanceOf(OtherComment::class, $foundComment);
 
         $this->em->getFilters()->disable(self::SOFT_DELETEABLE_FILTER_NAME);
 
@@ -277,7 +267,7 @@ final class SoftDeleteableEntityTest extends BaseTestCaseORM
         static::assertIsObject($foundArt->getDeletedAt());
         static::assertInstanceOf(\DateTime::class, $foundArt->getDeletedAt());
         static::assertIsObject($foundComment);
-        static::assertInstanceOf(self::OTHER_COMMENT_CLASS, $foundComment);
+        static::assertInstanceOf(OtherComment::class, $foundComment);
     }
 
     /**
@@ -285,8 +275,8 @@ final class SoftDeleteableEntityTest extends BaseTestCaseORM
      */
     public function testSoftDeleteableWithDateTimeInterface(): void
     {
-        $repo = $this->em->getRepository(self::ARTICLE_CLASS);
-        $commentRepo = $this->em->getRepository(self::COMMENT_CLASS);
+        $repo = $this->em->getRepository(Article::class);
+        $commentRepo = $this->em->getRepository(Comment::class);
 
         $comment = new Comment();
         $commentField = 'comment';
@@ -323,7 +313,7 @@ final class SoftDeleteableEntityTest extends BaseTestCaseORM
         static::assertIsObject($comment);
         static::assertNull($comment->getDeletedAt());
 
-        $this->em->createQuery('UPDATE '.self::ARTICLE_CLASS.' a SET a.deletedAt = NULL')->execute();
+        $this->em->createQuery('UPDATE '.Article::class.' a SET a.deletedAt = NULL')->execute();
 
         $this->em->refresh($art);
         $this->em->refresh($comment);
@@ -331,7 +321,7 @@ final class SoftDeleteableEntityTest extends BaseTestCaseORM
         // Now we try with a DQL Delete query
         $this->em->getFilters()->enable(self::SOFT_DELETEABLE_FILTER_NAME);
         $dql = sprintf('DELETE FROM %s a WHERE a.%s = :%s',
-            self::ARTICLE_CLASS, $field, $field);
+            Article::class, $field, $field);
         $query = $this->em->createQuery($dql);
         $query->setParameter($field, $value);
         $query->setHint(
@@ -357,7 +347,7 @@ final class SoftDeleteableEntityTest extends BaseTestCaseORM
         // Inheritance tree DELETE DQL
         $this->em->getFilters()->enable(self::SOFT_DELETEABLE_FILTER_NAME);
 
-        $megaPageRepo = $this->em->getRepository(self::MEGA_PAGE_CLASS);
+        $megaPageRepo = $this->em->getRepository(MegaPage::class);
         $module = new Module();
         $module->setTitle('Module 1');
         $page = new MegaPage();
@@ -370,7 +360,7 @@ final class SoftDeleteableEntityTest extends BaseTestCaseORM
         $this->em->flush();
 
         $dql = sprintf('DELETE FROM %s p',
-            self::PAGE_CLASS);
+            Page::class);
         $query = $this->em->createQuery($dql);
         $query->setHint(
             Query::HINT_CUSTOM_OUTPUT_WALKER,
@@ -395,8 +385,8 @@ final class SoftDeleteableEntityTest extends BaseTestCaseORM
         // Test of #301
         $this->em->getFilters()->enable(self::SOFT_DELETEABLE_FILTER_NAME);
 
-        $otherArticleRepo = $this->em->getRepository(self::OTHER_ARTICLE_CLASS);
-        $otherCommentRepo = $this->em->getRepository(self::OTHER_COMMENT_CLASS);
+        $otherArticleRepo = $this->em->getRepository(OtherArticle::class);
+        $otherCommentRepo = $this->em->getRepository(OtherComment::class);
         $otherArt = new OtherArticle();
         $otherComment = new OtherComment();
         $otherArt->setTitle('Page 1');
@@ -422,7 +412,7 @@ final class SoftDeleteableEntityTest extends BaseTestCaseORM
 
         static::assertNull($foundArt);
         static::assertIsObject($foundComment);
-        static::assertInstanceOf(self::OTHER_COMMENT_CLASS, $foundComment);
+        static::assertInstanceOf(OtherComment::class, $foundComment);
 
         $this->em->getFilters()->disable(self::SOFT_DELETEABLE_FILTER_NAME);
 
@@ -433,7 +423,7 @@ final class SoftDeleteableEntityTest extends BaseTestCaseORM
         static::assertIsObject($foundArt->getDeletedAt());
         static::assertInstanceOf('DateTimeInterface', $foundArt->getDeletedAt());
         static::assertIsObject($foundComment);
-        static::assertInstanceOf(self::OTHER_COMMENT_CLASS, $foundComment);
+        static::assertInstanceOf(OtherComment::class, $foundComment);
     }
 
     /**
@@ -451,7 +441,7 @@ final class SoftDeleteableEntityTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $repo = $this->em->getRepository(self::MAPPED_SUPERCLASS_CHILD_CLASS);
+        $repo = $this->em->getRepository(Child::class);
         static::assertNull($repo->findOneBy(['id' => $child->getId()]));
 
         $this->em->getFilters()->enable(self::SOFT_DELETEABLE_FILTER_NAME);
@@ -462,9 +452,9 @@ final class SoftDeleteableEntityTest extends BaseTestCaseORM
     {
         $filter = $this->em->getFilters()->enable(self::SOFT_DELETEABLE_FILTER_NAME);
         static::assertInstanceOf(SoftDeleteableFilter::class, $filter);
-        $filter->disableForEntity(self::USER_CLASS);
+        $filter->disableForEntity(User::class);
 
-        $repo = $this->em->getRepository(self::USER_CLASS);
+        $repo = $this->em->getRepository(User::class);
 
         $newUser = new User();
         $username = 'test_user';
@@ -483,7 +473,7 @@ final class SoftDeleteableEntityTest extends BaseTestCaseORM
         $user = $repo->findOneBy(['username' => $username]);
         static::assertNotNull($user->getDeletedAt());
 
-        $filter->enableForEntity(self::USER_CLASS);
+        $filter->enableForEntity(User::class);
 
         $user = $repo->findOneBy(['username' => $username]);
         static::assertNull($user);
@@ -495,9 +485,9 @@ final class SoftDeleteableEntityTest extends BaseTestCaseORM
 
         $filter = $this->em->getFilters()->enable(self::SOFT_DELETEABLE_FILTER_NAME);
         static::assertInstanceOf(SoftDeleteableFilter::class, $filter);
-        $filter->disableForEntity(self::USER_CLASS);
+        $filter->disableForEntity(User::class);
 
-        $repo = $this->em->getRepository(self::USER_CLASS);
+        $repo = $this->em->getRepository(User::class);
 
         $newUser = new User();
         $username = 'test_user';
@@ -513,7 +503,7 @@ final class SoftDeleteableEntityTest extends BaseTestCaseORM
         $this->em->remove($user);
         $this->em->flush();
 
-        $dql = 'SELECT u FROM '.self::USER_CLASS.' u WHERE u.username = :username';
+        $dql = 'SELECT u FROM '.User::class.' u WHERE u.username = :username';
         $q = $this->em->createQuery($dql)
                       ->setParameter('username', $username)
         ;
@@ -522,7 +512,7 @@ final class SoftDeleteableEntityTest extends BaseTestCaseORM
         $user = $data[0];
         static::assertNotNull($user->getDeletedAt());
 
-        $filter->enableForEntity(self::USER_CLASS);
+        $filter->enableForEntity(User::class);
 
         // The result should be different even with the query cache enabled.
         $q = $this->em->createQuery($dql)
@@ -553,7 +543,7 @@ final class SoftDeleteableEntityTest extends BaseTestCaseORM
 
     public function testShouldNotDeleteIfColumnNameDifferFromPropertyName(): void
     {
-        $repo = $this->em->getRepository(self::USER_NO_HARD_DELETE_CLASS);
+        $repo = $this->em->getRepository(UserNoHardDelete::class);
 
         $newUser = new UserNoHardDelete();
         $username = 'test_user';
@@ -587,22 +577,22 @@ final class SoftDeleteableEntityTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::ARTICLE_CLASS,
-            self::PAGE_CLASS,
-            self::MEGA_PAGE_CLASS,
-            self::MODULE_CLASS,
-            self::COMMENT_CLASS,
-            self::USER_CLASS,
-            self::OTHER_ARTICLE_CLASS,
-            self::OTHER_COMMENT_CLASS,
-            self::MAPPED_SUPERCLASS_CHILD_CLASS,
-            self::USER_NO_HARD_DELETE_CLASS,
+            Article::class,
+            Page::class,
+            MegaPage::class,
+            Module::class,
+            Comment::class,
+            User::class,
+            OtherArticle::class,
+            OtherComment::class,
+            Child::class,
+            UserNoHardDelete::class,
         ];
     }
 
     private function doTestPostSoftDeleteEventIsDispatched(): void
     {
-        $repo = $this->em->getRepository(self::ARTICLE_CLASS);
+        $repo = $this->em->getRepository(Article::class);
 
         $comment = new Comment();
         $commentValue = 'Comment 1';

--- a/tests/Gedmo/Sortable/SortableDocumentGroupTest.php
+++ b/tests/Gedmo/Sortable/SortableDocumentGroupTest.php
@@ -25,9 +25,6 @@ use Gedmo\Tests\Tool\BaseTestCaseMongoODM;
  */
 final class SortableDocumentGroupTest extends BaseTestCaseMongoODM
 {
-    private const POST = Post::class;
-    private const CATEGORY = Category::class;
-    private const KID = Kid::class;
     private const KID_DATE1 = '1999-12-31';
     private const KID_DATE2 = '2000-01-01';
 
@@ -46,7 +43,7 @@ final class SortableDocumentGroupTest extends BaseTestCaseMongoODM
      */
     public function testKidInitialPositions(): void
     {
-        $repo = $this->dm->getRepository(self::KID);
+        $repo = $this->dm->getRepository(Kid::class);
 
         for ($i = 0; $i < 2; ++$i) {
             $kids = $repo->findBy(['position' => $i]);
@@ -59,10 +56,10 @@ final class SortableDocumentGroupTest extends BaseTestCaseMongoODM
      */
     public function testKidMovePosition(): void
     {
-        $repo = $this->dm->getRepository(self::KID);
+        $repo = $this->dm->getRepository(Kid::class);
 
         $kid = $repo->findOneBy(['lastname' => 'kid2']);
-        static::assertInstanceOf(self::KID, $kid);
+        static::assertInstanceOf(Kid::class, $kid);
 
         $kid->setPosition(0);
         $this->dm->flush();
@@ -81,7 +78,7 @@ final class SortableDocumentGroupTest extends BaseTestCaseMongoODM
      */
     public function testPostsInitialPositions(): void
     {
-        $repo = $this->dm->getRepository(self::POST);
+        $repo = $this->dm->getRepository(Post::class);
 
         for ($i = 0; $i < 3; ++$i) {
             $posts = $repo->findBy(['position' => $i]);
@@ -94,17 +91,17 @@ final class SortableDocumentGroupTest extends BaseTestCaseMongoODM
      */
     public function testPostsMovePosition(): void
     {
-        $repo_category = $this->dm->getRepository(self::CATEGORY);
-        $repo_post = $this->dm->getRepository(self::POST);
+        $repo_category = $this->dm->getRepository(Category::class);
+        $repo_post = $this->dm->getRepository(Post::class);
 
         $category = $repo_category->findOneBy(['name' => 'category1']);
-        static::assertInstanceOf(self::CATEGORY, $category);
+        static::assertInstanceOf(Category::class, $category);
 
         $post = $repo_post->findOneBy([
             'position' => 2,
             'category.id' => $category->getId(),
         ]);
-        static::assertInstanceOf(self::POST, $post);
+        static::assertInstanceOf(Post::class, $post);
 
         $post->setPosition(0);
 
@@ -126,17 +123,17 @@ final class SortableDocumentGroupTest extends BaseTestCaseMongoODM
      */
     public function testPostsDeletePosition(): void
     {
-        $repo_category = $this->dm->getRepository(self::CATEGORY);
-        $repo_post = $this->dm->getRepository(self::POST);
+        $repo_category = $this->dm->getRepository(Category::class);
+        $repo_post = $this->dm->getRepository(Post::class);
 
         $category = $repo_category->findOneBy(['name' => 'category1']);
-        static::assertInstanceOf(self::CATEGORY, $category);
+        static::assertInstanceOf(Category::class, $category);
 
         $post = $repo_post->findOneBy([
             'position' => 1,
             'category.id' => $category->getId(),
         ]);
-        static::assertInstanceOf(self::POST, $post);
+        static::assertInstanceOf(Post::class, $post);
 
         $this->dm->remove($post);
         $this->dm->flush();

--- a/tests/Gedmo/Sortable/SortableDocumentTest.php
+++ b/tests/Gedmo/Sortable/SortableDocumentTest.php
@@ -23,8 +23,6 @@ use Gedmo\Tests\Tool\BaseTestCaseMongoODM;
  */
 final class SortableDocumentTest extends BaseTestCaseMongoODM
 {
-    private const ARTICLE = Article::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -37,7 +35,7 @@ final class SortableDocumentTest extends BaseTestCaseMongoODM
 
     public function testInitialPositions(): void
     {
-        $repo = $this->dm->getRepository(self::ARTICLE);
+        $repo = $this->dm->getRepository(Article::class);
         for ($i = 0; $i <= 4; ++$i) {
             $article = $repo->findOneBy(['position' => $i]);
             static::assertSame('article'.$i, $article->getTitle());
@@ -46,7 +44,7 @@ final class SortableDocumentTest extends BaseTestCaseMongoODM
 
     public function testMovePositions(): void
     {
-        $repo = $this->dm->getRepository(self::ARTICLE);
+        $repo = $this->dm->getRepository(Article::class);
 
         $article = $repo->findOneBy(['position' => 4]);
         $article->setPosition(0);
@@ -60,7 +58,7 @@ final class SortableDocumentTest extends BaseTestCaseMongoODM
 
     public function testMoveLastPositions(): void
     {
-        $repo = $this->dm->getRepository(self::ARTICLE);
+        $repo = $this->dm->getRepository(Article::class);
 
         $article = $repo->findOneBy(['position' => 0]);
         $article->setPosition(-1);
@@ -76,7 +74,7 @@ final class SortableDocumentTest extends BaseTestCaseMongoODM
 
     public function testDeletePositions(): void
     {
-        $repo = $this->dm->getRepository(self::ARTICLE);
+        $repo = $this->dm->getRepository(Article::class);
 
         $article = $repo->findOneBy(['position' => 0]);
         $this->dm->remove($article);

--- a/tests/Gedmo/Sortable/SortableGroupTest.php
+++ b/tests/Gedmo/Sortable/SortableGroupTest.php
@@ -30,15 +30,6 @@ use Gedmo\Tests\Tool\BaseTestCaseORM;
  */
 final class SortableGroupTest extends BaseTestCaseORM
 {
-    private const CAR = Car::class;
-    private const BUS = Bus::class;
-    private const VEHICLE = Vehicle::class;
-    private const ENGINE = Engine::class;
-    private const RESERVATION = Reservation::class;
-    private const ITEM = Item::class;
-    private const CATEGORY = Category::class;
-    private const ITEM_WITH_DATE_COLUMN = ItemWithDateColumn::class;
-
     private const SEATS = 3;
 
     private const TRAVEL_DATE_FORMAT = 'Y-m-d H:i';
@@ -58,7 +49,7 @@ final class SortableGroupTest extends BaseTestCaseORM
     public function testShouldBeAbleToRemove(): void
     {
         $this->populate();
-        $carRepo = $this->em->getRepository(self::CAR);
+        $carRepo = $this->em->getRepository(Car::class);
 
         $audi80 = $carRepo->findOneBy(['title' => 'Audi-80']);
         static::assertSame(0, $audi80->getSortByEngine());
@@ -66,7 +57,7 @@ final class SortableGroupTest extends BaseTestCaseORM
         $audi80s = $carRepo->findOneBy(['title' => 'Audi-80s']);
         static::assertSame(1, $audi80s->getSortByEngine());
 
-        $icarus = $this->em->getRepository(self::BUS)->findOneBy(['title' => 'Icarus']);
+        $icarus = $this->em->getRepository(Bus::class)->findOneBy(['title' => 'Icarus']);
         static::assertSame(2, $icarus->getSortByEngine());
 
         $this->em->remove($audi80);
@@ -75,7 +66,7 @@ final class SortableGroupTest extends BaseTestCaseORM
         $audi80s = $carRepo->findOneBy(['title' => 'Audi-80s']);
         static::assertSame(0, $audi80s->getSortByEngine());
 
-        $icarus = $this->em->getRepository(self::BUS)->findOneBy(['title' => 'Icarus']);
+        $icarus = $this->em->getRepository(Bus::class)->findOneBy(['title' => 'Icarus']);
         static::assertSame(1, $icarus->getSortByEngine());
     }
 
@@ -85,7 +76,7 @@ final class SortableGroupTest extends BaseTestCaseORM
     public function testShouldBeAbleToChangeGroup(): void
     {
         $this->populate();
-        $carRepo = $this->em->getRepository(self::CAR);
+        $carRepo = $this->em->getRepository(Car::class);
 
         // position 0
         $audi80 = $carRepo->findOneBy(['title' => 'Audi-80']);
@@ -96,7 +87,7 @@ final class SortableGroupTest extends BaseTestCaseORM
         static::assertSame(1, $audi80s->getSortByEngine());
 
         // position 2
-        $icarus = $this->em->getRepository(self::BUS)->findOneBy(['title' => 'Icarus']);
+        $icarus = $this->em->getRepository(Bus::class)->findOneBy(['title' => 'Icarus']);
         static::assertSame(2, $icarus->getSortByEngine());
 
         // theres only 1 v6 so this should be position:0
@@ -104,7 +95,7 @@ final class SortableGroupTest extends BaseTestCaseORM
         static::assertSame(0, $audiJet->getSortByEngine());
 
         // change engines
-        $v6engine = $this->em->getRepository(self::ENGINE)->findOneBy(['type' => 'V6']);
+        $v6engine = $this->em->getRepository(Engine::class)->findOneBy(['type' => 'V6']);
 
         $audi80s->setEngine($v6engine);
 
@@ -126,7 +117,7 @@ final class SortableGroupTest extends BaseTestCaseORM
     {
         $this->populate();
 
-        $repo = $this->em->getRepository(self::RESERVATION);
+        $repo = $this->em->getRepository(Reservation::class);
         $today = \DateTime::createFromFormat(self::TRAVEL_DATE_FORMAT, self::TODAY);
         $tomorrow = \DateTime::createFromFormat(self::TRAVEL_DATE_FORMAT, self::TOMORROW);
 
@@ -191,8 +182,8 @@ final class SortableGroupTest extends BaseTestCaseORM
     {
         $this->populate();
 
-        $repo = $this->em->getRepository(self::ITEM);
-        $repoCategory = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(Item::class);
+        $repoCategory = $this->em->getRepository(Category::class);
 
         $vehicle = $repoCategory->findOneBy(['name' => 'Vehicle']);
 
@@ -252,7 +243,7 @@ final class SortableGroupTest extends BaseTestCaseORM
         }
         $this->em->flush();
 
-        $repo = $this->em->getRepository(self::ITEM_WITH_DATE_COLUMN);
+        $repo = $this->em->getRepository(ItemWithDateColumn::class);
 
         /** @var ItemWithDateColumn $testItem */
         $testItem = $repo->findOneBy(['id' => 5]);
@@ -272,14 +263,14 @@ final class SortableGroupTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::VEHICLE,
-            self::CAR,
-            self::ENGINE,
-            self::BUS,
-            self::RESERVATION,
-            self::ITEM,
-            self::CATEGORY,
-            self::ITEM_WITH_DATE_COLUMN,
+            Vehicle::class,
+            Car::class,
+            Engine::class,
+            Bus::class,
+            Reservation::class,
+            Item::class,
+            Category::class,
+            ItemWithDateColumn::class,
         ];
     }
 

--- a/tests/Gedmo/Sortable/SortableTest.php
+++ b/tests/Gedmo/Sortable/SortableTest.php
@@ -34,17 +34,6 @@ use Gedmo\Tests\Tool\BaseTestCaseORM;
  */
 final class SortableTest extends BaseTestCaseORM
 {
-    private const NODE = Node::class;
-    private const NOTIFY_NODE = NotifyNode::class;
-    private const ITEM = Item::class;
-    private const CATEGORY = Category::class;
-    private const SIMPLE_LIST_ITEM = SimpleListItem::class;
-    private const AUTHOR = Author::class;
-    private const PAPER = Paper::class;
-    private const EVENT = Event::class;
-    private const CUSTOMER = Customer::class;
-    private const CUSTOMER_TYPE = CustomerType::class;
-
     private ?int $nodeId = null;
 
     protected function setUp(): void
@@ -60,7 +49,7 @@ final class SortableTest extends BaseTestCaseORM
 
     public function testShouldSetSortPositionToInsertedNode(): void
     {
-        $node = $this->em->find(self::NODE, $this->nodeId);
+        $node = $this->em->find(Node::class, $this->nodeId);
         static::assertSame(0, $node->getPosition());
     }
 
@@ -74,7 +63,7 @@ final class SortableTest extends BaseTestCaseORM
         }
         $this->em->flush();
 
-        $repo = $this->em->getRepository(self::NODE);
+        $repo = $this->em->getRepository(Node::class);
 
         $node = $repo->findOneBy(['position' => 0]);
         $node->setPosition(-1);
@@ -101,7 +90,7 @@ final class SortableTest extends BaseTestCaseORM
         }
         $this->em->flush();
 
-        $dql = 'SELECT node FROM '.self::NODE.' node';
+        $dql = 'SELECT node FROM '.Node::class.' node';
         $dql .= ' WHERE node.path = :path ORDER BY node.position';
         $nodes = $this->em
             ->createQuery($dql)
@@ -143,7 +132,7 @@ final class SortableTest extends BaseTestCaseORM
         $this->em->persist($node2);
         $this->em->flush();
 
-        $repo = $this->em->getRepository(self::NODE);
+        $repo = $this->em->getRepository(Node::class);
         $nodes = $repo->getBySortableGroups(['path' => '/']);
 
         static::assertSame('Node1', $nodes[0]->getName());
@@ -188,7 +177,7 @@ final class SortableTest extends BaseTestCaseORM
         $this->em->persist($node3);
         $this->em->flush();
 
-        $repo = $this->em->getRepository(self::NODE);
+        $repo = $this->em->getRepository(Node::class);
         $nodes = $repo->getBySortableGroups(['path' => '/']);
 
         static::assertSame('Node1', $nodes[0]->getName());
@@ -232,7 +221,7 @@ final class SortableTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear(); // to reload from database
 
-        $repo = $this->em->getRepository(self::NODE);
+        $repo = $this->em->getRepository(Node::class);
         $nodes = $repo->getBySortableGroups(['path' => '/']);
 
         static::assertSame('Node1', $nodes[0]->getName());
@@ -248,7 +237,7 @@ final class SortableTest extends BaseTestCaseORM
 
     public function testShouldSyncPositionAfterDelete(): void
     {
-        $repo = $this->em->getRepository(self::NODE);
+        $repo = $this->em->getRepository(Node::class);
 
         $node2 = new Node();
         $node2->setName('Node2');
@@ -290,7 +279,7 @@ final class SortableTest extends BaseTestCaseORM
      */
     public function testShouldSyncPositionAfterMultipleDeletes(): void
     {
-        $repo = $this->em->getRepository(self::NODE);
+        $repo = $this->em->getRepository(Node::class);
 
         $node2 = new Node();
         $node2->setName('Node2');
@@ -340,7 +329,7 @@ final class SortableTest extends BaseTestCaseORM
      */
     public function testShouldSyncPositionAfterMultipleAddsAndMultipleDeletes(): void
     {
-        $repo = $this->em->getRepository(self::NODE);
+        $repo = $this->em->getRepository(Node::class);
 
         $node2 = new Node();
         $node2->setName('Node2');
@@ -402,7 +391,7 @@ final class SortableTest extends BaseTestCaseORM
      */
     public function testShouldRollbackPositionAfterExceptionOnDelete(): void
     {
-        $repo = $this->em->getRepository(self::CUSTOMER_TYPE);
+        $repo = $this->em->getRepository(CustomerType::class);
 
         $customerType1 = new CustomerType();
         $customerType1->setName('CustomerType1');
@@ -489,11 +478,11 @@ final class SortableTest extends BaseTestCaseORM
         $this->em->persist($item1);
         $this->em->flush();
 
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(Category::class);
         $category1 = $repo->findOneBy(['name' => 'Category1']);
         $category2 = $repo->findOneBy(['name' => 'Category2']);
 
-        $repo = $this->em->getRepository(self::ITEM);
+        $repo = $this->em->getRepository(Item::class);
 
         $items = $repo->getBySortableGroups(['category' => $category1]);
 
@@ -531,10 +520,10 @@ final class SortableTest extends BaseTestCaseORM
         $this->em->persist($category1);
         $this->em->flush();
 
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(Category::class);
         $category1 = $repo->findOneBy(['name' => 'Category1']);
 
-        $repo = $this->em->getRepository(self::ITEM);
+        $repo = $this->em->getRepository(Item::class);
 
         $items = $repo->getBySortableGroups(['category' => $category1]);
 
@@ -626,9 +615,9 @@ final class SortableTest extends BaseTestCaseORM
 
         $this->em->clear(); // @TODO: this should not be required
 
-        $author1 = $this->em->find(self::AUTHOR, $author1->getId());
-        $author2 = $this->em->find(self::AUTHOR, $author2->getId());
-        $author3 = $this->em->find(self::AUTHOR, $author3->getId());
+        $author1 = $this->em->find(Author::class, $author1->getId());
+        $author2 = $this->em->find(Author::class, $author2->getId());
+        $author3 = $this->em->find(Author::class, $author3->getId());
 
         static::assertSame(1, $author1->getPosition());
         static::assertSame(2, $author2->getPosition());
@@ -671,7 +660,7 @@ final class SortableTest extends BaseTestCaseORM
 
         $this->em->clear(); // @TODO: this should not be required
 
-        $repo = $this->em->getRepository(self::AUTHOR);
+        $repo = $this->em->getRepository(Author::class);
         $author1 = $repo->findOneBy(['id' => $author1->getId()]);
         $author2 = $repo->findOneBy(['id' => $author2->getId()]);
 
@@ -737,7 +726,7 @@ final class SortableTest extends BaseTestCaseORM
 
         $this->em->clear(); // @TODO: this should not be required
 
-        $repo = $this->em->getRepository(self::AUTHOR);
+        $repo = $this->em->getRepository(Author::class);
         $author1 = $repo->findOneBy(['id' => $author1->getId()]);
         $author2 = $repo->findOneBy(['id' => $author2->getId()]);
         $author3 = $repo->findOneBy(['id' => $author3->getId()]);
@@ -764,7 +753,7 @@ final class SortableTest extends BaseTestCaseORM
         }
         $this->em->flush();
 
-        $node1 = $this->em->find(self::NODE, $this->nodeId);
+        $node1 = $this->em->find(Node::class, $this->nodeId);
         $node1->setPosition(5);
 
         $this->em->flush();
@@ -772,13 +761,13 @@ final class SortableTest extends BaseTestCaseORM
         static::assertSame(5, $node1->getPosition());
 
         $this->em->detach($node1);
-        $node1 = $this->em->find(self::NODE, $this->nodeId);
+        $node1 = $this->em->find(Node::class, $this->nodeId);
         static::assertSame(5, $node1->getPosition());
     }
 
     public function testIncrementPositionOfLastObjectByOne(): void
     {
-        $node0 = $this->em->find(self::NODE, $this->nodeId);
+        $node0 = $this->em->find(Node::class, $this->nodeId);
 
         $nodes = [$node0];
 
@@ -806,7 +795,7 @@ final class SortableTest extends BaseTestCaseORM
 
     public function testSetOutOfBoundsHighPosition(): void
     {
-        $node0 = $this->em->find(self::NODE, $this->nodeId);
+        $node0 = $this->em->find(Node::class, $this->nodeId);
 
         $nodes = [$node0];
 
@@ -854,19 +843,19 @@ final class SortableTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         $fixtures = [
-            self::NODE,
-            self::ITEM,
-            self::CATEGORY,
-            self::SIMPLE_LIST_ITEM,
-            self::AUTHOR,
-            self::PAPER,
-            self::EVENT,
-            self::CUSTOMER,
-            self::CUSTOMER_TYPE,
+            Node::class,
+            Item::class,
+            Category::class,
+            SimpleListItem::class,
+            Author::class,
+            Paper::class,
+            Event::class,
+            Customer::class,
+            CustomerType::class,
         ];
 
         if (class_exists(AnnotationDriver::class)) {
-            $fixtures[] = self::NOTIFY_NODE;
+            $fixtures[] = NotifyNode::class;
         }
 
         return $fixtures;

--- a/tests/Gedmo/Timestampable/AttributeChangeTest.php
+++ b/tests/Gedmo/Timestampable/AttributeChangeTest.php
@@ -30,8 +30,6 @@ use Gedmo\Tests\Tool\BaseTestCaseORM;
  */
 final class AttributeChangeTest extends BaseTestCaseORM
 {
-    private const FIXTURE = TitledArticle::class;
-
     /**
      * @var TimestampableListenerStub
      */
@@ -64,7 +62,7 @@ final class AttributeChangeTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $test = $this->em->getRepository(self::FIXTURE)->findOneBy(['title' => 'Test']);
+        $test = $this->em->getRepository(TitledArticle::class)->findOneBy(['title' => 'Test']);
         $test->setTitle('New Title');
         $test->setState('Closed');
         $this->em->persist($test);
@@ -83,7 +81,7 @@ final class AttributeChangeTest extends BaseTestCaseORM
         $anotherDate = \DateTime::createFromFormat('Y-m-d H:i:s', '2000-01-01 00:00:00');
         $this->listener->eventAdapter->setDateValue($anotherDate);
 
-        $test = $this->em->getRepository(self::FIXTURE)->findOneBy(['title' => 'New Title']);
+        $test = $this->em->getRepository(TitledArticle::class)->findOneBy(['title' => 'New Title']);
         $test->setText('New Text');
         $test->setState('Open');
         $this->em->persist($test);
@@ -99,7 +97,7 @@ final class AttributeChangeTest extends BaseTestCaseORM
             $test->getClosed()->format('Y-m-d H:i:s')
         );
 
-        $test = $this->em->getRepository(self::FIXTURE)->findOneBy(['title' => 'New Title']);
+        $test = $this->em->getRepository(TitledArticle::class)->findOneBy(['title' => 'New Title']);
         $test->setState('Published');
         $this->em->persist($test);
         $this->em->flush();
@@ -114,7 +112,7 @@ final class AttributeChangeTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::FIXTURE,
+            TitledArticle::class,
         ];
     }
 }

--- a/tests/Gedmo/Timestampable/CarbonTest.php
+++ b/tests/Gedmo/Timestampable/CarbonTest.php
@@ -27,10 +27,6 @@ use Gedmo\Timestampable\TimestampableListener;
 
 final class CarbonTest extends BaseTestCaseORM
 {
-    private const ARTICLE = ArticleCarbon::class;
-    private const COMMENT = CommentCarbon::class;
-    private const TYPE = Type::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -79,7 +75,7 @@ final class CarbonTest extends BaseTestCaseORM
         $this->em->flush();
 
         /** @var ArticleCarbon $sport */
-        $sport = $this->em->getRepository(self::ARTICLE)->findOneBy(['title' => 'Sport']);
+        $sport = $this->em->getRepository(ArticleCarbon::class)->findOneBy(['title' => 'Sport']);
         static::assertInstanceOf(CarbonImmutable::class, $sport->getUpdated(), 'Type DATETIME_MUTABLE should become CarbonImmutable');
         static::assertInstanceOf(Carbon::class, $sport->getCreated(), 'Type DATE_MUTABLE should become Carbon');
 
@@ -94,7 +90,7 @@ final class CarbonTest extends BaseTestCaseORM
         $sport->setAuthor($author);
 
         /** @var CommentCarbon $sportComment */
-        $sportComment = $this->em->getRepository(self::COMMENT)->findOneBy(['message' => 'hello']);
+        $sportComment = $this->em->getRepository(CommentCarbon::class)->findOneBy(['message' => 'hello']);
         static::assertInstanceOf(\DateTime::class, $sportComment->getModified(), 'Type TIME_MUTABLE should stay DateTime');
 
         static::assertNotNull($sportComment->getModified());
@@ -110,7 +106,7 @@ final class CarbonTest extends BaseTestCaseORM
         $this->em->persist($sportComment);
         $this->em->flush();
 
-        $sportComment = $this->em->getRepository(self::COMMENT)->findOneBy(['message' => 'hello']);
+        $sportComment = $this->em->getRepository(CommentCarbon::class)->findOneBy(['message' => 'hello']);
         static::assertInstanceOf(CarbonImmutable::class, $sportComment->getClosed(), 'Type DATETIME_MUTABLE should become CarbonImmutable');
         static::assertInstanceOf(CarbonImmutable::class, $sport->getPublished(), 'Type DATETIME_MUTABLE should become CarbonImmutable');
         static::assertInstanceOf(CarbonImmutable::class, $sport->getAuthorChanged(), 'Type DATETIME_MUTABLE should become CarbonImmutable');
@@ -153,9 +149,9 @@ final class CarbonTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::ARTICLE,
-            self::COMMENT,
-            self::TYPE,
+            ArticleCarbon::class,
+            CommentCarbon::class,
+            Type::class,
         ];
     }
 }

--- a/tests/Gedmo/Timestampable/ChangeTest.php
+++ b/tests/Gedmo/Timestampable/ChangeTest.php
@@ -26,8 +26,6 @@ use Gedmo\Timestampable\Mapping\Event\TimestampableAdapter;
  */
 final class ChangeTest extends BaseTestCaseORM
 {
-    private const FIXTURE = TitledArticle::class;
-
     /**
      * @var TimestampableListenerStub
      */
@@ -60,7 +58,7 @@ final class ChangeTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $test = $this->em->getRepository(self::FIXTURE)->findOneBy(['title' => 'Test']);
+        $test = $this->em->getRepository(TitledArticle::class)->findOneBy(['title' => 'Test']);
         $test->setTitle('New Title');
         $test->setState('Closed');
         $this->em->persist($test);
@@ -79,7 +77,7 @@ final class ChangeTest extends BaseTestCaseORM
         $anotherDate = \DateTime::createFromFormat('Y-m-d H:i:s', '2000-01-01 00:00:00');
         $this->listener->eventAdapter->setDateValue($anotherDate);
 
-        $test = $this->em->getRepository(self::FIXTURE)->findOneBy(['title' => 'New Title']);
+        $test = $this->em->getRepository(TitledArticle::class)->findOneBy(['title' => 'New Title']);
         $test->setText('New Text');
         $test->setState('Open');
         $this->em->persist($test);
@@ -95,7 +93,7 @@ final class ChangeTest extends BaseTestCaseORM
             $test->getClosed()->format('Y-m-d H:i:s')
         );
 
-        $test = $this->em->getRepository(self::FIXTURE)->findOneBy(['title' => 'New Title']);
+        $test = $this->em->getRepository(TitledArticle::class)->findOneBy(['title' => 'New Title']);
         $test->setState('Published');
         $this->em->persist($test);
         $this->em->flush();
@@ -110,7 +108,7 @@ final class ChangeTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::FIXTURE,
+            TitledArticle::class,
         ];
     }
 }

--- a/tests/Gedmo/Timestampable/NoInterfaceTest.php
+++ b/tests/Gedmo/Timestampable/NoInterfaceTest.php
@@ -23,8 +23,6 @@ use Gedmo\Timestampable\TimestampableListener;
  */
 final class NoInterfaceTest extends BaseTestCaseORM
 {
-    private const FIXTURE = WithoutInterface::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -45,7 +43,7 @@ final class NoInterfaceTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $test = $this->em->getRepository(self::FIXTURE)->findOneBy(['title' => 'Test']);
+        $test = $this->em->getRepository(WithoutInterface::class)->findOneBy(['title' => 'Test']);
         static::assertSame(
             $date->format('Y-m-d 00:00:00'),
             $test->getCreated()->format('Y-m-d H:i:s')
@@ -59,7 +57,7 @@ final class NoInterfaceTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::FIXTURE,
+            WithoutInterface::class,
         ];
     }
 }

--- a/tests/Gedmo/Timestampable/ProtectedPropertySupperclassTest.php
+++ b/tests/Gedmo/Timestampable/ProtectedPropertySupperclassTest.php
@@ -25,9 +25,6 @@ use Gedmo\Translatable\TranslatableListener;
  */
 final class ProtectedPropertySupperclassTest extends BaseTestCaseORM
 {
-    private const SUPERCLASS = SupperClassExtension::class;
-    private const TRANSLATION = Translation::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -51,7 +48,7 @@ final class ProtectedPropertySupperclassTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $repo = $this->em->getRepository(self::TRANSLATION);
+        $repo = $this->em->getRepository(Translation::class);
         $translations = $repo->findTranslations($test);
         static::assertCount(0, $translations);
 
@@ -61,8 +58,8 @@ final class ProtectedPropertySupperclassTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::TRANSLATION,
-            self::SUPERCLASS,
+            Translation::class,
+            SupperClassExtension::class,
         ];
     }
 }

--- a/tests/Gedmo/Timestampable/TimestampableDocumentTest.php
+++ b/tests/Gedmo/Timestampable/TimestampableDocumentTest.php
@@ -24,8 +24,6 @@ use Gedmo\Timestampable\TimestampableListener;
  */
 final class TimestampableDocumentTest extends BaseTestCaseMongoODM
 {
-    private const ARTICLE = Article::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -38,7 +36,7 @@ final class TimestampableDocumentTest extends BaseTestCaseMongoODM
 
     public function testTimestampable(): void
     {
-        $repo = $this->dm->getRepository(self::ARTICLE);
+        $repo = $this->dm->getRepository(Article::class);
         $article = $repo->findOneBy(['title' => 'Timestampable Article']);
 
         $date = new \DateTime();
@@ -80,7 +78,7 @@ final class TimestampableDocumentTest extends BaseTestCaseMongoODM
         $this->dm->flush();
         $this->dm->clear();
 
-        $repo = $this->dm->getRepository(self::ARTICLE);
+        $repo = $this->dm->getRepository(Article::class);
         $sport = $repo->findOneBy(['title' => 'sport forced']);
         static::assertSame(
             $created,
@@ -111,7 +109,7 @@ final class TimestampableDocumentTest extends BaseTestCaseMongoODM
 
     public function testShouldHandleOnChangeWithBooleanValue(): void
     {
-        $repo = $this->dm->getRepository(self::ARTICLE);
+        $repo = $this->dm->getRepository(Article::class);
         $article = $repo->findOneBy(['title' => 'Timestampable Article']);
 
         static::assertNull($article->getReady());

--- a/tests/Gedmo/Timestampable/TimestampableEmbeddedDocumentTest.php
+++ b/tests/Gedmo/Timestampable/TimestampableEmbeddedDocumentTest.php
@@ -24,8 +24,6 @@ use Gedmo\Timestampable\TimestampableListener;
  */
 final class TimestampableEmbeddedDocumentTest extends BaseTestCaseMongoODM
 {
-    private const BOOK = Book::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -52,7 +50,7 @@ final class TimestampableEmbeddedDocumentTest extends BaseTestCaseMongoODM
         $this->dm->flush();
         $this->dm->clear();
 
-        $repo = $this->dm->getRepository(self::BOOK);
+        $repo = $this->dm->getRepository(Book::class);
 
         $bookFromRepo = $repo->findOneBy(['title' => 'Cats & Dogs']);
 

--- a/tests/Gedmo/Timestampable/TimestampableTest.php
+++ b/tests/Gedmo/Timestampable/TimestampableTest.php
@@ -28,10 +28,6 @@ use Gedmo\Timestampable\TimestampableListener;
  */
 final class TimestampableTest extends BaseTestCaseORM
 {
-    private const ARTICLE = Article::class;
-    private const COMMENT = Comment::class;
-    private const TYPE = Type::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -120,7 +116,7 @@ final class TimestampableTest extends BaseTestCaseORM
         $this->em->persist($sportComment);
         $this->em->flush();
 
-        $sport = $this->em->getRepository(self::ARTICLE)->findOneBy(['title' => 'Sport']);
+        $sport = $this->em->getRepository(Article::class)->findOneBy(['title' => 'Sport']);
         static::assertNotNull($sc = $sport->getCreated());
         static::assertNotNull($su = $sport->getUpdated());
         static::assertNull($sport->getContentChanged());
@@ -131,7 +127,7 @@ final class TimestampableTest extends BaseTestCaseORM
         $author->setName('New author');
         $sport->setAuthor($author);
 
-        $sportComment = $this->em->getRepository(self::COMMENT)->findOneBy(['message' => 'hello']);
+        $sportComment = $this->em->getRepository(Comment::class)->findOneBy(['message' => 'hello']);
         static::assertNotNull($sportComment->getModified());
         static::assertNull($sportComment->getClosed());
 
@@ -145,7 +141,7 @@ final class TimestampableTest extends BaseTestCaseORM
         $this->em->persist($sportComment);
         $this->em->flush();
 
-        $sportComment = $this->em->getRepository(self::COMMENT)->findOneBy(['message' => 'hello']);
+        $sportComment = $this->em->getRepository(Comment::class)->findOneBy(['message' => 'hello']);
         static::assertNotNull($scc = $sportComment->getClosed());
         static::assertNotNull($sp = $sport->getPublished());
         static::assertNotNull($sa = $sport->getAuthorChanged());
@@ -191,7 +187,7 @@ final class TimestampableTest extends BaseTestCaseORM
         $this->em->persist($sport);
         $this->em->flush();
 
-        $repo = $this->em->getRepository(self::ARTICLE);
+        $repo = $this->em->getRepository(Article::class);
         $sport = $repo->findOneBy(['title' => 'sport forced']);
         static::assertSame(
             '2000-01-01',
@@ -233,7 +229,7 @@ final class TimestampableTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $type = $this->em->getReference(self::TYPE, $type->getId());
+        $type = $this->em->getReference(Type::class, $type->getId());
         static::assertInstanceOf(Proxy::class, $type);
 
         $art = new Article();
@@ -264,7 +260,7 @@ final class TimestampableTest extends BaseTestCaseORM
         $this->em->persist($timespampable);
         $this->em->flush();
 
-        $repo = $this->em->getRepository(self::ARTICLE);
+        $repo = $this->em->getRepository(Article::class);
         $found = $repo->findOneBy(['body' => 'My article body.']);
 
         static::assertNull($found->getReachedRelevantLevel());
@@ -291,9 +287,9 @@ final class TimestampableTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::ARTICLE,
-            self::COMMENT,
-            self::TYPE,
+            Article::class,
+            Comment::class,
+            Type::class,
         ];
     }
 }

--- a/tests/Gedmo/Timestampable/TraitUsageTest.php
+++ b/tests/Gedmo/Timestampable/TraitUsageTest.php
@@ -23,8 +23,6 @@ use Gedmo\Timestampable\TimestampableListener;
  */
 final class TraitUsageTest extends BaseTestCaseORM
 {
-    private const TARGET = UsingTrait::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -57,7 +55,7 @@ final class TraitUsageTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::TARGET,
+            UsingTrait::class,
         ];
     }
 }

--- a/tests/Gedmo/Translatable/AttributeEntityTranslationTableTest.php
+++ b/tests/Gedmo/Translatable/AttributeEntityTranslationTableTest.php
@@ -28,10 +28,6 @@ use Gedmo\Translatable\TranslatableListener;
  */
 final class AttributeEntityTranslationTableTest extends BaseTestCaseORM
 {
-    private const PERSON = Person::class;
-    private const TRANSLATION = PersonTranslation::class;
-    private const FILE = File::class;
-
     private TranslatableListener $translatableListener;
 
     protected function setUp(): void
@@ -56,7 +52,7 @@ final class AttributeEntityTranslationTableTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $repo = $this->em->getRepository(self::TRANSLATION);
+        $repo = $this->em->getRepository(PersonTranslation::class);
         static::assertInstanceOf(TranslationRepository::class, $repo);
 
         $translations = $repo->findTranslations($person);
@@ -64,7 +60,7 @@ final class AttributeEntityTranslationTableTest extends BaseTestCaseORM
         static::assertCount(0, $translations);
 
         // test second translations
-        $person = $this->em->find(self::PERSON, $person->getId());
+        $person = $this->em->find(Person::class, $person->getId());
         $this->translatableListener->setTranslatableLocale('de_de');
         $person->setName('name in de');
 
@@ -92,7 +88,7 @@ final class AttributeEntityTranslationTableTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $file = $this->em->find(self::FILE, $file->getId());
+        $file = $this->em->find(File::class, $file->getId());
 
         $file->locale = 'de';
         $file->setTitle('title in de');
@@ -100,7 +96,7 @@ final class AttributeEntityTranslationTableTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $file = $this->em->find(self::FILE, $file->getId());
+        $file = $this->em->find(File::class, $file->getId());
 
         static::assertSame('title in en', $file->getTitle());
         $file->locale = 'de';
@@ -111,9 +107,9 @@ final class AttributeEntityTranslationTableTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::PERSON,
-            self::TRANSLATION,
-            self::FILE,
+            Person::class,
+            PersonTranslation::class,
+            File::class,
         ];
     }
 }

--- a/tests/Gedmo/Translatable/EntityTranslationTableTest.php
+++ b/tests/Gedmo/Translatable/EntityTranslationTableTest.php
@@ -25,9 +25,6 @@ use Gedmo\Translatable\TranslatableListener;
  */
 final class EntityTranslationTableTest extends BaseTestCaseORM
 {
-    private const PERSON = Person::class;
-    private const TRANSLATION = PersonTranslation::class;
-
     private TranslatableListener $translatableListener;
 
     protected function setUp(): void
@@ -52,7 +49,7 @@ final class EntityTranslationTableTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $repo = $this->em->getRepository(self::TRANSLATION);
+        $repo = $this->em->getRepository(PersonTranslation::class);
         static::assertInstanceOf(TranslationRepository::class, $repo);
 
         $translations = $repo->findTranslations($person);
@@ -60,7 +57,7 @@ final class EntityTranslationTableTest extends BaseTestCaseORM
         static::assertCount(0, $translations);
 
         // test second translations
-        $person = $this->em->find(self::PERSON, $person->getId());
+        $person = $this->em->find(Person::class, $person->getId());
         $this->translatableListener->setTranslatableLocale('de_de');
         $person->setName('name in de');
 
@@ -89,7 +86,7 @@ final class EntityTranslationTableTest extends BaseTestCaseORM
         $person = new Person();
         $person->setName('de');
 
-        $repo = $this->em->getRepository(self::TRANSLATION);
+        $repo = $this->em->getRepository(PersonTranslation::class);
         $repo
             ->translate($person, 'name', 'de', 'de')
             ->translate($person, 'name', 'en_us', 'en_us')
@@ -98,9 +95,9 @@ final class EntityTranslationTableTest extends BaseTestCaseORM
         $this->em->flush();
 
         $this->translatableListener->setTranslatableLocale('en_us');
-        $articles = $this->em->createQuery('SELECT p FROM '.self::PERSON.' p')->getArrayResult();
+        $articles = $this->em->createQuery('SELECT p FROM '.Person::class.' p')->getArrayResult();
         static::assertSame('en_us', $articles[0]['name']);
-        $trans = $this->em->createQuery('SELECT t FROM '.self::TRANSLATION.' t')->getArrayResult();
+        $trans = $this->em->createQuery('SELECT t FROM '.PersonTranslation::class.' t')->getArrayResult();
         static::assertCount(2, $trans);
         foreach ($trans as $item) {
             static::assertSame($item['locale'], $item['content']);
@@ -110,8 +107,8 @@ final class EntityTranslationTableTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::PERSON,
-            self::TRANSLATION,
+            Person::class,
+            PersonTranslation::class,
         ];
     }
 }

--- a/tests/Gedmo/Translatable/InheritanceTest.php
+++ b/tests/Gedmo/Translatable/InheritanceTest.php
@@ -29,13 +29,6 @@ use Gedmo\Translatable\TranslatableListener;
  */
 final class InheritanceTest extends BaseTestCaseORM
 {
-    private const ARTICLE = TemplatedArticle::class;
-    private const TRANSLATION = Translation::class;
-    private const FILE = File::class;
-    private const IMAGE = Image::class;
-
-    private const TREE_WALKER_TRANSLATION = TranslationWalker::class;
-
     private TranslatableListener $translatableListener;
 
     protected function setUp(): void
@@ -62,14 +55,14 @@ final class InheritanceTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $repo = $this->em->getRepository(self::TRANSLATION);
+        $repo = $this->em->getRepository(Translation::class);
         static::assertInstanceOf(TranslationRepository::class, $repo);
 
         $translations = $repo->findTranslations($article);
         static::assertCount(0, $translations);
 
         // test second translations
-        $article = $this->em->getRepository(self::ARTICLE)->find(1);
+        $article = $this->em->getRepository(TemplatedArticle::class)->find(1);
         $this->translatableListener->setTranslatableLocale('de');
         $article->setName('name in de');
         $article->setContent('content in de');
@@ -123,9 +116,9 @@ final class InheritanceTest extends BaseTestCaseORM
 
         $this->em->clear();
 
-        $dql = 'SELECT f FROM '.self::FILE.' f INDEX BY f.id';
+        $dql = 'SELECT f FROM '.File::class.' f INDEX BY f.id';
         $q = $this->em->createQuery($dql);
-        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, self::TREE_WALKER_TRANSLATION);
+        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, TranslationWalker::class);
 
         $files = $q->getArrayResult();
         static::assertCount(2, $files);
@@ -134,7 +127,7 @@ final class InheritanceTest extends BaseTestCaseORM
         static::assertSame('file de', $files[$fileId]['name']);
 
         // test loading in locale
-        $images = $this->em->getRepository(self::IMAGE)->findAll();
+        $images = $this->em->getRepository(Image::class)->findAll();
         static::assertCount(1, $images);
         static::assertSame('image de', $images[0]->getName());
         static::assertSame('mime de', $images[0]->getMime());
@@ -143,10 +136,10 @@ final class InheritanceTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::ARTICLE,
-            self::TRANSLATION,
-            self::FILE,
-            self::IMAGE,
+            TemplatedArticle::class,
+            Translation::class,
+            File::class,
+            Image::class,
         ];
     }
 }

--- a/tests/Gedmo/Translatable/Issue/Issue109Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue109Test.php
@@ -28,12 +28,6 @@ use Gedmo\Translatable\TranslatableListener;
  */
 final class Issue109Test extends BaseTestCaseORM
 {
-    private const ARTICLE = Article::class;
-    private const COMMENT = Comment::class;
-    private const TRANSLATION = Translation::class;
-
-    private const TREE_WALKER_TRANSLATION = TranslationWalker::class;
-
     private TranslatableListener $translatableListener;
 
     protected function setUp(): void
@@ -58,7 +52,7 @@ final class Issue109Test extends BaseTestCaseORM
         );
         $query = $this->em->createQueryBuilder();
         $query->select('a')
-            ->from(self::ARTICLE, 'a')
+            ->from(Article::class, 'a')
             ->add('where', $query->expr()->not($query->expr()->eq('a.title', ':title')))
             ->setParameter('title', 'NA')
         ;
@@ -67,7 +61,7 @@ final class Issue109Test extends BaseTestCaseORM
         $this->translatableListener->setDefaultLocale('en');
         $this->translatableListener->setTranslationFallback(true);
         $query = $query->getQuery();
-        $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, self::TREE_WALKER_TRANSLATION);
+        $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, TranslationWalker::class);
 
         $result = $query->getResult();
         static::assertCount(3, $result);
@@ -107,9 +101,9 @@ final class Issue109Test extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::ARTICLE,
-            self::TRANSLATION,
-            self::COMMENT,
+            Article::class,
+            Translation::class,
+            Comment::class,
         ];
     }
 }

--- a/tests/Gedmo/Translatable/Issue/Issue1123Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue1123Test.php
@@ -22,10 +22,6 @@ use Gedmo\Translatable\TranslatableListener;
 
 final class Issue1123Test extends BaseTestCaseORM
 {
-    private const TRANSLATION = Translation::class;
-    private const BASE_ENTITY = BaseEntity::class;
-    private const CHILD_ENTITY = ChildEntity::class;
-
     private TranslatableListener $translatableListener;
 
     protected function setUp(): void
@@ -44,7 +40,7 @@ final class Issue1123Test extends BaseTestCaseORM
 
     public function testShouldFindInheritedClassTranslations(): void
     {
-        $repo = $this->em->getRepository(self::TRANSLATION);
+        $repo = $this->em->getRepository(Translation::class);
 
         $title = 'Hello World';
         $deTitle = 'Hallo Welt';
@@ -70,7 +66,7 @@ final class Issue1123Test extends BaseTestCaseORM
         static::assertSame(['childTitle' => $deTitle], $translations['de']);
 
         // find using QueryBuilder
-        $qb = $this->em->createQueryBuilder()->select('e')->from(self::CHILD_ENTITY, 'e');
+        $qb = $this->em->createQueryBuilder()->select('e')->from(ChildEntity::class, 'e');
 
         $query = $qb->getQuery();
         $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, TranslationWalker::class);
@@ -89,9 +85,9 @@ final class Issue1123Test extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::TRANSLATION,
-            self::BASE_ENTITY,
-            self::CHILD_ENTITY,
+            Translation::class,
+            BaseEntity::class,
+            ChildEntity::class,
         ];
     }
 }

--- a/tests/Gedmo/Translatable/Issue/Issue114Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue114Test.php
@@ -25,10 +25,6 @@ use Gedmo\Translatable\TranslatableListener;
  */
 final class Issue114Test extends BaseTestCaseORM
 {
-    private const CATEGORY = Category::class;
-    private const ARTICLE = Article::class;
-    private const TRANSLATION = Translation::class;
-
     private TranslatableListener $translatableListener;
 
     protected function setUp(): void
@@ -46,7 +42,7 @@ final class Issue114Test extends BaseTestCaseORM
 
     public function testIssue114(): void
     {
-        $repo = $this->em->getRepository(self::TRANSLATION);
+        $repo = $this->em->getRepository(Translation::class);
 
         // Categories
         $category1 = new Category();
@@ -118,9 +114,9 @@ final class Issue114Test extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::CATEGORY,
-            self::ARTICLE,
-            self::TRANSLATION,
+            Category::class,
+            Article::class,
+            Translation::class,
         ];
     }
 }

--- a/tests/Gedmo/Translatable/Issue/Issue135Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue135Test.php
@@ -27,12 +27,6 @@ use Gedmo\Translatable\TranslatableListener;
  */
 final class Issue135Test extends BaseTestCaseORM
 {
-    private const ARTICLE = Article::class;
-    private const COMMENT = Comment::class;
-    private const TRANSLATION = Translation::class;
-
-    private const TREE_WALKER_TRANSLATION = TranslationWalker::class;
-
     private TranslatableListener $translatableListener;
 
     protected function setUp(): void
@@ -53,7 +47,7 @@ final class Issue135Test extends BaseTestCaseORM
     {
         $query = $this->em->createQueryBuilder();
         $query->select('a')
-            ->from(self::ARTICLE, 'a')
+            ->from(Article::class, 'a')
             ->add('where', $query->expr()->not($query->expr()->eq('a.title', ':title')))
             ->setParameter('title', 'NA')
         ;
@@ -61,7 +55,7 @@ final class Issue135Test extends BaseTestCaseORM
         $this->translatableListener->setTranslatableLocale('en');
         $this->translatableListener->setTranslationFallback(true);
         $query = $query->getQuery();
-        $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, self::TREE_WALKER_TRANSLATION);
+        $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, TranslationWalker::class);
 
         $count = 0;
         str_replace("locale = 'en'", '', $query->getSQL(), $count);
@@ -104,9 +98,9 @@ final class Issue135Test extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::ARTICLE,
-            self::TRANSLATION,
-            self::COMMENT,
+            Article::class,
+            Translation::class,
+            Comment::class,
         ];
     }
 }

--- a/tests/Gedmo/Translatable/Issue/Issue138Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue138Test.php
@@ -26,10 +26,6 @@ use Gedmo\Translatable\TranslatableListener;
  */
 final class Issue138Test extends BaseTestCaseORM
 {
-    private const ARTICLE = Article::class;
-    private const TRANSLATION = Translation::class;
-    private const TREE_WALKER_TRANSLATION = TranslationWalker::class;
-
     private TranslatableListener $translatableListener;
 
     protected function setUp(): void
@@ -49,10 +45,10 @@ final class Issue138Test extends BaseTestCaseORM
     public function testIssue138(): void
     {
         $this->populate();
-        $dql = 'SELECT a FROM '.self::ARTICLE.' a';
+        $dql = 'SELECT a FROM '.Article::class.' a';
         $dql .= " WHERE a.title LIKE '%foo%'";
         $q = $this->em->createQuery($dql);
-        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, self::TREE_WALKER_TRANSLATION);
+        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, TranslationWalker::class);
 
         // array hydration
         $this->translatableListener->setTranslatableLocale('en_us');
@@ -65,8 +61,8 @@ final class Issue138Test extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::ARTICLE,
-            self::TRANSLATION,
+            Article::class,
+            Translation::class,
         ];
     }
 

--- a/tests/Gedmo/Translatable/Issue/Issue173Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue173Test.php
@@ -30,11 +30,6 @@ use Gedmo\Translatable\TranslatableListener;
  */
 final class Issue173Test extends BaseTestCaseORM
 {
-    private const CATEGORY = Category::class;
-    private const ARTICLE = Article::class;
-    private const PRODUCT = Product::class;
-    private const TRANSLATION = Translation::class;
-
     private TranslatableListener $translatableListener;
 
     protected function setUp(): void
@@ -66,10 +61,10 @@ final class Issue173Test extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::CATEGORY,
-            self::ARTICLE,
-            self::PRODUCT,
-            self::TRANSLATION,
+            Category::class,
+            Article::class,
+            Product::class,
+            Translation::class,
         ];
     }
 
@@ -83,19 +78,19 @@ final class Issue173Test extends BaseTestCaseORM
         $query3 = $this->em->createQueryBuilder();
         $dql1 = $query2
             ->select('c1')
-            ->from(self::CATEGORY, 'c1')
+            ->from(Category::class, 'c1')
             ->join('c1.products', 'p')
             ->getDQL()
         ;
         $dql2 = $query3
             ->select('c2')
-            ->from(self::CATEGORY, 'c2')
+            ->from(Category::class, 'c2')
             ->join('c2.articles', 'a')
             ->getDQL()
         ;
         $query
             ->select('c')
-            ->from(self::CATEGORY, 'c')
+            ->from(Category::class, 'c')
             ->where($query->expr()->notIn('c.id', $dql1))
             ->andWhere($query->expr()->notIn('c.id', $dql2))
         ;

--- a/tests/Gedmo/Translatable/Issue/Issue2152Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue2152Test.php
@@ -19,9 +19,6 @@ use Gedmo\Translatable\TranslatableListener;
 
 final class Issue2152Test extends BaseTestCaseORM
 {
-    private const TRANSLATION = Translation::class;
-    private const ENTITY = EntityWithTranslatableBoolean::class;
-
     private TranslatableListener $translatableListener;
 
     protected function setUp(): void
@@ -84,8 +81,8 @@ final class Issue2152Test extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::TRANSLATION,
-            self::ENTITY,
+            Translation::class,
+            EntityWithTranslatableBoolean::class,
         ];
     }
 
@@ -94,7 +91,7 @@ final class Issue2152Test extends BaseTestCaseORM
         $this->em->clear();
         $this->translatableListener->setTranslatableLocale($locale);
 
-        $qb = $this->em->createQueryBuilder()->select('e')->from(self::ENTITY, 'e');
+        $qb = $this->em->createQueryBuilder()->select('e')->from(EntityWithTranslatableBoolean::class, 'e');
 
         return $qb->getQuery()->getSingleResult();
     }

--- a/tests/Gedmo/Translatable/Issue/Issue2167Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue2167Test.php
@@ -19,9 +19,6 @@ use Gedmo\Translatable\TranslatableListener;
 
 class Issue2167Test extends BaseTestCaseORM
 {
-    private const TRANSLATION = Translation::class;
-    private const ENTITY = Article::class;
-
     private TranslatableListener $translatableListener;
 
     protected function setUp(): void
@@ -91,8 +88,8 @@ class Issue2167Test extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::TRANSLATION,
-            self::ENTITY,
+            Translation::class,
+            Article::class,
         ];
     }
 
@@ -101,7 +98,7 @@ class Issue2167Test extends BaseTestCaseORM
         $this->em->clear();
         $this->translatableListener->setTranslatableLocale($locale);
 
-        $qb = $this->em->createQueryBuilder()->select('e')->from(self::ENTITY, 'e');
+        $qb = $this->em->createQueryBuilder()->select('e')->from(Article::class, 'e');
 
         return $qb->getQuery()->getSingleResult();
     }

--- a/tests/Gedmo/Translatable/Issue/Issue84Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue84Test.php
@@ -25,9 +25,6 @@ use Gedmo\Translatable\TranslatableListener;
  */
 final class Issue84Test extends BaseTestCaseORM
 {
-    private const ARTICLE = Article::class;
-    private const TRANSLATION = Translation::class;
-
     private TranslatableListener $translatableListener;
 
     protected function setUp(): void
@@ -44,7 +41,7 @@ final class Issue84Test extends BaseTestCaseORM
 
     public function testIssue84(): void
     {
-        $repo = $this->em->getRepository(self::TRANSLATION);
+        $repo = $this->em->getRepository(Translation::class);
 
         $article = new Article();
         $article->setTitle('en art');
@@ -53,7 +50,7 @@ final class Issue84Test extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $article = $this->em->getReference(self::ARTICLE, 1);
+        $article = $this->em->getReference(Article::class, 1);
         static::assertInstanceOf(Proxy::class, $article);
 
         $trans = $repo->findTranslations($article);
@@ -63,8 +60,8 @@ final class Issue84Test extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::ARTICLE,
-            self::TRANSLATION,
+            Article::class,
+            Translation::class,
         ];
     }
 }

--- a/tests/Gedmo/Translatable/Issue/Issue922Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue922Test.php
@@ -22,11 +22,6 @@ use Gedmo\Translatable\TranslatableListener;
 
 final class Issue922Test extends BaseTestCaseORM
 {
-    private const POST = Post::class;
-    private const TRANSLATION = Translation::class;
-
-    private const TREE_WALKER_TRANSLATION = TranslationWalker::class;
-
     private TranslatableListener $translatableListener;
 
     protected function setUp(): void
@@ -63,7 +58,7 @@ final class Issue922Test extends BaseTestCaseORM
         // clear and test postLoad event values set
         $this->em->clear();
 
-        $p1 = $this->em->find(self::POST, $p1->getId());
+        $p1 = $this->em->find(Post::class, $p1->getId());
         static::assertInstanceOf('DateTime', $p1->getPublishedAt());
         static::assertInstanceOf('DateTime', $p1->getTimestampAt());
         static::assertInstanceOf('DateTime', $p1->getDateAt());
@@ -76,8 +71,8 @@ final class Issue922Test extends BaseTestCaseORM
             ObjectHydrator::class
         );
 
-        $q = $this->em->createQuery('SELECT p FROM '.self::POST.' p');
-        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, self::TREE_WALKER_TRANSLATION);
+        $q = $this->em->createQuery('SELECT p FROM '.Post::class.' p');
+        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, TranslationWalker::class);
         $q->setHint(TranslatableListener::HINT_TRANSLATABLE_LOCALE, 'de');
 
         $p1 = $q->getSingleResult();
@@ -90,8 +85,8 @@ final class Issue922Test extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::POST,
-            self::TRANSLATION,
+            Post::class,
+            Translation::class,
         ];
     }
 }

--- a/tests/Gedmo/Translatable/MixedValueTranslationTest.php
+++ b/tests/Gedmo/Translatable/MixedValueTranslationTest.php
@@ -26,9 +26,6 @@ use Gedmo\Translatable\TranslatableListener;
  */
 final class MixedValueTranslationTest extends BaseTestCaseORM
 {
-    private const MIXED = MixedValue::class;
-    private const TRANSLATION = Translation::class;
-
     private TranslatableListener $translatableListener;
 
     protected function setUp(): void
@@ -51,7 +48,7 @@ final class MixedValueTranslationTest extends BaseTestCaseORM
 
     public function testFixtureGeneratedTranslations(): void
     {
-        $repo = $this->em->getRepository(self::MIXED);
+        $repo = $this->em->getRepository(MixedValue::class);
         $mixed = $repo->findOneBy(['id' => 1]);
 
         static::assertInstanceOf(\DateTime::class, $mixed->getDate());
@@ -61,7 +58,7 @@ final class MixedValueTranslationTest extends BaseTestCaseORM
 
     public function testOtherTranslation(): void
     {
-        $repo = $this->em->getRepository(self::MIXED);
+        $repo = $this->em->getRepository(MixedValue::class);
         $mixed = $repo->findOneBy(['id' => 1]);
 
         $this->translatableListener->setTranslatableLocale('de_de');
@@ -75,7 +72,7 @@ final class MixedValueTranslationTest extends BaseTestCaseORM
         $this->em->clear();
 
         $mixed = $repo->findOneBy(['id' => 1]);
-        $transRepo = $this->em->getRepository(self::TRANSLATION);
+        $transRepo = $this->em->getRepository(Translation::class);
         $translations = $transRepo->findTranslations($mixed);
 
         static::assertCount(1, $translations);
@@ -89,8 +86,8 @@ final class MixedValueTranslationTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::MIXED,
-            self::TRANSLATION,
+            MixedValue::class,
+            Translation::class,
         ];
     }
 

--- a/tests/Gedmo/Translatable/PersonalTranslationDocumentTest.php
+++ b/tests/Gedmo/Translatable/PersonalTranslationDocumentTest.php
@@ -24,8 +24,6 @@ use Gedmo\Translatable\TranslatableListener;
  */
 final class PersonalTranslationDocumentTest extends BaseTestCaseMongoODM
 {
-    private const ARTICLE = Article::class;
-
     private TranslatableListener $translatableListener;
 
     private ?string $id = null;
@@ -46,7 +44,7 @@ final class PersonalTranslationDocumentTest extends BaseTestCaseMongoODM
     public function testShouldCreateTranslations(): void
     {
         $this->populate();
-        $article = $this->dm->getRepository(self::ARTICLE)->find($this->id);
+        $article = $this->dm->getRepository(Article::class)->find($this->id);
         $translations = $article->getTranslations();
 
         static::assertCount(2, $translations);
@@ -57,7 +55,7 @@ final class PersonalTranslationDocumentTest extends BaseTestCaseMongoODM
         $this->populate();
         $this->translatableListener->setTranslatableLocale('lt');
 
-        $article = $this->dm->getRepository(self::ARTICLE)->find($this->id);
+        $article = $this->dm->getRepository(Article::class)->find($this->id);
         static::assertSame('lt', $article->getTitle());
     }
 

--- a/tests/Gedmo/Translatable/PersonalTranslationTest.php
+++ b/tests/Gedmo/Translatable/PersonalTranslationTest.php
@@ -27,10 +27,6 @@ use Gedmo\Translatable\TranslatableListener;
  */
 final class PersonalTranslationTest extends BaseTestCaseORM
 {
-    private const ARTICLE = Article::class;
-    private const TRANSLATION = PersonalArticleTranslation::class;
-    private const TREE_WALKER_TRANSLATION = TranslationWalker::class;
-
     private TranslatableListener $translatableListener;
 
     protected function setUp(): void
@@ -49,7 +45,7 @@ final class PersonalTranslationTest extends BaseTestCaseORM
     {
         $this->translatableListener->setPersistDefaultLocaleTranslation(true);
         $this->populate();
-        $article = $this->em->find(self::ARTICLE, ['id' => 1]);
+        $article = $this->em->find(Article::class, ['id' => 1]);
         $translations = $article->getTranslations();
         static::assertCount(3, $translations);
     }
@@ -57,7 +53,7 @@ final class PersonalTranslationTest extends BaseTestCaseORM
     public function testShouldCreateTranslations(): void
     {
         $this->populate();
-        $article = $this->em->find(self::ARTICLE, ['id' => 1]);
+        $article = $this->em->find(Article::class, ['id' => 1]);
         $translations = $article->getTranslations();
         static::assertCount(2, $translations);
     }
@@ -69,7 +65,7 @@ final class PersonalTranslationTest extends BaseTestCaseORM
 
         $this->queryLogger->reset();
 
-        $article = $this->em->find(self::ARTICLE, ['id' => 1]);
+        $article = $this->em->find(Article::class, ['id' => 1]);
 
         static::assertCount(2, $this->queryLogger->queries);
 
@@ -102,8 +98,8 @@ final class PersonalTranslationTest extends BaseTestCaseORM
         }
 
         $this->populate();
-        $this->em->createQuery('DELETE FROM '.self::ARTICLE.' a')->getSingleScalarResult();
-        $trans = $this->em->getRepository(self::TRANSLATION)->findAll();
+        $this->em->createQuery('DELETE FROM '.Article::class.' a')->getSingleScalarResult();
+        $trans = $this->em->getRepository(PersonalArticleTranslation::class)->findAll();
 
         static::assertCount(0, $trans);
     }
@@ -125,7 +121,7 @@ final class PersonalTranslationTest extends BaseTestCaseORM
         $this->em->persist($article);
         $this->em->flush();
 
-        $trans = $this->em->createQuery('SELECT t FROM '.self::TRANSLATION.' t')->getArrayResult();
+        $trans = $this->em->createQuery('SELECT t FROM '.PersonalArticleTranslation::class.' t')->getArrayResult();
         static::assertCount(1, $trans);
         static::assertSame('override', $trans[0]['content']);
     }
@@ -161,9 +157,9 @@ final class PersonalTranslationTest extends BaseTestCaseORM
         $this->em->flush();
 
         $this->translatableListener->setTranslatableLocale('en');
-        $articles = $this->em->createQuery('SELECT t FROM '.self::ARTICLE.' t')->getArrayResult();
+        $articles = $this->em->createQuery('SELECT t FROM '.Article::class.' t')->getArrayResult();
         static::assertSame('en', $articles[0]['title']);
-        $trans = $this->em->createQuery('SELECT t FROM '.self::TRANSLATION.' t')->getArrayResult();
+        $trans = $this->em->createQuery('SELECT t FROM '.PersonalArticleTranslation::class.' t')->getArrayResult();
         static::assertCount(2, $trans);
         foreach ($trans as $item) {
             static::assertSame($item['locale'], $item['content']);
@@ -225,10 +221,10 @@ final class PersonalTranslationTest extends BaseTestCaseORM
     public function testShouldBeAbleToUseTranslationQueryHint(): void
     {
         $this->populate();
-        $dql = 'SELECT a.title FROM '.self::ARTICLE.' a';
+        $dql = 'SELECT a.title FROM '.Article::class.' a';
         $query = $this
             ->em->createQuery($dql)
-            ->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, self::TREE_WALKER_TRANSLATION)
+            ->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, TranslationWalker::class)
             ->setHint(TranslatableListener::HINT_TRANSLATABLE_LOCALE, 'lt')
         ;
 
@@ -252,8 +248,8 @@ final class PersonalTranslationTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::ARTICLE,
-            self::TRANSLATION,
+            Article::class,
+            PersonalArticleTranslation::class,
         ];
     }
 

--- a/tests/Gedmo/Translatable/TranslatableDocumentCollectionTest.php
+++ b/tests/Gedmo/Translatable/TranslatableDocumentCollectionTest.php
@@ -25,9 +25,6 @@ use Gedmo\Translatable\TranslatableListener;
  */
 final class TranslatableDocumentCollectionTest extends BaseTestCaseMongoODM
 {
-    private const ARTICLE = Article::class;
-    private const TRANSLATION = Translation::class;
-
     private TranslatableListener $translatableListener;
 
     private ?string $id = null;
@@ -48,9 +45,9 @@ final class TranslatableDocumentCollectionTest extends BaseTestCaseMongoODM
 
     public function testShouldPersistMultipleTranslations(): void
     {
-        $repo = $this->dm->getRepository(self::TRANSLATION);
+        $repo = $this->dm->getRepository(Translation::class);
         static::assertInstanceOf(TranslationRepository::class, $repo);
-        $sport = $this->dm->getRepository(self::ARTICLE)->find($this->id);
+        $sport = $this->dm->getRepository(Article::class)->find($this->id);
         $translations = $repo->findTranslations($sport);
 
         static::assertArrayHasKey('de_de', $translations);
@@ -68,9 +65,9 @@ final class TranslatableDocumentCollectionTest extends BaseTestCaseMongoODM
 
     public function testShouldUpdateTranslation(): void
     {
-        $repo = $this->dm->getRepository(self::TRANSLATION);
+        $repo = $this->dm->getRepository(Translation::class);
         static::assertInstanceOf(TranslationRepository::class, $repo);
-        $sport = $this->dm->getRepository(self::ARTICLE)->find($this->id);
+        $sport = $this->dm->getRepository(Article::class)->find($this->id);
         $repo
             ->translate($sport, 'title', 'ru_ru', 'sport ru change')
             ->translate($sport, 'content', 'ru_ru', 'content ru change')
@@ -89,9 +86,9 @@ final class TranslatableDocumentCollectionTest extends BaseTestCaseMongoODM
 
     public function testShouldUpdateMultipleTranslations(): void
     {
-        $repo = $this->dm->getRepository(self::TRANSLATION);
+        $repo = $this->dm->getRepository(Translation::class);
         static::assertInstanceOf(TranslationRepository::class, $repo);
-        $sport = $this->dm->getRepository(self::ARTICLE)->find($this->id);
+        $sport = $this->dm->getRepository(Article::class)->find($this->id);
         $sport->setTitle('Changed');
         $repo
             ->translate($sport, 'title', 'lt_lt', 'sport lt')
@@ -130,7 +127,7 @@ final class TranslatableDocumentCollectionTest extends BaseTestCaseMongoODM
 
     private function populate(): void
     {
-        $repo = $this->dm->getRepository(self::TRANSLATION);
+        $repo = $this->dm->getRepository(Translation::class);
         static::assertInstanceOf(TranslationRepository::class, $repo);
         $sport = new Article();
         $sport->setTitle('Sport');

--- a/tests/Gedmo/Translatable/TranslatableDocumentTest.php
+++ b/tests/Gedmo/Translatable/TranslatableDocumentTest.php
@@ -26,9 +26,6 @@ use Gedmo\Translatable\TranslatableListener;
  */
 final class TranslatableDocumentTest extends BaseTestCaseMongoODM
 {
-    private const ARTICLE = Article::class;
-    private const TRANSLATION = Translation::class;
-
     private TranslatableListener $translatableListener;
 
     private ?string $articleId = null;
@@ -50,10 +47,10 @@ final class TranslatableDocumentTest extends BaseTestCaseMongoODM
     public function testTranslation(): void
     {
         // test inserted translations
-        $repo = $this->dm->getRepository(self::ARTICLE);
+        $repo = $this->dm->getRepository(Article::class);
         $article = $repo->findOneBy(['title' => 'Title EN']);
 
-        $transRepo = $this->dm->getRepository(self::TRANSLATION);
+        $transRepo = $this->dm->getRepository(Translation::class);
         static::assertInstanceOf(TranslationRepository::class, $transRepo);
 
         $translations = $transRepo->findTranslations($article);
@@ -116,9 +113,9 @@ final class TranslatableDocumentTest extends BaseTestCaseMongoODM
 
     public function testFindObjectByTranslatedField(): void
     {
-        $repo = $this->dm->getRepository(self::ARTICLE);
+        $repo = $this->dm->getRepository(Article::class);
         $article = $repo->findOneBy(['title' => 'Title EN']);
-        static::assertInstanceOf(self::ARTICLE, $article);
+        static::assertInstanceOf(Article::class, $article);
 
         $this->translatableListener->setTranslatableLocale('de_de');
         $article->setTitle('Title DE');
@@ -128,15 +125,15 @@ final class TranslatableDocumentTest extends BaseTestCaseMongoODM
         $this->dm->flush();
         $this->dm->clear();
 
-        $transRepo = $this->dm->getRepository(self::TRANSLATION);
+        $transRepo = $this->dm->getRepository(Translation::class);
         static::assertInstanceOf(TranslationRepository::class, $transRepo);
 
         $articleFound = $transRepo->findObjectByTranslatedField(
             'title',
             'Title DE',
-            self::ARTICLE
+            Article::class
         );
-        static::assertInstanceOf(self::ARTICLE, $articleFound);
+        static::assertInstanceOf(Article::class, $articleFound);
 
         static::assertSame($article->getId(), $articleFound->getId());
     }

--- a/tests/Gedmo/Translatable/TranslatableEntityCollectionTest.php
+++ b/tests/Gedmo/Translatable/TranslatableEntityCollectionTest.php
@@ -25,10 +25,6 @@ use Gedmo\Translatable\TranslatableListener;
  */
 final class TranslatableEntityCollectionTest extends BaseTestCaseORM
 {
-    private const ARTICLE = Article::class;
-    private const COMMENT = Comment::class;
-    private const TRANSLATION = Translation::class;
-
     private TranslatableListener $translatableListener;
 
     protected function setUp(): void
@@ -49,7 +45,7 @@ final class TranslatableEntityCollectionTest extends BaseTestCaseORM
         $this->translatableListener->setTranslatableLocale('de');
         $this->translatableListener->setDefaultLocale('en');
         $this->translatableListener->setPersistDefaultLocaleTranslation(true);
-        $repo = $this->em->getRepository(self::TRANSLATION);
+        $repo = $this->em->getRepository(Translation::class);
         $entity = new Article();
         $entity->setTitle('he'); // is translated to de
 
@@ -63,7 +59,7 @@ final class TranslatableEntityCollectionTest extends BaseTestCaseORM
         $this->em->persist($entity);
         $this->em->flush();
         $this->em->clear();
-        $trans = $repo->findTranslations($this->em->find(self::ARTICLE, $entity->getId()));
+        $trans = $repo->findTranslations($this->em->find(Article::class, $entity->getId()));
         static::assertCount(4, $trans);
         static::assertSame('my article de', $trans['de']['title']); // overrides "he" which would be used if translate for de not called
         static::assertSame('my article es', $trans['es']['title']);
@@ -74,8 +70,8 @@ final class TranslatableEntityCollectionTest extends BaseTestCaseORM
     public function testShouldPersistMultipleTranslations(): void
     {
         $this->populate();
-        $repo = $this->em->getRepository(self::TRANSLATION);
-        $sport = $this->em->getRepository(self::ARTICLE)->find(1);
+        $repo = $this->em->getRepository(Translation::class);
+        $sport = $this->em->getRepository(Article::class)->find(1);
         $translations = $repo->findTranslations($sport);
 
         static::assertCount(2, $translations);
@@ -96,8 +92,8 @@ final class TranslatableEntityCollectionTest extends BaseTestCaseORM
     public function testShouldUpdateTranslation(): void
     {
         $this->populate();
-        $repo = $this->em->getRepository(self::TRANSLATION);
-        $sport = $this->em->getRepository(self::ARTICLE)->find(1);
+        $repo = $this->em->getRepository(Translation::class);
+        $sport = $this->em->getRepository(Article::class)->find(1);
         $repo
             ->translate($sport, 'title', 'ru_ru', 'sport ru change')
             ->translate($sport, 'content', 'ru_ru', 'content ru change')
@@ -117,8 +113,8 @@ final class TranslatableEntityCollectionTest extends BaseTestCaseORM
     public function testShouldUpdateMultipleTranslations(): void
     {
         $this->populate();
-        $repo = $this->em->getRepository(self::TRANSLATION);
-        $sport = $this->em->getRepository(self::ARTICLE)->find(1);
+        $repo = $this->em->getRepository(Translation::class);
+        $sport = $this->em->getRepository(Article::class)->find(1);
         $repo
             ->translate($sport, 'title', 'lt_lt', 'sport lt')
             ->translate($sport, 'content', 'lt_lt', 'content lt')
@@ -157,15 +153,15 @@ final class TranslatableEntityCollectionTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::ARTICLE,
-            self::TRANSLATION,
-            self::COMMENT,
+            Article::class,
+            Translation::class,
+            Comment::class,
         ];
     }
 
     private function populate(): void
     {
-        $repo = $this->em->getRepository(self::TRANSLATION);
+        $repo = $this->em->getRepository(Translation::class);
         $sport = new Article();
         $sport->setTitle('Sport');
         $sport->setContent('about sport');

--- a/tests/Gedmo/Translatable/TranslatableEntityDefaultTranslationTest.php
+++ b/tests/Gedmo/Translatable/TranslatableEntityDefaultTranslationTest.php
@@ -26,9 +26,6 @@ use Gedmo\Translatable\TranslatableListener;
  */
 final class TranslatableEntityDefaultTranslationTest extends BaseTestCaseORM
 {
-    private const ARTICLE = Article::class;
-    private const TRANSLATION = Translation::class;
-
     private TranslatableListener $translatableListener;
 
     /**
@@ -48,7 +45,7 @@ final class TranslatableEntityDefaultTranslationTest extends BaseTestCaseORM
 
         $this->getDefaultMockSqliteEntityManager($evm);
 
-        $this->repo = $this->em->getRepository(self::TRANSLATION);
+        $this->repo = $this->em->getRepository(Translation::class);
     }
 
     // --- Tests for default translation overruling the translated entity
@@ -113,10 +110,10 @@ final class TranslatableEntityDefaultTranslationTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $trans = $this->repo->findTranslations($this->em->find(self::ARTICLE, $entity->getId()));
+        $trans = $this->repo->findTranslations($this->em->find(Article::class, $entity->getId()));
         static::assertCount(0, $trans);
 
-        $articles = $this->em->createQuery('SELECT a FROM '.self::ARTICLE.' a')->getArrayResult();
+        $articles = $this->em->createQuery('SELECT a FROM '.Article::class.' a')->getArrayResult();
         static::assertCount(1, $articles);
         static::assertSame('title defaultLocale', $articles[0]['title']);
     }
@@ -133,11 +130,11 @@ final class TranslatableEntityDefaultTranslationTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $trans = $this->repo->findTranslations($this->em->find(self::ARTICLE, $entity->getId()));
+        $trans = $this->repo->findTranslations($this->em->find(Article::class, $entity->getId()));
         static::assertCount(1, $trans);
         static::assertSame('title defaultLocale', $trans['defaultLocale']['title']);
 
-        $articles = $this->em->createQuery('SELECT a FROM '.self::ARTICLE.' a')->getArrayResult();
+        $articles = $this->em->createQuery('SELECT a FROM '.Article::class.' a')->getArrayResult();
         static::assertCount(1, $articles);
         static::assertSame('title defaultLocale', $articles[0]['title']);
     }
@@ -154,7 +151,7 @@ final class TranslatableEntityDefaultTranslationTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $entity = $this->em->find(self::ARTICLE, 1);
+        $entity = $this->em->find(Article::class, 1);
         $entity->setTranslatableLocale('translatedLocale');
         $this->em->refresh($entity);
 
@@ -165,7 +162,7 @@ final class TranslatableEntityDefaultTranslationTest extends BaseTestCaseORM
 
         $qb = $this->em->createQueryBuilder();
         $qb->select('a')
-           ->from(self::ARTICLE, 'a')
+           ->from(Article::class, 'a')
            ->where('a.id = 1');
 
         $fields = $qb->getQuery()->getArrayResult();
@@ -185,7 +182,7 @@ final class TranslatableEntityDefaultTranslationTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $entity = $this->em->find(self::ARTICLE, 1);
+        $entity = $this->em->find(Article::class, 1);
         $entity->setTranslatableLocale('translatedLocale');
         $this->em->refresh($entity);
 
@@ -196,7 +193,7 @@ final class TranslatableEntityDefaultTranslationTest extends BaseTestCaseORM
 
         $qb = $this->em->createQueryBuilder();
         $qb->select('a')
-           ->from(self::ARTICLE, 'a')
+           ->from(Article::class, 'a')
            ->where('a.id = 1');
 
         $fields = $qb->getQuery()->getArrayResult();
@@ -220,11 +217,11 @@ final class TranslatableEntityDefaultTranslationTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $trans = $this->repo->findTranslations($this->em->find(self::ARTICLE, $entity->getId()));
+        $trans = $this->repo->findTranslations($this->em->find(Article::class, $entity->getId()));
         static::assertCount(1, $trans);
         static::assertSame('title translatedLocale', $trans['translatedLocale']['title']);
 
-        $articles = $this->em->createQuery('SELECT a FROM '.self::ARTICLE.' a')->getArrayResult();
+        $articles = $this->em->createQuery('SELECT a FROM '.Article::class.' a')->getArrayResult();
         static::assertCount(1, $articles);
         static::assertSame('title translatedLocale', $articles[0]['title']);
     }
@@ -245,11 +242,11 @@ final class TranslatableEntityDefaultTranslationTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $trans = $this->repo->findTranslations($this->em->find(self::ARTICLE, $entity->getId()));
+        $trans = $this->repo->findTranslations($this->em->find(Article::class, $entity->getId()));
         static::assertCount(1, $trans);
         static::assertSame('title translatedLocale', $trans['translatedLocale']['title']);
 
-        $articles = $this->em->createQuery('SELECT a FROM '.self::ARTICLE.' a')->getArrayResult();
+        $articles = $this->em->createQuery('SELECT a FROM '.Article::class.' a')->getArrayResult();
         static::assertCount(1, $articles);
         static::assertSame('title translatedLocale', $articles[0]['title']);
     }
@@ -267,11 +264,11 @@ final class TranslatableEntityDefaultTranslationTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $trans = $this->repo->findTranslations($this->em->find(self::ARTICLE, $entity->getId()));
+        $trans = $this->repo->findTranslations($this->em->find(Article::class, $entity->getId()));
         static::assertCount(1, $trans);
         static::assertSame('title translatedLocale', $trans['translatedLocale']['title']);
 
-        $articles = $this->em->createQuery('SELECT a FROM '.self::ARTICLE.' a')->getArrayResult();
+        $articles = $this->em->createQuery('SELECT a FROM '.Article::class.' a')->getArrayResult();
         static::assertCount(1, $articles);
         static::assertSame('title defaultLocale', $articles[0]['title']);
     }
@@ -289,11 +286,11 @@ final class TranslatableEntityDefaultTranslationTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $trans = $this->repo->findTranslations($this->em->find(self::ARTICLE, $entity->getId()));
+        $trans = $this->repo->findTranslations($this->em->find(Article::class, $entity->getId()));
         static::assertCount(1, $trans);
         static::assertSame('title translatedLocale', $trans['translatedLocale']['title']);
 
-        $articles = $this->em->createQuery('SELECT a FROM '.self::ARTICLE.' a')->getArrayResult();
+        $articles = $this->em->createQuery('SELECT a FROM '.Article::class.' a')->getArrayResult();
         static::assertCount(1, $articles);
         static::assertSame('title defaultLocale', $articles[0]['title']);
     }
@@ -311,12 +308,12 @@ final class TranslatableEntityDefaultTranslationTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $trans = $this->repo->findTranslations($this->em->find(self::ARTICLE, $entity->getId()));
+        $trans = $this->repo->findTranslations($this->em->find(Article::class, $entity->getId()));
         static::assertCount(2, $trans);
         static::assertSame('title translatedLocale', $trans['translatedLocale']['title']);
         static::assertSame('title defaultLocale', $trans['defaultLocale']['title']);
 
-        $articles = $this->em->createQuery('SELECT a FROM '.self::ARTICLE.' a')->getArrayResult();
+        $articles = $this->em->createQuery('SELECT a FROM '.Article::class.' a')->getArrayResult();
         static::assertCount(1, $articles);
         static::assertSame('title defaultLocale', $articles[0]['title']);
     }
@@ -334,12 +331,12 @@ final class TranslatableEntityDefaultTranslationTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $trans = $this->repo->findTranslations($this->em->find(self::ARTICLE, $entity->getId()));
+        $trans = $this->repo->findTranslations($this->em->find(Article::class, $entity->getId()));
         static::assertCount(2, $trans);
         static::assertSame('title translatedLocale', $trans['translatedLocale']['title']);
         static::assertSame('title defaultLocale', $trans['defaultLocale']['title']);
 
-        $articles = $this->em->createQuery('SELECT a FROM '.self::ARTICLE.' a')->getArrayResult();
+        $articles = $this->em->createQuery('SELECT a FROM '.Article::class.' a')->getArrayResult();
         static::assertCount(1, $articles);
         static::assertSame('title defaultLocale', $articles[0]['title']);
     }
@@ -359,12 +356,12 @@ final class TranslatableEntityDefaultTranslationTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $trans = $this->repo->findTranslations($this->em->find(self::ARTICLE, $entity->getId()));
+        $trans = $this->repo->findTranslations($this->em->find(Article::class, $entity->getId()));
         static::assertCount(1, $trans);
         static::assertSame('title translatedLocale', $trans['translatedLocale']['title']);
         static::assertSame('content translatedLocale', $trans['translatedLocale']['content']);
 
-        $articles = $this->em->createQuery('SELECT a FROM '.self::ARTICLE.' a')->getArrayResult();
+        $articles = $this->em->createQuery('SELECT a FROM '.Article::class.' a')->getArrayResult();
         static::assertCount(1, $articles);
         static::assertSame('title defaultLocale', $articles[0]['title']);
         static::assertSame('content defaultLocale', $articles[0]['content']);
@@ -385,12 +382,12 @@ final class TranslatableEntityDefaultTranslationTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $trans = $this->repo->findTranslations($this->em->find(self::ARTICLE, $entity->getId()));
+        $trans = $this->repo->findTranslations($this->em->find(Article::class, $entity->getId()));
         static::assertCount(1, $trans);
         static::assertSame('title translatedLocale', $trans['translatedLocale']['title']);
         static::assertSame('content translatedLocale', $trans['translatedLocale']['content']);
 
-        $articles = $this->em->createQuery('SELECT a FROM '.self::ARTICLE.' a')->getArrayResult();
+        $articles = $this->em->createQuery('SELECT a FROM '.Article::class.' a')->getArrayResult();
         static::assertCount(1, $articles);
         static::assertSame('title defaultLocale', $articles[0]['title']);
         static::assertSame('content defaultLocale', $articles[0]['content']);
@@ -411,14 +408,14 @@ final class TranslatableEntityDefaultTranslationTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $trans = $this->repo->findTranslations($this->em->find(self::ARTICLE, $entity->getId()));
+        $trans = $this->repo->findTranslations($this->em->find(Article::class, $entity->getId()));
         static::assertCount(2, $trans);
         static::assertSame('title translatedLocale', $trans['translatedLocale']['title']);
         static::assertSame('title defaultLocale', $trans['defaultLocale']['title']);
         static::assertSame('content translatedLocale', $trans['translatedLocale']['content']);
         static::assertSame('content defaultLocale', $trans['defaultLocale']['content']);
 
-        $articles = $this->em->createQuery('SELECT a FROM '.self::ARTICLE.' a')->getArrayResult();
+        $articles = $this->em->createQuery('SELECT a FROM '.Article::class.' a')->getArrayResult();
         static::assertCount(1, $articles);
         static::assertSame('title defaultLocale', $articles[0]['title']);
         static::assertSame('content defaultLocale', $articles[0]['content']);
@@ -439,14 +436,14 @@ final class TranslatableEntityDefaultTranslationTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $trans = $this->repo->findTranslations($this->em->find(self::ARTICLE, $entity->getId()));
+        $trans = $this->repo->findTranslations($this->em->find(Article::class, $entity->getId()));
         static::assertCount(2, $trans);
         static::assertSame('title translatedLocale', $trans['translatedLocale']['title']);
         static::assertSame('title defaultLocale', $trans['defaultLocale']['title']);
         static::assertSame('content translatedLocale', $trans['translatedLocale']['content']);
         static::assertSame('content defaultLocale', $trans['defaultLocale']['content']);
 
-        $articles = $this->em->createQuery('SELECT a FROM '.self::ARTICLE.' a')->getArrayResult();
+        $articles = $this->em->createQuery('SELECT a FROM '.Article::class.' a')->getArrayResult();
         static::assertCount(1, $articles);
         static::assertSame('title defaultLocale', $articles[0]['title']);
         static::assertSame('content defaultLocale', $articles[0]['content']);
@@ -457,8 +454,8 @@ final class TranslatableEntityDefaultTranslationTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::ARTICLE,
-            self::TRANSLATION,
+            Article::class,
+            Translation::class,
         ];
     }
 }

--- a/tests/Gedmo/Translatable/TranslatableIdentifierTest.php
+++ b/tests/Gedmo/Translatable/TranslatableIdentifierTest.php
@@ -24,9 +24,6 @@ use Gedmo\Translatable\TranslatableListener;
  */
 final class TranslatableIdentifierTest extends BaseTestCaseORM
 {
-    private const FIXTURE = StringIdentifier::class;
-    private const TRANSLATION = Translation::class;
-
     private ?string $testObjectId = null;
 
     private TranslatableListener $translatableListener;
@@ -48,20 +45,20 @@ final class TranslatableIdentifierTest extends BaseTestCaseORM
     {
         $object = new StringIdentifier();
         $object->setTitle('title in en');
-        $object->setUid(md5(self::FIXTURE.time()));
+        $object->setUid(md5(StringIdentifier::class.time()));
 
         $this->em->persist($object);
         $this->em->flush();
         $this->em->clear();
         $this->testObjectId = $object->getUid();
 
-        $repo = $this->em->getRepository(self::TRANSLATION);
-        $object = $this->em->find(self::FIXTURE, $this->testObjectId);
+        $repo = $this->em->getRepository(Translation::class);
+        $object = $this->em->find(StringIdentifier::class, $this->testObjectId);
 
         $translations = $repo->findTranslations($object);
         static::assertCount(0, $translations);
 
-        $object = $this->em->find(self::FIXTURE, $this->testObjectId);
+        $object = $this->em->find(StringIdentifier::class, $this->testObjectId);
         $object->setTitle('title in de');
         $object->setTranslatableLocale('de_de');
 
@@ -69,13 +66,13 @@ final class TranslatableIdentifierTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $repo = $this->em->getRepository(self::TRANSLATION);
+        $repo = $this->em->getRepository(Translation::class);
 
         // test the entity load by translated title
         $object = $repo->findObjectByTranslatedField(
             'title',
             'title in de',
-            self::FIXTURE
+            StringIdentifier::class
         );
 
         static::assertSame($this->testObjectId, $object->getUid());
@@ -89,7 +86,7 @@ final class TranslatableIdentifierTest extends BaseTestCaseORM
 
         // dql test object hydration
         $q = $this->em
-            ->createQuery('SELECT si FROM '.self::FIXTURE.' si WHERE si.uid = :id')
+            ->createQuery('SELECT si FROM '.StringIdentifier::class.' si WHERE si.uid = :id')
             ->setParameter('id', $this->testObjectId)
             ->disableResultCache()
         ;
@@ -109,8 +106,8 @@ final class TranslatableIdentifierTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::FIXTURE,
-            self::TRANSLATION,
+            StringIdentifier::class,
+            Translation::class,
         ];
     }
 }

--- a/tests/Gedmo/Translatable/TranslatableTest.php
+++ b/tests/Gedmo/Translatable/TranslatableTest.php
@@ -28,11 +28,6 @@ use Gedmo\Translatable\TranslatableListener;
  */
 final class TranslatableTest extends BaseTestCaseORM
 {
-    private const ARTICLE = Article::class;
-    private const SPORT = Sport::class;
-    private const COMMENT = Comment::class;
-    private const TRANSLATION = Translation::class;
-
     private ?int $articleId = null;
 
     private TranslatableListener $translatableListener;
@@ -54,7 +49,7 @@ final class TranslatableTest extends BaseTestCaseORM
     {
         $this->translatableListener->setTranslatableLocale('en');
         $this->translatableListener->setDefaultLocale('en');
-        $repo = $this->em->getRepository(self::ARTICLE);
+        $repo = $this->em->getRepository(Article::class);
 
         $entity = new Article();
         $entity->setTranslatableLocale('de');
@@ -79,7 +74,7 @@ final class TranslatableTest extends BaseTestCaseORM
 
         $this->em->clear();
         $entity = $repo->findOneBy(['id' => $entity->getId()]);
-        $repo = $this->em->getRepository(self::TRANSLATION);
+        $repo = $this->em->getRepository(Translation::class);
 
         $translations = $repo->findTranslations($entity);
         static::assertArrayHasKey('de', $translations);
@@ -98,7 +93,7 @@ final class TranslatableTest extends BaseTestCaseORM
         $this->em->persist($article);
         $this->em->flush();
 
-        $repo = $this->em->getRepository(self::TRANSLATION);
+        $repo = $this->em->getRepository(Translation::class);
 
         $translations = $repo->findTranslations($article);
         static::assertCount(1, $translations);
@@ -108,10 +103,10 @@ final class TranslatableTest extends BaseTestCaseORM
     public function testShouldGenerateTranslations(): void
     {
         $this->populate();
-        $repo = $this->em->getRepository(self::TRANSLATION);
+        $repo = $this->em->getRepository(Translation::class);
         static::assertInstanceOf(TranslationRepository::class, $repo);
 
-        $article = $this->em->find(self::ARTICLE, $this->articleId);
+        $article = $this->em->find(Article::class, $this->articleId);
         static::assertInstanceOf(Translatable::class, $article);
 
         $translations = $repo->findTranslations($article);
@@ -125,7 +120,7 @@ final class TranslatableTest extends BaseTestCaseORM
             static::assertCount(0, $translations);
         }
         // test default locale
-        $article = $this->em->find(self::ARTICLE, $this->articleId);
+        $article = $this->em->find(Article::class, $this->articleId);
         $article->setTranslatableLocale('de_de');
         $article->setContent('content in de');
         $article->setTitle('title in de');
@@ -136,7 +131,7 @@ final class TranslatableTest extends BaseTestCaseORM
 
         $qb = $this->em->createQueryBuilder();
         $qb->select('art')
-            ->from(self::ARTICLE, 'art')
+            ->from(Article::class, 'art')
             ->where('art.id = :id')
             ->setParameter('id', $article->getId());
         $q = $qb->getQuery();
@@ -145,7 +140,7 @@ final class TranslatableTest extends BaseTestCaseORM
         static::assertSame('title in en', $result[0]['title']);
         static::assertSame('content in en', $result[0]['content']);
 
-        $repo = $this->em->getRepository(self::TRANSLATION);
+        $repo = $this->em->getRepository(Translation::class);
         $translations = $repo->findTranslations($article);
         static::assertCount(1, $translations);
         static::assertArrayHasKey('de_de', $translations);
@@ -157,7 +152,7 @@ final class TranslatableTest extends BaseTestCaseORM
         static::assertSame('title in de', $translations['de_de']['title']);
 
         // test second translations
-        $article = $this->em->find(self::ARTICLE, $this->articleId);
+        $article = $this->em->find(Article::class, $this->articleId);
         $article->setTranslatableLocale('de_de');
         $article->setContent('content in de');
         $article->setTitle('title in de');
@@ -174,7 +169,7 @@ final class TranslatableTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $repo = $this->em->getRepository(self::TRANSLATION);
+        $repo = $this->em->getRepository(Translation::class);
         $translations = $repo->findTranslations($article);
         static::assertCount(1, $translations);
         static::assertArrayHasKey('de_de', $translations);
@@ -203,7 +198,7 @@ final class TranslatableTest extends BaseTestCaseORM
             static::assertSame($expected, $translations['de_de']['message']);
         }
 
-        $article = $this->em->find(self::ARTICLE, $this->articleId);
+        $article = $this->em->find(Article::class, $this->articleId);
         static::assertSame('title in en', $article->getTitle());
         static::assertSame('content in en', $article->getContent());
 
@@ -215,7 +210,7 @@ final class TranslatableTest extends BaseTestCaseORM
             static::assertSame("message{$number} in en", $comment->getMessage());
         }
         // test deletion
-        $article = $this->em->find(self::ARTICLE, $this->articleId);
+        $article = $this->em->find(Article::class, $this->articleId);
         $this->em->remove($article);
         $this->em->flush();
 
@@ -229,7 +224,7 @@ final class TranslatableTest extends BaseTestCaseORM
         $this->translatableListener->setTranslationFallback(false);
         $this->translatableListener->setTranslatableLocale('ru_RU');
 
-        $article = $this->em->find(self::ARTICLE, $this->articleId);
+        $article = $this->em->find(Article::class, $this->articleId);
         static::assertFalse((bool) $article->getTitle());
         static::assertFalse((bool) $article->getContent());
 
@@ -239,7 +234,7 @@ final class TranslatableTest extends BaseTestCaseORM
         }
         $this->em->clear();
         $this->translatableListener->setTranslationFallback(true);
-        $article = $this->em->find(self::ARTICLE, $this->articleId);
+        $article = $this->em->find(Article::class, $this->articleId);
 
         static::assertSame('title in en', $article->getTitle());
         static::assertSame('content in en', $article->getContent());
@@ -261,7 +256,7 @@ final class TranslatableTest extends BaseTestCaseORM
         $this->em->persist($judo);
         $this->em->flush();
 
-        $repo = $this->em->getRepository(self::TRANSLATION);
+        $repo = $this->em->getRepository(Translation::class);
         $translations = $repo->findTranslations($judo);
         static::assertCount(1, $translations);
 
@@ -291,7 +286,7 @@ final class TranslatableTest extends BaseTestCaseORM
 
         $this->translatableListener->setTranslatableLocale('ua_UA');
         $this->translatableListener->setTranslationFallback(true);
-        $article = $this->em->find(self::ARTICLE, $article->getId());
+        $article = $this->em->find(Article::class, $article->getId());
 
         static::assertSame('Euro2012', $article->getTitle());
         static::assertSame('Shevchenko', $article->getAuthor());
@@ -299,7 +294,7 @@ final class TranslatableTest extends BaseTestCaseORM
 
         $this->em->clear();
         $this->translatableListener->setTranslationFallback(false);
-        $article = $this->em->find(self::ARTICLE, $article->getId());
+        $article = $this->em->find(Article::class, $article->getId());
         static::assertEmpty($article->getTitle());
         static::assertSame('Shevchenko', $article->getAuthor());
         static::assertEmpty($article->getViews());
@@ -308,10 +303,10 @@ final class TranslatableTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::ARTICLE,
-            self::TRANSLATION,
-            self::COMMENT,
-            self::SPORT,
+            Article::class,
+            Translation::class,
+            Comment::class,
+            Sport::class,
         ];
     }
 

--- a/tests/Gedmo/Translatable/TranslatableWithEmbeddedTest.php
+++ b/tests/Gedmo/Translatable/TranslatableWithEmbeddedTest.php
@@ -22,11 +22,6 @@ use Gedmo\Translatable\TranslatableListener;
 
 final class TranslatableWithEmbeddedTest extends BaseTestCaseORM
 {
-    private const FIXTURE = Company::class;
-    private const TRANSLATION = Translation::class;
-
-    private const TREE_WALKER_TRANSLATION = TranslationWalker::class;
-
     private TranslatableListener $translatableListener;
 
     protected function setUp(): void
@@ -66,12 +61,12 @@ final class TranslatableWithEmbeddedTest extends BaseTestCaseORM
     public function testTranslate(): void
     {
         /** @var EntityRepository<Company> $repo */
-        $repo = $this->em->getRepository(self::FIXTURE);
+        $repo = $this->em->getRepository(Company::class);
 
         /** @var Company $entity */
         $entity = $repo->findOneBy(['id' => 1]);
 
-        $repo = $this->em->getRepository(self::TRANSLATION);
+        $repo = $this->em->getRepository(Translation::class);
 
         $translations = $repo->findTranslations($entity);
 
@@ -88,7 +83,7 @@ final class TranslatableWithEmbeddedTest extends BaseTestCaseORM
         $this->em->clear();
 
         $this->translatableListener->setTranslatableLocale('de');
-        $repo = $this->em->getRepository(self::FIXTURE);
+        $repo = $this->em->getRepository(Company::class);
         $entity = $repo->findOneBy(['id' => $entity->getId()]);
 
         static::assertSame('website-de', $entity->getLink()->getWebsite());
@@ -97,10 +92,10 @@ final class TranslatableWithEmbeddedTest extends BaseTestCaseORM
 
     public function testQueryWalker(): void
     {
-        $dql = 'SELECT f FROM '.self::FIXTURE.' f';
+        $dql = 'SELECT f FROM '.Company::class.' f';
 
         $q = $this->em->createQuery($dql);
-        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, self::TREE_WALKER_TRANSLATION);
+        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, TranslationWalker::class);
 
         $this->translatableListener->setTranslatableLocale('de');
 
@@ -115,8 +110,8 @@ final class TranslatableWithEmbeddedTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::FIXTURE,
-            self::TRANSLATION,
+            Company::class,
+            Translation::class,
         ];
     }
 }

--- a/tests/Gedmo/Translatable/TranslationQueryWalkerTest.php
+++ b/tests/Gedmo/Translatable/TranslationQueryWalkerTest.php
@@ -30,12 +30,6 @@ use Symfony\Component\Cache\Adapter\ArrayAdapter;
  */
 final class TranslationQueryWalkerTest extends BaseTestCaseORM
 {
-    private const ARTICLE = Article::class;
-    private const COMMENT = Comment::class;
-    private const TRANSLATION = Translation::class;
-
-    private const TREE_WALKER_TRANSLATION = TranslationWalker::class;
-
     private TranslatableListener $translatableListener;
 
     protected function setUp(): void
@@ -55,9 +49,9 @@ final class TranslationQueryWalkerTest extends BaseTestCaseORM
     public function testShouldHandleQueryCache(): void
     {
         $this->em->getConfiguration()->setQueryCache(new ArrayAdapter());
-        $dql = 'SELECT a FROM '.self::ARTICLE.' a';
+        $dql = 'SELECT a FROM '.Article::class.' a';
         $q = $this->em->createQuery($dql);
-        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, self::TREE_WALKER_TRANSLATION);
+        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, TranslationWalker::class);
 
         // array hydration
         $this->translatableListener->setTranslatableLocale('en_us');
@@ -65,7 +59,7 @@ final class TranslationQueryWalkerTest extends BaseTestCaseORM
         static::assertCount(1, $result);
 
         $q2 = clone $q;
-        $q2->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, self::TREE_WALKER_TRANSLATION);
+        $q2->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, TranslationWalker::class);
         $result = $q->getArrayResult();
         static::assertCount(1, $result);
     }
@@ -73,13 +67,13 @@ final class TranslationQueryWalkerTest extends BaseTestCaseORM
     public function testSubselectByTranslatedField(): void
     {
         $this->populateMore();
-        $dql = 'SELECT a FROM '.self::ARTICLE.' a';
-        $subSelect = 'SELECT a2.title FROM '.self::ARTICLE.' a2';
+        $dql = 'SELECT a FROM '.Article::class.' a';
+        $subSelect = 'SELECT a2.title FROM '.Article::class.' a2';
         $subSelect .= " WHERE a2.title LIKE '%ab%'";
         $dql .= " WHERE a.title IN ({$subSelect})";
         $dql .= ' ORDER BY a.title';
         $q = $this->em->createQuery($dql);
-        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, self::TREE_WALKER_TRANSLATION);
+        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, TranslationWalker::class);
 
         // array hydration
         $this->translatableListener->setTranslatableLocale('en_us');
@@ -92,13 +86,13 @@ final class TranslationQueryWalkerTest extends BaseTestCaseORM
     public function testSubselectStatements(): void
     {
         $this->populateMore();
-        $dql = 'SELECT a FROM '.self::ARTICLE.' a';
-        $subSelect = 'SELECT a2.id FROM '.self::ARTICLE.' a2';
+        $dql = 'SELECT a FROM '.Article::class.' a';
+        $subSelect = 'SELECT a2.id FROM '.Article::class.' a2';
         $subSelect .= " WHERE a2.title LIKE '%ab%'";
         $dql .= " WHERE a.id IN ({$subSelect})";
         $dql .= ' ORDER BY a.title';
         $q = $this->em->createQuery($dql);
-        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, self::TREE_WALKER_TRANSLATION);
+        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, TranslationWalker::class);
 
         // array hydration
         $this->translatableListener->setTranslatableLocale('en_us');
@@ -111,12 +105,12 @@ final class TranslationQueryWalkerTest extends BaseTestCaseORM
     public function testJoinedWithStatements(): void
     {
         $this->populateMore();
-        $dql = 'SELECT a, c FROM '.self::ARTICLE.' a';
+        $dql = 'SELECT a, c FROM '.Article::class.' a';
         $dql .= ' LEFT JOIN a.comments c WITH c.subject LIKE :lookup';
         $dql .= ' WHERE a.title LIKE :filter';
         $dql .= ' ORDER BY a.title';
         $q = $this->em->createQuery($dql);
-        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, self::TREE_WALKER_TRANSLATION);
+        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, TranslationWalker::class);
 
         // array hydration
         $this->translatableListener->setTranslatableLocale('en_us');
@@ -138,9 +132,9 @@ final class TranslationQueryWalkerTest extends BaseTestCaseORM
             SimpleObjectHydrator::class
         );
 
-        $dql = 'SELECT a FROM '.self::ARTICLE.' a';
+        $dql = 'SELECT a FROM '.Article::class.' a';
         $q = $this->em->createQuery($dql);
-        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, self::TREE_WALKER_TRANSLATION);
+        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, TranslationWalker::class);
 
         $this->translatableListener->setTranslatableLocale('ru_ru');
         $this->translatableListener->setTranslationFallback(false);
@@ -169,10 +163,10 @@ final class TranslationQueryWalkerTest extends BaseTestCaseORM
 
     public function testSelectWithTranslationFallbackOnArrayHydration(): void
     {
-        $dql = 'SELECT a, c FROM '.self::ARTICLE.' a';
+        $dql = 'SELECT a, c FROM '.Article::class.' a';
         $dql .= ' LEFT JOIN a.comments c';
         $q = $this->em->createQuery($dql);
-        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, self::TREE_WALKER_TRANSLATION);
+        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, TranslationWalker::class);
 
         $this->translatableListener->setTranslatableLocale('ru_ru');
         $this->translatableListener->setTranslationFallback(false);
@@ -206,9 +200,9 @@ final class TranslationQueryWalkerTest extends BaseTestCaseORM
             SimpleObjectHydrator::class
         );
 
-        $dql = 'SELECT a FROM '.self::ARTICLE.' a';
+        $dql = 'SELECT a FROM '.Article::class.' a';
         $q = $this->em->createQuery($dql);
-        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, self::TREE_WALKER_TRANSLATION);
+        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, TranslationWalker::class);
 
         $this->translatableListener->setTranslatableLocale('ru_ru');
         $this->translatableListener->setTranslationFallback(false);
@@ -238,9 +232,9 @@ final class TranslationQueryWalkerTest extends BaseTestCaseORM
 
     public function testShouldBeAbleToUseInnerJoinStrategyForTranslations(): void
     {
-        $dql = 'SELECT a FROM '.self::ARTICLE.' a';
+        $dql = 'SELECT a FROM '.Article::class.' a';
         $q = $this->em->createQuery($dql);
-        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, self::TREE_WALKER_TRANSLATION);
+        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, TranslationWalker::class);
         $q->setHint(TranslatableListener::HINT_INNER_JOIN, true);
 
         $this->translatableListener->setTranslatableLocale('ru_ru');
@@ -259,9 +253,9 @@ final class TranslationQueryWalkerTest extends BaseTestCaseORM
         $this->translatableListener->setTranslatableLocale('lt_lt');
         $this->translatableListener->setTranslationFallback(false);
 
-        $dql = 'SELECT a FROM '.self::ARTICLE.' a';
+        $dql = 'SELECT a FROM '.Article::class.' a';
         $q = $this->em->createQuery($dql);
-        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, self::TREE_WALKER_TRANSLATION);
+        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, TranslationWalker::class);
         $q->setHint(TranslatableListener::HINT_TRANSLATABLE_LOCALE, 'undefined');
         $q->setHint(TranslatableListener::HINT_FALLBACK, true);
 
@@ -281,9 +275,9 @@ final class TranslationQueryWalkerTest extends BaseTestCaseORM
 
     public function testShouldBeAbleToOverrideTranslatableLocale(): void
     {
-        $dql = 'SELECT a FROM '.self::ARTICLE.' a';
+        $dql = 'SELECT a FROM '.Article::class.' a';
         $q = $this->em->createQuery($dql);
-        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, self::TREE_WALKER_TRANSLATION);
+        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, TranslationWalker::class);
         $q->setHint(TranslatableListener::HINT_TRANSLATABLE_LOCALE, 'lt_lt');
 
         $this->translatableListener->setTranslatableLocale('ru_ru');
@@ -302,9 +296,9 @@ final class TranslationQueryWalkerTest extends BaseTestCaseORM
             ObjectHydrator::class
         );
 
-        $dql = 'SELECT a FROM '.self::ARTICLE.' a';
+        $dql = 'SELECT a FROM '.Article::class.' a';
         $q = $this->em->createQuery($dql);
-        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, self::TREE_WALKER_TRANSLATION);
+        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, TranslationWalker::class);
 
         $this->translatableListener->setTranslatableLocale('ru_ru');
         $this->translatableListener->setTranslationFallback(false);
@@ -350,10 +344,10 @@ final class TranslationQueryWalkerTest extends BaseTestCaseORM
 
     public function testShouldSelectCountStatement(): void
     {
-        $dql = 'SELECT COUNT(a) FROM '.self::ARTICLE.' a';
+        $dql = 'SELECT COUNT(a) FROM '.Article::class.' a';
         $dql .= ' WHERE a.title LIKE :title';
         $q = $this->em->createQuery($dql);
-        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, self::TREE_WALKER_TRANSLATION);
+        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, TranslationWalker::class);
 
         $this->translatableListener->setTranslatableLocale('en_us');
         $q->setParameter('title', 'Foo%');
@@ -379,11 +373,11 @@ final class TranslationQueryWalkerTest extends BaseTestCaseORM
         );
 
         $this->populateMore();
-        $dql = 'SELECT a, c FROM '.self::ARTICLE.' a';
+        $dql = 'SELECT a, c FROM '.Article::class.' a';
         $dql .= ' LEFT JOIN a.comments c';
         $dql .= ' ORDER BY a.title';
         $q = $this->em->createQuery($dql);
-        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, self::TREE_WALKER_TRANSLATION);
+        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, TranslationWalker::class);
 
         // array hydration
         $this->translatableListener->setTranslatableLocale('en_us');
@@ -424,10 +418,10 @@ final class TranslationQueryWalkerTest extends BaseTestCaseORM
     {
         // Given
         $this->populateMore();
-        $dql = 'SELECT a.title, a.views FROM '.self::ARTICLE.' a';
+        $dql = 'SELECT a.title, a.views FROM '.Article::class.' a';
         $dql .= ' ORDER BY a.views';
         $q = $this->em->createQuery($dql);
-        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, self::TREE_WALKER_TRANSLATION);
+        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, TranslationWalker::class);
 
         // Test original
         $this->translatableListener->setTranslatableLocale('en_us');
@@ -460,10 +454,10 @@ final class TranslationQueryWalkerTest extends BaseTestCaseORM
             ObjectHydrator::class
         );
 
-        $dql = 'SELECT a, c FROM '.self::ARTICLE.' a';
+        $dql = 'SELECT a, c FROM '.Article::class.' a';
         $dql .= ' LEFT JOIN a.comments c ORDER BY c.id ASC';
         $q = $this->em->createQuery($dql);
-        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, self::TREE_WALKER_TRANSLATION);
+        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, TranslationWalker::class);
 
         // array hydration
         $this->translatableListener->setTranslatableLocale('en_us');
@@ -527,7 +521,7 @@ final class TranslationQueryWalkerTest extends BaseTestCaseORM
         $comments = $food->getComments();
         static::assertCount(2, $comments);
         $good = $comments[0];
-        static::assertInstanceOf(self::COMMENT, $good);
+        static::assertInstanceOf(Comment::class, $good);
         static::assertSame('geras', $good->getSubject());
         static::assertSame('maistas yra geras', $good->getMessage());
         $bad = $comments[1];
@@ -542,9 +536,9 @@ final class TranslationQueryWalkerTest extends BaseTestCaseORM
             ObjectHydrator::class
         );
 
-        $dql = 'SELECT a.title FROM '.self::ARTICLE.' a';
+        $dql = 'SELECT a.title FROM '.Article::class.' a';
         $q = $this->em->createQuery($dql);
-        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, self::TREE_WALKER_TRANSLATION);
+        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, TranslationWalker::class);
 
         // array hydration
         $this->translatableListener->setTranslatableLocale('en_us');
@@ -582,9 +576,9 @@ final class TranslationQueryWalkerTest extends BaseTestCaseORM
             ObjectHydrator::class
         );
 
-        $dql = 'SELECT a FROM '.self::ARTICLE.' a';
+        $dql = 'SELECT a FROM '.Article::class.' a';
         $q = $this->em->createQuery($dql);
-        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, self::TREE_WALKER_TRANSLATION);
+        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, TranslationWalker::class);
 
         // array hydration
         $this->translatableListener->setTranslatableLocale('en_us');
@@ -607,7 +601,7 @@ final class TranslationQueryWalkerTest extends BaseTestCaseORM
         $result = $q->getResult();
         static::assertCount(1, $result);
         $food = $result[0];
-        static::assertInstanceOf(self::ARTICLE, $food);
+        static::assertInstanceOf(Article::class, $food);
         static::assertSame('Food', $food->getTitle());
         static::assertSame('about food', $food->getContent());
 
@@ -624,10 +618,10 @@ final class TranslationQueryWalkerTest extends BaseTestCaseORM
      */
     public function testShouldSelectWithUnmappedField(): void
     {
-        $dql = 'SELECT a.title, count(a.id) AS num FROM '.self::ARTICLE.' a';
+        $dql = 'SELECT a.title, count(a.id) AS num FROM '.Article::class.' a';
         $dql .= ' ORDER BY a.title';
         $q = $this->em->createQuery($dql);
-        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, self::TREE_WALKER_TRANSLATION);
+        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, TranslationWalker::class);
 
         // array hydration
         $this->translatableListener->setTranslatableLocale('en_us');
@@ -643,10 +637,10 @@ final class TranslationQueryWalkerTest extends BaseTestCaseORM
             TranslationWalker::HYDRATE_SIMPLE_OBJECT_TRANSLATION,
             SimpleObjectHydrator::class
         );
-        $dql = 'SELECT a FROM '.self::ARTICLE.' a';
+        $dql = 'SELECT a FROM '.Article::class.' a';
         $dql .= ' ORDER BY a.title';
         $q = $this->em->createQuery($dql);
-        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, self::TREE_WALKER_TRANSLATION);
+        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, TranslationWalker::class);
 
         // array hydration
         $this->translatableListener->setTranslatableLocale('en_us');
@@ -662,10 +656,10 @@ final class TranslationQueryWalkerTest extends BaseTestCaseORM
             TranslationWalker::HYDRATE_OBJECT_TRANSLATION,
             ObjectHydrator::class
         );
-        $dql = 'SELECT a FROM '.self::ARTICLE.' a';
+        $dql = 'SELECT a FROM '.Article::class.' a';
         $dql .= ' ORDER BY a.title';
         $q = $this->em->createQuery($dql);
-        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, self::TREE_WALKER_TRANSLATION);
+        $q->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, TranslationWalker::class);
 
         // array hydration
         $this->translatableListener->setTranslatableLocale('en_us');
@@ -678,15 +672,15 @@ final class TranslationQueryWalkerTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::ARTICLE,
-            self::TRANSLATION,
-            self::COMMENT,
+            Article::class,
+            Translation::class,
+            Comment::class,
         ];
     }
 
     private function populateMore(): void
     {
-        $repo = $this->em->getRepository(self::ARTICLE);
+        $repo = $this->em->getRepository(Article::class);
 
         $this->translatableListener->setTranslatableLocale('en_us');
         $alfabet = new Article();
@@ -735,8 +729,8 @@ final class TranslationQueryWalkerTest extends BaseTestCaseORM
 
     private function populate(): void
     {
-        $repo = $this->em->getRepository(self::ARTICLE);
-        $commentRepo = $this->em->getRepository(self::COMMENT);
+        $repo = $this->em->getRepository(Article::class);
+        $commentRepo = $this->em->getRepository(Comment::class);
 
         $food = new Article();
         $food->setTitle('Food');

--- a/tests/Gedmo/Translator/TranslatableTest.php
+++ b/tests/Gedmo/Translator/TranslatableTest.php
@@ -24,9 +24,6 @@ use Gedmo\Tests\Translator\Fixture\PersonCustom;
  */
 final class TranslatableTest extends BaseTestCaseORM
 {
-    private const PERSON = Person::class;
-    private const PERSON_CUSTOM_PROXY = PersonCustom::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -53,7 +50,7 @@ final class TranslatableTest extends BaseTestCaseORM
         $this->em->clear();
 
         // retrieve record (translations would be fetched later - by demand)
-        $person = $this->em->getRepository(self::PERSON)->findOneBy(['name' => 'Jen']);
+        $person = $this->em->getRepository(Person::class)->findOneBy(['name' => 'Jen']);
 
         static::assertSame('Jen', $person->getName());
         static::assertSame('Женя', $person->translate('ru_RU')->getName());
@@ -61,7 +58,7 @@ final class TranslatableTest extends BaseTestCaseORM
         static::assertSame('multilingual description', $person->getDescription());
 
         // retrieve record with all translations in one query
-        $persons = $this->em->getRepository(self::PERSON)
+        $persons = $this->em->getRepository(Person::class)
             ->createQueryBuilder('p')
             ->select('p, t')
             ->join('p.translations', 't')
@@ -79,7 +76,7 @@ final class TranslatableTest extends BaseTestCaseORM
         $this->em->flush();
 
         // retrieve record with all translations in one query
-        $persons = $this->em->getRepository(self::PERSON)
+        $persons = $this->em->getRepository(Person::class)
             ->createQueryBuilder('p')
             ->select('p, t')
             ->join('p.translations', 't')
@@ -114,7 +111,7 @@ final class TranslatableTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $person = $this->em->getRepository(self::PERSON)->findOneBy(['name' => 'Jen']);
+        $person = $this->em->getRepository(Person::class)->findOneBy(['name' => 'Jen']);
         static::assertSame('Женя', $person->translate('ru')->getName());
         $parent = $person->getParent();
         static::assertInstanceOf(Proxy::class, $parent);
@@ -135,7 +132,7 @@ final class TranslatableTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $personProxy = $this->em->getReference(self::PERSON, ['id' => 1]);
+        $personProxy = $this->em->getReference(Person::class, ['id' => 1]);
         static::assertInstanceOf(Proxy::class, $personProxy);
         $name = $personProxy->translate('ru_RU')->getName();
         static::assertSame('Женя', $name);
@@ -155,7 +152,7 @@ final class TranslatableTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $personProxy = $this->em->getReference(self::PERSON, ['id' => 1]);
+        $personProxy = $this->em->getReference(Person::class, ['id' => 1]);
         static::assertInstanceOf(Proxy::class, $personProxy);
         $name = $personProxy->translate('ru_RU')->getName();
         static::assertSame('Женя', $name);
@@ -195,7 +192,7 @@ final class TranslatableTest extends BaseTestCaseORM
         $this->em->clear();
 
         // retrieve record (translations would be fetched later - by demand)
-        $person = $this->em->getRepository(self::PERSON_CUSTOM_PROXY)->findOneBy(['name' => 'Jen']);
+        $person = $this->em->getRepository(PersonCustom::class)->findOneBy(['name' => 'Jen']);
 
         static::assertSame('Jen', $person->getName());
         static::assertSame('Женя', $person->translate('ru_RU')->getName());
@@ -203,7 +200,7 @@ final class TranslatableTest extends BaseTestCaseORM
         static::assertSame('multilingual description', $person->getDescription());
 
         // retrieve record with all translations in one query
-        $persons = $this->em->getRepository(self::PERSON_CUSTOM_PROXY)
+        $persons = $this->em->getRepository(PersonCustom::class)
             ->createQueryBuilder('p')
             ->select('p, t')
             ->join('p.translations', 't')
@@ -221,7 +218,7 @@ final class TranslatableTest extends BaseTestCaseORM
         $this->em->flush();
 
         // retrieve record with all translations in one query
-        $persons = $this->em->getRepository(self::PERSON_CUSTOM_PROXY)
+        $persons = $this->em->getRepository(PersonCustom::class)
             ->createQueryBuilder('p')
             ->select('p, t')
             ->join('p.translations', 't')
@@ -238,8 +235,8 @@ final class TranslatableTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::PERSON, self::PERSON.'Translation',
-            self::PERSON_CUSTOM_PROXY, self::PERSON_CUSTOM_PROXY.'Translation',
+            Person::class, Person::class.'Translation',
+            PersonCustom::class, PersonCustom::class.'Translation',
         ];
     }
 }

--- a/tests/Gedmo/Tree/ClosureTreeRepositoryTest.php
+++ b/tests/Gedmo/Tree/ClosureTreeRepositoryTest.php
@@ -32,11 +32,6 @@ use Gedmo\Tree\TreeListener;
  */
 final class ClosureTreeRepositoryTest extends BaseTestCaseORM
 {
-    private const CATEGORY = Category::class;
-    private const CLOSURE = CategoryClosure::class;
-    private const CATEGORY_WITHOUT_LEVEL = CategoryWithoutLevel::class;
-    private const CATEGORY_WITHOUT_LEVEL_CLOSURE = CategoryWithoutLevelClosure::class;
-
     /**
      * @var TreeListener
      */
@@ -58,7 +53,7 @@ final class ClosureTreeRepositoryTest extends BaseTestCaseORM
     {
         $this->populate();
 
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(Category::class);
         $food = $repo->findOneBy(['title' => 'Food']);
 
         // Count all
@@ -84,7 +79,7 @@ final class ClosureTreeRepositoryTest extends BaseTestCaseORM
     {
         $this->populate();
 
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(Category::class);
         $fruits = $repo->findOneBy(['title' => 'Fruits']);
 
         $path = $repo->getPath($fruits);
@@ -105,7 +100,7 @@ final class ClosureTreeRepositoryTest extends BaseTestCaseORM
     {
         $this->populate();
 
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(Category::class);
         $fruits = $repo->findOneBy(['title' => 'Fruits']);
 
         // direct children of node, sorted by title ascending order. NOT including the root node
@@ -195,7 +190,7 @@ final class ClosureTreeRepositoryTest extends BaseTestCaseORM
     {
         $this->populate();
 
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(Category::class);
         $fruits = $repo->findOneBy(['title' => 'Fruits']);
 
         $repo->removeFromTree($fruits);
@@ -226,23 +221,23 @@ final class ClosureTreeRepositoryTest extends BaseTestCaseORM
     {
         $this->populate();
 
-        $this->buildTreeTests(self::CATEGORY);
+        $this->buildTreeTests(Category::class);
     }
 
     public function testBuildTreeWithoutLevelProperty(): void
     {
-        $this->populate(self::CATEGORY_WITHOUT_LEVEL);
+        $this->populate(CategoryWithoutLevel::class);
 
-        $this->buildTreeTests(self::CATEGORY_WITHOUT_LEVEL);
+        $this->buildTreeTests(CategoryWithoutLevel::class);
     }
 
     public function testHavingLevelPropertyAvoidsSubqueryInSelectInGetNodesHierarchy(): void
     {
         $this->populate();
 
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(Category::class);
         $roots = $repo->getRootNodes();
-        $meta = $this->em->getClassMetadata(self::CATEGORY);
+        $meta = $this->em->getClassMetadata(Category::class);
         $config = $this->listener->getConfiguration($this->em, $meta->getName());
         $qb = $repo->getNodesHierarchyQueryBuilder($roots[0], false, $config);
 
@@ -251,11 +246,11 @@ final class ClosureTreeRepositoryTest extends BaseTestCaseORM
 
     public function testNotHavingLevelPropertyUsesASubqueryInSelectInGetNodesHierarchy(): void
     {
-        $this->populate(self::CATEGORY_WITHOUT_LEVEL);
+        $this->populate(CategoryWithoutLevel::class);
 
-        $repo = $this->em->getRepository(self::CATEGORY_WITHOUT_LEVEL);
+        $repo = $this->em->getRepository(CategoryWithoutLevel::class);
         $roots = $repo->getRootNodes();
-        $meta = $this->em->getClassMetadata(self::CATEGORY_WITHOUT_LEVEL);
+        $meta = $this->em->getClassMetadata(CategoryWithoutLevel::class);
         $config = $this->listener->getConfiguration($this->em, $meta->getName());
         $qb = $repo->getNodesHierarchyQueryBuilder($roots[0], false, $config);
 
@@ -264,10 +259,10 @@ final class ClosureTreeRepositoryTest extends BaseTestCaseORM
 
     public function testChangeChildrenIndex(): void
     {
-        $this->populate(self::CATEGORY);
+        $this->populate(Category::class);
 
         $childrenIndex = 'myChildren';
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(Category::class);
         $repo->setChildrenIndex($childrenIndex);
 
         $tree = $repo->childrenHierarchy();
@@ -496,14 +491,14 @@ final class ClosureTreeRepositoryTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::CATEGORY,
-            self::CLOSURE,
-            self::CATEGORY_WITHOUT_LEVEL,
-            self::CATEGORY_WITHOUT_LEVEL_CLOSURE,
+            Category::class,
+            CategoryClosure::class,
+            CategoryWithoutLevel::class,
+            CategoryWithoutLevelClosure::class,
         ];
     }
 
-    private function populate(string $class = self::CATEGORY): void
+    private function populate(string $class = Category::class): void
     {
         $food = new $class();
         $food->setTitle('Food');

--- a/tests/Gedmo/Tree/ClosureTreeTest.php
+++ b/tests/Gedmo/Tree/ClosureTreeTest.php
@@ -34,15 +34,6 @@ use Gedmo\Tree\TreeListener;
  */
 final class ClosureTreeTest extends BaseTestCaseORM
 {
-    private const CATEGORY = Category::class;
-    private const CLOSURE = CategoryClosure::class;
-    private const PERSON = Person::class;
-    private const USER = User::class;
-    private const PERSON_CLOSURE = PersonClosure::class;
-    private const NEWS = News::class;
-    private const CATEGORY_WITHOUT_LEVEL = CategoryWithoutLevel::class;
-    private const CATEGORY_WITHOUT_LEVEL_CLOSURE = CategoryWithoutLevelClosure::class;
-
     /**
      * @var TreeListener
      */
@@ -69,7 +60,7 @@ final class ClosureTreeTest extends BaseTestCaseORM
             $minutes = intval($took / 60); $seconds = $took % 60;
             echo sprintf("%s --> %02d:%02d", $msg, $minutes, $seconds) . PHP_EOL;
         };
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(Category::class);
         $parent = null;
         $num = 800;
         for($i = 0; $i < 500; $i++) {
@@ -106,10 +97,10 @@ final class ClosureTreeTest extends BaseTestCaseORM
 
     public function testClosureTree(): void
     {
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(Category::class);
 
         $food = $repo->findOneBy(['title' => 'Food']);
-        $dql = 'SELECT c FROM '.self::CLOSURE.' c';
+        $dql = 'SELECT c FROM '.CategoryClosure::class.' c';
         $dql .= ' WHERE c.ancestor = :ancestor';
         $query = $this->em->createQuery($dql);
         $query->setParameter('ancestor', $food);
@@ -168,7 +159,7 @@ final class ClosureTreeTest extends BaseTestCaseORM
 
     public function testUpdateOfParent(): void
     {
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(Category::class);
         $strawberries = $repo->findOneBy(['title' => 'Strawberries']);
         $cheese = $repo->findOneBy(['title' => 'Cheese']);
 
@@ -176,7 +167,7 @@ final class ClosureTreeTest extends BaseTestCaseORM
         $this->em->persist($strawberries);
         $this->em->flush();
 
-        $dql = 'SELECT c FROM '.self::CLOSURE.' c';
+        $dql = 'SELECT c FROM '.CategoryClosure::class.' c';
         $dql .= ' WHERE c.descendant = :descendant';
         $query = $this->em->createQuery($dql);
         $query->setParameter('descendant', $strawberries);
@@ -191,14 +182,14 @@ final class ClosureTreeTest extends BaseTestCaseORM
 
     public function testAnotherUpdateOfParent(): void
     {
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(Category::class);
         $strawberries = $repo->findOneBy(['title' => 'Strawberries']);
 
         $strawberries->setParent(null);
         $this->em->persist($strawberries);
         $this->em->flush();
 
-        $dql = 'SELECT c FROM '.self::CLOSURE.' c';
+        $dql = 'SELECT c FROM '.CategoryClosure::class.' c';
         $dql .= ' WHERE c.descendant = :descendant';
         $query = $this->em->createQuery($dql);
         $query->setParameter('descendant', $strawberries);
@@ -210,14 +201,14 @@ final class ClosureTreeTest extends BaseTestCaseORM
 
     public function testBranchRemoval(): void
     {
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(Category::class);
         $fruits = $repo->findOneBy(['title' => 'Fruits']);
 
         $id = $fruits->getId();
         $this->em->remove($fruits);
         $this->em->flush();
 
-        $dql = 'SELECT COUNT(c) FROM '.self::CLOSURE.' c';
+        $dql = 'SELECT COUNT(c) FROM '.CategoryClosure::class.' c';
         $dql .= ' JOIN c.descendant d';
         $dql .= ' JOIN c.ancestor a';
         $dql .= ' WHERE (a.id = :id OR d.id = :id)';
@@ -231,7 +222,7 @@ final class ClosureTreeTest extends BaseTestCaseORM
     public function testSettingParentToChild(): void
     {
         $this->expectException(UnexpectedValueException::class);
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(Category::class);
         $fruits = $repo->findOneBy(['title' => 'Fruits']);
         $strawberries = $repo->findOneBy(['title' => 'Strawberries']);
 
@@ -277,7 +268,7 @@ final class ClosureTreeTest extends BaseTestCaseORM
 
         $closure = $this->em->createQueryBuilder()
                     ->select('c')
-                    ->from(self::CLOSURE, 'c')
+                    ->from(CategoryClosure::class, 'c')
                     ->where('c.ancestor = :ancestor')
                     ->setParameter('ancestor', $politics->getId())
                     ->getQuery()
@@ -362,14 +353,14 @@ final class ClosureTreeTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::CATEGORY,
-            self::CLOSURE,
-            self::PERSON,
-            self::PERSON_CLOSURE,
-            self::USER,
-            self::NEWS,
-            self::CATEGORY_WITHOUT_LEVEL,
-            self::CATEGORY_WITHOUT_LEVEL_CLOSURE,
+            Category::class,
+            CategoryClosure::class,
+            Person::class,
+            PersonClosure::class,
+            User::class,
+            News::class,
+            CategoryWithoutLevel::class,
+            CategoryWithoutLevelClosure::class,
         ];
     }
 

--- a/tests/Gedmo/Tree/ConcurrencyTest.php
+++ b/tests/Gedmo/Tree/ConcurrencyTest.php
@@ -25,10 +25,6 @@ use Gedmo\Tree\TreeListener;
  */
 final class ConcurrencyTest extends BaseTestCaseORM
 {
-    private const CATEGORY = Category::class;
-    private const ARTICLE = Article::class;
-    private const COMMENT = Comment::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -42,7 +38,7 @@ final class ConcurrencyTest extends BaseTestCaseORM
 
     public function testConcurrentEntitiesInOneFlush(): void
     {
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(Category::class);
         $sport = $repo->findOneBy(['title' => 'Root2']);
         $sport->setTitle('Sport');
 
@@ -80,7 +76,7 @@ final class ConcurrencyTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $meta = $this->em->getClassMetadata(self::CATEGORY);
+        $meta = $this->em->getClassMetadata(Category::class);
         $sport = $repo->findOneBy(['title' => 'Sport']);
         $left = $meta->getReflectionProperty('lft')->getValue($sport);
         $right = $meta->getReflectionProperty('rgt')->getValue($sport);
@@ -98,9 +94,9 @@ final class ConcurrencyTest extends BaseTestCaseORM
 
     public function testConcurrentTree(): void
     {
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(Category::class);
         // Force metadata class loading.
-        $this->em->getClassMetadata(self::CATEGORY);
+        $this->em->getClassMetadata(Category::class);
 
         $root = $repo->findOneBy(['title' => 'Root']);
 
@@ -126,9 +122,9 @@ final class ConcurrencyTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::CATEGORY,
-            self::ARTICLE,
-            self::COMMENT,
+            Category::class,
+            Article::class,
+            Comment::class,
         ];
     }
 

--- a/tests/Gedmo/Tree/InMemoryUpdatesTest.php
+++ b/tests/Gedmo/Tree/InMemoryUpdatesTest.php
@@ -23,8 +23,6 @@ use Gedmo\Tree\TreeListener;
  */
 final class InMemoryUpdatesTest extends BaseTestCaseORM
 {
-    private const CATEGORY = Category::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -37,8 +35,8 @@ final class InMemoryUpdatesTest extends BaseTestCaseORM
 
     public function testInMemoryTreeInserts(): void
     {
-        $meta = $this->em->getClassMetadata(self::CATEGORY);
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $meta = $this->em->getClassMetadata(Category::class);
+        $repo = $this->em->getRepository(Category::class);
 
         $root = new Category();
         $this->em->persist($root);
@@ -85,7 +83,7 @@ final class InMemoryUpdatesTest extends BaseTestCaseORM
 
         /*print "Tree:\n";
         for ($i=1; $i < 5; $i++) {
-            $node = $this->em->getRepository(self::CATEGORY)->find($i);
+            $node = $this->em->getRepository(Category::class)->find($i);
             $left = $meta->getReflectionProperty('lft')->getValue($node);
             $right = $meta->getReflectionProperty('rgt')->getValue($node);
             $level = $meta->getReflectionProperty('level')->getValue($node);
@@ -97,7 +95,7 @@ final class InMemoryUpdatesTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::CATEGORY,
+            Category::class,
         ];
     }
 }

--- a/tests/Gedmo/Tree/InMemoryUpdatesWithInheritanceTest.php
+++ b/tests/Gedmo/Tree/InMemoryUpdatesWithInheritanceTest.php
@@ -25,10 +25,6 @@ use Gedmo\Tree\TreeListener;
  */
 final class InMemoryUpdatesWithInheritanceTest extends BaseTestCaseORM
 {
-    private const PERSON = Person::class;
-    private const MAN = Man::class;
-    private const WOMAN = Woman::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -90,9 +86,9 @@ final class InMemoryUpdatesWithInheritanceTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::PERSON,
-            self::MAN,
-            self::WOMAN,
+            Person::class,
+            Man::class,
+            Woman::class,
         ];
     }
 }

--- a/tests/Gedmo/Tree/MaterializedPathODMMongoDBRepositoryTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathODMMongoDBRepositoryTest.php
@@ -27,8 +27,6 @@ use Gedmo\Tree\TreeListener;
  */
 final class MaterializedPathODMMongoDBRepositoryTest extends BaseTestCaseMongoODM
 {
-    private const CATEGORY = Category::class;
-
     /**
      * @var MaterializedPathRepository<Category>
      */
@@ -44,7 +42,7 @@ final class MaterializedPathODMMongoDBRepositoryTest extends BaseTestCaseMongoOD
         $this->getDefaultDocumentManager($evm);
         $this->populate();
 
-        $this->repo = $this->dm->getRepository(self::CATEGORY);
+        $this->repo = $this->dm->getRepository(Category::class);
     }
 
     public function testGetRootNodes(): void
@@ -307,7 +305,7 @@ final class MaterializedPathODMMongoDBRepositoryTest extends BaseTestCaseMongoOD
 
     private function createCategory(): Category
     {
-        $class = self::CATEGORY;
+        $class = Category::class;
 
         return new $class();
     }

--- a/tests/Gedmo/Tree/MaterializedPathODMMongoDBTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathODMMongoDBTest.php
@@ -26,8 +26,6 @@ use Gedmo\Tree\TreeListener;
  */
 final class MaterializedPathODMMongoDBTest extends BaseTestCaseMongoODM
 {
-    private const CATEGORY = Category::class;
-
     /**
      * @var array<string, mixed>
      */
@@ -49,7 +47,7 @@ final class MaterializedPathODMMongoDBTest extends BaseTestCaseMongoODM
 
         $this->getDefaultDocumentManager($evm);
 
-        $meta = $this->dm->getClassMetadata(self::CATEGORY);
+        $meta = $this->dm->getClassMetadata(Category::class);
         $this->config = $this->listener->getConfiguration($this->dm, $meta->getName());
     }
 
@@ -111,7 +109,7 @@ final class MaterializedPathODMMongoDBTest extends BaseTestCaseMongoODM
         $this->dm->remove($category2);
         $this->dm->flush();
 
-        $result = $this->dm->createQueryBuilder()->find(self::CATEGORY)->getQuery()->getIterator();
+        $result = $this->dm->createQueryBuilder()->find(Category::class)->getQuery()->getIterator();
 
         static::assertInstanceOf(Iterator::class, $result);
 
@@ -136,7 +134,7 @@ final class MaterializedPathODMMongoDBTest extends BaseTestCaseMongoODM
 
     private function createCategory(): Category
     {
-        $class = self::CATEGORY;
+        $class = Category::class;
 
         return new $class();
     }

--- a/tests/Gedmo/Tree/MaterializedPathODMMongoDBTreeLockingTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathODMMongoDBTreeLockingTest.php
@@ -25,8 +25,6 @@ use Gedmo\Tests\Tree\Fixture\Mock\TreeListenerMock;
  */
 final class MaterializedPathODMMongoDBTreeLockingTest extends BaseTestCaseMongoODM
 {
-    private const ARTICLE = Article::class;
-
     /**
      * @var array<string, mixed>
      */
@@ -48,7 +46,7 @@ final class MaterializedPathODMMongoDBTreeLockingTest extends BaseTestCaseMongoO
 
         $this->getDefaultDocumentManager($evm);
 
-        $meta = $this->dm->getClassMetadata(self::ARTICLE);
+        $meta = $this->dm->getClassMetadata(Article::class);
         $this->config = $this->listener->getConfiguration($this->dm, $meta->getName());
     }
 
@@ -106,7 +104,7 @@ final class MaterializedPathODMMongoDBTreeLockingTest extends BaseTestCaseMongoO
         // But this should throw it, because the root of its tree ($article) is still locked
         $this->expectException(TreeLockingException::class);
 
-        $repo = $this->dm->getRepository(self::ARTICLE);
+        $repo = $this->dm->getRepository(Article::class);
         $article2 = $repo->findOneBy(['title' => '2']);
         $article2->setTitle('New title 2');
 
@@ -115,7 +113,7 @@ final class MaterializedPathODMMongoDBTreeLockingTest extends BaseTestCaseMongoO
 
     public function createArticle(): Article
     {
-        $class = self::ARTICLE;
+        $class = Article::class;
 
         return new $class();
     }

--- a/tests/Gedmo/Tree/MaterializedPathORMFeaturesTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathORMFeaturesTest.php
@@ -24,8 +24,6 @@ use Gedmo\Tree\TreeListener;
  */
 final class MaterializedPathORMFeaturesTest extends BaseTestCaseORM
 {
-    private const CATEGORY = MPFeaturesCategory::class;
-
     /**
      * @var array<string, mixed>
      */
@@ -47,7 +45,7 @@ final class MaterializedPathORMFeaturesTest extends BaseTestCaseORM
 
         $this->getDefaultMockSqliteEntityManager($evm);
 
-        $meta = $this->em->getClassMetadata(self::CATEGORY);
+        $meta = $this->em->getClassMetadata(MPFeaturesCategory::class);
         $this->config = $this->listener->getConfiguration($this->em, $meta->getName());
     }
 
@@ -95,13 +93,13 @@ final class MaterializedPathORMFeaturesTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::CATEGORY,
+            MPFeaturesCategory::class,
         ];
     }
 
     private function createCategory(): MPFeaturesCategory
     {
-        $class = self::CATEGORY;
+        $class = MPFeaturesCategory::class;
 
         return new $class();
     }

--- a/tests/Gedmo/Tree/MaterializedPathORMRepositoryTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathORMRepositoryTest.php
@@ -28,9 +28,6 @@ use Gedmo\Tree\TreeListener;
  */
 final class MaterializedPathORMRepositoryTest extends BaseTestCaseORM
 {
-    private const CATEGORY = MPCategory::class;
-    private const CATEGORY_WITH_TRIMMED_SEPARATOR = MPCategoryWithTrimmedSeparator::class;
-
     /** @var MaterializedPathRepository<MPCategory> */
     private MaterializedPathRepository $repo;
 
@@ -47,11 +44,11 @@ final class MaterializedPathORMRepositoryTest extends BaseTestCaseORM
 
         $this->getDefaultMockSqliteEntityManager($evm);
 
-        $meta = $this->em->getClassMetadata(self::CATEGORY);
+        $meta = $this->em->getClassMetadata(MPCategory::class);
         $this->listener->getConfiguration($this->em, $meta->getName());
         $this->populate();
 
-        $this->repo = $this->em->getRepository(self::CATEGORY);
+        $this->repo = $this->em->getRepository(MPCategory::class);
     }
 
     public function testGetRootNodes(): void
@@ -146,9 +143,9 @@ final class MaterializedPathORMRepositoryTest extends BaseTestCaseORM
 
     public function testGetChildrenForEntityWithTrimmedSeparators(): void
     {
-        $this->populate(self::CATEGORY_WITH_TRIMMED_SEPARATOR);
+        $this->populate(MPCategoryWithTrimmedSeparator::class);
 
-        $repo = $this->em->getRepository(self::CATEGORY_WITH_TRIMMED_SEPARATOR);
+        $repo = $this->em->getRepository(MPCategoryWithTrimmedSeparator::class);
         $root = $repo->findOneBy(['title' => 'Food']);
 
         // Get all children from the root, NOT including it
@@ -362,8 +359,8 @@ final class MaterializedPathORMRepositoryTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::CATEGORY,
-            self::CATEGORY_WITH_TRIMMED_SEPARATOR,
+            MPCategory::class,
+            MPCategoryWithTrimmedSeparator::class,
         ];
     }
 
@@ -373,7 +370,7 @@ final class MaterializedPathORMRepositoryTest extends BaseTestCaseORM
     private function createCategory(?string $class = null): object
     {
         if (!$class) {
-            $class = self::CATEGORY;
+            $class = MPCategory::class;
         }
 
         return new $class();

--- a/tests/Gedmo/Tree/MaterializedPathORMRootAssociationTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathORMRootAssociationTest.php
@@ -24,8 +24,6 @@ use Gedmo\Tree\TreeListener;
  */
 final class MaterializedPathORMRootAssociationTest extends BaseTestCaseORM
 {
-    private const CATEGORY = MPCategoryWithRootAssociation::class;
-
     /**
      * @var array<string, mixed>
      */
@@ -47,7 +45,7 @@ final class MaterializedPathORMRootAssociationTest extends BaseTestCaseORM
 
         $this->getDefaultMockSqliteEntityManager($evm);
 
-        $meta = $this->em->getClassMetadata(self::CATEGORY);
+        $meta = $this->em->getClassMetadata(MPCategoryWithRootAssociation::class);
         $this->config = $this->listener->getConfiguration($this->em, $meta->getName());
     }
 
@@ -119,7 +117,7 @@ final class MaterializedPathORMRootAssociationTest extends BaseTestCaseORM
         $this->em->remove($category2);
         $this->em->flush();
 
-        $result = $this->em->createQueryBuilder()->select('c')->from(self::CATEGORY, 'c')->getQuery()->getResult();
+        $result = $this->em->createQueryBuilder()->select('c')->from(MPCategoryWithRootAssociation::class, 'c')->getQuery()->getResult();
 
         $firstResult = $result[0];
 
@@ -132,13 +130,13 @@ final class MaterializedPathORMRootAssociationTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::CATEGORY,
+            MPCategoryWithRootAssociation::class,
         ];
     }
 
     private function createCategory(): MPCategoryWithRootAssociation
     {
-        $class = self::CATEGORY;
+        $class = MPCategoryWithRootAssociation::class;
 
         return new $class();
     }

--- a/tests/Gedmo/Tree/MaterializedPathORMTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathORMTest.php
@@ -25,8 +25,6 @@ use Gedmo\Tree\TreeListener;
  */
 final class MaterializedPathORMTest extends BaseTestCaseORM
 {
-    private const CATEGORY = MPCategory::class;
-
     /**
      * @var array<string, mixed>
      */
@@ -48,7 +46,7 @@ final class MaterializedPathORMTest extends BaseTestCaseORM
 
         $this->getDefaultMockSqliteEntityManager($evm);
 
-        $meta = $this->em->getClassMetadata(self::CATEGORY);
+        $meta = $this->em->getClassMetadata(MPCategory::class);
         $this->config = $this->listener->getConfiguration($this->em, $meta->getName());
     }
 
@@ -120,7 +118,7 @@ final class MaterializedPathORMTest extends BaseTestCaseORM
         $this->em->remove($category2);
         $this->em->flush();
 
-        $result = $this->em->createQueryBuilder()->select('c')->from(self::CATEGORY, 'c')->getQuery()->getResult();
+        $result = $this->em->createQueryBuilder()->select('c')->from(MPCategory::class, 'c')->getQuery()->getResult();
 
         $firstResult = $result[0];
 
@@ -144,13 +142,13 @@ final class MaterializedPathORMTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::CATEGORY,
+            MPCategory::class,
         ];
     }
 
     private function createCategory(): MPCategory
     {
-        $class = self::CATEGORY;
+        $class = MPCategory::class;
 
         return new $class();
     }

--- a/tests/Gedmo/Tree/MultInheritanceWithJoinedTableTest.php
+++ b/tests/Gedmo/Tree/MultInheritanceWithJoinedTableTest.php
@@ -28,11 +28,6 @@ use Gedmo\Tree\TreeListener;
  */
 final class MultInheritanceWithJoinedTableTest extends BaseTestCaseORM
 {
-    private const USER = User::class;
-    private const GROUP = UserGroup::class;
-    private const ROLE = Role::class;
-    private const USERLDAP = UserLDAP::class;
-
     private TreeListener $tree;
 
     protected function setUp(): void
@@ -49,7 +44,7 @@ final class MultInheritanceWithJoinedTableTest extends BaseTestCaseORM
 
     public function testShouldHandleMultilevelInheritance(): void
     {
-        $admins = $this->em->getRepository(self::GROUP)->findOneBy(['name' => 'Admins']);
+        $admins = $this->em->getRepository(UserGroup::class)->findOneBy(['name' => 'Admins']);
         $adminRight = $admins->getRight();
         $userLdap = new UserLDAP('testname');
         $userLdap->init();
@@ -58,13 +53,13 @@ final class MultInheritanceWithJoinedTableTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $admins = $this->em->getRepository(self::GROUP)->findOneBy(['name' => 'Admins']);
+        $admins = $this->em->getRepository(UserGroup::class)->findOneBy(['name' => 'Admins']);
         static::assertNotSame($adminRight, $admins->getRight());
     }
 
     public function testShouldBeAbleToPopulateTree(): void
     {
-        $admins = $this->em->getRepository(self::GROUP)->findOneBy(['name' => 'Admins']);
+        $admins = $this->em->getRepository(UserGroup::class)->findOneBy(['name' => 'Admins']);
         $user3 = new User('user3@test.com', 'secret');
         $user3->init();
         $user3->setParent($admins);
@@ -75,37 +70,37 @@ final class MultInheritanceWithJoinedTableTest extends BaseTestCaseORM
 
         // run tree consistence checks
 
-        $everyBody = $this->em->getRepository(self::GROUP)->findOneBy(['name' => 'Everybody']);
+        $everyBody = $this->em->getRepository(UserGroup::class)->findOneBy(['name' => 'Everybody']);
         static::assertSame(1, $everyBody->getLeft());
         static::assertSame(14, $everyBody->getRight());
         static::assertSame(0, $everyBody->getLevel());
 
-        $admins = $this->em->getRepository(self::GROUP)->findOneBy(['name' => 'Admins']);
+        $admins = $this->em->getRepository(UserGroup::class)->findOneBy(['name' => 'Admins']);
         static::assertSame(2, $admins->getLeft());
         static::assertSame(7, $admins->getRight());
         static::assertSame(1, $admins->getLevel());
 
-        $visitors = $this->em->getRepository(self::GROUP)->findOneBy(['name' => 'Visitors']);
+        $visitors = $this->em->getRepository(UserGroup::class)->findOneBy(['name' => 'Visitors']);
         static::assertSame(8, $visitors->getLeft());
         static::assertSame(13, $visitors->getRight());
         static::assertSame(1, $visitors->getLevel());
 
-        $user0 = $this->em->getRepository(self::USER)->findOneBy(['email' => 'user0@test.com']);
+        $user0 = $this->em->getRepository(User::class)->findOneBy(['email' => 'user0@test.com']);
         static::assertSame(3, $user0->getLeft());
         static::assertSame(4, $user0->getRight());
         static::assertSame(2, $user0->getLevel());
 
-        $user1 = $this->em->getRepository(self::USER)->findOneBy(['email' => 'user1@test.com']);
+        $user1 = $this->em->getRepository(User::class)->findOneBy(['email' => 'user1@test.com']);
         static::assertSame(9, $user1->getLeft());
         static::assertSame(10, $user1->getRight());
         static::assertSame(2, $user1->getLevel());
 
-        $user2 = $this->em->getRepository(self::USER)->findOneBy(['email' => 'user2@test.com']);
+        $user2 = $this->em->getRepository(User::class)->findOneBy(['email' => 'user2@test.com']);
         static::assertSame(11, $user2->getLeft());
         static::assertSame(12, $user2->getRight());
         static::assertSame(2, $user2->getLevel());
 
-        $user3 = $this->em->getRepository(self::USER)->findOneBy(['email' => 'user3@test.com']);
+        $user3 = $this->em->getRepository(User::class)->findOneBy(['email' => 'user3@test.com']);
         static::assertSame(5, $user3->getLeft());
         static::assertSame(6, $user3->getRight());
         static::assertSame(2, $user3->getLevel());
@@ -114,10 +109,10 @@ final class MultInheritanceWithJoinedTableTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::USER,
-            self::GROUP,
-            self::ROLE,
-            self::USERLDAP,
+            User::class,
+            UserGroup::class,
+            Role::class,
+            UserLDAP::class,
         ];
     }
 

--- a/tests/Gedmo/Tree/MultiInheritanceTest.php
+++ b/tests/Gedmo/Tree/MultiInheritanceTest.php
@@ -24,11 +24,6 @@ use Gedmo\Translatable\Entity\Translation;
  */
 final class MultiInheritanceTest extends BaseTestCaseORM
 {
-    private const NODE = Node::class;
-    private const BASE_NODE = BaseNode::class;
-    private const ANODE = ANode::class;
-    private const TRANSLATION = Translation::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -39,8 +34,8 @@ final class MultiInheritanceTest extends BaseTestCaseORM
 
     public function testInheritance(): void
     {
-        $meta = $this->em->getClassMetadata(self::NODE);
-        $repo = $this->em->getRepository(self::NODE);
+        $meta = $this->em->getClassMetadata(Node::class);
+        $repo = $this->em->getRepository(Node::class);
 
         $food = $repo->findOneBy(['identifier' => 'food']);
         $left = $meta->getReflectionProperty('lft')->getValue($food);
@@ -49,7 +44,7 @@ final class MultiInheritanceTest extends BaseTestCaseORM
         static::assertNotNull($food->getCreated());
         static::assertNotNull($food->getUpdated());
 
-        $translationRepo = $this->em->getRepository(self::TRANSLATION);
+        $translationRepo = $this->em->getRepository(Translation::class);
         $translations = $translationRepo->findTranslations($food);
 
         static::assertCount(0, $translations);
@@ -63,7 +58,7 @@ final class MultiInheritanceTest extends BaseTestCaseORM
      */
     public function testCaseGithubIssue7(): void
     {
-        $repo = $this->em->getRepository(self::NODE);
+        $repo = $this->em->getRepository(Node::class);
         $vegies = $repo->findOneBy(['title' => 'Vegitables']);
 
         $count = $repo->childCount($vegies, true/* direct */);
@@ -73,7 +68,7 @@ final class MultiInheritanceTest extends BaseTestCaseORM
         static::assertCount(3, $children);
 
         // node repository will not find it
-        $baseNodeRepo = $this->em->getRepository(self::BASE_NODE);
+        $baseNodeRepo = $this->em->getRepository(BaseNode::class);
         $cabbage = $baseNodeRepo->findOneBy(['identifier' => 'cabbage']);
         $path = $baseNodeRepo->getPath($cabbage);
         static::assertCount(3, $path);
@@ -82,10 +77,10 @@ final class MultiInheritanceTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::NODE,
-            self::ANODE,
-            self::TRANSLATION,
-            self::BASE_NODE,
+            Node::class,
+            ANode::class,
+            Translation::class,
+            BaseNode::class,
         ];
     }
 

--- a/tests/Gedmo/Tree/MultiInheritanceWithSingleTableTest.php
+++ b/tests/Gedmo/Tree/MultiInheritanceWithSingleTableTest.php
@@ -26,11 +26,6 @@ use Gedmo\Tree\TreeListener;
  */
 final class MultiInheritanceWithSingleTableTest extends BaseTestCaseORM
 {
-    private const CAR = Car::class;
-    private const BUS = Bus::class;
-    private const VEHICLE = Vehicle::class;
-    private const ENGINE = Engine::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -46,7 +41,7 @@ final class MultiInheritanceWithSingleTableTest extends BaseTestCaseORM
         $this->populate();
         $this->em->clear();
 
-        $carRepo = $this->em->getRepository(self::CAR);
+        $carRepo = $this->em->getRepository(Car::class);
         $audi = $carRepo->findOneBy(['title' => 'Audi-80']);
         static::assertSame(2, $carRepo->childCount($audi));
         static::assertSame(1, $audi->getLeft());
@@ -67,7 +62,7 @@ final class MultiInheritanceWithSingleTableTest extends BaseTestCaseORM
 
     /*public function testHeavyLoad()
     {
-        $carRepo = $this->em->getRepository(self::CAR);
+        $carRepo = $this->em->getRepository(Car::class);
         $parent = null;
         $num = 100;
         for($i = 0; $i < 100; $i++) {
@@ -106,10 +101,10 @@ final class MultiInheritanceWithSingleTableTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::VEHICLE,
-            self::CAR,
-            self::ENGINE,
-            self::BUS,
+            Vehicle::class,
+            Car::class,
+            Engine::class,
+            Bus::class,
         ];
     }
 

--- a/tests/Gedmo/Tree/NestedTreePositionTest.php
+++ b/tests/Gedmo/Tree/NestedTreePositionTest.php
@@ -24,9 +24,6 @@ use Gedmo\Tree\TreeListener;
  */
 final class NestedTreePositionTest extends BaseTestCaseORM
 {
-    private const CATEGORY = Category::class;
-    private const ROOT_CATEGORY = RootCategory::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -45,7 +42,7 @@ final class NestedTreePositionTest extends BaseTestCaseORM
         $sport = new Category();
         $sport->setTitle('Sport');
 
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(Category::class);
 
         $repo->persistAsFirstChild($food);
         $repo->persistAsNextSiblingOf($sport, $food);
@@ -65,7 +62,7 @@ final class NestedTreePositionTest extends BaseTestCaseORM
         $sport = new RootCategory();
         $sport->setTitle('Sport');
 
-        $repo = $this->em->getRepository(self::ROOT_CATEGORY);
+        $repo = $this->em->getRepository(RootCategory::class);
 
         $repo->persistAsFirstChild($food);
         $repo->persistAsNextSiblingOf($sport, $food);
@@ -76,7 +73,7 @@ final class NestedTreePositionTest extends BaseTestCaseORM
     public function testTreeChildPositionMove2(): void
     {
         $this->populate();
-        $repo = $this->em->getRepository(self::ROOT_CATEGORY);
+        $repo = $this->em->getRepository(RootCategory::class);
 
         $oranges = $repo->findOneBy(['title' => 'Oranges']);
         $meat = $repo->findOneBy(['title' => 'Meat']);
@@ -99,7 +96,7 @@ final class NestedTreePositionTest extends BaseTestCaseORM
         static::assertSame(10, $meat->getRight());
 
         // Raw query to show the issue #108 with wrong left value by Doctrine
-        $dql = 'SELECT c FROM '.self::ROOT_CATEGORY.' c';
+        $dql = 'SELECT c FROM '.RootCategory::class.' c';
         $dql .= ' WHERE c.id = 5'; // 5 == meat
         $meat_array = $this->em->createQuery($dql)->getScalarResult();
 
@@ -111,7 +108,7 @@ final class NestedTreePositionTest extends BaseTestCaseORM
     public function testTreeChildPositionMove3(): void
     {
         $this->populate();
-        $repo = $this->em->getRepository(self::ROOT_CATEGORY);
+        $repo = $this->em->getRepository(RootCategory::class);
 
         $oranges = $repo->findOneBy(['title' => 'Oranges']);
         $milk = $repo->findOneBy(['title' => 'Milk']);
@@ -131,7 +128,7 @@ final class NestedTreePositionTest extends BaseTestCaseORM
         static::assertSame(10, $milk->getRight());
 
         // Raw query to show the issue #108 with wrong left value by Doctrine
-        $dql = 'SELECT c FROM '.self::ROOT_CATEGORY.' c';
+        $dql = 'SELECT c FROM '.RootCategory::class.' c';
         $dql .= ' WHERE c.id = 4 '; // 4 == Milk
         $milk_array = $this->em->createQuery($dql)->getScalarResult();
         static::assertSame(9, $milk_array[0]['c_lft']);
@@ -142,7 +139,7 @@ final class NestedTreePositionTest extends BaseTestCaseORM
     public function testPositionedUpdates(): void
     {
         $this->populate();
-        $repo = $this->em->getRepository(self::ROOT_CATEGORY);
+        $repo = $this->em->getRepository(RootCategory::class);
 
         $citrons = $repo->findOneBy(['title' => 'Citrons']);
         $vegitables = $repo->findOneBy(['title' => 'Vegitables']);
@@ -172,7 +169,7 @@ final class NestedTreePositionTest extends BaseTestCaseORM
     public function testTreeChildPositionMove(): void
     {
         $this->populate();
-        $repo = $this->em->getRepository(self::ROOT_CATEGORY);
+        $repo = $this->em->getRepository(RootCategory::class);
 
         $oranges = $repo->findOneBy(['title' => 'Oranges']);
         $fruits = $repo->findOneBy(['title' => 'Fruits']);
@@ -198,7 +195,7 @@ final class NestedTreePositionTest extends BaseTestCaseORM
     public function testOnRootCategory(): void
     {
         // need to check if this does not produce errors
-        $repo = $this->em->getRepository(self::ROOT_CATEGORY);
+        $repo = $this->em->getRepository(RootCategory::class);
 
         $fruits = new RootCategory();
         $fruits->setTitle('Fruits');
@@ -229,12 +226,12 @@ final class NestedTreePositionTest extends BaseTestCaseORM
             ->persistAsPrevSibling($drinks);
 
         $this->em->flush();
-        $dql = 'SELECT COUNT(c) FROM '.self::ROOT_CATEGORY.' c';
+        $dql = 'SELECT COUNT(c) FROM '.RootCategory::class.' c';
         $dql .= ' WHERE c.lft = 1 AND c.rgt = 2 AND c.parent IS NULL AND c.level = 1';
         $count = $this->em->createQuery($dql)->getSingleScalarResult();
         static::assertSame(6, (int) $count);
 
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(Category::class);
 
         $fruits = new Category();
         $fruits->setTitle('Fruits');
@@ -265,7 +262,7 @@ final class NestedTreePositionTest extends BaseTestCaseORM
             ->persistAsPrevSibling($drinks);
 
         $this->em->flush();
-        $dql = 'SELECT COUNT(c) FROM '.self::CATEGORY.' c';
+        $dql = 'SELECT COUNT(c) FROM '.Category::class.' c';
         $dql .= ' WHERE c.parentId IS NULL AND c.level = 0';
         $dql .= ' AND c.lft BETWEEN 1 AND 11';
         $count = $this->em->createQuery($dql)->getSingleScalarResult();
@@ -274,7 +271,7 @@ final class NestedTreePositionTest extends BaseTestCaseORM
 
     public function testRootTreePositionedInserts(): void
     {
-        $repo = $this->em->getRepository(self::ROOT_CATEGORY);
+        $repo = $this->em->getRepository(RootCategory::class);
 
         // test child positioned inserts
         $food = new RootCategory();
@@ -337,7 +334,7 @@ final class NestedTreePositionTest extends BaseTestCaseORM
 
     public function testRootlessTreeTopLevelInserts(): void
     {
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(Category::class);
 
         // test top level positioned inserts
         $fruits = new Category();
@@ -396,7 +393,7 @@ final class NestedTreePositionTest extends BaseTestCaseORM
 
     public function testSimpleTreePositionedInserts(): void
     {
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(Category::class);
 
         // test child positioned inserts
         $food = new Category();
@@ -462,14 +459,14 @@ final class NestedTreePositionTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::CATEGORY,
-            self::ROOT_CATEGORY,
+            Category::class,
+            RootCategory::class,
         ];
     }
 
     private function populate(): void
     {
-        $repo = $this->em->getRepository(self::ROOT_CATEGORY);
+        $repo = $this->em->getRepository(RootCategory::class);
 
         $food = new RootCategory();
         $food->setTitle('Food');

--- a/tests/Gedmo/Tree/NestedTreeRootAssociationTest.php
+++ b/tests/Gedmo/Tree/NestedTreeRootAssociationTest.php
@@ -23,8 +23,6 @@ use Gedmo\Tree\TreeListener;
  */
 final class NestedTreeRootAssociationTest extends BaseTestCaseORM
 {
-    private const CATEGORY = RootAssociationCategory::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -38,7 +36,7 @@ final class NestedTreeRootAssociationTest extends BaseTestCaseORM
 
     public function testRootEntity(): void
     {
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(RootAssociationCategory::class);
 
         // Foods
         $food = $repo->findOneBy(['title' => 'Food']);
@@ -63,7 +61,7 @@ final class NestedTreeRootAssociationTest extends BaseTestCaseORM
 
     public function testRemoveParentForNode(): void
     {
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(RootAssociationCategory::class);
 
         /** @var RootAssociationCategory $food */
         $food = $repo->findOneBy(['title' => 'Food']);
@@ -99,7 +97,7 @@ final class NestedTreeRootAssociationTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::CATEGORY,
+            RootAssociationCategory::class,
         ];
     }
 

--- a/tests/Gedmo/Tree/NestedTreeRootRepositoryTest.php
+++ b/tests/Gedmo/Tree/NestedTreeRootRepositoryTest.php
@@ -25,8 +25,6 @@ use Gedmo\Tree\TreeListener;
  */
 final class NestedTreeRootRepositoryTest extends BaseTestCaseORM
 {
-    private const CATEGORY = RootCategory::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -43,7 +41,7 @@ final class NestedTreeRootRepositoryTest extends BaseTestCaseORM
      */
     public function testShouldBeAbleToShiftRootNode(): void
     {
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(RootCategory::class);
 
         $food = $repo->findOneBy(['title' => 'Food']);
         $acme = new RootCategory();
@@ -67,7 +65,7 @@ final class NestedTreeRootRepositoryTest extends BaseTestCaseORM
 
     public function testShouldSupportChildrenHierarchyAsArray(): void
     {
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(RootCategory::class);
         $result = $repo->childrenHierarchy();
         static::assertCount(2, $result);
         static::assertTrue(isset($result[0]['__children'][0]['__children']));
@@ -128,7 +126,7 @@ final class NestedTreeRootRepositoryTest extends BaseTestCaseORM
 
     public function testShouldSupportChildrenHierarchyAsHtml(): void
     {
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(RootCategory::class);
         $food = $repo->findOneBy(['title' => 'Food']);
         $decorate = true;
         $defaultHtmlTree = $repo->childrenHierarchy($food, false, ['decorate' => $decorate]);
@@ -204,11 +202,11 @@ final class NestedTreeRootRepositoryTest extends BaseTestCaseORM
 
     public function testShouldSupportChildrenHierarchyByBuildTreeFunction(): void
     {
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(RootCategory::class);
         $q = $this->em
             ->createQueryBuilder()
             ->select('node')
-            ->from(self::CATEGORY, 'node')
+            ->from(RootCategory::class, 'node')
             ->orderBy('node.root, node.lft', 'ASC')
             ->where('node.root = 1')
             ->getQuery()
@@ -223,7 +221,7 @@ final class NestedTreeRootRepositoryTest extends BaseTestCaseORM
 
     public function testShouldRemoveRootNodeFromTree(): void
     {
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(RootCategory::class);
         $this->populateMore();
 
         $food = $repo->findOneBy(['title' => 'Food']);
@@ -255,7 +253,7 @@ final class NestedTreeRootRepositoryTest extends BaseTestCaseORM
      */
     public function testGetPathAsStringWithInvalidStringMethod($stringMethod): void
     {
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(RootCategory::class);
         $carrots = $repo->findOneBy(['title' => 'Carrots']);
 
         $this->expectException(InvalidArgumentException::class);
@@ -278,7 +276,7 @@ final class NestedTreeRootRepositoryTest extends BaseTestCaseORM
     public function testShouldHandleBasicRepositoryMethods(): void
     {
         /** @var NestedTreeRepository<RootCategory> $repo */
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(RootCategory::class);
         $carrots = $repo->findOneBy(['title' => 'Carrots']);
 
         $path = $repo->getPath($carrots);
@@ -330,13 +328,13 @@ final class NestedTreeRootRepositoryTest extends BaseTestCaseORM
     {
         $this->populateMore();
         /** @var NestedTreeRepository<RootCategory> $repo */
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(RootCategory::class);
 
         // verification
 
         static::assertTrue($repo->verify());
 
-        $dql = 'UPDATE '.self::CATEGORY.' node';
+        $dql = 'UPDATE '.RootCategory::class.' node';
         $dql .= ' SET node.lft = 5';
         $dql .= ' WHERE node.id = 4';
         $this->em->createQuery($dql)->getSingleScalarResult();
@@ -517,7 +515,7 @@ final class NestedTreeRootRepositoryTest extends BaseTestCaseORM
 
         // test fast recover
 
-        $dql = 'UPDATE '.self::CATEGORY.' node';
+        $dql = 'UPDATE '.RootCategory::class.' node';
         $dql .= ' SET node.lft = 1';
         $dql .= ' WHERE node.id = 8';
         $this->em->createQuery($dql)->execute();
@@ -538,7 +536,7 @@ final class NestedTreeRootRepositoryTest extends BaseTestCaseORM
     public function testShouldRemoveTreeLeafFromTree(): void
     {
         $this->populateMore();
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(RootCategory::class);
         $onions = $repo->findOneBy(['title' => 'Onions']);
         $id = $onions->getId();
         $repo->removeFromTree($onions);
@@ -551,7 +549,7 @@ final class NestedTreeRootRepositoryTest extends BaseTestCaseORM
 
     public function testGetRootNodesTest(): void
     {
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(RootCategory::class);
 
         // Test getRootNodes without custom ordering
         $roots = $repo->getRootNodes();
@@ -570,7 +568,7 @@ final class NestedTreeRootRepositoryTest extends BaseTestCaseORM
 
     public function testChangeChildrenIndexTest(): void
     {
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(RootCategory::class);
         $childrenIndex = 'myChildren';
         $repo->setChildrenIndex($childrenIndex);
 
@@ -582,13 +580,13 @@ final class NestedTreeRootRepositoryTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::CATEGORY,
+            RootCategory::class,
         ];
     }
 
     private function populateMore(): void
     {
-        $vegies = $this->em->getRepository(self::CATEGORY)
+        $vegies = $this->em->getRepository(RootCategory::class)
             ->findOneBy(['title' => 'Vegitables']);
 
         $cabbages = new RootCategory();

--- a/tests/Gedmo/Tree/NestedTreeRootTest.php
+++ b/tests/Gedmo/Tree/NestedTreeRootTest.php
@@ -25,8 +25,6 @@ use Gedmo\Tree\TreeListener;
  */
 final class NestedTreeRootTest extends BaseTestCaseORM
 {
-    private const CATEGORY = RootCategory::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -40,7 +38,7 @@ final class NestedTreeRootTest extends BaseTestCaseORM
 
     public function testShouldRemoveAndSynchronize(): void
     {
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(RootCategory::class);
         $vegies = $repo->findOneBy(['title' => 'Vegitables']);
 
         $this->em->remove($vegies);
@@ -71,7 +69,7 @@ final class NestedTreeRootTest extends BaseTestCaseORM
             $minutes = intval($took / 60); $seconds = $took % 60;
             echo sprintf("%s --> %02d:%02d", $msg, $minutes, $seconds) . PHP_EOL;
         };
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(RootCategory::class);
         $parent = null;
         $num = 800;
         for($i = 0; $i < 500; $i++) {
@@ -108,7 +106,7 @@ final class NestedTreeRootTest extends BaseTestCaseORM
 
     public function testTheTree(): void
     {
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(RootCategory::class);
         $node = $repo->findOneBy(['title' => 'Food']);
 
         static::assertSame(1, $node->getRoot());
@@ -154,7 +152,7 @@ final class NestedTreeRootTest extends BaseTestCaseORM
 
     public function testSetParentToNull(): void
     {
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(RootCategory::class);
         $node = $repo->findOneBy(['title' => 'Vegitables']);
         $node->setParent(null);
 
@@ -171,7 +169,7 @@ final class NestedTreeRootTest extends BaseTestCaseORM
 
     public function testTreeUpdateShiftToNextBranch(): void
     {
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(RootCategory::class);
         $sport = $repo->findOneBy(['title' => 'Sports']);
         $food = $repo->findOneBy(['title' => 'Food']);
 
@@ -200,7 +198,7 @@ final class NestedTreeRootTest extends BaseTestCaseORM
 
     public function testTreeUpdateShiftToRoot(): void
     {
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(RootCategory::class);
         $vegies = $repo->findOneBy(['title' => 'Vegitables']);
 
         $vegies->setParent(null);
@@ -230,7 +228,7 @@ final class NestedTreeRootTest extends BaseTestCaseORM
 
     public function testTreeUpdateShiftToOtherParent(): void
     {
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(RootCategory::class);
         $carrots = $repo->findOneBy(['title' => 'Carrots']);
         $food = $repo->findOneBy(['title' => 'Food']);
 
@@ -262,7 +260,7 @@ final class NestedTreeRootTest extends BaseTestCaseORM
     public function testTreeUpdateShiftToChildParent(): void
     {
         $this->expectException('UnexpectedValueException');
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(RootCategory::class);
         $vegies = $repo->findOneBy(['title' => 'Vegitables']);
         $food = $repo->findOneBy(['title' => 'Food']);
 
@@ -274,7 +272,7 @@ final class NestedTreeRootTest extends BaseTestCaseORM
 
     public function testTwoUpdateOperations(): void
     {
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(RootCategory::class);
 
         $sport = $repo->findOneBy(['title' => 'Sports']);
         $food = $repo->findOneBy(['title' => 'Food']);
@@ -312,7 +310,7 @@ final class NestedTreeRootTest extends BaseTestCaseORM
 
     public function testRemoval(): void
     {
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(RootCategory::class);
         $vegies = $repo->findOneBy(['title' => 'Vegitables']);
 
         $this->em->remove($vegies);
@@ -495,7 +493,7 @@ final class NestedTreeRootTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::CATEGORY,
+            RootCategory::class,
             ForeignRootCategory::class,
         ];
     }

--- a/tests/Gedmo/Tree/RepositoryTest.php
+++ b/tests/Gedmo/Tree/RepositoryTest.php
@@ -24,9 +24,6 @@ use Gedmo\Tree\TreeListener;
  */
 final class RepositoryTest extends BaseTestCaseORM
 {
-    private const CATEGORY = Category::class;
-    private const CATEGORY_UUID = CategoryUuid::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -40,40 +37,40 @@ final class RepositoryTest extends BaseTestCaseORM
 
     public function testBasicFunctions(): void
     {
-        $vegies = $this->em->getRepository(self::CATEGORY)
+        $vegies = $this->em->getRepository(Category::class)
             ->findOneBy(['title' => 'Vegitables']);
 
-        $food = $this->em->getRepository(self::CATEGORY)
+        $food = $this->em->getRepository(Category::class)
             ->findOneBy(['title' => 'Food']);
 
         // test childCount
 
-        $childCount = $this->em->getRepository(self::CATEGORY)
+        $childCount = $this->em->getRepository(Category::class)
             ->childCount($vegies);
         static::assertSame(2, $childCount);
 
-        $childCount = $this->em->getRepository(self::CATEGORY)
+        $childCount = $this->em->getRepository(Category::class)
             ->childCount($food);
         static::assertSame(4, $childCount);
 
-        $childCount = $this->em->getRepository(self::CATEGORY)
+        $childCount = $this->em->getRepository(Category::class)
             ->childCount($food, true);
         static::assertSame(2, $childCount);
 
-        $childCount = $this->em->getRepository(self::CATEGORY)
+        $childCount = $this->em->getRepository(Category::class)
             ->childCount();
         static::assertSame(6, $childCount);
 
         // test children
 
-        $children = $this->em->getRepository(self::CATEGORY)
+        $children = $this->em->getRepository(Category::class)
             ->children($vegies);
 
         static::assertCount(2, $children);
         static::assertSame('Carrots', $children[0]->getTitle());
         static::assertSame('Potatoes', $children[1]->getTitle());
 
-        $children = $this->em->getRepository(self::CATEGORY)
+        $children = $this->em->getRepository(Category::class)
             ->children($food);
 
         static::assertCount(4, $children);
@@ -82,28 +79,28 @@ final class RepositoryTest extends BaseTestCaseORM
         static::assertSame('Carrots', $children[2]->getTitle());
         static::assertSame('Potatoes', $children[3]->getTitle());
 
-        $children = $this->em->getRepository(self::CATEGORY)
+        $children = $this->em->getRepository(Category::class)
             ->children($food, true);
 
         static::assertCount(2, $children);
         static::assertSame('Fruits', $children[0]->getTitle());
         static::assertSame('Vegitables', $children[1]->getTitle());
 
-        $children = $this->em->getRepository(self::CATEGORY)
+        $children = $this->em->getRepository(Category::class)
             ->children();
 
         static::assertCount(6, $children);
 
         // test children sorting
 
-        $children = $this->em->getRepository(self::CATEGORY)
+        $children = $this->em->getRepository(Category::class)
              ->children($food, true, ['title'], 'ASC');
 
         static::assertCount(2, $children);
         static::assertSame('Fruits', $children[0]->getTitle());
         static::assertSame('Vegitables', $children[1]->getTitle());
 
-        $children = $this->em->getRepository(self::CATEGORY)
+        $children = $this->em->getRepository(Category::class)
              ->children($food, false, ['level', 'title'], ['ASC', 'DESC']);
 
         static::assertCount(4, $children);
@@ -112,7 +109,7 @@ final class RepositoryTest extends BaseTestCaseORM
         static::assertSame('Potatoes', $children[2]->getTitle());
         static::assertSame('Carrots', $children[3]->getTitle());
 
-        $children = $this->em->getRepository(self::CATEGORY)
+        $children = $this->em->getRepository(Category::class)
              ->children($food, false, ['level', 'title'], ['ASC']);
 
         static::assertCount(4, $children);
@@ -122,7 +119,7 @@ final class RepositoryTest extends BaseTestCaseORM
         static::assertSame('Potatoes', $children[3]->getTitle());
 
         // test sorting by single-valued association field
-        $children = $this->em->getRepository(self::CATEGORY)
+        $children = $this->em->getRepository(Category::class)
             ->children($food, false, 'parentId');
 
         static::assertCount(4, $children);
@@ -131,7 +128,7 @@ final class RepositoryTest extends BaseTestCaseORM
         static::assertSame('Carrots', $children[2]->getTitle());
         static::assertSame('Potatoes', $children[3]->getTitle());
 
-        $children = $this->em->getRepository(self::CATEGORY)
+        $children = $this->em->getRepository(Category::class)
             ->children($food, false, ['parentId'], ['ASC']);
 
         static::assertCount(4, $children);
@@ -142,17 +139,17 @@ final class RepositoryTest extends BaseTestCaseORM
 
         // path
 
-        $path = $this->em->getRepository(self::CATEGORY)
+        $path = $this->em->getRepository(Category::class)
             ->getPath($vegies);
 
         static::assertCount(2, $path);
         static::assertSame('Food', $path[0]->getTitle());
         static::assertSame('Vegitables', $path[1]->getTitle());
 
-        $carrots = $this->em->getRepository(self::CATEGORY)
+        $carrots = $this->em->getRepository(Category::class)
             ->findOneBy(['title' => 'Carrots']);
 
-        $path = $this->em->getRepository(self::CATEGORY)
+        $path = $this->em->getRepository(Category::class)
             ->getPath($carrots);
 
         static::assertCount(3, $path);
@@ -162,7 +159,7 @@ final class RepositoryTest extends BaseTestCaseORM
 
         // leafs
 
-        $leafs = $this->em->getRepository(self::CATEGORY)
+        $leafs = $this->em->getRepository(Category::class)
             ->getLeafs();
 
         static::assertCount(4, $leafs);
@@ -175,10 +172,10 @@ final class RepositoryTest extends BaseTestCaseORM
     public function testAdvancedFunctions(): void
     {
         $this->populateMore();
-        $onions = $this->em->getRepository(self::CATEGORY)
+        $onions = $this->em->getRepository(Category::class)
             ->findOneBy(['title' => 'Onions']);
-        $repo = $this->em->getRepository(self::CATEGORY);
-        $meta = $this->em->getClassMetadata(self::CATEGORY);
+        $repo = $this->em->getRepository(Category::class);
+        $meta = $this->em->getClassMetadata(Category::class);
 
         $left = $meta->getReflectionProperty('lft')->getValue($onions);
         $right = $meta->getReflectionProperty('rgt')->getValue($onions);
@@ -221,7 +218,7 @@ final class RepositoryTest extends BaseTestCaseORM
         $food = $repo->findOneBy(['title' => 'Food']);
         $repo->reorder($food, 'title');
 
-        $node = $this->em->getRepository(self::CATEGORY)
+        $node = $this->em->getRepository(Category::class)
             ->findOneBy(['title' => 'Cabbages']);
         $left = $meta->getReflectionProperty('lft')->getValue($node);
         $right = $meta->getReflectionProperty('rgt')->getValue($node);
@@ -229,7 +226,7 @@ final class RepositoryTest extends BaseTestCaseORM
         static::assertSame(5, $left);
         static::assertSame(6, $right);
 
-        $node = $this->em->getRepository(self::CATEGORY)
+        $node = $this->em->getRepository(Category::class)
             ->findOneBy(['title' => 'Carrots']);
         $left = $meta->getReflectionProperty('lft')->getValue($node);
         $right = $meta->getReflectionProperty('rgt')->getValue($node);
@@ -237,7 +234,7 @@ final class RepositoryTest extends BaseTestCaseORM
         static::assertSame(7, $left);
         static::assertSame(8, $right);
 
-        $node = $this->em->getRepository(self::CATEGORY)
+        $node = $this->em->getRepository(Category::class)
             ->findOneBy(['title' => 'Onions']);
         $left = $meta->getReflectionProperty('lft')->getValue($node);
         $right = $meta->getReflectionProperty('rgt')->getValue($node);
@@ -245,7 +242,7 @@ final class RepositoryTest extends BaseTestCaseORM
         static::assertSame(9, $left);
         static::assertSame(10, $right);
 
-        $node = $this->em->getRepository(self::CATEGORY)
+        $node = $this->em->getRepository(Category::class)
             ->findOneBy(['title' => 'Potatoes']);
         $left = $meta->getReflectionProperty('lft')->getValue($node);
         $right = $meta->getReflectionProperty('rgt')->getValue($node);
@@ -255,19 +252,19 @@ final class RepositoryTest extends BaseTestCaseORM
 
         // test removal with reparenting
 
-        $vegies = $this->em->getRepository(self::CATEGORY)
+        $vegies = $this->em->getRepository(Category::class)
             ->findOneBy(['title' => 'Vegitables']);
 
         $repo->removeFromTree($vegies);
 
         $this->em->clear(); // clear all cached nodes
 
-        $vegies = $this->em->getRepository(self::CATEGORY)
+        $vegies = $this->em->getRepository(Category::class)
             ->findOneBy(['title' => 'Vegitables']);
 
         static::assertNull($vegies);
 
-        $node = $this->em->getRepository(self::CATEGORY)
+        $node = $this->em->getRepository(Category::class)
             ->findOneBy(['title' => 'Fruits']);
         $left = $meta->getReflectionProperty('lft')->getValue($node);
         $right = $meta->getReflectionProperty('rgt')->getValue($node);
@@ -276,7 +273,7 @@ final class RepositoryTest extends BaseTestCaseORM
         static::assertSame(3, $right);
         static::assertSame('Food', $node->getParent()->getTitle());
 
-        $node = $this->em->getRepository(self::CATEGORY)
+        $node = $this->em->getRepository(Category::class)
             ->findOneBy(['title' => 'Cabbages']);
         $left = $meta->getReflectionProperty('lft')->getValue($node);
         $right = $meta->getReflectionProperty('rgt')->getValue($node);
@@ -288,8 +285,8 @@ final class RepositoryTest extends BaseTestCaseORM
 
     public function testRootRemoval(): void
     {
-        $repo = $this->em->getRepository(self::CATEGORY);
-        $meta = $this->em->getClassMetadata(self::CATEGORY);
+        $repo = $this->em->getRepository(Category::class);
+        $meta = $this->em->getClassMetadata(Category::class);
         $this->populateMore();
 
         $food = $repo->findOneBy(['title' => 'Food']);
@@ -318,7 +315,7 @@ final class RepositoryTest extends BaseTestCaseORM
 
     public function testVerificationAndRecover(): void
     {
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(Category::class);
         $this->populateMore();
         // test verification of tree
 
@@ -326,7 +323,7 @@ final class RepositoryTest extends BaseTestCaseORM
 
         // now lets brake something
 
-        $dql = 'UPDATE '.self::CATEGORY.' node';
+        $dql = 'UPDATE '.Category::class.' node';
         $dql .= ' SET node.lft = 1, node.level = 99';
         $dql .= ' WHERE node.id = 8';
         $q = $this->em->createQuery($dql);
@@ -363,12 +360,12 @@ final class RepositoryTest extends BaseTestCaseORM
 
     public function testMoveRootNode(): void
     {
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(Category::class);
         $food = $repo->findOneBy(['title' => 'Food']);
 
         $repo->moveDown($food, 1);
 
-        $meta = $this->em->getClassMetadata(self::CATEGORY);
+        $meta = $this->em->getClassMetadata(Category::class);
 
         $left = $meta->getReflectionProperty('lft')->getValue($food);
         $right = $meta->getReflectionProperty('rgt')->getValue($food);
@@ -384,40 +381,40 @@ final class RepositoryTest extends BaseTestCaseORM
     {
         $this->populateUuid();
 
-        $vegies = $this->em->getRepository(self::CATEGORY_UUID)
+        $vegies = $this->em->getRepository(CategoryUuid::class)
             ->findOneBy(['title' => 'Vegitables']);
 
-        $food = $this->em->getRepository(self::CATEGORY_UUID)
+        $food = $this->em->getRepository(CategoryUuid::class)
             ->findOneBy(['title' => 'Food']);
 
         // test childCount
 
-        $childCount = $this->em->getRepository(self::CATEGORY_UUID)
+        $childCount = $this->em->getRepository(CategoryUuid::class)
             ->childCount($vegies);
         static::assertSame(2, $childCount);
 
-        $childCount = $this->em->getRepository(self::CATEGORY_UUID)
+        $childCount = $this->em->getRepository(CategoryUuid::class)
             ->childCount($food);
         static::assertSame(4, $childCount);
 
-        $childCount = $this->em->getRepository(self::CATEGORY_UUID)
+        $childCount = $this->em->getRepository(CategoryUuid::class)
             ->childCount($food, true);
         static::assertSame(2, $childCount);
 
-        $childCount = $this->em->getRepository(self::CATEGORY_UUID)
+        $childCount = $this->em->getRepository(CategoryUuid::class)
             ->childCount();
         static::assertSame(6, $childCount);
 
         // test children
 
-        $children = $this->em->getRepository(self::CATEGORY_UUID)
+        $children = $this->em->getRepository(CategoryUuid::class)
             ->children($vegies);
 
         static::assertCount(2, $children);
         static::assertSame('Carrots', $children[0]->getTitle());
         static::assertSame('Potatoes', $children[1]->getTitle());
 
-        $children = $this->em->getRepository(self::CATEGORY_UUID)
+        $children = $this->em->getRepository(CategoryUuid::class)
             ->children($food);
 
         static::assertCount(4, $children);
@@ -426,31 +423,31 @@ final class RepositoryTest extends BaseTestCaseORM
         static::assertSame('Carrots', $children[2]->getTitle());
         static::assertSame('Potatoes', $children[3]->getTitle());
 
-        $children = $this->em->getRepository(self::CATEGORY_UUID)
+        $children = $this->em->getRepository(CategoryUuid::class)
             ->children($food, true);
 
         static::assertCount(2, $children);
         static::assertSame('Fruits', $children[0]->getTitle());
         static::assertSame('Vegitables', $children[1]->getTitle());
 
-        $children = $this->em->getRepository(self::CATEGORY_UUID)
+        $children = $this->em->getRepository(CategoryUuid::class)
             ->children();
 
         static::assertCount(6, $children);
 
         // path
 
-        $path = $this->em->getRepository(self::CATEGORY_UUID)
+        $path = $this->em->getRepository(CategoryUuid::class)
             ->getPath($vegies);
 
         static::assertCount(2, $path);
         static::assertSame('Food', $path[0]->getTitle());
         static::assertSame('Vegitables', $path[1]->getTitle());
 
-        $carrots = $this->em->getRepository(self::CATEGORY_UUID)
+        $carrots = $this->em->getRepository(CategoryUuid::class)
             ->findOneBy(['title' => 'Carrots']);
 
-        $path = $this->em->getRepository(self::CATEGORY_UUID)
+        $path = $this->em->getRepository(CategoryUuid::class)
             ->getPath($carrots);
 
         static::assertCount(3, $path);
@@ -460,7 +457,7 @@ final class RepositoryTest extends BaseTestCaseORM
 
         // leafs
 
-        $leafs = $this->em->getRepository(self::CATEGORY_UUID)
+        $leafs = $this->em->getRepository(CategoryUuid::class)
             ->getLeafs($path[0]);
 
         static::assertCount(3, $leafs);
@@ -472,14 +469,14 @@ final class RepositoryTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::CATEGORY,
-            self::CATEGORY_UUID,
+            Category::class,
+            CategoryUuid::class,
         ];
     }
 
     private function populateMore(): void
     {
-        $vegies = $this->em->getRepository(self::CATEGORY)
+        $vegies = $this->em->getRepository(Category::class)
             ->findOneBy(['title' => 'Vegitables']);
 
         $cabbages = new Category();

--- a/tests/Gedmo/Tree/TranslatableSluggableTreeTest.php
+++ b/tests/Gedmo/Tree/TranslatableSluggableTreeTest.php
@@ -29,11 +29,6 @@ use Gedmo\Tree\TreeListener;
  */
 final class TranslatableSluggableTreeTest extends BaseTestCaseORM
 {
-    private const CATEGORY = BehavioralCategory::class;
-    private const ARTICLE = Article::class;
-    private const COMMENT = Comment::class;
-    private const TRANSLATION = Translation::class;
-
     private TranslatableListener $translatableListener;
 
     protected function setUp(): void
@@ -53,10 +48,10 @@ final class TranslatableSluggableTreeTest extends BaseTestCaseORM
 
     public function testNestedBehaviors(): void
     {
-        $vegies = $this->em->getRepository(self::CATEGORY)
+        $vegies = $this->em->getRepository(BehavioralCategory::class)
             ->findOneBy(['title' => 'Vegitables']);
 
-        $childCount = $this->em->getRepository(self::CATEGORY)
+        $childCount = $this->em->getRepository(BehavioralCategory::class)
             ->childCount($vegies);
         static::assertSame(2, $childCount);
 
@@ -74,10 +69,10 @@ final class TranslatableSluggableTreeTest extends BaseTestCaseORM
 
         $this->translatableListener->setTranslatableLocale('en_US');
 
-        $vegies = $this->em->getRepository(self::CATEGORY)
+        $vegies = $this->em->getRepository(BehavioralCategory::class)
             ->find($vegies->getId());
 
-        $translations = $this->em->getRepository(self::TRANSLATION)
+        $translations = $this->em->getRepository(Translation::class)
             ->findTranslations($vegies);
 
         static::assertCount(1, $translations);
@@ -93,7 +88,7 @@ final class TranslatableSluggableTreeTest extends BaseTestCaseORM
     public function testTranslations(): void
     {
         $this->populateDeTranslations();
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(BehavioralCategory::class);
         $vegies = $repo->find(4);
 
         static::assertSame('Vegitables', $vegies->getTitle());
@@ -117,17 +112,17 @@ final class TranslatableSluggableTreeTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::CATEGORY,
-            self::ARTICLE,
-            self::COMMENT,
-            self::TRANSLATION,
+            BehavioralCategory::class,
+            Article::class,
+            Comment::class,
+            Translation::class,
         ];
     }
 
     private function populateDeTranslations(): void
     {
         $this->translatableListener->setTranslatableLocale('de_DE');
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(BehavioralCategory::class);
         $food = $repo->findOneBy(['title' => 'Food']);
         $food->setTitle('Lebensmittel');
 

--- a/tests/Gedmo/Tree/TreeObjectHydratorTest.php
+++ b/tests/Gedmo/Tree/TreeObjectHydratorTest.php
@@ -27,9 +27,6 @@ use Gedmo\Tree\TreeListener;
  */
 final class TreeObjectHydratorTest extends BaseTestCaseORM
 {
-    private const CATEGORY = Category::class;
-    private const ROOT_CATEGORY = RootCategory::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -49,7 +46,7 @@ final class TreeObjectHydratorTest extends BaseTestCaseORM
 
         $this->queryLogger->reset();
 
-        $repo = $this->em->getRepository(self::ROOT_CATEGORY);
+        $repo = $this->em->getRepository(RootCategory::class);
 
         $result = $repo->createQueryBuilder('node')
             ->orderBy('node.lft', 'ASC')
@@ -99,7 +96,7 @@ final class TreeObjectHydratorTest extends BaseTestCaseORM
         $this->queryLogger->reset();
 
         /** @var NestedTreeRepository<RootCategory> $repo */
-        $repo = $this->em->getRepository(self::ROOT_CATEGORY);
+        $repo = $this->em->getRepository(RootCategory::class);
 
         $fruits = $repo->findOneBy(['title' => 'Fruits']);
 
@@ -132,7 +129,7 @@ final class TreeObjectHydratorTest extends BaseTestCaseORM
         $this->queryLogger->reset();
 
         /** @var NestedTreeRepository<RootCategory> $repo */
-        $repo = $this->em->getRepository(self::ROOT_CATEGORY);
+        $repo = $this->em->getRepository(RootCategory::class);
 
         $food = $repo->findOneBy(['title' => 'Food']);
 
@@ -172,14 +169,14 @@ final class TreeObjectHydratorTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::CATEGORY,
-            self::ROOT_CATEGORY,
+            Category::class,
+            RootCategory::class,
         ];
     }
 
     private function populate(): void
     {
-        $repo = $this->em->getRepository(self::ROOT_CATEGORY);
+        $repo = $this->em->getRepository(RootCategory::class);
 
         $food = new RootCategory();
         $food->setTitle('Food');

--- a/tests/Gedmo/Tree/TreeTest.php
+++ b/tests/Gedmo/Tree/TreeTest.php
@@ -25,9 +25,6 @@ use Gedmo\Tree\TreeListener;
  */
 final class TreeTest extends BaseTestCaseORM
 {
-    private const CATEGORY = Category::class;
-    private const CATEGORY_UUID = CategoryUuid::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -40,7 +37,7 @@ final class TreeTest extends BaseTestCaseORM
 
     public function testTheTree(): void
     {
-        $meta = $this->em->getClassMetadata(self::CATEGORY);
+        $meta = $this->em->getClassMetadata(Category::class);
 
         $root = new Category();
         $root->setTitle('Root');
@@ -50,7 +47,7 @@ final class TreeTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $root = $this->em->getRepository(self::CATEGORY)->find(1);
+        $root = $this->em->getRepository(Category::class)->find(1);
         $left = $meta->getReflectionProperty('lft')->getValue($root);
         $right = $meta->getReflectionProperty('rgt')->getValue($root);
 
@@ -65,7 +62,7 @@ final class TreeTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $root = $this->em->getRepository(self::CATEGORY)->find(1);
+        $root = $this->em->getRepository(Category::class)->find(1);
         $left = $meta->getReflectionProperty('lft')->getValue($root);
         $right = $meta->getReflectionProperty('rgt')->getValue($root);
         $level = $meta->getReflectionProperty('level')->getValue($root);
@@ -74,7 +71,7 @@ final class TreeTest extends BaseTestCaseORM
         static::assertSame(4, $right);
         static::assertSame(0, $level);
 
-        $child = $this->em->getRepository(self::CATEGORY)->find(2);
+        $child = $this->em->getRepository(Category::class)->find(2);
         $left = $meta->getReflectionProperty('lft')->getValue($child);
         $right = $meta->getReflectionProperty('rgt')->getValue($child);
         $level = $meta->getReflectionProperty('level')->getValue($child);
@@ -91,7 +88,7 @@ final class TreeTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $root = $this->em->getRepository(self::CATEGORY)->find(1);
+        $root = $this->em->getRepository(Category::class)->find(1);
         $left = $meta->getReflectionProperty('lft')->getValue($root);
         $right = $meta->getReflectionProperty('rgt')->getValue($root);
         $level = $meta->getReflectionProperty('level')->getValue($root);
@@ -100,7 +97,7 @@ final class TreeTest extends BaseTestCaseORM
         static::assertSame(6, $right);
         static::assertSame(0, $level);
 
-        $child2 = $this->em->getRepository(self::CATEGORY)->find(3);
+        $child2 = $this->em->getRepository(Category::class)->find(3);
         $left = $meta->getReflectionProperty('lft')->getValue($child2);
         $right = $meta->getReflectionProperty('rgt')->getValue($child2);
         $level = $meta->getReflectionProperty('level')->getValue($child2);
@@ -117,7 +114,7 @@ final class TreeTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $child2 = $this->em->getRepository(self::CATEGORY)->find(3);
+        $child2 = $this->em->getRepository(Category::class)->find(3);
         $left = $meta->getReflectionProperty('lft')->getValue($child2);
         $right = $meta->getReflectionProperty('rgt')->getValue($child2);
         $level = $meta->getReflectionProperty('level')->getValue($child2);
@@ -132,8 +129,8 @@ final class TreeTest extends BaseTestCaseORM
 
         // test updates to nodes, parent changes
 
-        $childsChild = $this->em->getRepository(self::CATEGORY)->find(4);
-        $child = $this->em->getRepository(self::CATEGORY)->find(2);
+        $childsChild = $this->em->getRepository(Category::class)->find(4);
+        $child = $this->em->getRepository(Category::class)->find(2);
         $childsChild->setTitle('childs_child');
         $childsChild->setParent($child);
 
@@ -141,7 +138,7 @@ final class TreeTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $child = $this->em->getRepository(self::CATEGORY)->find(2);
+        $child = $this->em->getRepository(Category::class)->find(2);
         $left = $meta->getReflectionProperty('lft')->getValue($child);
         $right = $meta->getReflectionProperty('rgt')->getValue($child);
         $level = $meta->getReflectionProperty('level')->getValue($child);
@@ -156,7 +153,7 @@ final class TreeTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $root = $this->em->getRepository(self::CATEGORY)->find(1);
+        $root = $this->em->getRepository(Category::class)->find(1);
         $left = $meta->getReflectionProperty('lft')->getValue($root);
         $right = $meta->getReflectionProperty('rgt')->getValue($root);
 
@@ -183,7 +180,7 @@ final class TreeTest extends BaseTestCaseORM
 
     public function testIssue33(): void
     {
-        $repo = $this->em->getRepository(self::CATEGORY);
+        $repo = $this->em->getRepository(Category::class);
 
         $root = new Category();
         $root->setTitle('root');
@@ -215,7 +212,7 @@ final class TreeTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $meta = $this->em->getClassMetadata(self::CATEGORY);
+        $meta = $this->em->getClassMetadata(Category::class);
         $subNode = $repo->findOneBy(['title' => 'sub-node']);
         $left = $meta->getReflectionProperty('lft')->getValue($subNode);
         $right = $meta->getReflectionProperty('rgt')->getValue($subNode);
@@ -231,7 +228,7 @@ final class TreeTest extends BaseTestCaseORM
 
     public function testIssue273(): void
     {
-        $meta = $this->em->getClassMetadata(self::CATEGORY_UUID);
+        $meta = $this->em->getClassMetadata(CategoryUuid::class);
 
         $root = new CategoryUuid();
         $root->setTitle('Root');
@@ -242,7 +239,7 @@ final class TreeTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $root = $this->em->getRepository(self::CATEGORY_UUID)->find($rootId);
+        $root = $this->em->getRepository(CategoryUuid::class)->find($rootId);
         $left = $meta->getReflectionProperty('lft')->getValue($root);
         $right = $meta->getReflectionProperty('rgt')->getValue($root);
 
@@ -258,7 +255,7 @@ final class TreeTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $root = $this->em->getRepository(self::CATEGORY_UUID)->find($rootId);
+        $root = $this->em->getRepository(CategoryUuid::class)->find($rootId);
         $left = $meta->getReflectionProperty('lft')->getValue($root);
         $right = $meta->getReflectionProperty('rgt')->getValue($root);
         $level = $meta->getReflectionProperty('level')->getValue($root);
@@ -267,7 +264,7 @@ final class TreeTest extends BaseTestCaseORM
         static::assertSame(4, $right);
         static::assertSame(0, $level);
 
-        $child = $this->em->getRepository(self::CATEGORY_UUID)->find($childId);
+        $child = $this->em->getRepository(CategoryUuid::class)->find($childId);
         $left = $meta->getReflectionProperty('lft')->getValue($child);
         $right = $meta->getReflectionProperty('rgt')->getValue($child);
         $level = $meta->getReflectionProperty('level')->getValue($child);
@@ -285,7 +282,7 @@ final class TreeTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $root = $this->em->getRepository(self::CATEGORY_UUID)->find($rootId);
+        $root = $this->em->getRepository(CategoryUuid::class)->find($rootId);
         $left = $meta->getReflectionProperty('lft')->getValue($root);
         $right = $meta->getReflectionProperty('rgt')->getValue($root);
         $level = $meta->getReflectionProperty('level')->getValue($root);
@@ -294,7 +291,7 @@ final class TreeTest extends BaseTestCaseORM
         static::assertSame(6, $right);
         static::assertSame(0, $level);
 
-        $child2 = $this->em->getRepository(self::CATEGORY_UUID)->find($child2Id);
+        $child2 = $this->em->getRepository(CategoryUuid::class)->find($child2Id);
         $left = $meta->getReflectionProperty('lft')->getValue($child2);
         $right = $meta->getReflectionProperty('rgt')->getValue($child2);
         $level = $meta->getReflectionProperty('level')->getValue($child2);
@@ -312,7 +309,7 @@ final class TreeTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $child2 = $this->em->getRepository(self::CATEGORY_UUID)->find($child2Id);
+        $child2 = $this->em->getRepository(CategoryUuid::class)->find($child2Id);
         $left = $meta->getReflectionProperty('lft')->getValue($child2);
         $right = $meta->getReflectionProperty('rgt')->getValue($child2);
         $level = $meta->getReflectionProperty('level')->getValue($child2);
@@ -327,8 +324,8 @@ final class TreeTest extends BaseTestCaseORM
 
         // test updates to nodes, parent changes
 
-        $childsChild = $this->em->getRepository(self::CATEGORY_UUID)->find($childsChildId);
-        $child = $this->em->getRepository(self::CATEGORY_UUID)->find($childId);
+        $childsChild = $this->em->getRepository(CategoryUuid::class)->find($childsChildId);
+        $child = $this->em->getRepository(CategoryUuid::class)->find($childId);
         $childsChild->setTitle('childs_child');
         $childsChild->setParent($child);
 
@@ -336,7 +333,7 @@ final class TreeTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $child = $this->em->getRepository(self::CATEGORY_UUID)->find($childId);
+        $child = $this->em->getRepository(CategoryUuid::class)->find($childId);
         $left = $meta->getReflectionProperty('lft')->getValue($child);
         $right = $meta->getReflectionProperty('rgt')->getValue($child);
         $level = $meta->getReflectionProperty('level')->getValue($child);
@@ -351,7 +348,7 @@ final class TreeTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $root = $this->em->getRepository(self::CATEGORY_UUID)->find($rootId);
+        $root = $this->em->getRepository(CategoryUuid::class)->find($rootId);
         $left = $meta->getReflectionProperty('lft')->getValue($root);
         $right = $meta->getReflectionProperty('rgt')->getValue($root);
 
@@ -379,8 +376,8 @@ final class TreeTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::CATEGORY,
-            self::CATEGORY_UUID,
+            Category::class,
+            CategoryUuid::class,
         ];
     }
 }

--- a/tests/Gedmo/Uploadable/UploadableEntitySizeTypeTest.php
+++ b/tests/Gedmo/Uploadable/UploadableEntitySizeTypeTest.php
@@ -23,8 +23,6 @@ use Gedmo\Uploadable\Mapping\Validator;
  */
 final class UploadableEntitySizeTypeTest extends BaseTestCaseORM
 {
-    private const IMAGE_WITH_TYPED_PROPERTIES_CLASS = ImageWithTypedProperties::class;
-
     private UploadableListenerStub $listener;
 
     private string $destinationTestDir;
@@ -93,7 +91,7 @@ final class UploadableEntitySizeTypeTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::IMAGE_WITH_TYPED_PROPERTIES_CLASS,
+            ImageWithTypedProperties::class,
         ];
     }
 

--- a/tests/Gedmo/Uploadable/UploadableEntityTest.php
+++ b/tests/Gedmo/Uploadable/UploadableEntityTest.php
@@ -55,18 +55,7 @@ use Gedmo\Uploadable\Mapping\Validator;
  */
 final class UploadableEntityTest extends BaseTestCaseORM
 {
-    private const IMAGE_CLASS = Image::class;
-    private const ARTICLE_CLASS = Article::class;
-    private const FILE_CLASS = File::class;
-    private const FILE_APPEND_NUMBER_CLASS = FileAppendNumber::class;
-    private const FILE_APPEND_NUMBER__RELATIVE_PATH_CLASS = FileAppendNumberRelative::class;
-    private const FILE_WITHOUT_PATH_CLASS = FileWithoutPath::class;
     private const FILE_WITH_SHA1_NAME_CLASS = FileWithSha1Name::class;
-    private const FILE_WITH_ALPHANUMERIC_NAME_CLASS = FileWithAlphanumericName::class;
-    private const FILE_WITH_CUSTOM_FILENAME_GENERATOR_CLASS = FileWithCustomFilenameGenerator::class;
-    private const FILE_WITH_MAX_SIZE_CLASS = FileWithMaxSize::class;
-    private const FILE_WITH_ALLOWED_TYPES_CLASS = FileWithAllowedTypes::class;
-    private const FILE_WITH_DISALLOWED_TYPES_CLASS = FileWithDisallowedTypes::class;
 
     private UploadableListenerStub $listener;
 
@@ -251,7 +240,7 @@ final class UploadableEntityTest extends BaseTestCaseORM
 
     public function testEntityWithUploadableEntities(): void
     {
-        $artRepo = $this->em->getRepository(self::ARTICLE_CLASS);
+        $artRepo = $this->em->getRepository(Article::class);
         $article = new Article();
         $article->setTitle('Test');
 
@@ -759,18 +748,18 @@ final class UploadableEntityTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::IMAGE_CLASS,
-            self::ARTICLE_CLASS,
-            self::FILE_CLASS,
-            self::FILE_WITHOUT_PATH_CLASS,
-            self::FILE_APPEND_NUMBER_CLASS,
-            self::FILE_APPEND_NUMBER__RELATIVE_PATH_CLASS,
-            self::FILE_WITH_ALPHANUMERIC_NAME_CLASS,
+            Image::class,
+            Article::class,
+            File::class,
+            FileWithoutPath::class,
+            FileAppendNumber::class,
+            FileAppendNumberRelative::class,
+            FileWithAlphanumericName::class,
             self::FILE_WITH_SHA1_NAME_CLASS,
-            self::FILE_WITH_CUSTOM_FILENAME_GENERATOR_CLASS,
-            self::FILE_WITH_MAX_SIZE_CLASS,
-            self::FILE_WITH_ALLOWED_TYPES_CLASS,
-            self::FILE_WITH_DISALLOWED_TYPES_CLASS,
+            FileWithCustomFilenameGenerator::class,
+            FileWithMaxSize::class,
+            FileWithAllowedTypes::class,
+            FileWithDisallowedTypes::class,
         ];
     }
 

--- a/tests/Gedmo/Wrapper/EntityWrapperTest.php
+++ b/tests/Gedmo/Wrapper/EntityWrapperTest.php
@@ -26,10 +26,6 @@ use Gedmo\Tool\Wrapper\EntityWrapper;
  */
 final class EntityWrapperTest extends BaseTestCaseORM
 {
-    private const ARTICLE = Article::class;
-    private const COMPOSITE = Composite::class;
-    private const COMPOSITE_RELATION = CompositeRelation::class;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -39,8 +35,8 @@ final class EntityWrapperTest extends BaseTestCaseORM
 
     public function testManaged(): void
     {
-        $test = $this->em->find(self::ARTICLE, ['id' => 1]);
-        static::assertInstanceOf(self::ARTICLE, $test);
+        $test = $this->em->find(Article::class, ['id' => 1]);
+        static::assertInstanceOf(Article::class, $test);
         $wrapped = new EntityWrapper($test, $this->em);
 
         static::assertSame(1, $wrapped->getIdentifier());
@@ -54,7 +50,7 @@ final class EntityWrapperTest extends BaseTestCaseORM
     public function testProxy(): void
     {
         $this->em->clear();
-        $test = $this->em->getReference(self::ARTICLE, ['id' => 1]);
+        $test = $this->em->getReference(Article::class, ['id' => 1]);
         static::assertInstanceOf(Proxy::class, $test);
         $wrapped = new EntityWrapper($test, $this->em);
 
@@ -69,8 +65,8 @@ final class EntityWrapperTest extends BaseTestCaseORM
 
     public function testComposite(): void
     {
-        $test = $this->em->getReference(self::COMPOSITE, ['one' => 1, 'two' => 2]);
-        static::assertInstanceOf(self::COMPOSITE, $test);
+        $test = $this->em->getReference(Composite::class, ['one' => 1, 'two' => 2]);
+        static::assertInstanceOf(Composite::class, $test);
         $wrapped = new EntityWrapper($test, $this->em);
 
         $id = $wrapped->getIdentifier(false);
@@ -90,9 +86,9 @@ final class EntityWrapperTest extends BaseTestCaseORM
 
     public function testCompositeRelation(): void
     {
-        $art1 = $this->em->getReference(self::ARTICLE, ['id' => 1]);
-        $test = $this->em->getReference(self::COMPOSITE_RELATION, ['article' => $art1->getId(), 'status' => 2]);
-        static::assertInstanceOf(self::COMPOSITE_RELATION, $test);
+        $art1 = $this->em->getReference(Article::class, ['id' => 1]);
+        $test = $this->em->getReference(CompositeRelation::class, ['article' => $art1->getId(), 'status' => 2]);
+        static::assertInstanceOf(CompositeRelation::class, $test);
         $wrapped = new EntityWrapper($test, $this->em);
 
         $id = $wrapped->getIdentifier(false);
@@ -110,7 +106,7 @@ final class EntityWrapperTest extends BaseTestCaseORM
 
     public function testDetachedEntity(): void
     {
-        $test = $this->em->find(self::ARTICLE, ['id' => 1]);
+        $test = $this->em->find(Article::class, ['id' => 1]);
         $this->em->clear();
         $wrapped = new EntityWrapper($test, $this->em);
 
@@ -120,7 +116,7 @@ final class EntityWrapperTest extends BaseTestCaseORM
 
     public function testDetachedProxy(): void
     {
-        $test = $this->em->getReference(self::ARTICLE, ['id' => 1]);
+        $test = $this->em->getReference(Article::class, ['id' => 1]);
         $this->em->clear();
         $wrapped = new EntityWrapper($test, $this->em);
 
@@ -130,7 +126,7 @@ final class EntityWrapperTest extends BaseTestCaseORM
 
     public function testDetachedCompositeRelation(): void
     {
-        $test = $this->em->getReference(self::COMPOSITE_RELATION, ['article' => 1, 'status' => 2]);
+        $test = $this->em->getReference(CompositeRelation::class, ['article' => 1, 'status' => 2]);
         $this->em->clear();
         $wrapped = new EntityWrapper($test, $this->em);
 
@@ -141,8 +137,8 @@ final class EntityWrapperTest extends BaseTestCaseORM
     public function testCompositeRelationProxy(): void
     {
         $this->em->clear();
-        $art1 = $this->em->getReference(self::ARTICLE, ['id' => 1]);
-        $test = $this->em->getReference(self::COMPOSITE_RELATION, ['article' => $art1->getId(), 'status' => 2]);
+        $art1 = $this->em->getReference(Article::class, ['id' => 1]);
+        $test = $this->em->getReference(CompositeRelation::class, ['article' => $art1->getId(), 'status' => 2]);
         static::assertInstanceOf(Proxy::class, $test);
         $wrapped = new EntityWrapper($test, $this->em);
 
@@ -164,9 +160,9 @@ final class EntityWrapperTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [
-            self::ARTICLE,
-            self::COMPOSITE,
-            self::COMPOSITE_RELATION,
+            Article::class,
+            Composite::class,
+            CompositeRelation::class,
         ];
     }
 

--- a/tests/Gedmo/Wrapper/MongoDocumentWrapperTest.php
+++ b/tests/Gedmo/Wrapper/MongoDocumentWrapperTest.php
@@ -23,8 +23,6 @@ use Gedmo\Tool\Wrapper\MongoDocumentWrapper;
  */
 final class MongoDocumentWrapperTest extends BaseTestCaseMongoODM
 {
-    private const ARTICLE = Article::class;
-
     private ?string $articleId = null;
 
     protected function setUp(): void
@@ -36,8 +34,8 @@ final class MongoDocumentWrapperTest extends BaseTestCaseMongoODM
 
     public function testManaged(): void
     {
-        $test = $this->dm->find(self::ARTICLE, $this->articleId);
-        static::assertInstanceOf(self::ARTICLE, $test);
+        $test = $this->dm->find(Article::class, $this->articleId);
+        static::assertInstanceOf(Article::class, $test);
         $wrapped = new MongoDocumentWrapper($test, $this->dm);
 
         static::assertSame($this->articleId, $wrapped->getIdentifier());
@@ -51,9 +49,9 @@ final class MongoDocumentWrapperTest extends BaseTestCaseMongoODM
     public function testProxy(): void
     {
         $this->dm->clear();
-        $test = $this->dm->getReference(self::ARTICLE, $this->articleId);
+        $test = $this->dm->getReference(Article::class, $this->articleId);
         static::assertStringStartsWith('Proxy', get_class($test));
-        static::assertInstanceOf(self::ARTICLE, $test);
+        static::assertInstanceOf(Article::class, $test);
         $wrapped = new MongoDocumentWrapper($test, $this->dm);
 
         $id = $wrapped->getIdentifier(false);
@@ -64,7 +62,7 @@ final class MongoDocumentWrapperTest extends BaseTestCaseMongoODM
 
     public function testDetachedEntity(): void
     {
-        $test = $this->dm->find(self::ARTICLE, $this->articleId);
+        $test = $this->dm->find(Article::class, $this->articleId);
         $this->dm->clear();
         $wrapped = new MongoDocumentWrapper($test, $this->dm);
 
@@ -74,7 +72,7 @@ final class MongoDocumentWrapperTest extends BaseTestCaseMongoODM
 
     public function testDetachedProxy(): void
     {
-        $test = $this->dm->getReference(self::ARTICLE, $this->articleId);
+        $test = $this->dm->getReference(Article::class, $this->articleId);
         $this->dm->clear();
         $wrapped = new MongoDocumentWrapper($test, $this->dm);
 


### PR DESCRIPTION
Originally, the motivation for using constants for the fixture classes was the lack of a proper reference to these classes.
Now, we can use the `::class` pseudo constant with the QCNs instead of its hardcoded string representation.