### PR TITLE
Resolved a bug where a soft-deleted object isn't remove from the ObjectManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ a release.
 
 ## [Unreleased]
 
+### Fixed
+- SoftDeleteable: Resolved a bug where a soft-deleted object isn't remove from the ObjectManager (#2930)
+
 ## [3.19.0] - 2025-02-24
 ### Added
 - Actor provider for use with extensions with user references (#2914)
@@ -103,7 +106,7 @@ a release.
 - Dropped support for doctrine/dbal < 3.2
 
 ### Deprecated
-- Calling `Gedmo\Mapping\Event\Adapter\ORM::getObjectManager()` and `getObject()` on EventArgs that do not implement `getObjectManager()` and `getObject()` (such as old EventArgs implementing `getEntityManager()` and `getEntity()`) 
+- Calling `Gedmo\Mapping\Event\Adapter\ORM::getObjectManager()` and `getObject()` on EventArgs that do not implement `getObjectManager()` and `getObject()` (such as old EventArgs implementing `getEntityManager()` and `getEntity()`)
 - Calling `Gedmo\Uploadable\Event\UploadableBaseEventArgs::getEntityManager()` and `getEntity()`. Call `getObjectManager()` and `getObject()` instead.
 
 ## [3.13.0] - 2023-09-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ a release.
 ---
 
 ## [Unreleased]
-
 ### Fixed
 - SoftDeleteable: Resolved a bug where a soft-deleted object isn't remove from the ObjectManager (#2930)
 

--- a/src/SoftDeleteable/SoftDeleteableListener.php
+++ b/src/SoftDeleteable/SoftDeleteableListener.php
@@ -147,8 +147,6 @@ class SoftDeleteableListener extends MappedEventSubscriber
     /**
      * Detach soft-deleted objects from object manager.
      *
-     * @param EventArgs $args
-     *
      * @return void
      */
     public function postFlush(EventArgs $args)

--- a/src/SoftDeleteable/SoftDeleteableListener.php
+++ b/src/SoftDeleteable/SoftDeleteableListener.php
@@ -51,7 +51,6 @@ class SoftDeleteableListener extends MappedEventSubscriber
      */
     public const POST_SOFT_DELETE = 'postSoftDelete';
 
-
     /**
      * Objects soft-deleted on flush.
      *

--- a/tests/Gedmo/Blameable/Fixture/Entity/Article.php
+++ b/tests/Gedmo/Blameable/Fixture/Entity/Article.php
@@ -43,7 +43,7 @@ class Article implements Blameable
     private ?string $title = null;
 
     /**
-     * @var Collection<Comment>
+     * @var Collection<int, Comment>
      *
      * @ORM\OneToMany(targetEntity="Gedmo\Tests\Blameable\Fixture\Entity\Comment", mappedBy="article")
      */
@@ -115,7 +115,7 @@ class Article implements Blameable
     }
 
     /**
-     * @return Collection<Comment>
+     * @return Collection<int, Comment>
      */
     public function getComments(): Collection
     {

--- a/tests/Gedmo/Blameable/Fixture/Entity/Article.php
+++ b/tests/Gedmo/Blameable/Fixture/Entity/Article.php
@@ -43,12 +43,12 @@ class Article implements Blameable
     private ?string $title = null;
 
     /**
-     * @var Collection<int, Comment>
+     * @var Collection<Comment>
      *
      * @ORM\OneToMany(targetEntity="Gedmo\Tests\Blameable\Fixture\Entity\Comment", mappedBy="article")
      */
     #[ORM\OneToMany(targetEntity: Comment::class, mappedBy: 'article')]
-    private $comments;
+    private Collection $comments;
 
     /**
      * @Gedmo\Blameable(on="create")
@@ -115,7 +115,7 @@ class Article implements Blameable
     }
 
     /**
-     * @return Collection<int, Comment>
+     * @return Collection<Comment>
      */
     public function getComments(): Collection
     {

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/Article.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/Article.php
@@ -93,6 +93,9 @@ class Article
         $this->comments[] = $comment;
     }
 
+    /**
+     * @return Collection<int, Comment>
+     */
     public function getComments(): Collection
     {
         return $this->comments;

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/Article.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/Article.php
@@ -92,4 +92,9 @@ class Article
     {
         $this->comments[] = $comment;
     }
+
+    public function getComments(): Collection
+    {
+        return $this->comments;
+    }
 }

--- a/tests/Gedmo/SoftDeleteable/SoftDeleteableEntityTest.php
+++ b/tests/Gedmo/SoftDeleteable/SoftDeleteableEntityTest.php
@@ -522,6 +522,42 @@ final class SoftDeleteableEntityTest extends BaseTestCaseORM
         static::assertCount(0, $data);
     }
 
+    public function testSoftDeletedObjectIsRemovedPostFlush(): void
+    {
+        $repo = $this->em->getRepository(Article::class);
+        $commentRepo = $this->em->getRepository(Comment::class);
+
+        $comment = new Comment();
+        $commentValue = 'Comment 1';
+        $comment->setComment($commentValue);
+
+        $art0 = new Article();
+        $field = 'title';
+        $value = 'Title 1';
+        $art0->setTitle($value);
+        $art0->addComment($comment);
+
+        $this->em->persist($art0);
+        $this->em->flush();
+
+        $art = $repo->findOneBy([$field => $value]);
+
+        $this->assertNull($art->getDeletedAt());
+        $this->assertNull($comment->getDeletedAt());
+        $this->assertCount(1, $art->getComments());
+
+        $this->em->remove($comment);
+
+        // The Comment has been marked for removal, but not yet flushed.  This means the
+        // Comment should still be available.
+        $this->assertInstanceOf(Comment::class, $commentRepo->find($comment->getId()));
+
+        $this->em->flush();
+
+        // Now that we've flushed, the Comment should no longer be available and should return null
+        $this->assertNull($commentRepo->find($comment->getId()));
+    }
+
     public function testPostSoftDeleteEventIsDispatched(): void
     {
         $this->em->getEventManager()->addEventSubscriber(new WithPreAndPostSoftDeleteEventArgsTypeListener());

--- a/tests/Gedmo/SoftDeleteable/SoftDeleteableEntityTest.php
+++ b/tests/Gedmo/SoftDeleteable/SoftDeleteableEntityTest.php
@@ -542,20 +542,20 @@ final class SoftDeleteableEntityTest extends BaseTestCaseORM
 
         $art = $repo->findOneBy([$field => $value]);
 
-        $this->assertNull($art->getDeletedAt());
-        $this->assertNull($comment->getDeletedAt());
-        $this->assertCount(1, $art->getComments());
+        static::assertNull($art->getDeletedAt());
+        static::assertNull($comment->getDeletedAt());
+        static::assertCount(1, $art->getComments());
 
         $this->em->remove($comment);
 
         // The Comment has been marked for removal, but not yet flushed.  This means the
         // Comment should still be available.
-        $this->assertInstanceOf(Comment::class, $commentRepo->find($comment->getId()));
+        static::assertInstanceOf(Comment::class, $commentRepo->find($comment->getId()));
 
         $this->em->flush();
 
         // Now that we've flushed, the Comment should no longer be available and should return null
-        $this->assertNull($commentRepo->find($comment->getId()));
+        static::assertNull($commentRepo->find($comment->getId()));
     }
 
     public function testPostSoftDeleteEventIsDispatched(): void

--- a/tests/Gedmo/SoftDeleteable/SoftDeleteableEntityTest.php
+++ b/tests/Gedmo/SoftDeleteable/SoftDeleteableEntityTest.php
@@ -548,7 +548,7 @@ final class SoftDeleteableEntityTest extends BaseTestCaseORM
 
         $this->em->remove($comment);
 
-        // The Comment has been marked for removal, but not yet flushed.  This means the
+        // The Comment has been marked for removal, but not yet flushed. This means the
         // Comment should still be available.
         static::assertInstanceOf(Comment::class, $commentRepo->find($comment->getId()));
 

--- a/tests/Gedmo/SoftDeleteable/SoftDeleteableEntityTest.php
+++ b/tests/Gedmo/SoftDeleteable/SoftDeleteableEntityTest.php
@@ -554,7 +554,7 @@ final class SoftDeleteableEntityTest extends BaseTestCaseORM
 
         $this->em->flush();
 
-        // Now that we've flushed, the Comment should no longer be available and should return null
+        // Now that we've flushed, the Comment should no longer be available and should return null.
         static::assertNull($commentRepo->find($comment->getId()));
     }
 


### PR DESCRIPTION
Currently, after you remove an entity, it's still queryable by the pk, as it's cached in the `ObjectManager`.  This PR fixes this bug by removing it `postFlush`.  See test for more details.