### PR TITLE
[Sluggable] Use public property instead of deprecated array access

### DIFF
--- a/src/Sluggable/Mapping/Driver/Attribute.php
+++ b/src/Sluggable/Mapping/Driver/Attribute.php
@@ -82,7 +82,7 @@ class Attribute extends AbstractAnnotationDriver
         // Embedded entity
         if (property_exists($meta, 'embeddedClasses') && $meta->embeddedClasses) {
             foreach ($meta->embeddedClasses as $propertyName => $embeddedClassInfo) {
-                $embeddedClass = new \ReflectionClass($embeddedClassInfo['class']);
+                $embeddedClass = new \ReflectionClass($embeddedClassInfo->class);
 
                 foreach ($embeddedClass->getProperties() as $embeddedProperty) {
                     $config = $this->retrieveSlug($meta, $config, $embeddedProperty, $propertyName);


### PR DESCRIPTION
This property is already available in doctrine/orm 2.14.0 which is the lowest supported version ([see here](https://github.com/doctrine/orm/blob/2.14.0/lib/Doctrine/ORM/Mapping/Embedded.php#L22)) so we can easily use it instead of [the deprecated array access](https://github.com/doctrine/orm/pull/11211).