### PR TITLE
[Timestampable] - Add types to createdAt and updatedAt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ a release.
 
 ## [Unreleased]
 ### New
-- Add return types to createdAt and updatedAt
+- Timestampable: Add types to createdAt and updatedAt
 ### Deprecated
 - Sluggable: Annotation-specific mapping parameters (#2837)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ a release.
 ---
 
 ## [Unreleased]
+### New
+- Add return types to createdAt and updatedAt
 ### Deprecated
 - Sluggable: Annotation-specific mapping parameters (#2837)
 

--- a/src/Timestampable/Traits/Timestampable.php
+++ b/src/Timestampable/Traits/Timestampable.php
@@ -21,19 +21,19 @@ trait Timestampable
     /**
      * @var \DateTime|null
      */
-    protected $createdAt;
+    protected ?\DateTime $createdAt;
 
     /**
      * @var \DateTime|null
      */
-    protected $updatedAt;
+    protected ?\DateTime $updatedAt;
 
     /**
      * Sets createdAt.
      *
      * @return $this
      */
-    public function setCreatedAt(\DateTime $createdAt)
+    public function setCreatedAt(\DateTime $createdAt): static
     {
         $this->createdAt = $createdAt;
 
@@ -45,7 +45,7 @@ trait Timestampable
      *
      * @return \DateTime|null
      */
-    public function getCreatedAt()
+    public function getCreatedAt(): ?\DateTime
     {
         return $this->createdAt;
     }
@@ -55,7 +55,7 @@ trait Timestampable
      *
      * @return $this
      */
-    public function setUpdatedAt(\DateTime $updatedAt)
+    public function setUpdatedAt(\DateTime $updatedAt): static
     {
         $this->updatedAt = $updatedAt;
 
@@ -67,7 +67,7 @@ trait Timestampable
      *
      * @return \DateTime|null
      */
-    public function getUpdatedAt()
+    public function getUpdatedAt(): ?\DateTime
     {
         return $this->updatedAt;
     }

--- a/src/Timestampable/Traits/TimestampableEntity.php
+++ b/src/Timestampable/Traits/TimestampableEntity.php
@@ -31,7 +31,7 @@ trait TimestampableEntity
      */
     #[Gedmo\Timestampable(on: 'create')]
     #[ORM\Column(type: Types::DATETIME_MUTABLE)]
-    protected $createdAt;
+    protected ?\DateTime $createdAt;
 
     /**
      * @var \DateTime|null
@@ -42,14 +42,14 @@ trait TimestampableEntity
      */
     #[Gedmo\Timestampable(on: 'update')]
     #[ORM\Column(type: Types::DATETIME_MUTABLE)]
-    protected $updatedAt;
+    protected ?\DateTime $updatedAt;
 
     /**
      * Sets createdAt.
      *
      * @return $this
      */
-    public function setCreatedAt(\DateTime $createdAt)
+    public function setCreatedAt(\DateTime $createdAt): static
     {
         $this->createdAt = $createdAt;
 
@@ -61,7 +61,7 @@ trait TimestampableEntity
      *
      * @return \DateTime|null
      */
-    public function getCreatedAt()
+    public function getCreatedAt(): ?\DateTime
     {
         return $this->createdAt;
     }
@@ -71,7 +71,7 @@ trait TimestampableEntity
      *
      * @return $this
      */
-    public function setUpdatedAt(\DateTime $updatedAt)
+    public function setUpdatedAt(\DateTime $updatedAt): static
     {
         $this->updatedAt = $updatedAt;
 
@@ -83,7 +83,7 @@ trait TimestampableEntity
      *
      * @return \DateTime|null
      */
-    public function getUpdatedAt()
+    public function getUpdatedAt(): ?\DateTime
     {
         return $this->updatedAt;
     }


### PR DESCRIPTION
Based on the requirements of our project to be compatible with PHPStan Level 10, I had to add the types to createdAt and updatedAt, as we're using Timestampable in some of our entities