### PR TITLE
[Uploadable] Remove deprecation warning when calling is_file with a null value

### DIFF
--- a/src/Uploadable/UploadableListener.php
+++ b/src/Uploadable/UploadableListener.php
@@ -389,7 +389,7 @@ class UploadableListener extends MappedEventSubscriber
      */
     public function removeFile($filePath)
     {
-        if (is_file($filePath)) {
+        if (!is_null($filePath) && is_file($filePath)) {
             return @unlink($filePath);
         }
 


### PR DESCRIPTION
Hi!

We've been getting lots of deprecation warning (_Deprecated: is_file(): Passing null to parameter #1 ($filename) of type string is deprecated_) coming from `src/Uploadable/UploadableListener::removeFile`:
```php
public function removeFile($filePath)
{
    if (is_file($filePath)) {
        return @unlink($filePath);
    }

     return false;
}
```

This PR simply adds a check for null:
```php
if (!is_null($filePath) && is_file($filePath)) {
```

Thanks for reviewing!