### PR TITLE
Bump behat/transliterator to ^1.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     },
     "require": {
         "php": "^7.4 || ^8.0",
-        "behat/transliterator": "^1.2",
+        "behat/transliterator": "^1.3",
         "doctrine/collections": "^1.2 || ^2.0",
         "doctrine/common": "^2.13 || ^3.0",
         "doctrine/deprecations": "^1.0",


### PR DESCRIPTION
Composer say project is compatible with PHP 7.4 but require `behat/transliterator:^1.2` which is not compatible with PHP 7.4 so bump `behat/transliterator` to ^1.3 min.