### PR TITLE
Make the doctrine/common dependency optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,6 @@
         "php": "^7.4 || ^8.0",
         "behat/transliterator": "^1.2",
         "doctrine/collections": "^1.2 || ^2.0",
-        "doctrine/common": "^2.13 || ^3.0",
         "doctrine/deprecations": "^1.0",
         "doctrine/event-manager": "^1.2 || ^2.0",
         "doctrine/persistence": "^2.2 || ^3.0",
@@ -54,6 +53,7 @@
     "require-dev": {
         "doctrine/annotations": "^1.13 || ^2.0",
         "doctrine/cache": "^1.11 || ^2.0",
+        "doctrine/common": "^2.13 || ^3.0",
         "doctrine/dbal": "^3.7 || ^4.0",
         "doctrine/doctrine-bundle": "^2.3",
         "doctrine/mongodb-odm": "^2.3",
@@ -73,6 +73,7 @@
     },
     "conflict": {
         "doctrine/annotations": "<1.13 || >=3.0",
+        "doctrine/common": "<2.13 || >=4.0",
         "doctrine/dbal": "<3.7 || >=5.0",
         "doctrine/mongodb-odm": "<2.3 || >=3.0",
         "doctrine/orm": "<2.14.0 || 2.16.0 || 2.16.1 || >=4.0"

--- a/src/Sortable/Mapping/Event/Adapter/ODM.php
+++ b/src/Sortable/Mapping/Event/Adapter/ODM.php
@@ -9,10 +9,10 @@
 
 namespace Gedmo\Sortable\Mapping\Event\Adapter;
 
-use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Gedmo\Mapping\Event\Adapter\ODM as BaseAdapterODM;
 use Gedmo\Sortable\Mapping\Event\SortableAdapter;
+use Gedmo\Tool\ClassUtils;
 
 /**
  * Doctrine event adapter for ODM adapted

--- a/src/Sortable/SortableListener.php
+++ b/src/Sortable/SortableListener.php
@@ -11,7 +11,6 @@ namespace Gedmo\Sortable;
 
 use Doctrine\Common\Comparable;
 use Doctrine\Common\EventArgs;
-use Doctrine\Common\Util\ClassUtils;
 use Doctrine\Deprecations\Deprecation;
 use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
@@ -20,6 +19,7 @@ use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\ObjectManager;
 use Gedmo\Mapping\MappedEventSubscriber;
 use Gedmo\Sortable\Mapping\Event\SortableAdapter;
+use Gedmo\Tool\ClassUtils;
 use ProxyManager\Proxy\GhostObjectInterface;
 
 /**

--- a/src/Tool/ClassUtils.php
+++ b/src/Tool/ClassUtils.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tool;
+
+use Doctrine\Common\Util\ClassUtils as CommonClassUtils;
+
+/**
+ * Utility class for Doctrine Common proxies.
+ */
+final class ClassUtils
+{
+    private function __construct()
+    {
+    }
+
+    /**
+     * Gets the real class name of an object (even if it's a proxy).
+     *
+     * If doctrine/common is not installed, this method behaves like {@see get_class()}.
+     *
+     * @param TObject $object
+     * @return class-string<TObject>
+     * @template TObject of object
+     */
+    public static function getClass(object $object): string
+    {
+        if (class_exists(CommonClassUtils::class)) {
+            return CommonClassUtils::getClass($object);
+        }
+
+        return get_class($object);
+    }
+}

--- a/src/Tool/Wrapper/EntityWrapper.php
+++ b/src/Tool/Wrapper/EntityWrapper.php
@@ -9,10 +9,10 @@
 
 namespace Gedmo\Tool\Wrapper;
 
-use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Persistence\Proxy as PersistenceProxy;
+use Gedmo\Tool\ClassUtils;
 
 /**
  * Wraps entity or proxy for more convenient


### PR DESCRIPTION
Doctrine ORM has moved away from the Doctrine Common proxy implementation. Yet, this package still forces the installation of doctrine/common.

The only class that we need from doctrine/common is `ClassUtils` which can resolve proxy class names. However, if doctrine/common is not installed, we can be sure that we won't encounter any Common proxies and fall back to `get_class()`. This class introduces a new utility method that does exactly that.