### PR TITLE
Bump CS-Fixer to latest minor, update config

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -28,13 +28,12 @@ $finder = PhpCsFixer\Finder::create()
     ]);
 
 return (new PhpCsFixer\Config())
+    ->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())
     ->setRules([
         '@DoctrineAnnotation' => true,
-        '@PHP71Migration' => true,
-        '@PHP71Migration:risky' => true,
         '@PHP74Migration' => true,
         '@PHP74Migration:risky' => true,
-        '@PHPUnit84Migration:risky' => true,
+        '@PHPUnit91Migration:risky' => true,
         '@PSR2' => true,
         '@Symfony' => true,
         'array_syntax' => ['syntax' => 'short'],
@@ -55,7 +54,7 @@ return (new PhpCsFixer\Config())
         'no_superfluous_phpdoc_tags' => ['allow_mixed' => true],
         'no_unset_on_property' => true,
         'no_useless_else' => true,
-        'nullable_type_declaration_for_default_null_value' => ['use_nullable_type_declaration' => true],
+        'nullable_type_declaration_for_default_null_value' => true,
         'ordered_class_elements' => true,
         'ordered_imports' => ['sort_algorithm' => 'alpha'],
         'phpdoc_order' => ['order' => ['param', 'throws', 'return']],

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
         "doctrine/doctrine-bundle": "^2.3",
         "doctrine/mongodb-odm": "^2.3",
         "doctrine/orm": "^2.20 || ^3.3",
-        "friendsofphp/php-cs-fixer": "^3.14.0",
+        "friendsofphp/php-cs-fixer": "^3.70",
         "nesbot/carbon": "^2.71 || ^3.0",
         "phpstan/phpstan": "^2.1.1",
         "phpstan/phpstan-doctrine": "^2.0.1",


### PR DESCRIPTION
PHP-CS-Fixer doesn't need to have an extremely wide range of supported versions, so this updates the tool to require the latest minor release to close that gap down significantly.  I've also updated the config to:

- Enable the experimental parallel runner, which with 800 files being processed doesn't seem like a terrible thing
- Removed the explicit `@PHP71Migration` rules as they're implied in the `@PHP74` rules
- Updated the `@PHPUnitMigration` rule from 8.4 to 9.1 which ensures certain renamed assertions use the newer name (pretty sure this was already done anyway since there weren't any changes locally after this)
- Updated the `nullable_type_declaration_for_default_null_value` rule to stop using deprecated configuration