### PR TITLE
[Tree][NestedSet] Fix inserting multiple roots in one flush

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ a release.
 ### Changed
 - All: Removed the dollar sign from the generated cache ID for extension metadata to ensure only characters mandated by [PSR-6](https://www.php-fig.org/psr/psr-6/#definitions) are used, improving compatibility with caching implementations with strict character requirements (#2978)
 
+### Fixed
+- Tree: Fixed inserting multiple root nodes in one flush operation with the nested set strategy in certain circumstances (#2582)
+
 ## [3.22.0] - 2025-12-13
 ### Added
 - Support for Symfony 8

--- a/src/Tree/Strategy/ORM/Nested.php
+++ b/src/Tree/Strategy/ORM/Nested.php
@@ -407,6 +407,11 @@ class Nested implements Strategy
                 $wrapped->setPropertyValue($config['right'], $right);
             }
             $newRoot = $parentRoot;
+
+            if (!isset($this->treeEdges[$meta->getName()])) {
+                $this->treeEdges[$meta->getName()] = $this->max($em, $config['useObjectClass'], $newRoot) + 1;
+            }
+            $this->treeEdges[$meta->getName()] += 2;
         } elseif (!isset($config['root'])
             || ($meta->isSingleValuedAssociation($config['root']) && null !== $parent && ($newRoot = $meta->getFieldValue($node, $config['root'])))) {
             if (!isset($this->treeEdges[$meta->getName()])) {

--- a/tests/Gedmo/Tree/Fixture/Issue2582/OU.php
+++ b/tests/Gedmo/Tree/Fixture/Issue2582/OU.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Gedmo\Tests\Tree\Fixture\Issue2582;
 
 use Doctrine\Common\Collections\ArrayCollection;
@@ -73,6 +80,8 @@ class OU
     /**
      * @ORM\OneToMany(targetEntity="\Gedmo\Tests\Tree\Fixture\Issue2582\OU", mappedBy="parent")
      * @ORM\OrderBy({"left" = "ASC"})
+     *
+     * @var Collection<int, self>
      */
     #[ORM\OneToMany(targetEntity: self::class, mappedBy: 'parent')]
     #[ORM\OrderBy(['left' => 'ASC'])]
@@ -80,9 +89,9 @@ class OU
 
     public function __construct(string $id, ?self $parent = null)
     {
-        $this->id       = $id;
+        $this->id = $id;
         $this->children = new ArrayCollection();
-        $this->parent   = $parent;
+        $this->parent = $parent;
         if ($parent) {
             $parent->children->add($this);
         }
@@ -93,7 +102,7 @@ class OU
         return $this->id;
     }
 
-    public function getParent(): ?OU
+    public function getParent(): ?self
     {
         return $this->parent;
     }
@@ -113,6 +122,9 @@ class OU
         return $this->right;
     }
 
+    /**
+     * @return Collection<int, self>
+     */
     public function getChildren(): Collection
     {
         return $this->children;

--- a/tests/Gedmo/Tree/Fixture/Issue2582/OU.php
+++ b/tests/Gedmo/Tree/Fixture/Issue2582/OU.php
@@ -10,8 +10,12 @@ use Gedmo\Mapping\Annotation as Gedmo;
 /**
  * @Gedmo\Tree(type="nested")
  *
- * @ORM\Table(name="ous")
- * @ORM\Index(name="idx_tree", columns={"lft", "rgt"})
+ * @ORM\Table(
+ *     name="ous",
+ *     indexes={
+ *          @ORM\Index(name="idx_tree", fields={"left", "right"})
+ *    }
+ * )
  * @ORM\Entity()
  */
 #[ORM\Table(name: 'ous')]

--- a/tests/Gedmo/Tree/Fixture/Issue2582/OU.php
+++ b/tests/Gedmo/Tree/Fixture/Issue2582/OU.php
@@ -12,7 +12,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
  *
  * @ORM\Table(name="ous")
  * @ORM\Index(name="idx_tree", columns={"lft", "rgt"})
- * @ORM\Entity())
+ * @ORM\Entity()
  */
 #[ORM\Table(name: 'ous')]
 #[ORM\Index(name: 'idx_tree', columns: ['lft', 'rgt'])]

--- a/tests/Gedmo/Tree/Fixture/Issue2582/OU.php
+++ b/tests/Gedmo/Tree/Fixture/Issue2582/OU.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Gedmo\Tests\Tree\Fixture\Issue2582;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * @Gedmo\Tree(type="nested")
+ *
+ * @ORM\Table(name="ous")
+ * @ORM\Index(name="idx_tree", columns={"lft", "rgt"})
+ * @ORM\Entity())
+ */
+#[ORM\Table(name: 'ous')]
+#[ORM\Index(name: 'idx_tree', columns: ['lft', 'rgt'])]
+#[ORM\Entity]
+#[Gedmo\Tree(type: 'nested')]
+class OU
+{
+    /**
+     * @ORM\Column(name="id", type="guid")
+     * @ORM\Id()
+     */
+    #[ORM\Column('id', 'guid')]
+    #[ORM\Id]
+    private string $id;
+
+    /**
+     * @Gedmo\TreeParent()
+     *
+     * @ORM\ManyToOne(targetEntity="\Gedmo\Tests\Tree\Fixture\Issue2582\OU", inversedBy="children")
+     * @ORM\JoinColumn(name="parent", referencedColumnName="id", nullable=true, onDelete="CASCADE")
+     */
+    #[ORM\ManyToOne(targetEntity: self::class, inversedBy: 'children')]
+    #[ORM\JoinColumn(name: 'parent', referencedColumnName: 'id', nullable: true, onDelete: 'CASCADE')]
+    #[Gedmo\TreeParent]
+    private ?self $parent = null;
+
+    /**
+     * @Gedmo\TreeLeft()
+     *
+     * @ORM\Column(name="lft", type="integer", options={"unsigned"=true})
+     */
+    #[ORM\Column(name: 'lft', type: 'integer', options: ['unsigned' => true])]
+    #[Gedmo\TreeLeft]
+    private int $left = 1;
+
+    /**
+     * @Gedmo\TreeLevel()
+     *
+     * @ORM\Column(name="lvl", type="integer", options={"unsigned"=true})
+     */
+    #[ORM\Column(name: 'lvl', type: 'integer', options: ['unsigned' => true])]
+    #[Gedmo\TreeLevel]
+    private int $level = 0;
+
+    /**
+     * @Gedmo\TreeRight()
+     *
+     * @ORM\Column(name="rgt", type="integer", options={"unsigned"=true})
+     */
+    #[ORM\Column(name: 'rgt', type: 'integer', options: ['unsigned' => true])]
+    #[Gedmo\TreeRight]
+    private int $right = 2;
+
+    /**
+     * @ORM\OneToMany(targetEntity="\Gedmo\Tests\Tree\Fixture\Issue2582\OU", mappedBy="parent")
+     * @ORM\OrderBy({"left" = "ASC"})
+     */
+    #[ORM\OneToMany(targetEntity: self::class, mappedBy: 'parent')]
+    #[ORM\OrderBy(['left' => 'ASC'])]
+    private Collection $children;
+
+    public function __construct(string $id, ?self $parent = null)
+    {
+        $this->id       = $id;
+        $this->children = new ArrayCollection();
+        $this->parent   = $parent;
+        if ($parent) {
+            $parent->children->add($this);
+        }
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getParent(): ?OU
+    {
+        return $this->parent;
+    }
+
+    public function getLeft(): int
+    {
+        return $this->left;
+    }
+
+    public function getLevel(): int
+    {
+        return $this->level;
+    }
+
+    public function getRight(): int
+    {
+        return $this->right;
+    }
+
+    public function getChildren(): Collection
+    {
+        return $this->children;
+    }
+}

--- a/tests/Gedmo/Tree/Issue/Issue2582Test.php
+++ b/tests/Gedmo/Tree/Issue/Issue2582Test.php
@@ -57,7 +57,7 @@ class Issue2582Test extends BaseTestCaseORM
                 $expected[$i],
                 [
                     $a->getId(),
-                    $a->getParent()?->getId(),
+                    $a->getParent() ? $a->getParent()->getId() : null,
                     $a->getLeft(),
                     $a->getLevel(),
                     $a->getRight(),
@@ -93,7 +93,7 @@ class Issue2582Test extends BaseTestCaseORM
                 $expected[$i],
                 [
                     $a->getId(),
-                    $a->getParent()?->getId(),
+                    $a->getParent() ? $a->getParent()->getId() : null,
                     $a->getLeft(),
                     $a->getLevel(),
                     $a->getRight(),
@@ -130,7 +130,7 @@ class Issue2582Test extends BaseTestCaseORM
                 $expected[$i],
                 [
                     $a->getId(),
-                    $a->getParent()?->getId(),
+                    $a->getParent() ? $a->getParent()->getId() : null,
                     $a->getLeft(),
                     $a->getLevel(),
                     $a->getRight(),

--- a/tests/Gedmo/Tree/Issue/Issue2582Test.php
+++ b/tests/Gedmo/Tree/Issue/Issue2582Test.php
@@ -1,0 +1,156 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Tree\Issue;
+
+use Doctrine\Common\EventManager;
+use Gedmo\Tests\Tool\BaseTestCaseORM;
+use Gedmo\Tests\Tree\Fixture\Issue2582\OU;
+use Gedmo\Tree\TreeListener;
+
+class Issue2582Test extends BaseTestCaseORM
+{
+    private TreeListener $listener;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->listener = new TreeListener();
+
+        $evm = new EventManager();
+        $evm->addEventSubscriber($this->listener);
+
+        $this->getDefaultMockSqliteEntityManager($evm);
+    }
+
+    public function testInsertTwoRootsInOneFlush(): void
+    {
+        $ou1  = new OU('00000000-0000-0000-0000-000000000001', null);
+        $ou11 = new OU('00000000-0000-0000-0000-000000000011', $ou1);
+        $ou2  = new OU('00000000-0000-0000-0000-000000000002', null);
+        $ou21 = new OU('00000000-0000-0000-0000-000000000021', $ou2);
+
+
+        $this->em->persist($ou1);
+        $this->em->persist($ou11);
+        $this->em->persist($ou2);
+        $this->em->persist($ou21);
+        $this->em->flush();
+
+        $this->em->clear();
+
+        $expected = [
+            ['00000000-0000-0000-0000-000000000001', null, 1, 0, 4],
+            ['00000000-0000-0000-0000-000000000011', '00000000-0000-0000-0000-000000000001', 2, 1, 3],
+            ['00000000-0000-0000-0000-000000000002', null, 5, 0, 8],
+            ['00000000-0000-0000-0000-000000000021', '00000000-0000-0000-0000-000000000002', 6, 1, 7],
+        ];
+        foreach ($this->fetchAllOUs() as $i => $a) {
+            self::assertSame(
+                $expected[$i],
+                [
+                    $a->getId(),
+                    $a->getParent()?->getId(),
+                    $a->getLeft(),
+                    $a->getLevel(),
+                    $a->getRight(),
+                ],
+            );
+        }
+    }
+
+    public function testInsertTwoRootsInOneFlushRootsFirst(): void
+    {
+        $ou1  = new OU('00000000-0000-0000-0000-000000000001', null);
+        $ou11 = new OU('00000000-0000-0000-0000-000000000011', $ou1);
+        $ou2  = new OU('00000000-0000-0000-0000-000000000002', null);
+        $ou21 = new OU('00000000-0000-0000-0000-000000000021', $ou2);
+
+
+        $this->em->persist($ou1);
+        $this->em->persist($ou2);
+        $this->em->persist($ou11);
+        $this->em->persist($ou21);
+        $this->em->flush();
+
+        $this->em->clear();
+
+        $expected = [
+            ['00000000-0000-0000-0000-000000000001', null, 1, 0, 4],
+            ['00000000-0000-0000-0000-000000000011', '00000000-0000-0000-0000-000000000001', 2, 1, 3],
+            ['00000000-0000-0000-0000-000000000002', null, 5, 0, 8],
+            ['00000000-0000-0000-0000-000000000021', '00000000-0000-0000-0000-000000000002', 6, 1, 7],
+        ];
+        foreach ($this->fetchAllOUs() as $i => $a) {
+            self::assertSame(
+                $expected[$i],
+                [
+                    $a->getId(),
+                    $a->getParent()?->getId(),
+                    $a->getLeft(),
+                    $a->getLevel(),
+                    $a->getRight(),
+                ],
+            );
+        }
+    }
+
+    public function testInsertTwoRootsInTwoFlushes(): void
+    {
+        $ou1  = new OU('00000000-0000-0000-0000-000000000001', null);
+        $ou11 = new OU('00000000-0000-0000-0000-000000000011', $ou1);
+        $ou2  = new OU('00000000-0000-0000-0000-000000000002', null);
+        $ou21 = new OU('00000000-0000-0000-0000-000000000021', $ou2);
+
+
+        $this->em->persist($ou1);
+        $this->em->persist($ou11);
+        $this->em->flush();
+        $this->em->persist($ou2);
+        $this->em->persist($ou21);
+        $this->em->flush();
+
+        $this->em->clear();
+
+        $expected = [
+            ['00000000-0000-0000-0000-000000000001', null, 1, 0, 4],
+            ['00000000-0000-0000-0000-000000000011', '00000000-0000-0000-0000-000000000001', 2, 1, 3],
+            ['00000000-0000-0000-0000-000000000002', null, 5, 0, 8],
+            ['00000000-0000-0000-0000-000000000021', '00000000-0000-0000-0000-000000000002', 6, 1, 7],
+        ];
+        foreach ($this->fetchAllOUs() as $i => $a) {
+            self::assertSame(
+                $expected[$i],
+                [
+                    $a->getId(),
+                    $a->getParent()?->getId(),
+                    $a->getLeft(),
+                    $a->getLevel(),
+                    $a->getRight(),
+                ],
+            );
+        }
+    }
+
+    private function fetchAllOUs(): array
+    {
+        $categoryRepo = $this->em->getRepository(OU::class);
+        return $categoryRepo
+            ->createQueryBuilder('ou')
+            ->orderBy('ou.left', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    protected function getUsedEntityFixtures(): array
+    {
+        return [OU::class];
+    }
+}

--- a/tests/Gedmo/Tree/Issue/Issue2582Test.php
+++ b/tests/Gedmo/Tree/Issue/Issue2582Test.php
@@ -14,7 +14,7 @@ use Gedmo\Tests\Tool\BaseTestCaseORM;
 use Gedmo\Tests\Tree\Fixture\Issue2582\OU;
 use Gedmo\Tree\TreeListener;
 
-class Issue2582Test extends BaseTestCaseORM
+final class Issue2582Test extends BaseTestCaseORM
 {
     private TreeListener $listener;
 

--- a/tests/Gedmo/Tree/Issue/Issue2582Test.php
+++ b/tests/Gedmo/Tree/Issue/Issue2582Test.php
@@ -37,7 +37,6 @@ class Issue2582Test extends BaseTestCaseORM
         $ou2 = new OU('00000000-0000-0000-0000-000000000002', null);
         $ou21 = new OU('00000000-0000-0000-0000-000000000021', $ou2);
 
-
         $this->em->persist($ou1);
         $this->em->persist($ou11);
         $this->em->persist($ou2);
@@ -73,7 +72,6 @@ class Issue2582Test extends BaseTestCaseORM
         $ou2 = new OU('00000000-0000-0000-0000-000000000002', null);
         $ou21 = new OU('00000000-0000-0000-0000-000000000021', $ou2);
 
-
         $this->em->persist($ou1);
         $this->em->persist($ou2);
         $this->em->persist($ou11);
@@ -108,7 +106,6 @@ class Issue2582Test extends BaseTestCaseORM
         $ou11 = new OU('00000000-0000-0000-0000-000000000011', $ou1);
         $ou2 = new OU('00000000-0000-0000-0000-000000000002', null);
         $ou21 = new OU('00000000-0000-0000-0000-000000000021', $ou2);
-
 
         $this->em->persist($ou1);
         $this->em->persist($ou11);
@@ -150,6 +147,7 @@ class Issue2582Test extends BaseTestCaseORM
     private function fetchAllOUs(): array
     {
         $categoryRepo = $this->em->getRepository(OU::class);
+
         return $categoryRepo
             ->createQueryBuilder('ou')
             ->orderBy('ou.left', 'ASC')

--- a/tests/Gedmo/Tree/Issue/Issue2582Test.php
+++ b/tests/Gedmo/Tree/Issue/Issue2582Test.php
@@ -32,9 +32,9 @@ class Issue2582Test extends BaseTestCaseORM
 
     public function testInsertTwoRootsInOneFlush(): void
     {
-        $ou1  = new OU('00000000-0000-0000-0000-000000000001', null);
+        $ou1 = new OU('00000000-0000-0000-0000-000000000001', null);
         $ou11 = new OU('00000000-0000-0000-0000-000000000011', $ou1);
-        $ou2  = new OU('00000000-0000-0000-0000-000000000002', null);
+        $ou2 = new OU('00000000-0000-0000-0000-000000000002', null);
         $ou21 = new OU('00000000-0000-0000-0000-000000000021', $ou2);
 
 
@@ -53,7 +53,7 @@ class Issue2582Test extends BaseTestCaseORM
             ['00000000-0000-0000-0000-000000000021', '00000000-0000-0000-0000-000000000002', 6, 1, 7],
         ];
         foreach ($this->fetchAllOUs() as $i => $a) {
-            self::assertSame(
+            static::assertSame(
                 $expected[$i],
                 [
                     $a->getId(),
@@ -68,9 +68,9 @@ class Issue2582Test extends BaseTestCaseORM
 
     public function testInsertTwoRootsInOneFlushRootsFirst(): void
     {
-        $ou1  = new OU('00000000-0000-0000-0000-000000000001', null);
+        $ou1 = new OU('00000000-0000-0000-0000-000000000001', null);
         $ou11 = new OU('00000000-0000-0000-0000-000000000011', $ou1);
-        $ou2  = new OU('00000000-0000-0000-0000-000000000002', null);
+        $ou2 = new OU('00000000-0000-0000-0000-000000000002', null);
         $ou21 = new OU('00000000-0000-0000-0000-000000000021', $ou2);
 
 
@@ -89,7 +89,7 @@ class Issue2582Test extends BaseTestCaseORM
             ['00000000-0000-0000-0000-000000000021', '00000000-0000-0000-0000-000000000002', 6, 1, 7],
         ];
         foreach ($this->fetchAllOUs() as $i => $a) {
-            self::assertSame(
+            static::assertSame(
                 $expected[$i],
                 [
                     $a->getId(),
@@ -104,9 +104,9 @@ class Issue2582Test extends BaseTestCaseORM
 
     public function testInsertTwoRootsInTwoFlushes(): void
     {
-        $ou1  = new OU('00000000-0000-0000-0000-000000000001', null);
+        $ou1 = new OU('00000000-0000-0000-0000-000000000001', null);
         $ou11 = new OU('00000000-0000-0000-0000-000000000011', $ou1);
-        $ou2  = new OU('00000000-0000-0000-0000-000000000002', null);
+        $ou2 = new OU('00000000-0000-0000-0000-000000000002', null);
         $ou21 = new OU('00000000-0000-0000-0000-000000000021', $ou2);
 
 
@@ -126,7 +126,7 @@ class Issue2582Test extends BaseTestCaseORM
             ['00000000-0000-0000-0000-000000000021', '00000000-0000-0000-0000-000000000002', 6, 1, 7],
         ];
         foreach ($this->fetchAllOUs() as $i => $a) {
-            self::assertSame(
+            static::assertSame(
                 $expected[$i],
                 [
                     $a->getId(),
@@ -139,6 +139,14 @@ class Issue2582Test extends BaseTestCaseORM
         }
     }
 
+    protected function getUsedEntityFixtures(): array
+    {
+        return [OU::class];
+    }
+
+    /**
+     * @return list<OU>
+     */
     private function fetchAllOUs(): array
     {
         $categoryRepo = $this->em->getRepository(OU::class);
@@ -147,10 +155,5 @@ class Issue2582Test extends BaseTestCaseORM
             ->orderBy('ou.left', 'ASC')
             ->getQuery()
             ->getResult();
-    }
-
-    protected function getUsedEntityFixtures(): array
-    {
-        return [OU::class];
     }
 }


### PR DESCRIPTION
This PR tries to solve the issue described in #2582. Currently it only provides a test case that reproduces the issue and the observations made in https://github.com/doctrine-extensions/DoctrineExtensions/issues/2582#issuecomment-1961459995 (persisting roots first) and in https://github.com/doctrine-extensions/DoctrineExtensions/issues/2582#issue-1585812779 (doing two flushes).

`\Gedmo\Tests\Tree\Issue\Issue2582Test::testInsertTwoRootsInOneFlush` fails as expected right now because it is a direct replication of the issue. `\Gedmo\Tests\Tree\Issue\Issue2582Test::testInsertTwoRootsInOneFlushRootsFirst` and `\Gedmo\Tests\Tree\Issue\Issue2582Test::testInsertTwoRootsInTwoFlushes` both succeed.