### PR TITLE
[Tree] Add support of Symfony UIDs at binary format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ a release.
 ---
 
 ## [Unreleased]
+### Added
+- Tree: Support of Symfony UIDs at binary format
 
 ## [3.16.1]
 ### Fixed

--- a/tests/Gedmo/Tree/Fixture/RootAssociationCategoryBinaryUuid.php
+++ b/tests/Gedmo/Tree/Fixture/RootAssociationCategoryBinaryUuid.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Tree\Fixture;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
+use Symfony\Bridge\Doctrine\Types\UuidType;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @ORM\Entity(repositoryClass="Gedmo\Tree\Entity\Repository\NestedTreeRepository")
+ *
+ * @Gedmo\Tree(type="nested")
+ */
+#[ORM\Entity(repositoryClass: NestedTreeRepository::class)]
+#[Gedmo\Tree(type: 'nested')]
+class RootAssociationCategoryBinaryUuid
+{
+    /**
+     * @var Collection<int, self>
+     *
+     * @ORM\OneToMany(targetEntity="RootAssociationCategory", mappedBy="parent")
+     */
+    #[ORM\OneToMany(targetEntity: self::class, mappedBy: 'parent')]
+    protected $children;
+    /**
+     * @ORM\Column(name="id", type="uuid", nullable=false)
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="NONE")
+     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'NONE')]
+    #[ORM\Column(name: 'id', type: UuidType::NAME, nullable: false)]
+    private ?Uuid $id = null;
+
+    /**
+     * @ORM\Column(name="title", type="string", length=64)
+     */
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
+    private ?string $title = null;
+
+    /**
+     * @var int|null
+     *
+     * @Gedmo\TreeLeft
+     *
+     * @ORM\Column(name="lft", type="integer")
+     */
+    #[ORM\Column(name: 'lft', type: Types::INTEGER)]
+    #[Gedmo\TreeLeft]
+    private int $lft;
+
+    /**
+     * @var int|null
+     *
+     * @Gedmo\TreeRight
+     *
+     * @ORM\Column(name="rgt", type="integer")
+     */
+    #[ORM\Column(name: 'rgt', type: Types::INTEGER)]
+    #[Gedmo\TreeRight]
+    private int $rgt;
+
+    /**
+     * @Gedmo\TreeParent
+     *
+     * @ORM\ManyToOne(targetEntity="RootAssociationCategory", inversedBy="children")
+     * @ORM\JoinColumns({
+     *     @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
+     * })
+     */
+    #[ORM\ManyToOne(targetEntity: self::class, inversedBy: 'children')]
+    #[ORM\JoinColumn(name: 'parent_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
+    #[Gedmo\TreeParent]
+    private ?RootAssociationCategoryBinaryUuid $parent = null;
+
+    /**
+     * @var self|null
+     *
+     * @Gedmo\TreeRoot
+     *
+     * @ORM\ManyToOne(targetEntity="RootAssociationCategory")
+     * @ORM\JoinColumns({
+     *     @ORM\JoinColumn(name="tree_root", referencedColumnName="id", onDelete="CASCADE")
+     * })
+     */
+    #[ORM\ManyToOne(targetEntity: self::class)]
+    #[ORM\JoinColumn(name: 'tree_root', referencedColumnName: 'id', onDelete: 'CASCADE')]
+    #[Gedmo\TreeRoot]
+    private ?RootAssociationCategoryBinaryUuid$root;
+
+    /**
+     * @var int|null
+     *
+     * @Gedmo\TreeLevel
+     *
+     * @ORM\Column(name="lvl", type="integer")
+     */
+    #[ORM\Column(name: 'lvl', type: Types::INTEGER)]
+    #[Gedmo\TreeLevel]
+    private int $level;
+
+    public function __construct()
+    {
+        $this->id = Uuid::v7();
+        $this->children = new ArrayCollection();
+    }
+
+    public function getId(): ?Uuid
+    {
+        return $this->id;
+    }
+
+    public function setTitle(?string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setParent(?self $parent = null): void
+    {
+        $this->parent = $parent;
+    }
+
+    public function getParent(): ?self
+    {
+        return $this->parent;
+    }
+
+    public function getRoot(): ?self
+    {
+        return $this->root;
+    }
+
+    public function getLeft(): ?int
+    {
+        return $this->lft;
+    }
+
+    public function getRight(): ?int
+    {
+        return $this->rgt;
+    }
+
+    public function getLevel(): ?int
+    {
+        return $this->level;
+    }
+}

--- a/tests/Gedmo/Tree/NestedTreePositionTest.php
+++ b/tests/Gedmo/Tree/NestedTreePositionTest.php
@@ -14,6 +14,7 @@ namespace Gedmo\Tests\Tree;
 use Doctrine\Common\EventManager;
 use Gedmo\Tests\Tool\BaseTestCaseORM;
 use Gedmo\Tests\Tree\Fixture\Category;
+use Gedmo\Tests\Tree\Fixture\RootAssociationCategoryBinaryUuid;
 use Gedmo\Tests\Tree\Fixture\RootCategory;
 use Gedmo\Tree\TreeListener;
 
@@ -26,6 +27,7 @@ final class NestedTreePositionTest extends BaseTestCaseORM
 {
     private const CATEGORY = Category::class;
     private const ROOT_CATEGORY = RootCategory::class;
+    private const ROOT_CATEGORY_BINARY_UUID = RootAssociationCategoryBinaryUuid::class;
 
     protected function setUp(): void
     {
@@ -318,6 +320,72 @@ final class NestedTreePositionTest extends BaseTestCaseORM
         $cookies->setTitle('Cookies');
 
         $drinks = new RootCategory();
+        $drinks->setTitle('Drinks');
+
+        $repo
+            ->persistAsNextSiblingOf($cookies, $milk)
+            ->persistAsPrevSiblingOf($drinks, $milk);
+
+        $this->em->flush();
+
+        static::assertSame(6, $drinks->getLeft());
+        static::assertSame(7, $drinks->getRight());
+
+        static::assertSame(10, $cookies->getLeft());
+        static::assertSame(11, $cookies->getRight());
+
+        static::assertTrue($repo->verify());
+    }
+
+    /**
+     * This test is the same as above (testRootTreePositionedInserts), apart testing behavior of binary column for UUID
+     */
+    public function testRootBinaryUuidTreePositionedInserts(): void
+    {
+        $repo = $this->em->getRepository(self::ROOT_CATEGORY_BINARY_UUID);
+
+        // test child positioned inserts
+        $food = new RootAssociationCategoryBinaryUuid();
+        $food->setTitle('Food');
+
+        $fruits = new RootAssociationCategoryBinaryUuid();
+        $fruits->setTitle('Fruits');
+
+        $vegitables = new RootAssociationCategoryBinaryUuid();
+        $vegitables->setTitle('Vegitables');
+
+        $milk = new RootAssociationCategoryBinaryUuid();
+        $milk->setTitle('Milk');
+
+        $meat = new RootAssociationCategoryBinaryUuid();
+        $meat->setTitle('Meat');
+
+        $repo
+            ->persistAsFirstChild($food)
+            ->persistAsFirstChildOf($fruits, $food)
+            ->persistAsFirstChildOf($vegitables, $food)
+            ->persistAsLastChildOf($milk, $food)
+            ->persistAsLastChildOf($meat, $food);
+
+        $this->em->flush();
+
+        static::assertSame(4, $fruits->getLeft());
+        static::assertSame(5, $fruits->getRight());
+
+        static::assertSame(2, $vegitables->getLeft());
+        static::assertSame(3, $vegitables->getRight());
+
+        static::assertSame(6, $milk->getLeft());
+        static::assertSame(7, $milk->getRight());
+
+        static::assertSame(8, $meat->getLeft());
+        static::assertSame(9, $meat->getRight());
+
+        // test sibling positioned inserts
+        $cookies = new RootAssociationCategoryBinaryUuid();
+        $cookies->setTitle('Cookies');
+
+        $drinks = new RootAssociationCategoryBinaryUuid();
         $drinks->setTitle('Drinks');
 
         $repo


### PR DESCRIPTION
The Nested strategy does not specify data types for parameters in queries, leading to incorrect serialization toward database.

**Consequences**: 

The function `updateNode` couldn't execute properly the SQL "update" request, as objects where serialized using toString() method (returning the UUID at string format), instead of using `toRfc4122` or `toBinary`.
Leading to a different identifier value into the database transaction.

```log
[2024-09-16T07:26:29.749158+00:00] doctrine.DEBUG: Beginning transaction [] []
[2024-09-16T07:26:29.749704+00:00] doctrine.DEBUG: Executing statement: INSERT INTO tree_node (id, name, tree_left, tree_right, tree_level, tree_root, parent_id) VALUES (?, ?, ?, ?, ?, ?, ?) (parameters: array{"1":"\u0001��'\u000b~J��+b�\u0004ו","2":"root","3":0,"4":0,"5":0,"6":null,"7":null}, types: array{"1":2,"2":2,"3":1,"4":1,"5":1,"6":2,"7":2}) {"sql":"INSERT INTO tree_node (id, name, tree_left, tree_right, tree_level, tree_root, parent_id) VALUES (?, ?, ?, ?, ?, ?, ?)","params":{"1":"\u0001��'\u000b~J��+b�\u0004ו","2":"root","3":0,"4":0,"5":0,"6":null,"7":null},"types":{"1":2,"2":2,"3":1,"4":1,"5":1,"6":2,"7":2}} []
[2024-09-16T07:26:29.759326+00:00] doctrine.DEBUG: Executing statement: UPDATE tree_node SET tree_root = ?, tree_level = 0, tree_left = 1, tree_right = 2 WHERE id = ? (parameters: array{"1":"0191e1a6-270b-7e4a-bbef-2b62ac04d795","2":"0191e1a6-270b-7e4a-bbef-2b62ac04d795"}, types: array{"1":2,"2":2}) {"sql":"UPDATE tree_node SET tree_root = ?, tree_level = 0, tree_left = 1, tree_right = 2 WHERE id = ?","params":{"1":{"Symfony\\Component\\Uid\\UuidV7":"0191e1a6-270b-7e4a-bbef-2b62ac04d795"},"2":{"Symfony\\Component\\Uid\\UuidV7":"0191e1a6-270b-7e4a-bbef-2b62ac04d795"}},"types":{"1":2,"2":2}} []
[2024-09-16T07:26:29.759798+00:00] doctrine.DEBUG: Committing transaction [] []
```

The behavior is vicious because it just silently fail, changing position from null to 0 to every new nodes, and was not obvious to catch.

Solution:

Add everywhere needed, the correct parameter type, letting the DBAL doing it's job.

Tests:

- [x] No regressions onto previous ones, to ensure that the fix not breaking expected behavior
- [x] Add a new test to test behavior with UIDs stored as `binary(16)`

Tests added aims to not overlap with existing ones, testing only the `binary(16)` behavior
