### PR TITLE
Configure "trailing_comma_in_multiline" rule for PHP-CS-Fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -83,6 +83,11 @@ return (new PhpCsFixer\Config())
         'static_lambda' => true,
         'strict_param' => true,
         'ternary_to_null_coalescing' => true,
+        'trailing_comma_in_multiline' => [
+            'elements' => [
+                'arrays',
+            ],
+        ],
         // @todo: Change the following rule to `true` in the next major release.
         'void_return' => false,
     ])


### PR DESCRIPTION
Without this change, the fixer is trying to add trailing commas to parameter lists in multi-line function declarations, which is not supported for all the PHP versions allowed in this project.