### PR TITLE
Partial DBAL 4.x support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
     "require-dev": {
         "doctrine/annotations": "^1.13 || ^2.0",
         "doctrine/cache": "^1.11 || ^2.0",
-        "doctrine/dbal": "^3.2",
+        "doctrine/dbal": "^3.7 || ^4.0",
         "doctrine/doctrine-bundle": "^2.3",
         "doctrine/mongodb-odm": "^2.3",
         "doctrine/orm": "^2.14.0 || ^3.0",
@@ -73,7 +73,7 @@
     },
     "conflict": {
         "doctrine/annotations": "<1.13 || >=3.0",
-        "doctrine/dbal": "<3.2 || >=4.0",
+        "doctrine/dbal": "<3.7 || >=5.0",
         "doctrine/mongodb-odm": "<2.3 || >=3.0",
         "doctrine/orm": "<2.14.0 || 2.16.0 || 2.16.1 || >=4.0"
     },

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,11 +11,6 @@ parameters:
 			path: src/AbstractTrackingListener.php
 
 		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\ObjectManager\\:\\:getConnection\\(\\)\\.$#"
-			count: 1
-			path: src/AbstractTrackingListener.php
-
-		-
 			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\ObjectManager\\:\\:getUnitOfWork\\(\\)\\.$#"
 			count: 3
 			path: src/AbstractTrackingListener.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -20,9 +20,11 @@ parameters:
         - '#^Result of static method Gedmo\\Uploadable\\Mapping\\Validator::validateConfiguration\(\) \(void\) is used\.$#'
         - '#^Result of method Gedmo\\Mapping\\Driver::readExtendedMetadata\(\) \(void\) is used\.$#'
     excludePaths:
+        # Deprecated and unused class, interface does not exist as of 4.0
+        - src/Tool/Logging/DBAL/QueryAnalyzer.php
         # Generates non-ignorable errors like " Parameter #1 $method (string) of method Gedmo\Tree\Entity\Repository\NestedTreeRepository::__call() is not contravariant with parameter #1 $method (mixed) of method Doctrine\ORM\EntityRepository::__call()."
         - src/Tool/ORM/Repository/EntityRepositoryCompat.php
-        # Compat file for ORM 2, causes analysis errors with ORM 3
-        - src/Tool/ORM/Walker/orm-2.php
         # Uses a tracking policy that was removed in ORM 3, PHPStan crashes on this file
         - tests/Gedmo/Sortable/Fixture/NotifyNode.php
+        # Generates non-ignorable errors regarding covariance due to the internal compat layer
+        - tests/Gedmo/Translatable/Fixture/Type/Custom.php

--- a/src/AbstractTrackingListener.php
+++ b/src/AbstractTrackingListener.php
@@ -13,6 +13,7 @@ use Doctrine\Common\EventArgs;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Types\Type as TypeODM;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\UnitOfWork;
 use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
@@ -267,9 +268,13 @@ abstract class AbstractTrackingListener extends MappedEventSubscriber
                     } else {
                         $values[$i] = $value;
                     }
-                } elseif (Type::hasType($type)) {
-                    $values[$i] = Type::getType($type)
-                        ->convertToPHPValue($value, $om->getConnection()->getDatabasePlatform());
+                } elseif ($om instanceof EntityManagerInterface) {
+                    if (Type::hasType($type)) {
+                        $values[$i] = $om->getConnection()
+                            ->convertToPHPValue($value, $type);
+                    } else {
+                        $values[$i] = $value;
+                    }
                 }
             }
         }

--- a/src/Loggable/Entity/MappedSuperclass/AbstractLogEntry.php
+++ b/src/Loggable/Entity/MappedSuperclass/AbstractLogEntry.php
@@ -84,8 +84,10 @@ abstract class AbstractLogEntry implements LogEntryInterface
      * @var array<string, mixed>|null
      *
      * @ORM\Column(type="array", nullable=true)
+     *
+     * @note The attribute uses the "array" name directly instead of the constant since it was removed in DBAL 4.0.
      */
-    #[ORM\Column(type: Types::ARRAY, nullable: true)]
+    #[ORM\Column(type: 'array', nullable: true)]
     protected $data;
 
     /**

--- a/src/SoftDeleteable/Mapping/Event/Adapter/ORM.php
+++ b/src/SoftDeleteable/Mapping/Event/Adapter/ORM.php
@@ -9,7 +9,6 @@
 
 namespace Gedmo\SoftDeleteable\Mapping\Event\Adapter;
 
-use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\FieldMapping;
@@ -42,10 +41,11 @@ final class ORM extends BaseAdapterORM implements SoftDeleteableAdapter, ClockAw
     public function getDateValue($meta, $field)
     {
         $mapping = $meta->getFieldMapping($field);
-        $converter = Type::getType($mapping['type'] ?? Types::DATETIME_MUTABLE);
-        $platform = $this->getObjectManager()->getConnection()->getDriver()->getDatabasePlatform();
 
-        return $converter->convertToPHPValue($this->getRawDateValue($mapping), $platform);
+        return $this->getObjectManager()->getConnection()->convertToPHPValue(
+            $this->getRawDateValue($mapping),
+            $mapping instanceof FieldMapping ? $mapping->type : ($mapping['type'] ?? Types::DATETIME_MUTABLE)
+        );
     }
 
     /**

--- a/src/Timestampable/Mapping/Event/Adapter/ORM.php
+++ b/src/Timestampable/Mapping/Event/Adapter/ORM.php
@@ -9,7 +9,6 @@
 
 namespace Gedmo\Timestampable\Mapping\Event\Adapter;
 
-use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\FieldMapping;
@@ -42,10 +41,11 @@ final class ORM extends BaseAdapterORM implements TimestampableAdapter, ClockAwa
     public function getDateValue($meta, $field)
     {
         $mapping = $meta->getFieldMapping($field);
-        $converter = Type::getType($mapping['type'] ?? Types::DATETIME_MUTABLE);
-        $platform = $this->getObjectManager()->getConnection()->getDriver()->getDatabasePlatform();
 
-        return $converter->convertToPHPValue($this->getRawDateValue($mapping), $platform);
+        return $this->getObjectManager()->getConnection()->convertToPHPValue(
+            $this->getRawDateValue($mapping),
+            $mapping instanceof FieldMapping ? $mapping->type : ($mapping['type'] ?? Types::DATETIME_MUTABLE)
+        );
     }
 
     /**

--- a/src/Translatable/Entity/Repository/TranslationRepository.php
+++ b/src/Translatable/Entity/Repository/TranslationRepository.php
@@ -9,7 +9,6 @@
 
 namespace Gedmo\Translatable\Entity\Repository;
 
-use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -99,8 +98,7 @@ class TranslationRepository extends EntityRepository
                 $listener->setTranslationInDefaultLocale(spl_object_id($entity), $field, $trans);
                 $needsPersist = $listener->getPersistDefaultLocaleTranslation();
             }
-            $type = Type::getType($meta->getTypeOfField($field));
-            $transformed = $type->convertToDatabaseValue($value, $this->getEntityManager()->getConnection()->getDatabasePlatform());
+            $transformed = $this->getEntityManager()->getConnection()->convertToDatabaseValue($value, $meta->getTypeOfField($field));
             $transMeta->getReflectionProperty('content')->setValue($trans, $transformed);
             if ($needsPersist) {
                 if ($this->getEntityManager()->getUnitOfWork()->isInIdentityMap($entity)) {

--- a/src/Translatable/Mapping/Event/Adapter/ORM.php
+++ b/src/Translatable/Mapping/Event/Adapter/ORM.php
@@ -211,12 +211,12 @@ final class ORM extends BaseAdapterORM implements TranslatableAdapter
         $em = $this->getObjectManager();
         $wrapped = AbstractWrapper::wrap($object, $em);
         $meta = $wrapped->getMetadata();
-        $type = Type::getType($meta->getTypeOfField($field));
+
         if (false === $value) {
             $value = $wrapped->getPropertyValue($field);
         }
 
-        return $type->convertToDatabaseValue($value, $em->getConnection()->getDatabasePlatform());
+        return $em->getConnection()->convertToDatabaseValue($value, $meta->getTypeOfField($field));
     }
 
     public function setTranslationValue($object, $field, $value)
@@ -224,13 +224,12 @@ final class ORM extends BaseAdapterORM implements TranslatableAdapter
         $em = $this->getObjectManager();
         $wrapped = AbstractWrapper::wrap($object, $em);
         $meta = $wrapped->getMetadata();
-        $type = Type::getType($meta->getTypeOfField($field));
-        $value = $type->convertToPHPValue($value, $em->getConnection()->getDatabasePlatform());
+        $value = $em->getConnection()->convertToPHPValue($value, $meta->getTypeOfField($field));
         $wrapped->setPropertyValue($field, $value);
     }
 
     /**
-     * Transforms foreing key of translation to appropriate PHP value
+     * Transforms foreign key of translation to appropriate PHP value
      * to prevent database level cast
      *
      * @param mixed  $key       foreign key value
@@ -245,7 +244,8 @@ final class ORM extends BaseAdapterORM implements TranslatableAdapter
         $em = $this->getObjectManager();
         $meta = $em->getClassMetadata($className);
         $type = Type::getType($meta->getTypeOfField('foreignKey'));
-        switch ($type->getName()) {
+
+        switch (Type::lookupName($type)) {
             case Types::BIGINT:
             case Types::INTEGER:
             case Types::SMALLINT:

--- a/src/Translatable/Query/TreeWalker/TranslationWalker.php
+++ b/src/Translatable/Query/TreeWalker/TranslationWalker.php
@@ -90,10 +90,8 @@ class TranslationWalker extends SqlWalker
 
     /**
      * DBAL database platform
-     *
-     * @var AbstractPlatform
      */
-    private $platform;
+    private AbstractPlatform $platform;
 
     /**
      * DBAL database connection

--- a/src/Tree/Strategy/ORM/Closure.php
+++ b/src/Tree/Strategy/ORM/Closure.php
@@ -9,7 +9,7 @@
 
 namespace Gedmo\Tree\Strategy\ORM;
 
-use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\AssociationMapping;
@@ -524,7 +524,7 @@ class Closure implements Strategy
             }
 
             // Avoid type conversion performance penalty
-            $type = 'integer' === $mapping['type'] ? Connection::PARAM_INT_ARRAY : Connection::PARAM_STR_ARRAY;
+            $type = 'integer' === $mapping['type'] ? ArrayParameterType::INTEGER : ArrayParameterType::STRING;
 
             // We calculate levels for all nodes
             $sql = 'SELECT c.descendant, MAX(c.depth) + 1 AS levelNum ';

--- a/src/Uploadable/UploadableListener.php
+++ b/src/Uploadable/UploadableListener.php
@@ -10,7 +10,6 @@
 namespace Gedmo\Uploadable;
 
 use Doctrine\Common\EventArgs;
-use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
 use Doctrine\Persistence\Event\ManagerEventArgs;
@@ -338,10 +337,9 @@ class UploadableListener extends MappedEventSubscriber
         }
 
         if ($config['fileSizeField']) {
-            $typeOfSizeField = Type::getType($meta->getTypeOfField($config['fileSizeField']));
-            $value = $typeOfSizeField->convertToPHPValue(
+            $value = $om->getConnection()->convertToPHPValue(
                 $info['fileSize'],
-                $om->getConnection()->getDatabasePlatform()
+                $meta->getTypeOfField($config['fileSizeField'])
             );
             $this->updateField($object, $uow, $ea, $meta, $config['fileSizeField'], $value);
         }

--- a/tests/Gedmo/Loggable/LoggableEntityTest.php
+++ b/tests/Gedmo/Loggable/LoggableEntityTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Gedmo\Tests\Loggable;
 
+use Doctrine\DBAL\Types\ArrayType;
 use Gedmo\Loggable\Entity\LogEntry;
 use Gedmo\Loggable\Entity\Repository\LogEntryRepository;
 use Gedmo\Tests\Loggable\Fixture\Entity\Address;
@@ -36,6 +37,13 @@ abstract class LoggableEntityTest extends BaseTestCaseORM
     private const COMPOSITE_RELATION = CompositeRelation::class;
     private const RELATED_ARTICLE = RelatedArticle::class;
     private const COMMENT_LOG = Fixture\Entity\Log\Comment::class;
+
+    public static function setUpBeforeClass(): void
+    {
+        if (!class_exists(ArrayType::class)) {
+            static::markTestSkipped('The loggable extension is not compatible with doctrine/dbal:>=4.0');
+        }
+    }
 
     public function testShouldHandleClonedEntity(): void
     {

--- a/tests/Gedmo/Mapping/Driver/Xml/Gedmo.Tests.Mapping.Fixture.Xml.Uploadable.dcm.xml
+++ b/tests/Gedmo/Mapping/Driver/Xml/Gedmo.Tests.Mapping.Fixture.Xml.Uploadable.dcm.xml
@@ -7,7 +7,7 @@
         <field name="mimeType" column="mime" type="string">
             <gedmo:uploadable-file-mime-type/>
         </field>
-        <field name="size" column="size" type="decimal">
+        <field name="size" column="size" type="decimal" precision="10" scale="2">
             <gedmo:uploadable-file-size/>
         </field>
         <field name="path" column="path" type="string">

--- a/tests/Gedmo/Mapping/Fixture/Uploadable.php
+++ b/tests/Gedmo/Mapping/Fixture/Uploadable.php
@@ -56,11 +56,11 @@ class Uploadable
     /**
      * @var float
      *
-     * @ORM\Column(name="size", type="decimal")
+     * @ORM\Column(name="size", type="decimal", precision=10, scale=2)
      *
      * @Gedmo\UploadableFileSize
      */
-    #[ORM\Column(name: 'size', type: Types::DECIMAL)]
+    #[ORM\Column(name: 'size', type: Types::DECIMAL, precision: 10, scale: 2)]
     #[Gedmo\UploadableFileSize]
     private $size;
 

--- a/tests/Gedmo/Translatable/Fixture/Type/Custom.php
+++ b/tests/Gedmo/Translatable/Fixture/Type/Custom.php
@@ -12,34 +12,148 @@ declare(strict_types=1);
 namespace Gedmo\Tests\Translatable\Fixture\Type;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\ArrayType;
 use Doctrine\DBAL\Types\Type;
 
-class Custom extends Type
+if (class_exists(ArrayType::class)) {
+    // DBAL 3.x
+    /**
+     * Helper class to address compatibility issues between DBAL 3.x and 4.x.
+     *
+     * @internal
+     */
+    abstract class CompatType extends Type
+    {
+        /**
+         * @param array<string, mixed> $column
+         *
+         * @return string
+         */
+        public function getSQLDeclaration(array $column, AbstractPlatform $platform)
+        {
+            return $this->doGetSQLDeclaration($column, $platform);
+        }
+
+        /**
+         * @param mixed $value
+         *
+         * @return mixed
+         */
+        public function convertToDatabaseValue($value, AbstractPlatform $platform)
+        {
+            return $this->doConvertToDatabaseValue($value, $platform);
+        }
+
+        /**
+         * @param mixed $value
+         *
+         * @return mixed
+         */
+        public function convertToPHPValue($value, AbstractPlatform $platform)
+        {
+            return $this->doConvertToPHPValue($value, $platform);
+        }
+
+        /**
+         * @param array<string, mixed> $column
+         */
+        abstract protected function doGetSQLDeclaration(array $column, AbstractPlatform $platform): string;
+
+        /**
+         * @param mixed $value
+         *
+         * @return mixed
+         */
+        abstract protected function doConvertToDatabaseValue($value, AbstractPlatform $platform);
+
+        /**
+         * @param mixed $value
+         *
+         * @return mixed
+         */
+        abstract protected function doConvertToPHPValue($value, AbstractPlatform $platform);
+    }
+} else {
+    // DBAL 4.x
+    /**
+     * Helper class to address compatibility issues between DBAL 3.x and 4.x.
+     *
+     * @internal
+     */
+    abstract class CompatType extends Type
+    {
+        /**
+         * @param array<string, mixed> $column
+         */
+        public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
+        {
+            return $this->doGetSQLDeclaration($column, $platform);
+        }
+
+        public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): mixed
+        {
+            return $this->doConvertToDatabaseValue($value, $platform);
+        }
+
+        public function convertToPHPValue(mixed $value, AbstractPlatform $platform): mixed
+        {
+            return $this->doConvertToPHPValue($value, $platform);
+        }
+
+        /**
+         * @param array<string, mixed> $column
+         */
+        abstract protected function doGetSQLDeclaration(array $column, AbstractPlatform $platform): string;
+
+        /**
+         * @param mixed $value
+         *
+         * @return mixed
+         */
+        abstract protected function doConvertToDatabaseValue($value, AbstractPlatform $platform);
+
+        /**
+         * @param mixed $value
+         *
+         * @return mixed
+         */
+        abstract protected function doConvertToPHPValue($value, AbstractPlatform $platform);
+    }
+}
+
+class Custom extends CompatType
 {
     private const NAME = 'custom';
 
-    /**
-     * @param mixed[] $fieldDeclaration
-     *
-     * @return string
-     */
-    public function getSqlDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getName(): string
     {
-        return $platform->getClobTypeDeclarationSQL($fieldDeclaration);
+        return self::NAME;
     }
 
     /**
+     * @param array<string, mixed> $column
+     */
+    protected function doGetSQLDeclaration(array $column, AbstractPlatform $platform): string
+    {
+        return $platform->getClobTypeDeclarationSQL($column);
+    }
+
+    /**
+     * @param mixed $value
+     *
      * @return mixed
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    protected function doConvertToDatabaseValue($value, AbstractPlatform $platform)
     {
         return serialize($value);
     }
 
     /**
+     * @param mixed $value
+     *
      * @return mixed
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    protected function doConvertToPHPValue($value, AbstractPlatform $platform)
     {
         if (null === $value) {
             return null;
@@ -52,10 +166,5 @@ class Custom extends Type
         }
 
         return $val;
-    }
-
-    public function getName(): string
-    {
-        return self::NAME;
     }
 }

--- a/tests/Gedmo/Translatable/PersonalTranslationTest.php
+++ b/tests/Gedmo/Translatable/PersonalTranslationTest.php
@@ -96,9 +96,11 @@ final class PersonalTranslationTest extends BaseTestCaseORM
 
     public function testShouldCascadeDeletionsByForeignKeyConstraints(): void
     {
-        if ('sqlite' === $this->em->getConnection()->getDatabasePlatform()->getName()) {
-            static::markTestSkipped('Foreign key constraints does not map in sqlite.');
+        // Uses normalized comparison due to case differences between versions
+        if ('doctrine\dbal\platforms\sqliteplatform' === strtolower(get_class($this->em->getConnection()->getDatabasePlatform()))) {
+            static::markTestSkipped('Foreign key constraints do not map in SQLite.');
         }
+
         $this->populate();
         $this->em->createQuery('DELETE FROM '.self::ARTICLE.' a')->getSingleScalarResult();
         $trans = $this->em->getRepository(self::TRANSLATION)->findAll();

--- a/tests/Gedmo/Uploadable/Fixture/Entity/FileWithAllowedTypes.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/FileWithAllowedTypes.php
@@ -52,11 +52,11 @@ class FileWithAllowedTypes
     private ?string $filePath = null;
 
     /**
-     * @ORM\Column(name="size", type="decimal", nullable=true)
+     * @ORM\Column(name="size", type="decimal", precision=10, scale=2, nullable=true)
      *
      * @Gedmo\UploadableFileSize
      */
-    #[ORM\Column(name: 'size', type: Types::DECIMAL, nullable: true)]
+    #[ORM\Column(name: 'size', type: Types::DECIMAL, precision: 10, scale: 2, nullable: true)]
     #[Gedmo\UploadableFileSize]
     private ?string $fileSize = null;
 

--- a/tests/Gedmo/Uploadable/Fixture/Entity/FileWithDisallowedTypes.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/FileWithDisallowedTypes.php
@@ -52,11 +52,11 @@ class FileWithDisallowedTypes
     private ?string $filePath = null;
 
     /**
-     * @ORM\Column(name="size", type="decimal", nullable=true)
+     * @ORM\Column(name="size", type="decimal", precision=10, scale=2, nullable=true)
      *
      * @Gedmo\UploadableFileSize
      */
-    #[ORM\Column(name: 'size', type: Types::DECIMAL, nullable: true)]
+    #[ORM\Column(name: 'size', type: Types::DECIMAL, precision: 10, scale: 2, nullable: true)]
     #[Gedmo\UploadableFileSize]
     private ?string $fileSize = null;
 

--- a/tests/Gedmo/Uploadable/Fixture/Entity/FileWithMaxSize.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/FileWithMaxSize.php
@@ -57,11 +57,11 @@ class FileWithMaxSize
     private ?string $filePath = null;
 
     /**
-     * @ORM\Column(name="size", type="decimal")
+     * @ORM\Column(name="size", type="decimal", precision=10, scale=2)
      *
      * @Gedmo\UploadableFileSize
      */
-    #[ORM\Column(name: 'size', type: Types::DECIMAL)]
+    #[ORM\Column(name: 'size', type: Types::DECIMAL, precision: 10, scale: 2)]
     #[Gedmo\UploadableFileSize]
     private ?string $fileSize = null;
 

--- a/tests/Gedmo/Uploadable/Fixture/Entity/Image.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/Image.php
@@ -52,11 +52,11 @@ class Image
     private ?string $filePath = null;
 
     /**
-     * @ORM\Column(name="size", type="decimal", nullable=true)
+     * @ORM\Column(name="size", type="decimal", precision=10, scale=2, nullable=true)
      *
      * @Gedmo\UploadableFileSize
      */
-    #[ORM\Column(name: 'size', type: Types::DECIMAL, nullable: true)]
+    #[ORM\Column(name: 'size', type: Types::DECIMAL, precision: 10, scale: 2, nullable: true)]
     #[Gedmo\UploadableFileSize]
     private ?string $size = null;
 

--- a/tests/Gedmo/Uploadable/Fixture/Entity/ImageWithTypedProperties.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/ImageWithTypedProperties.php
@@ -50,11 +50,11 @@ class ImageWithTypedProperties
     private ?string $filePath = null;
 
     /**
-     * @ORM\Column(name="size", type="decimal", nullable=true)
+     * @ORM\Column(name="size", type="decimal", precision=10, scale=2, nullable=true)
      *
      * @Gedmo\UploadableFileSize
      */
-    #[ORM\Column(name: 'size', type: Types::DECIMAL, nullable: true)]
+    #[ORM\Column(name: 'size', type: Types::DECIMAL, precision: 10, scale: 2, nullable: true)]
     #[Gedmo\UploadableFileSize]
     private ?string $size = null;
 

--- a/tests/Gedmo/Uploadable/UploadableEntitySizeTypeTest.php
+++ b/tests/Gedmo/Uploadable/UploadableEntitySizeTypeTest.php
@@ -20,8 +20,6 @@ use Gedmo\Uploadable\Mapping\Validator;
 
 /**
  * This test is for Uploadable behavior with typed properties
- *
- * @requires PHP >= 7.4
  */
 final class UploadableEntitySizeTypeTest extends BaseTestCaseORM
 {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -32,11 +32,12 @@ require dirname(__DIR__).'/vendor/autoload.php';
 
 if (class_exists(AnnotationReader::class)) {
     $_ENV['annotation_reader'] = new PsrCachedReader(new AnnotationReader(), new ArrayAdapter());
+    AnnotationReader::addGlobalIgnoredName('note');
+
+    // With ORM 3 and `doctrine/annotations` installed together, have the annotations library ignore the ORM's mapping namespace
+    if (!class_exists(AnnotationDriver::class)) {
+        AnnotationReader::addGlobalIgnoredNamespace('Doctrine\ORM\Mapping');
+    }
 }
 
 Type::addType('uuid', UuidType::class);
-
-// With ORM 3 and `doctrine/annotations` installed together, have the annotations library ignore the ORM's mapping namespace
-if (!class_exists(AnnotationDriver::class) && class_exists(AnnotationReader::class)) {
-    AnnotationReader::addGlobalIgnoredNamespace('Doctrine\ORM\Mapping');
-}


### PR DESCRIPTION
Fixes #2752

This adds support for DBAL 4.x everywhere outside the loggable extension, which isn't really feasible due to the removal of the array type and the data migration required to just change to the JSON type (follow https://github.com/doctrine-extensions/DoctrineExtensions/issues/2502 and https://github.com/doctrine-extensions/DoctrineExtensions/pull/2825 for more on this).

The worst B/C issues here are the removal of the `Type::getName()` method and the removal of the `Connection::PARAM_*_ARRAY` constants.  The type name replacement (`Type::lookupName()`) only came in DBAL 3.7 and the constant replacements in DBAL 3.6, so I've bumped the DBAL minimum to use those.  Most other changes are just for convenience by using the methods on the DBAL connection to handle type conversions instead of doing that stuff directly in the package code or updating the tests to add required properties for decimal fields.