### PR TITLE
[Tree] Fix TreeObjectHydrator, when $parent field is defined before $children field

### DIFF
--- a/src/Tree/Hydrator/ORM/TreeObjectHydrator.php
+++ b/src/Tree/Hydrator/ORM/TreeObjectHydrator.php
@@ -249,7 +249,7 @@ class TreeObjectHydrator extends ObjectHydrator
             $associationMapping = $meta->getAssociationMapping($property->getName());
 
             // Make sure the association is mapped by the parent property
-            if ($associationMapping['mappedBy'] !== $this->parentField) {
+            if (!isset($associationMapping['mappedBy']) || $associationMapping['mappedBy'] !== $this->parentField) {
                 continue;
             }
 


### PR DESCRIPTION
I followed the documentation https://github.com/doctrine-extensions/DoctrineExtensions/blob/main/doc/tree.md#building-trees-from-your-entities

And I'm encountering this error:

```
In AssociationMapping.php line 256:

  Unknown property "mappedBy" on class Doctrine\ORM\Mapping\ManyToOneAssociationMapping
```

The error occurs when the $parent field is defined before $children in a Tree entity. I forked the repository and ran the tests, reversing the order of the fields in tests/Gedmo/Tree/Fixture/RootCategory.php, and I managed to reproduce the same error.