### PR TITLE
Address deprecation of the ORM's `ClassMetadata::$reflFields` property

### DIFF
--- a/src/Tree/Strategy/ORM/Closure.php
+++ b/src/Tree/Strategy/ORM/Closure.php
@@ -14,6 +14,7 @@ use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata as ORMClassMetadata;
+use Doctrine\ORM\Mapping\PropertyAccessors\PropertyAccessorFactory;
 use Doctrine\ORM\Mapping\ToOneOwningSideMapping;
 use Doctrine\ORM\Query;
 use Doctrine\Persistence\Mapping\AbstractClassMetadataFactory;
@@ -132,10 +133,20 @@ class Closure implements Strategy
                 'fetch' => ORMClassMetadata::FETCH_LAZY,
             ];
             $closureMetadata->mapManyToOne($ancestorMapping);
-            $closureMetadata->reflFields['ancestor'] = $cmf
-                ->getReflectionService()
-                ->getAccessibleProperty($closureMetadata->getName(), 'ancestor')
-            ;
+
+            if (property_exists($closureMetadata, 'propertyAccessors')) {
+                // ORM 3.4+
+                $closureMetadata->propertyAccessors['ancestor'] = PropertyAccessorFactory::createPropertyAccessor(
+                    $closureMetadata->getName(),
+                    'ancestor'
+                );
+            } else {
+                // ORM 3.3-
+                $closureMetadata->reflFields['ancestor'] = $cmf
+                    ->getReflectionService()
+                    ->getAccessibleProperty($closureMetadata->getName(), 'ancestor')
+                ;
+            }
         }
 
         if (!$closureMetadata->hasAssociation('descendant')) {
@@ -170,10 +181,20 @@ class Closure implements Strategy
                 'fetch' => ORMClassMetadata::FETCH_LAZY,
             ];
             $closureMetadata->mapManyToOne($descendantMapping);
-            $closureMetadata->reflFields['descendant'] = $cmf
-                ->getReflectionService()
-                ->getAccessibleProperty($closureMetadata->getName(), 'descendant')
-            ;
+
+            if (property_exists($closureMetadata, 'propertyAccessors')) {
+                // ORM 3.4+
+                $closureMetadata->propertyAccessors['descendant'] = PropertyAccessorFactory::createPropertyAccessor(
+                    $closureMetadata->getName(),
+                    'descendant'
+                );
+            } else {
+                // ORM 3.3-
+                $closureMetadata->reflFields['descendant'] = $cmf
+                    ->getReflectionService()
+                    ->getAccessibleProperty($closureMetadata->getName(), 'descendant')
+                ;
+            }
         }
 
         if (!$this->hasClosureTableUniqueConstraint($closureMetadata)) {

--- a/src/Tree/Strategy/ORM/Closure.php
+++ b/src/Tree/Strategy/ORM/Closure.php
@@ -136,6 +136,7 @@ class Closure implements Strategy
 
             if (property_exists($closureMetadata, 'propertyAccessors')) {
                 // ORM 3.4+
+                /** @phpstan-ignore-next-line class.NotFound Class introduced in ORM 3.4 */
                 $closureMetadata->propertyAccessors['ancestor'] = PropertyAccessorFactory::createPropertyAccessor(
                     $closureMetadata->getName(),
                     'ancestor'
@@ -184,6 +185,7 @@ class Closure implements Strategy
 
             if (property_exists($closureMetadata, 'propertyAccessors')) {
                 // ORM 3.4+
+                /** @phpstan-ignore-next-line class.NotFound Class introduced in ORM 3.4 */
                 $closureMetadata->propertyAccessors['descendant'] = PropertyAccessorFactory::createPropertyAccessor(
                     $closureMetadata->getName(),
                     'descendant'

--- a/src/Tree/Strategy/ORM/Nested.php
+++ b/src/Tree/Strategy/ORM/Nested.php
@@ -626,8 +626,16 @@ class Nested implements Strategy
 
                 $nodeMeta = $em->getClassMetadata(get_class($node));
 
-                if (!array_key_exists($config['left'], $nodeMeta->getReflectionProperties())) {
-                    continue;
+                if (property_exists($nodeMeta, 'propertyAccessors')) {
+                    // ORM 3.4+
+                    if (!array_key_exists($config['left'], $nodeMeta->getPropertyAccessors())) {
+                        continue;
+                    }
+                } else {
+                    // ORM 3.3-
+                    if (!array_key_exists($config['left'], $nodeMeta->getReflectionProperties())) {
+                        continue;
+                    }
                 }
 
                 $oid = spl_object_id($node);
@@ -717,8 +725,16 @@ class Nested implements Strategy
 
                 $nodeMeta = $em->getClassMetadata(get_class($node));
 
-                if (!array_key_exists($config['left'], $nodeMeta->getReflectionProperties())) {
-                    continue;
+                if (property_exists($nodeMeta, 'propertyAccessors')) {
+                    // ORM 3.4+
+                    if (!array_key_exists($config['left'], $nodeMeta->getPropertyAccessors())) {
+                        continue;
+                    }
+                } else {
+                    // ORM 3.3-
+                    if (!array_key_exists($config['left'], $nodeMeta->getReflectionProperties())) {
+                        continue;
+                    }
                 }
 
                 $left = $meta->getReflectionProperty($config['left'])->getValue($node);

--- a/src/Tree/Strategy/ORM/Nested.php
+++ b/src/Tree/Strategy/ORM/Nested.php
@@ -628,6 +628,7 @@ class Nested implements Strategy
 
                 if (property_exists($nodeMeta, 'propertyAccessors')) {
                     // ORM 3.4+
+                    /** @phpstan-ignore-next-line method.NotFound Method introduced in ORM 3.4 */
                     if (!array_key_exists($config['left'], $nodeMeta->getPropertyAccessors())) {
                         continue;
                     }
@@ -727,6 +728,7 @@ class Nested implements Strategy
 
                 if (property_exists($nodeMeta, 'propertyAccessors')) {
                     // ORM 3.4+
+                    /** @phpstan-ignore-next-line method.NotFound Method introduced in ORM 3.4 */
                     if (!array_key_exists($config['left'], $nodeMeta->getPropertyAccessors())) {
                         continue;
                     }


### PR DESCRIPTION
This PR addresses the deprecations and documented B/C break introduced in https://github.com/doctrine/orm/pull/11659 for the ORM's 3.4 release, see that PR for full details.

The B/C break is in changing the `ClassMetadata::$reflFields` property (and the associated `getReflectionProperties` method) from an array to an object implementing `ArrayAccess`, which breaks the use of `array_key_exists()`.

The deprecation implements a new `propertyAccessors` property and set of objects, and this should allow the affected tree strategies to work with the new API without issue.

(PHPStan CI failures are expected without it running with ORM 3.4 installed)