### PR TITLE
[WIP] Bump the requirements to PHP 8.1

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -24,8 +24,6 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - "7.4"
-          - "8.0"
           - "8.1"
           - "8.2"
           - "8.3"
@@ -38,12 +36,12 @@ jobs:
           - ""
         include:
           - deps: "lowest"
-            php-version: "7.4"
+            php-version: "8.1"
           - deps: "highest"
             php-version: "8.4"
           # Run builds on low and high PHP versions with `doctrine/annotations` removed
           - deps: "highest"
-            php-version: "7.4"
+            php-version: "8.1"
             no-annotations: true
           - deps: "highest"
             php-version: "8.4"
@@ -51,7 +49,7 @@ jobs:
           # Run builds on high PHP version with `doctrine/orm` version pinned
           - deps: "highest"
             php-version: "8.4"
-            orm: "^2.14"
+            orm: "^2.20"
           - deps: "highest"
             php-version: "8.4"
             orm: "^3.0"
@@ -109,7 +107,7 @@ jobs:
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
-          php-version: "8.2"
+          php-version: "8.4"
           extensions: mongodb
 
       - name: "Install dependencies with Composer"

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -31,8 +31,8 @@ return (new PhpCsFixer\Config())
     ->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())
     ->setRules([
         '@DoctrineAnnotation' => true,
-        '@PHP74Migration' => true,
-        '@PHP74Migration:risky' => true,
+        '@PHP81Migration' => true,
+        '@PHP80Migration:risky' => true,
         '@PHPUnit91Migration:risky' => true,
         '@PSR2' => true,
         '@Symfony' => true,
@@ -78,6 +78,7 @@ return (new PhpCsFixer\Config())
         'random_api_migration' => true,
         'return_assignment' => true,
         'self_accessor' => true,
+        'single_line_empty_body' => true,
         'static_lambda' => true,
         'strict_param' => true,
         'ternary_to_null_coalescing' => true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ a release.
 
 ## [Unreleased]
 
+### Changed
+- Dropped support for PHP < 8.1
+
 ## [3.21.0] - 2025-09-22
 ### Added
 - SoftDeleteable: `$handlePostFlushEvent` parameter to `SoftDeleteableListener::__construct()` to enable or disable handling of the `postFlush` event (#2958)

--- a/composer.json
+++ b/composer.json
@@ -40,21 +40,21 @@
         "docs": "https://github.com/doctrine-extensions/DoctrineExtensions/tree/main/doc"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
-        "doctrine/collections": "^1.2 || ^2.0",
+        "php": "^8.1",
+        "doctrine/collections": "^1.6.5 || ^2.0",
         "doctrine/deprecations": "^1.0",
         "doctrine/event-manager": "^1.2 || ^2.0",
-        "doctrine/persistence": "^2.2 || ^3.0 || ^4.0",
+        "doctrine/persistence": "^2.5.2 || ^3.0 || ^4.0",
         "psr/cache": "^1 || ^2 || ^3",
         "psr/clock": "^1",
         "symfony/cache": "^5.4 || ^6.0 || ^7.0",
         "symfony/string": "^5.4 || ^6.0 || ^7.0"
     },
     "require-dev": {
-        "behat/transliterator": "^1.2",
-        "doctrine/annotations": "^1.13 || ^2.0",
-        "doctrine/cache": "^1.11 || ^2.0",
-        "doctrine/common": "^2.13 || ^3.0",
+        "behat/transliterator": "^1.3",
+        "doctrine/annotations": "^1.14 || ^2.0",
+        "doctrine/cache": "^1.12.1 || ^2.0",
+        "doctrine/common": "^3.1",
         "doctrine/dbal": "^3.7 || ^4.0",
         "doctrine/doctrine-bundle": "^2.3",
         "doctrine/mongodb-odm": "^2.3",
@@ -73,9 +73,9 @@
         "symfony/yaml": "^5.4 || ^6.0 || ^7.0"
     },
     "conflict": {
-        "behat/transliterator": "<1.2 || >=2.0",
-        "doctrine/annotations": "<1.13 || >=3.0",
-        "doctrine/common": "<2.13 || >=4.0",
+        "behat/transliterator": "<1.3 || >=2.0",
+        "doctrine/annotations": "<1.14 || >=3.0",
+        "doctrine/common": "<3.1 || >=4.0",
         "doctrine/dbal": "<3.7 || >=5.0",
         "doctrine/mongodb-odm": "<2.3 || >=3.0",
         "doctrine/orm": "<2.20 || >=3.0 <3.3 || >=4.0"

--- a/example/app/Command/PrintCategoryTranslationTreeCommand.php
+++ b/example/app/Command/PrintCategoryTranslationTreeCommand.php
@@ -18,15 +18,14 @@ use Doctrine\ORM\Query;
 use Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper;
 use Gedmo\Translatable\Query\TreeWalker\TranslationWalker;
 use Gedmo\Translatable\TranslatableListener;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'app:print-category-translation-tree', description: 'Seeds an example category tree with translations and prints the tree.')]
 final class PrintCategoryTranslationTreeCommand extends Command
 {
-    protected static $defaultName = 'app:print-category-translation-tree';
-    protected static $defaultDescription = 'Seeds an example category tree with translations and prints the tree.';
-
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         /** @var EntityManagerHelper $helper */

--- a/example/app/Entity/Category.php
+++ b/example/app/Entity/Category.php
@@ -13,6 +13,7 @@ namespace App\Entity;
 
 use App\Entity\Repository\CategoryRepository;
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
@@ -29,7 +30,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 #[ORM\Table(name: 'ext_categories')]
 #[ORM\Entity(repositoryClass: CategoryRepository::class)]
 #[Gedmo\TranslationEntity(class: CategoryTranslation::class)]
-class Category
+class Category implements \Stringable
 {
     /**
      * @ORM\Column(type="integer")
@@ -39,33 +40,27 @@ class Category
     #[ORM\Column(type: Types::INTEGER)]
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    private $id;
+    private ?int $id = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      *
      * @ORM\Column(length=64)
      */
     #[Gedmo\Translatable]
     #[ORM\Column(length: 64)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      *
      * @ORM\Column(type="text", nullable=true)
      */
     #[Gedmo\Translatable]
     #[ORM\Column(type: Types::TEXT, nullable: true)]
-    private $description;
+    private ?string $description = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @Gedmo\Slug(fields={"created", "title"})
      *
@@ -74,7 +69,7 @@ class Category
     #[Gedmo\Translatable]
     #[Gedmo\Slug(fields: ['created', 'title'])]
     #[ORM\Column(length: 64, unique: true)]
-    private $slug;
+    private ?string $slug = null;
 
     /**
      * @Gedmo\TreeLeft
@@ -83,7 +78,7 @@ class Category
      */
     #[Gedmo\TreeLeft]
     #[ORM\Column(type: Types::INTEGER)]
-    private $lft;
+    private ?int $lft = null;
 
     /**
      * @Gedmo\TreeRight
@@ -92,7 +87,7 @@ class Category
      */
     #[Gedmo\TreeRight]
     #[ORM\Column(type: Types::INTEGER)]
-    private $rgt;
+    private ?int $rgt = null;
 
     /**
      * @Gedmo\TreeParent
@@ -103,7 +98,7 @@ class Category
     #[Gedmo\TreeParent]
     #[ORM\ManyToOne(targetEntity: self::class, inversedBy: 'children')]
     #[ORM\JoinColumn(name: 'parent_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
-    private $parent;
+    private ?self $parent = null;
 
     /**
      * @Gedmo\TreeRoot
@@ -112,7 +107,7 @@ class Category
      */
     #[Gedmo\TreeRoot]
     #[ORM\Column(type: Types::INTEGER, nullable: true)]
-    private $root;
+    private ?int $root = null;
 
     /**
      * @Gedmo\TreeLevel
@@ -121,9 +116,11 @@ class Category
      */
     #[Gedmo\TreeLevel]
     #[ORM\Column(name: 'lvl', type: Types::INTEGER)]
-    private $level;
+    private ?int $level = null;
 
     /**
+     * @var Collection<array-key, self>
+     *
      * @ORM\OneToMany(targetEntity="Category", mappedBy="parent")
      */
     #[ORM\OneToMany(targetEntity: self::class, mappedBy: 'parent')]
@@ -136,7 +133,7 @@ class Category
      */
     #[Gedmo\Timestampable(on: 'create')]
     #[ORM\Column(type: Types::DATETIME_MUTABLE)]
-    private $created;
+    private ?\DateTime $created = null;
 
     /**
      * @Gedmo\Timestampable(on="update")
@@ -145,7 +142,7 @@ class Category
      */
     #[Gedmo\Timestampable(on: 'update')]
     #[ORM\Column(type: Types::DATETIME_MUTABLE)]
-    private $updated;
+    private ?\DateTime $updated = null;
 
     /**
      * @Gedmo\Blameable(on="create")
@@ -154,7 +151,7 @@ class Category
      */
     #[Gedmo\Blameable(on: 'create')]
     #[ORM\Column(type: Types::STRING)]
-    private $createdBy;
+    private ?string $createdBy = null;
 
     /**
      * @Gedmo\Blameable(on="update")
@@ -163,9 +160,11 @@ class Category
      */
     #[Gedmo\Blameable(on: 'update')]
     #[ORM\Column(type: Types::STRING)]
-    private $updatedBy;
+    private ?string $updatedBy = null;
 
     /**
+     * @var Collection<array-key, CategoryTranslation>
+     *
      * @ORM\OneToMany(
      *     targetEntity="CategoryTranslation",
      *     mappedBy="object",
@@ -173,7 +172,7 @@ class Category
      * )
      */
     #[ORM\OneToMany(targetEntity: CategoryTranslation::class, mappedBy: 'object', cascade: ['persist', 'remove'])]
-    private $translations;
+    private Collection $translations;
 
     public function __construct()
     {
@@ -181,17 +180,20 @@ class Category
         $this->translations = new ArrayCollection();
     }
 
-    public function __toString()
+    public function __toString(): string
     {
-        return $this->getTitle();
+        return (string) $this->getTitle();
     }
 
-    public function getTranslations()
+    /**
+     * @return Collection<CategoryTranslation>
+     */
+    public function getTranslations(): Collection
     {
         return $this->translations;
     }
 
-    public function addTranslation(CategoryTranslation $t)
+    public function addTranslation(CategoryTranslation $t): void
     {
         if (!$this->translations->contains($t)) {
             $this->translations[] = $t;
@@ -199,87 +201,90 @@ class Category
         }
     }
 
-    public function getSlug()
+    public function getSlug(): ?string
     {
         return $this->slug;
     }
 
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }
 
-    public function setTitle($title)
+    public function setTitle(?string $title): void
     {
         $this->title = $title;
     }
 
-    public function getTitle()
+    public function getTitle(): ?string
     {
         return $this->title;
     }
 
-    public function setDescription($description)
+    public function setDescription(?string $description): void
     {
         $this->description = $description;
     }
 
-    public function getDescription()
+    public function getDescription(): ?string
     {
         return $this->description;
     }
 
-    public function setParent($parent)
+    public function setParent(?self $parent): void
     {
         $this->parent = $parent;
     }
 
-    public function getParent()
+    public function getParent(): ?self
     {
         return $this->parent;
     }
 
-    public function getRoot()
+    public function getRoot(): ?int
     {
         return $this->root;
     }
 
-    public function getLevel()
+    public function getLevel(): ?int
     {
         return $this->level;
     }
 
-    public function getChildren()
+    /**
+     * @return Collection<self>
+     */
+    public function getChildren(): Collection
     {
         return $this->children;
     }
 
-    public function getLeft()
+    public function getLeft(): ?int
     {
         return $this->lft;
     }
 
-    public function getRight()
+    public function getRight(): ?int
     {
         return $this->rgt;
     }
 
-    public function getCreated()
+    public function getCreated(): ?\DateTime
     {
         return $this->created;
     }
 
-    public function getUpdated()
+    public function getUpdated(): ?\DateTime
     {
         return $this->updated;
     }
 
-    public function getCreatedBy()
+    public function getCreatedBy(): ?string
     {
         return $this->createdBy;
     }
 
-    public function getUpdatedBy()
+    public function getUpdatedBy(): ?string
     {
         return $this->updatedBy;
     }

--- a/example/app/Entity/CategoryTranslation.php
+++ b/example/app/Entity/CategoryTranslation.php
@@ -35,14 +35,7 @@ class CategoryTranslation extends AbstractPersonalTranslation
     #[ORM\JoinColumn(name: 'object_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
     protected $object;
 
-    /**
-     * Convenient constructor
-     *
-     * @param string $locale
-     * @param string $field
-     * @param string $value
-     */
-    public function __construct($locale, $field, $value)
+    public function __construct(string $locale, string $field, string $value)
     {
         $this->setLocale($locale);
         $this->setField($field);

--- a/example/app/Entity/Repository/CategoryRepository.php
+++ b/example/app/Entity/Repository/CategoryRepository.php
@@ -17,6 +17,4 @@ use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
 /**
  * @template-extends NestedTreeRepository<Category>
  */
-final class CategoryRepository extends NestedTreeRepository
-{
-}
+final class CategoryRepository extends NestedTreeRepository {}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -43,12 +43,6 @@ parameters:
 			path: src/Blameable/Mapping/Driver/Yaml.php
 
 		-
-			message: '#^Instantiated class Doctrine\\ORM\\Mapping\\Driver\\AnnotationDriver not found\.$#'
-			identifier: class.notFound
-			count: 2
-			path: src/DoctrineExtensions.php
-
-		-
 			message: '#^Access to offset ''inherited'' on an unknown class Doctrine\\ODM\\MongoDB\\Mapping\\AssociationFieldMapping\.$#'
 			identifier: class.notFound
 			count: 1
@@ -473,18 +467,6 @@ parameters:
 			identifier: method.notFound
 			count: 1
 			path: src/SoftDeleteable/Mapping/Validator.php
-
-		-
-			message: '#^Access to an undefined property Gedmo\\SoftDeleteable\\Query\\TreeWalker\\Exec\\MultiTableDeleteExecutor\:\:\$_sqlStatements\.$#'
-			identifier: property.notFound
-			count: 1
-			path: src/SoftDeleteable/Query/TreeWalker/Exec/MultiTableDeleteExecutor.php
-
-		-
-			message: '#^Call to function property_exists\(\) with \$this\(Gedmo\\SoftDeleteable\\Query\\TreeWalker\\Exec\\MultiTableDeleteExecutor\) and ''sqlStatements'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/SoftDeleteable/Query/TreeWalker/Exec/MultiTableDeleteExecutor.php
 
 		-
 			message: '#^Method Gedmo\\SoftDeleteable\\Query\\TreeWalker\\SoftDeleteableWalker\:\:__construct\(\) has parameter \$parserResult with no type specified\.$#'
@@ -937,42 +919,6 @@ parameters:
 			path: src/Tree/TreeListener.php
 
 		-
-			message: '#^Method Gedmo\\Uploadable\\Event\\UploadableBaseEventArgs\:\:__construct\(\) has parameter \$config with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Uploadable/Event/UploadableBaseEventArgs.php
-
-		-
-			message: '#^Method Gedmo\\Uploadable\\Event\\UploadableBaseEventArgs\:\:getExtensionConfiguration\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Uploadable/Event/UploadableBaseEventArgs.php
-
-		-
-			message: '#^Property Gedmo\\Uploadable\\Event\\UploadableBaseEventArgs\:\:\$config is never read, only written\.$#'
-			identifier: property.onlyWritten
-			count: 1
-			path: src/Uploadable/Event/UploadableBaseEventArgs.php
-
-		-
-			message: '#^Property Gedmo\\Uploadable\\Event\\UploadableBaseEventArgs\:\:\$config type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Uploadable/Event/UploadableBaseEventArgs.php
-
-		-
-			message: '#^Property Gedmo\\Uploadable\\Event\\UploadableBaseEventArgs\:\:\$extensionConfiguration is never written, only read\.$#'
-			identifier: property.onlyRead
-			count: 1
-			path: src/Uploadable/Event/UploadableBaseEventArgs.php
-
-		-
-			message: '#^Property Gedmo\\Uploadable\\Event\\UploadableBaseEventArgs\:\:\$extensionConfiguration type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Uploadable/Event/UploadableBaseEventArgs.php
-
-		-
 			message: '#^Method Gedmo\\Uploadable\\FileInfo\\FileInfoArray\:\:getName\(\) never returns null so it can be removed from the return type\.$#'
 			identifier: return.unusedType
 			count: 1
@@ -1033,60 +979,6 @@ parameters:
 			path: src/Uploadable/UploadableListener.php
 
 		-
-			message: '#^Class Doctrine\\ORM\\Mapping\\Driver\\AnnotationDriver not found\.$#'
-			identifier: class.notFound
-			count: 2
-			path: tests/Gedmo/DoctrineExtensionsTest.php
-
-		-
-			message: '#^Property Gedmo\\Tests\\Mapping\\Fixture\\Attribute\\TranslatableModel\:\:\$title \(string\|null\) is never assigned string so it can be removed from the property type\.$#'
-			identifier: property.unusedType
-			count: 1
-			path: tests/Gedmo/Mapping/Fixture/Attribute/TranslatableModel.php
-
-		-
-			message: '#^Property Gedmo\\Tests\\Mapping\\Fixture\\Attribute\\TranslatableModel\:\:\$titleFallbackFalse \(string\|null\) is never assigned string so it can be removed from the property type\.$#'
-			identifier: property.unusedType
-			count: 1
-			path: tests/Gedmo/Mapping/Fixture/Attribute/TranslatableModel.php
-
-		-
-			message: '#^Property Gedmo\\Tests\\Mapping\\Fixture\\Attribute\\TranslatableModel\:\:\$titleFallbackTrue \(string\|null\) is never assigned string so it can be removed from the property type\.$#'
-			identifier: property.unusedType
-			count: 1
-			path: tests/Gedmo/Mapping/Fixture/Attribute/TranslatableModel.php
-
-		-
-			message: '#^Class Gedmo\\Tests\\Translatable\\Fixture\\CategoryTranslation not found\.$#'
-			identifier: class.notFound
-			count: 1
-			path: tests/Gedmo/Mapping/Fixture/Category.php
-
-		-
-			message: '#^Instantiated class Doctrine\\ORM\\Mapping\\Driver\\AnnotationDriver not found\.$#'
-			identifier: class.notFound
-			count: 2
-			path: tests/Gedmo/Mapping/MappingEventSubscriberTest.php
-
-		-
-			message: '#^Parameter \#1 \$driverImpl of method Doctrine\\ORM\\Configuration\:\:setMetadataDriverImpl\(\) expects Doctrine\\Persistence\\Mapping\\Driver\\MappingDriver, Doctrine\\ORM\\Mapping\\Driver\\AnnotationDriver given\.$#'
-			identifier: argument.type
-			count: 2
-			path: tests/Gedmo/Mapping/MappingEventSubscriberTest.php
-
-		-
-			message: '#^Instantiated class Doctrine\\ORM\\Mapping\\Driver\\AnnotationDriver not found\.$#'
-			identifier: class.notFound
-			count: 1
-			path: tests/Gedmo/Mapping/MappingTest.php
-
-		-
-			message: '#^Parameter \#1 \$driverImpl of method Doctrine\\ORM\\Configuration\:\:setMetadataDriverImpl\(\) expects Doctrine\\Persistence\\Mapping\\Driver\\MappingDriver, Doctrine\\ORM\\Mapping\\Driver\\AnnotationDriver given\.$#'
-			identifier: argument.type
-			count: 1
-			path: tests/Gedmo/Mapping/MappingTest.php
-
-		-
 			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<T of object\>\:\:mapField\(\)\.$#'
 			identifier: method.notFound
 			count: 2
@@ -1101,18 +993,6 @@ parameters:
 		-
 			message: '#^Class Doctrine\\ORM\\Id\\IdentityGenerator does not have a constructor and must be instantiated without any parameters\.$#'
 			identifier: new.noConstructor
-			count: 1
-			path: tests/Gedmo/Mapping/MetadataFactory/ForcedMetadataTest.php
-
-		-
-			message: '#^Instantiated class Doctrine\\ORM\\Mapping\\Driver\\AnnotationDriver not found\.$#'
-			identifier: class.notFound
-			count: 1
-			path: tests/Gedmo/Mapping/MetadataFactory/ForcedMetadataTest.php
-
-		-
-			message: '#^Parameter \#1 \$driverImpl of method Doctrine\\ORM\\Configuration\:\:setMetadataDriverImpl\(\) expects Doctrine\\Persistence\\Mapping\\Driver\\MappingDriver, Doctrine\\ORM\\Mapping\\Driver\\AnnotationDriver given\.$#'
-			identifier: argument.type
 			count: 1
 			path: tests/Gedmo/Mapping/MetadataFactory/ForcedMetadataTest.php
 
@@ -1133,18 +1013,6 @@ parameters:
 			identifier: class.notFound
 			count: 1
 			path: tests/Gedmo/Mapping/Mock/Extension/Encoder/Mapping/Driver/Attribute.php
-
-		-
-			message: '#^Instantiated class Doctrine\\ORM\\Mapping\\Driver\\AnnotationDriver not found\.$#'
-			identifier: class.notFound
-			count: 2
-			path: tests/Gedmo/Mapping/MultiManagerMappingTest.php
-
-		-
-			message: '#^Parameter \#1 \$nestedDriver of method Doctrine\\Persistence\\Mapping\\Driver\\MappingDriverChain\:\:addDriver\(\) expects Doctrine\\Persistence\\Mapping\\Driver\\MappingDriver, Doctrine\\ORM\\Mapping\\Driver\\AnnotationDriver given\.$#'
-			identifier: argument.type
-			count: 1
-			path: tests/Gedmo/Mapping/ORMMappingTestCase.php
 
 		-
 			message: '#^Parameter \#1 \$nestedDriver of method Doctrine\\Persistence\\Mapping\\Driver\\MappingDriverChain\:\:addDriver\(\) expects Doctrine\\Persistence\\Mapping\\Driver\\MappingDriver, Doctrine\\ORM\\Mapping\\Driver\\YamlDriver given\.$#'
@@ -1171,12 +1039,6 @@ parameters:
 			path: tests/Gedmo/Mapping/ReferenceIntegrityMappingTest.php
 
 		-
-			message: '#^Instantiated class Doctrine\\ORM\\Mapping\\Driver\\AnnotationDriver not found\.$#'
-			identifier: class.notFound
-			count: 1
-			path: tests/Gedmo/Mapping/TreeMappingTest.php
-
-		-
 			message: '#^Instantiated class Doctrine\\ORM\\Mapping\\Driver\\YamlDriver not found\.$#'
 			identifier: class.notFound
 			count: 1
@@ -1187,48 +1049,12 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: tests/Gedmo/Mapping/TreeMappingTest.php
-
-		-
-			message: '#^Instantiated class Doctrine\\ORM\\Mapping\\Driver\\AnnotationDriver not found\.$#'
-			identifier: class.notFound
-			count: 1
-			path: tests/Gedmo/Mapping/Xml/ClosureTreeMappingTest.php
-
-		-
-			message: '#^Instantiated class Doctrine\\ORM\\Mapping\\Driver\\AnnotationDriver not found\.$#'
-			identifier: class.notFound
-			count: 1
-			path: tests/Gedmo/Mapping/Xml/MaterializedPathTreeMappingTest.php
-
-		-
-			message: '#^Instantiated class Doctrine\\ORM\\Mapping\\Driver\\AnnotationDriver not found\.$#'
-			identifier: class.notFound
-			count: 1
-			path: tests/Gedmo/Mapping/Xml/ReferencesMappingTest.php
-
-		-
-			message: '#^Instantiated class Doctrine\\ORM\\Mapping\\Driver\\AnnotationDriver not found\.$#'
-			identifier: class.notFound
-			count: 1
-			path: tests/Gedmo/Mapping/Xml/TranslatableMappingTest.php
 
 		-
 			message: '#^Method Gedmo\\Tests\\Sluggable\\Fixture\\Doctrine\\FakeFilter\:\:addFilterConstraint\(\) has parameter \$targetTableAlias with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: tests/Gedmo/Sluggable/Fixture/Doctrine/FakeFilter.php
-
-		-
-			message: '#^Instantiated class Doctrine\\ORM\\Mapping\\Driver\\YamlDriver not found\.$#'
-			identifier: class.notFound
-			count: 1
-			path: tests/Gedmo/Sluggable/Issue/Issue116Test.php
-
-		-
-			message: '#^Parameter \#1 \$nestedDriver of method Doctrine\\Persistence\\Mapping\\Driver\\MappingDriverChain\:\:addDriver\(\) expects Doctrine\\Persistence\\Mapping\\Driver\\MappingDriver, Doctrine\\ORM\\Mapping\\Driver\\YamlDriver given\.$#'
-			identifier: argument.type
-			count: 1
-			path: tests/Gedmo/Sluggable/Issue/Issue116Test.php
 
 		-
 			message: '#^Parameter \$args of method Gedmo\\Tests\\SoftDeleteable\\Fixture\\Listener\\WithLifecycleEventArgsFromORMTypeListener\:\:postSoftDelete\(\) has invalid type Doctrine\\ORM\\Event\\LifecycleEventArgs\.$#'
@@ -1243,40 +1069,10 @@ parameters:
 			path: tests/Gedmo/SoftDeleteable/Fixture/Listener/WithLifecycleEventArgsFromORMTypeListener.php
 
 		-
-			message: '#^Method Gedmo\\Tests\\Timestampable\\Fixture\\ArticleCarbon\:\:getCreated\(\) should return Carbon\\Carbon\|null but returns DateTime\|null\.$#'
-			identifier: return.type
-			count: 1
-			path: tests/Gedmo/Timestampable/Fixture/ArticleCarbon.php
-
-		-
 			message: '#^Call to function method_exists\(\) with Doctrine\\ORM\\EntityManager\|null and ''merge'' will always evaluate to false\.$#'
 			identifier: function.impossibleType
 			count: 2
 			path: tests/Gedmo/Timestampable/TimestampableTest.php
-
-		-
-			message: '#^Instantiated class Doctrine\\ORM\\Mapping\\Driver\\AnnotationDriver not found\.$#'
-			identifier: class.notFound
-			count: 1
-			path: tests/Gedmo/Tool/BaseTestCaseOM.php
-
-		-
-			message: '#^Method Gedmo\\Tests\\Tool\\BaseTestCaseOM\:\:getORMDriver\(\) should return Doctrine\\Persistence\\Mapping\\Driver\\MappingDriver but returns Doctrine\\ORM\\Mapping\\Driver\\AnnotationDriver\.$#'
-			identifier: return.type
-			count: 1
-			path: tests/Gedmo/Tool/BaseTestCaseOM.php
-
-		-
-			message: '#^Instantiated class Doctrine\\ORM\\Mapping\\Driver\\AnnotationDriver not found\.$#'
-			identifier: class.notFound
-			count: 1
-			path: tests/Gedmo/Tool/BaseTestCaseORM.php
-
-		-
-			message: '#^Method Gedmo\\Tests\\Tool\\BaseTestCaseORM\:\:getMetadataDriverImplementation\(\) should return Doctrine\\Persistence\\Mapping\\Driver\\MappingDriver but returns Doctrine\\ORM\\Mapping\\Driver\\AnnotationDriver\.$#'
-			identifier: return.type
-			count: 1
-			path: tests/Gedmo/Tool/BaseTestCaseORM.php
 
 		-
 			message: '#^Property Gedmo\\Tests\\Tree\\MaterializedPathODMMongoDBRepositoryTest\:\:\$repo \(Gedmo\\Tree\\Document\\MongoDB\\Repository\\MaterializedPathRepository\<Gedmo\\Tests\\Tree\\Fixture\\Document\\Category\>\) does not accept Doctrine\\ORM\\EntityRepository\<Gedmo\\Tests\\Tree\\Fixture\\Document\\Category\>\.$#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -17,6 +17,7 @@ parameters:
         - '#^Property Gedmo\\Tests\\.+\\Fixture\\[^:]+::\$\w+ is never written, only read\.$#'
         - '#^Property Gedmo\\Tests\\.+\\Fixture\\[^:]+::\$\w+ is never read, only written\.$#'
         - '#^Property Gedmo\\Tests\\.+\\Fixture\\[^:]+::\$\w+ is unused\.$#'
+        - '#^Property Gedmo\\Tests\\.+\\Fixture\\[^:]+::\$\w+ (.*) is never assigned (.*) so it can be removed from the property type\.$#'
         - '#^Method Gedmo\\(?:[^\\]+\\)*Mapping\\Driver[^:]+::readExtendedMetadata\(\) with return type void returns [\w\|<>\s,]+ but should not return anything\.$#'
         - '#^Result of method Gedmo\\Mapping\\Driver::readExtendedMetadata\(\) \(void\) is used\.$#'
     excludePaths:

--- a/rector.php
+++ b/rector.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
  */
 
 use Rector\Config\RectorConfig;
+use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
+use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
 use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector;
 use Rector\ValueObject\PhpVersion;
 
@@ -19,12 +21,17 @@ return RectorConfig::configure()
         __DIR__.'/tests',
         __DIR__.'/example',
     ])
-    ->withPhpVersion(PhpVersion::PHP_74)
+    ->withPhpVersion(PhpVersion::PHP_81)
     ->withPhpSets()
     ->withConfiguredRule(TypedPropertyFromAssignsRector::class, [])
     ->withSkip([
+        ReadOnlyPropertyRector::class => [
+            __DIR__.'/tests', // A lot of test fixtures have properties that aren't mutated, don't let Rector try to make them readonly though
+        ],
+        ClassPropertyAssignToConstructorPromotionRector::class => [
+            __DIR__.'/tests/Gedmo/Wrapper/Fixture/Entity/CompositeRelation.php', // @todo: Remove this when https://github.com/doctrine/orm/issues/8255 is solved
+        ],
         TypedPropertyFromAssignsRector::class => [
-            __DIR__.'/src/Mapping/MappedEventSubscriber.php', // Rector is trying to set a type on the $annotationReader property which requires a union type, not supported on PHP 7.4
             __DIR__.'/tests/Gedmo/Blameable/Fixture/Entity/Company.php', // @todo: Remove this when fixing the configuration for the `Company::$created` property
             __DIR__.'/tests/Gedmo/Wrapper/Fixture/Entity/CompositeRelation.php', // @todo: Remove this when https://github.com/doctrine/orm/issues/8255 is solved
         ],

--- a/src/AbstractTrackingListener.php
+++ b/src/AbstractTrackingListener.php
@@ -82,7 +82,7 @@ abstract class AbstractTrackingListener extends MappedEventSubscriber
         // check all scheduled updates
         $all = array_merge($ea->getScheduledObjectInsertions($uow), $ea->getScheduledObjectUpdates($uow));
         foreach ($all as $object) {
-            $meta = $om->getClassMetadata(get_class($object));
+            $meta = $om->getClassMetadata($object::class);
             if (!$config = $this->getConfiguration($om, $meta->getName())) {
                 continue;
             }
@@ -129,7 +129,7 @@ abstract class AbstractTrackingListener extends MappedEventSubscriber
                     foreach ($trackedFields as $trackedField) {
                         $trackedChild = null;
                         $tracked = null;
-                        $parts = explode('.', $trackedField);
+                        $parts = explode('.', (string) $trackedField);
                         if (isset($parts[1])) {
                             $tracked = $parts[0];
                             $trackedChild = $parts[1];
@@ -147,7 +147,7 @@ abstract class AbstractTrackingListener extends MappedEventSubscriber
                                 if (!is_object($changingObject)) {
                                     throw new UnexpectedValueException("Field - [{$tracked}] is expected to be object in class - {$meta->getName()}");
                                 }
-                                $objectMeta = $om->getClassMetadata(get_class($changingObject));
+                                $objectMeta = $om->getClassMetadata($changingObject::class);
                                 $om->initializeObject($changingObject);
                                 $value = $objectMeta->getFieldValue($changingObject, $trackedChild);
                             } else {
@@ -185,7 +185,7 @@ abstract class AbstractTrackingListener extends MappedEventSubscriber
         $ea = $this->getEventAdapter($args);
         $om = $ea->getObjectManager();
         $object = $ea->getObject();
-        $meta = $om->getClassMetadata(get_class($object));
+        $meta = $om->getClassMetadata($object::class);
         if ($config = $this->getConfiguration($om, $meta->getName())) {
             if (isset($config['update'])) {
                 foreach ($config['update'] as $field) {

--- a/src/Blameable/Mapping/Driver/Annotation.php
+++ b/src/Blameable/Mapping/Driver/Annotation.php
@@ -18,6 +18,4 @@ use Gedmo\Mapping\Driver\AnnotationDriverInterface;
  *
  * @internal
  */
-class Annotation extends Attribute implements AnnotationDriverInterface
-{
-}
+class Annotation extends Attribute implements AnnotationDriverInterface {}

--- a/src/Blameable/Mapping/Event/Adapter/ODM.php
+++ b/src/Blameable/Mapping/Event/Adapter/ODM.php
@@ -18,6 +18,4 @@ use Gedmo\Mapping\Event\Adapter\ODM as BaseAdapterODM;
  *
  * @author David Buchmann <mail@davidbu.ch>
  */
-final class ODM extends BaseAdapterODM implements BlameableAdapter
-{
-}
+final class ODM extends BaseAdapterODM implements BlameableAdapter {}

--- a/src/Blameable/Mapping/Event/Adapter/ORM.php
+++ b/src/Blameable/Mapping/Event/Adapter/ORM.php
@@ -18,6 +18,4 @@ use Gedmo\Mapping\Event\Adapter\ORM as BaseAdapterORM;
  *
  * @author David Buchmann <mail@davidbu.ch>
  */
-final class ORM extends BaseAdapterORM implements BlameableAdapter
-{
-}
+final class ORM extends BaseAdapterORM implements BlameableAdapter {}

--- a/src/Blameable/Mapping/Event/BlameableAdapter.php
+++ b/src/Blameable/Mapping/Event/BlameableAdapter.php
@@ -16,6 +16,4 @@ use Gedmo\Mapping\Event\AdapterInterface;
  *
  * @author David Buchmann <mail@davidbu.ch>
  */
-interface BlameableAdapter extends AdapterInterface
-{
-}
+interface BlameableAdapter extends AdapterInterface {}

--- a/src/DoctrineExtensions.php
+++ b/src/DoctrineExtensions.php
@@ -9,15 +9,11 @@
 
 namespace Gedmo;
 
-use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\Common\Annotations\PsrCachedReader;
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\Deprecations\Deprecation;
 use Doctrine\ODM\MongoDB\Mapping\Driver as DriverMongodbODM;
 use Doctrine\ORM\Mapping\Driver as DriverORM;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
-use Gedmo\Exception\RuntimeException;
-use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 /**
  * Version class allows checking the required dependencies
@@ -44,11 +40,7 @@ final class DoctrineExtensions
             __DIR__.'/Tree/Entity',
         ];
 
-        if (\PHP_VERSION_ID >= 80000) {
-            $driver = new DriverORM\AttributeDriver($paths);
-        } else {
-            $driver = new DriverORM\AnnotationDriver($reader ?? self::createAnnotationReader(), $paths);
-        }
+        $driver = new DriverORM\AttributeDriver($paths);
 
         $driverChain->addDriver($driver, 'Gedmo');
     }
@@ -65,11 +57,7 @@ final class DoctrineExtensions
             __DIR__.'/Tree/Entity/MappedSuperclass',
         ];
 
-        if (\PHP_VERSION_ID >= 80000) {
-            $driver = new DriverORM\AttributeDriver($paths);
-        } else {
-            $driver = new DriverORM\AnnotationDriver($reader ?? self::createAnnotationReader(), $paths);
-        }
+        $driver = new DriverORM\AttributeDriver($paths);
 
         $driverChain->addDriver($driver, 'Gedmo');
     }
@@ -85,11 +73,7 @@ final class DoctrineExtensions
             __DIR__.'/Loggable/Document',
         ];
 
-        if (\PHP_VERSION_ID >= 80000) {
-            $driver = new DriverMongodbODM\AttributeDriver($paths);
-        } else {
-            $driver = new DriverMongodbODM\AnnotationDriver($reader ?? self::createAnnotationReader(), $paths);
-        }
+        $driver = new DriverMongodbODM\AttributeDriver($paths);
 
         $driverChain->addDriver($driver, 'Gedmo');
     }
@@ -105,11 +89,7 @@ final class DoctrineExtensions
             __DIR__.'/Loggable/Document/MappedSuperclass',
         ];
 
-        if (\PHP_VERSION_ID >= 80000) {
-            $driver = new DriverMongodbODM\AttributeDriver($paths);
-        } else {
-            $driver = new DriverMongodbODM\AnnotationDriver($reader ?? self::createAnnotationReader(), $paths);
-        }
+        $driver = new DriverMongodbODM\AttributeDriver($paths);
 
         $driverChain->addDriver($driver, 'Gedmo');
     }
@@ -129,17 +109,5 @@ final class DoctrineExtensions
         );
 
         // Purposefully no-op'd, all supported versions of `doctrine/annotations` support autoloading
-    }
-
-    /**
-     * @throws RuntimeException if running PHP 7 and the `doctrine/annotations` package is not installed
-     */
-    private static function createAnnotationReader(): PsrCachedReader
-    {
-        if (!class_exists(AnnotationReader::class)) {
-            throw new RuntimeException(sprintf('The "%1$s" class requires the "doctrine/annotations" package to use annotations but it is not available. Try running "composer require doctrine/annotations" or upgrade to PHP 8 to use attributes.', self::class));
-        }
-
-        return new PsrCachedReader(new AnnotationReader(), new ArrayAdapter());
     }
 }

--- a/src/Exception/BadMethodCallException.php
+++ b/src/Exception/BadMethodCallException.php
@@ -18,6 +18,4 @@ use Gedmo\Exception;
  *
  * @final since gedmo/doctrine-extensions 3.11
  */
-class BadMethodCallException extends \BadMethodCallException implements Exception
-{
-}
+class BadMethodCallException extends \BadMethodCallException implements Exception {}

--- a/src/Exception/FeatureNotImplementedException.php
+++ b/src/Exception/FeatureNotImplementedException.php
@@ -19,6 +19,4 @@ use Gedmo\Exception;
  *
  * @final since gedmo/doctrine-extensions 3.11
  */
-class FeatureNotImplementedException extends \RuntimeException implements Exception
-{
-}
+class FeatureNotImplementedException extends \RuntimeException implements Exception {}

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -16,6 +16,4 @@ use Gedmo\Exception;
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
-class InvalidArgumentException extends \InvalidArgumentException implements Exception
-{
-}
+class InvalidArgumentException extends \InvalidArgumentException implements Exception {}

--- a/src/Exception/InvalidMappingException.php
+++ b/src/Exception/InvalidMappingException.php
@@ -21,6 +21,4 @@ use Gedmo\Exception;
  *
  * @final since gedmo/doctrine-extensions 3.11
  */
-class InvalidMappingException extends InvalidArgumentException implements Exception
-{
-}
+class InvalidMappingException extends InvalidArgumentException implements Exception {}

--- a/src/Exception/ReferenceIntegrityStrictException.php
+++ b/src/Exception/ReferenceIntegrityStrictException.php
@@ -16,6 +16,4 @@ namespace Gedmo\Exception;
  *
  * @final since gedmo/doctrine-extensions 3.11
  */
-class ReferenceIntegrityStrictException extends RuntimeException
-{
-}
+class ReferenceIntegrityStrictException extends RuntimeException {}

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -16,6 +16,4 @@ use Gedmo\Exception;
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
-class RuntimeException extends \RuntimeException implements Exception
-{
-}
+class RuntimeException extends \RuntimeException implements Exception {}

--- a/src/Exception/TreeLockingException.php
+++ b/src/Exception/TreeLockingException.php
@@ -17,6 +17,4 @@ namespace Gedmo\Exception;
  *
  * @final since gedmo/doctrine-extensions 3.11
  */
-class TreeLockingException extends RuntimeException
-{
-}
+class TreeLockingException extends RuntimeException {}

--- a/src/Exception/UnexpectedValueException.php
+++ b/src/Exception/UnexpectedValueException.php
@@ -18,6 +18,4 @@ use Gedmo\Exception;
  *
  * @final since gedmo/doctrine-extensions 3.11
  */
-class UnexpectedValueException extends \UnexpectedValueException implements Exception
-{
-}
+class UnexpectedValueException extends \UnexpectedValueException implements Exception {}

--- a/src/Exception/UnsupportedObjectManagerException.php
+++ b/src/Exception/UnsupportedObjectManagerException.php
@@ -18,6 +18,4 @@ use Gedmo\Exception;
  *
  * @final since gedmo/doctrine-extensions 3.11
  */
-class UnsupportedObjectManagerException extends InvalidArgumentException implements Exception
-{
-}
+class UnsupportedObjectManagerException extends InvalidArgumentException implements Exception {}

--- a/src/Exception/UploadableCantWriteException.php
+++ b/src/Exception/UploadableCantWriteException.php
@@ -19,6 +19,4 @@ use Gedmo\Exception;
  *
  * @final since gedmo/doctrine-extensions 3.11
  */
-class UploadableCantWriteException extends UploadableException implements Exception
-{
-}
+class UploadableCantWriteException extends UploadableException implements Exception {}

--- a/src/Exception/UploadableCouldntGuessMimeTypeException.php
+++ b/src/Exception/UploadableCouldntGuessMimeTypeException.php
@@ -19,6 +19,4 @@ use Gedmo\Exception;
  *
  * @final since gedmo/doctrine-extensions 3.11
  */
-class UploadableCouldntGuessMimeTypeException extends UploadableException implements Exception
-{
-}
+class UploadableCouldntGuessMimeTypeException extends UploadableException implements Exception {}

--- a/src/Exception/UploadableDirectoryNotFoundException.php
+++ b/src/Exception/UploadableDirectoryNotFoundException.php
@@ -19,6 +19,4 @@ use Gedmo\Exception;
  *
  * @final since gedmo/doctrine-extensions 3.11
  */
-class UploadableDirectoryNotFoundException extends UploadableException implements Exception
-{
-}
+class UploadableDirectoryNotFoundException extends UploadableException implements Exception {}

--- a/src/Exception/UploadableException.php
+++ b/src/Exception/UploadableException.php
@@ -17,6 +17,4 @@ use Gedmo\Exception;
  * @author Gustavo Falco <comfortablynumb84@gmail.com>
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
-class UploadableException extends RuntimeException implements Exception
-{
-}
+class UploadableException extends RuntimeException implements Exception {}

--- a/src/Exception/UploadableExtensionException.php
+++ b/src/Exception/UploadableExtensionException.php
@@ -19,6 +19,4 @@ use Gedmo\Exception;
  *
  * @final since gedmo/doctrine-extensions 3.11
  */
-class UploadableExtensionException extends UploadableException implements Exception
-{
-}
+class UploadableExtensionException extends UploadableException implements Exception {}

--- a/src/Exception/UploadableFileAlreadyExistsException.php
+++ b/src/Exception/UploadableFileAlreadyExistsException.php
@@ -19,6 +19,4 @@ use Gedmo\Exception;
  *
  * @final since gedmo/doctrine-extensions 3.11
  */
-class UploadableFileAlreadyExistsException extends UploadableException implements Exception
-{
-}
+class UploadableFileAlreadyExistsException extends UploadableException implements Exception {}

--- a/src/Exception/UploadableFileNotReadableException.php
+++ b/src/Exception/UploadableFileNotReadableException.php
@@ -19,6 +19,4 @@ use Gedmo\Exception;
  *
  * @final since gedmo/doctrine-extensions 3.11
  */
-class UploadableFileNotReadableException extends UploadableException implements Exception
-{
-}
+class UploadableFileNotReadableException extends UploadableException implements Exception {}

--- a/src/Exception/UploadableFormSizeException.php
+++ b/src/Exception/UploadableFormSizeException.php
@@ -19,6 +19,4 @@ use Gedmo\Exception;
  *
  * @final since gedmo/doctrine-extensions 3.11
  */
-class UploadableFormSizeException extends UploadableException implements Exception
-{
-}
+class UploadableFormSizeException extends UploadableException implements Exception {}

--- a/src/Exception/UploadableIniSizeException.php
+++ b/src/Exception/UploadableIniSizeException.php
@@ -19,6 +19,4 @@ use Gedmo\Exception;
  *
  * @final since gedmo/doctrine-extensions 3.11
  */
-class UploadableIniSizeException extends UploadableException implements Exception
-{
-}
+class UploadableIniSizeException extends UploadableException implements Exception {}

--- a/src/Exception/UploadableInvalidFileException.php
+++ b/src/Exception/UploadableInvalidFileException.php
@@ -19,6 +19,4 @@ use Gedmo\Exception;
  *
  * @final since gedmo/doctrine-extensions 3.11
  */
-class UploadableInvalidFileException extends UploadableException implements Exception
-{
-}
+class UploadableInvalidFileException extends UploadableException implements Exception {}

--- a/src/Exception/UploadableInvalidMimeTypeException.php
+++ b/src/Exception/UploadableInvalidMimeTypeException.php
@@ -19,6 +19,4 @@ use Gedmo\Exception;
  *
  * @final since gedmo/doctrine-extensions 3.11
  */
-class UploadableInvalidMimeTypeException extends UploadableException implements Exception
-{
-}
+class UploadableInvalidMimeTypeException extends UploadableException implements Exception {}

--- a/src/Exception/UploadableInvalidPathException.php
+++ b/src/Exception/UploadableInvalidPathException.php
@@ -19,6 +19,4 @@ use Gedmo\Exception;
  *
  * @final since gedmo/doctrine-extensions 3.11
  */
-class UploadableInvalidPathException extends UploadableException implements Exception
-{
-}
+class UploadableInvalidPathException extends UploadableException implements Exception {}

--- a/src/Exception/UploadableMaxSizeException.php
+++ b/src/Exception/UploadableMaxSizeException.php
@@ -19,6 +19,4 @@ use Gedmo\Exception;
  *
  * @final since gedmo/doctrine-extensions 3.11
  */
-class UploadableMaxSizeException extends UploadableException implements Exception
-{
-}
+class UploadableMaxSizeException extends UploadableException implements Exception {}

--- a/src/Exception/UploadableNoFileException.php
+++ b/src/Exception/UploadableNoFileException.php
@@ -19,6 +19,4 @@ use Gedmo\Exception;
  *
  * @final since gedmo/doctrine-extensions 3.11
  */
-class UploadableNoFileException extends UploadableException implements Exception
-{
-}
+class UploadableNoFileException extends UploadableException implements Exception {}

--- a/src/Exception/UploadableNoPathDefinedException.php
+++ b/src/Exception/UploadableNoPathDefinedException.php
@@ -19,6 +19,4 @@ use Gedmo\Exception;
  *
  * @final since gedmo/doctrine-extensions 3.11
  */
-class UploadableNoPathDefinedException extends UploadableException implements Exception
-{
-}
+class UploadableNoPathDefinedException extends UploadableException implements Exception {}

--- a/src/Exception/UploadableNoTmpDirException.php
+++ b/src/Exception/UploadableNoTmpDirException.php
@@ -19,6 +19,4 @@ use Gedmo\Exception;
  *
  * @final since gedmo/doctrine-extensions 3.11
  */
-class UploadableNoTmpDirException extends UploadableException implements Exception
-{
-}
+class UploadableNoTmpDirException extends UploadableException implements Exception {}

--- a/src/Exception/UploadablePartialException.php
+++ b/src/Exception/UploadablePartialException.php
@@ -19,6 +19,4 @@ use Gedmo\Exception;
  *
  * @final since gedmo/doctrine-extensions 3.11
  */
-class UploadablePartialException extends UploadableException implements Exception
-{
-}
+class UploadablePartialException extends UploadableException implements Exception {}

--- a/src/Exception/UploadableUploadException.php
+++ b/src/Exception/UploadableUploadException.php
@@ -19,6 +19,4 @@ use Gedmo\Exception;
  *
  * @final since gedmo/doctrine-extensions 3.11
  */
-class UploadableUploadException extends UploadableException implements Exception
-{
-}
+class UploadableUploadException extends UploadableException implements Exception {}

--- a/src/IpTraceable/Mapping/Driver/Annotation.php
+++ b/src/IpTraceable/Mapping/Driver/Annotation.php
@@ -18,6 +18,4 @@ use Gedmo\Mapping\Driver\AnnotationDriverInterface;
  *
  * @internal
  */
-class Annotation extends Attribute implements AnnotationDriverInterface
-{
-}
+class Annotation extends Attribute implements AnnotationDriverInterface {}

--- a/src/IpTraceable/Mapping/Event/Adapter/ODM.php
+++ b/src/IpTraceable/Mapping/Event/Adapter/ODM.php
@@ -18,6 +18,4 @@ use Gedmo\Mapping\Event\Adapter\ODM as BaseAdapterODM;
  *
  * @author Pierre-Charles Bertineau <pc.bertineau@alterphp.com>
  */
-final class ODM extends BaseAdapterODM implements IpTraceableAdapter
-{
-}
+final class ODM extends BaseAdapterODM implements IpTraceableAdapter {}

--- a/src/IpTraceable/Mapping/Event/Adapter/ORM.php
+++ b/src/IpTraceable/Mapping/Event/Adapter/ORM.php
@@ -18,6 +18,4 @@ use Gedmo\Mapping\Event\Adapter\ORM as BaseAdapterORM;
  *
  * @author Pierre-Charles Bertineau <pc.bertineau@alterphp.com>
  */
-final class ORM extends BaseAdapterORM implements IpTraceableAdapter
-{
-}
+final class ORM extends BaseAdapterORM implements IpTraceableAdapter {}

--- a/src/IpTraceable/Mapping/Event/IpTraceableAdapter.php
+++ b/src/IpTraceable/Mapping/Event/IpTraceableAdapter.php
@@ -16,6 +16,4 @@ use Gedmo\Mapping\Event\AdapterInterface;
  *
  * @author Pierre-Charles Bertineau <pc.bertineau@alterphp.com>
  */
-interface IpTraceableAdapter extends AdapterInterface
-{
-}
+interface IpTraceableAdapter extends AdapterInterface {}

--- a/src/Loggable/LoggableListener.php
+++ b/src/Loggable/LoggableListener.php
@@ -170,7 +170,7 @@ class LoggableListener extends MappedEventSubscriber
             $wrapped = AbstractWrapper::wrap($object, $om);
 
             $logEntry = $this->pendingLogEntryInserts[$oid];
-            $logEntryMeta = $om->getClassMetadata(get_class($logEntry));
+            $logEntryMeta = $om->getClassMetadata($logEntry::class);
 
             $id = $wrapped->getIdentifier(false, true);
             $logEntryMeta->setFieldValue($logEntry, 'objectId', $id);
@@ -185,7 +185,7 @@ class LoggableListener extends MappedEventSubscriber
             $identifiers = $wrapped->getIdentifier(false);
             foreach ($this->pendingRelatedObjects[$oid] as $props) {
                 $logEntry = $props['log'];
-                $logEntryMeta = $om->getClassMetadata(get_class($logEntry));
+                $logEntryMeta = $om->getClassMetadata($logEntry::class);
                 $oldData = $data = $logEntry->getData();
                 $data[$props['field']] = $identifiers;
 
@@ -272,7 +272,7 @@ class LoggableListener extends MappedEventSubscriber
                 return $actor->__toString();
             }
 
-            throw new UnexpectedValueException(\sprintf('The loggable extension requires the actor provider to return a string or an object implementing the "getUserIdentifier()", "getUsername()", or "__toString()" methods. "%s" cannot be used as an actor.', get_class($actor)));
+            throw new UnexpectedValueException(\sprintf('The loggable extension requires the actor provider to return a string or an object implementing the "getUserIdentifier()", "getUsername()", or "__toString()" methods. "%s" cannot be used as an actor.', $actor::class));
         }
 
         return $this->username;
@@ -290,9 +290,7 @@ class LoggableListener extends MappedEventSubscriber
      *
      * @return void
      */
-    protected function prePersistLogEntry($logEntry, $object)
-    {
-    }
+    protected function prePersistLogEntry($logEntry, $object) {}
 
     protected function getNamespace()
     {

--- a/src/Loggable/Mapping/Driver/Annotation.php
+++ b/src/Loggable/Mapping/Driver/Annotation.php
@@ -18,6 +18,4 @@ use Gedmo\Mapping\Driver\AnnotationDriverInterface;
  *
  * @internal
  */
-class Annotation extends Attribute implements AnnotationDriverInterface
-{
-}
+class Annotation extends Attribute implements AnnotationDriverInterface {}

--- a/src/Loggable/Mapping/Event/Adapter/ODM.php
+++ b/src/Loggable/Mapping/Event/Adapter/ODM.php
@@ -41,7 +41,7 @@ final class ODM extends BaseAdapterODM implements LoggableAdapter
     public function getNewVersion($meta, $object)
     {
         $dm = $this->getObjectManager();
-        $objectMeta = $dm->getClassMetadata(get_class($object));
+        $objectMeta = $dm->getClassMetadata($object::class);
         $identifierField = $this->getSingleIdentifierFieldName($objectMeta);
         $objectId = $objectMeta->getFieldValue($object, $identifierField);
 

--- a/src/Loggable/Mapping/Event/Adapter/ORM.php
+++ b/src/Loggable/Mapping/Event/Adapter/ORM.php
@@ -42,7 +42,7 @@ final class ORM extends BaseAdapterORM implements LoggableAdapter
     public function getNewVersion($meta, $object)
     {
         $em = $this->getObjectManager();
-        $objectMeta = $em->getClassMetadata(get_class($object));
+        $objectMeta = $em->getClassMetadata($object::class);
         $wrapper = new EntityWrapper($object, $em);
         $objectId = $wrapper->getIdentifier(false, true);
 

--- a/src/Mapping/Annotation/Annotation.php
+++ b/src/Mapping/Annotation/Annotation.php
@@ -14,6 +14,4 @@ namespace Gedmo\Mapping\Annotation;
 /**
  * @internal
  */
-interface Annotation
-{
-}
+interface Annotation {}

--- a/src/Mapping/Annotation/ForwardCompatibilityTrait.php
+++ b/src/Mapping/Annotation/ForwardCompatibilityTrait.php
@@ -21,11 +21,8 @@ trait ForwardCompatibilityTrait
     /**
      * @param array<string, mixed> $data
      * @param array<int, mixed>    $args
-     * @param mixed                $value
-     *
-     * @return mixed
      */
-    private function getAttributeValue(array $data, string $attributeName, array $args, int $argumentNum, $value)
+    private function getAttributeValue(array $data, string $attributeName, array $args, int $argumentNum, mixed $value): mixed
     {
         if (array_key_exists($argumentNum, $args)) {
             return $args[$argumentNum];

--- a/src/Mapping/Annotation/Language.php
+++ b/src/Mapping/Annotation/Language.php
@@ -22,6 +22,4 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
-final class Language implements GedmoAnnotation
-{
-}
+final class Language implements GedmoAnnotation {}

--- a/src/Mapping/Annotation/Locale.php
+++ b/src/Mapping/Annotation/Locale.php
@@ -22,6 +22,4 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
-final class Locale implements GedmoAnnotation
-{
-}
+final class Locale implements GedmoAnnotation {}

--- a/src/Mapping/Annotation/ReferenceMany.php
+++ b/src/Mapping/Annotation/ReferenceMany.php
@@ -22,6 +22,4 @@ namespace Gedmo\Mapping\Annotation;
  * @final since gedmo/doctrine-extensions 3.11
  */
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
-class ReferenceMany extends Reference
-{
-}
+class ReferenceMany extends Reference {}

--- a/src/Mapping/Annotation/ReferenceManyEmbed.php
+++ b/src/Mapping/Annotation/ReferenceManyEmbed.php
@@ -17,6 +17,4 @@ namespace Gedmo\Mapping\Annotation;
  * @final since gedmo/doctrine-extensions 3.11
  */
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
-class ReferenceManyEmbed extends Reference
-{
-}
+class ReferenceManyEmbed extends Reference {}

--- a/src/Mapping/Annotation/ReferenceOne.php
+++ b/src/Mapping/Annotation/ReferenceOne.php
@@ -22,6 +22,4 @@ namespace Gedmo\Mapping\Annotation;
  * @final since gedmo/doctrine-extensions 3.11
  */
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
-class ReferenceOne extends Reference
-{
-}
+class ReferenceOne extends Reference {}

--- a/src/Mapping/Annotation/SortableGroup.php
+++ b/src/Mapping/Annotation/SortableGroup.php
@@ -22,6 +22,4 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * @Target("PROPERTY")
  */
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
-final class SortableGroup implements GedmoAnnotation
-{
-}
+final class SortableGroup implements GedmoAnnotation {}

--- a/src/Mapping/Annotation/SortablePosition.php
+++ b/src/Mapping/Annotation/SortablePosition.php
@@ -22,6 +22,4 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * @Target("PROPERTY")
  */
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
-final class SortablePosition implements GedmoAnnotation
-{
-}
+final class SortablePosition implements GedmoAnnotation {}

--- a/src/Mapping/Annotation/TreeLeft.php
+++ b/src/Mapping/Annotation/TreeLeft.php
@@ -22,6 +22,4 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
-final class TreeLeft implements GedmoAnnotation
-{
-}
+final class TreeLeft implements GedmoAnnotation {}

--- a/src/Mapping/Annotation/TreeLockTime.php
+++ b/src/Mapping/Annotation/TreeLockTime.php
@@ -23,6 +23,4 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
-final class TreeLockTime implements GedmoAnnotation
-{
-}
+final class TreeLockTime implements GedmoAnnotation {}

--- a/src/Mapping/Annotation/TreeParent.php
+++ b/src/Mapping/Annotation/TreeParent.php
@@ -22,6 +22,4 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
-final class TreeParent implements GedmoAnnotation
-{
-}
+final class TreeParent implements GedmoAnnotation {}

--- a/src/Mapping/Annotation/TreePathHash.php
+++ b/src/Mapping/Annotation/TreePathHash.php
@@ -22,6 +22,4 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * @author <rocco@roccosportal.com>
  */
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
-final class TreePathHash implements GedmoAnnotation
-{
-}
+final class TreePathHash implements GedmoAnnotation {}

--- a/src/Mapping/Annotation/TreePathSource.php
+++ b/src/Mapping/Annotation/TreePathSource.php
@@ -23,6 +23,4 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
-final class TreePathSource implements GedmoAnnotation
-{
-}
+final class TreePathSource implements GedmoAnnotation {}

--- a/src/Mapping/Annotation/TreeRight.php
+++ b/src/Mapping/Annotation/TreeRight.php
@@ -22,6 +22,4 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
-final class TreeRight implements GedmoAnnotation
-{
-}
+final class TreeRight implements GedmoAnnotation {}

--- a/src/Mapping/Annotation/UploadableFileMimeType.php
+++ b/src/Mapping/Annotation/UploadableFileMimeType.php
@@ -23,6 +23,4 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
-final class UploadableFileMimeType implements GedmoAnnotation
-{
-}
+final class UploadableFileMimeType implements GedmoAnnotation {}

--- a/src/Mapping/Annotation/UploadableFileName.php
+++ b/src/Mapping/Annotation/UploadableFileName.php
@@ -22,6 +22,4 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * @author tiger-seo <tiger.seo@gmail.com>
  */
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
-final class UploadableFileName implements GedmoAnnotation
-{
-}
+final class UploadableFileName implements GedmoAnnotation {}

--- a/src/Mapping/Annotation/UploadableFilePath.php
+++ b/src/Mapping/Annotation/UploadableFilePath.php
@@ -23,6 +23,4 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
-final class UploadableFilePath implements GedmoAnnotation
-{
-}
+final class UploadableFilePath implements GedmoAnnotation {}

--- a/src/Mapping/Annotation/UploadableFileSize.php
+++ b/src/Mapping/Annotation/UploadableFileSize.php
@@ -23,6 +23,4 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
-final class UploadableFileSize implements GedmoAnnotation
-{
-}
+final class UploadableFileSize implements GedmoAnnotation {}

--- a/src/Mapping/Annotation/Versioned.php
+++ b/src/Mapping/Annotation/Versioned.php
@@ -24,6 +24,4 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
-final class Versioned implements GedmoAnnotation
-{
-}
+final class Versioned implements GedmoAnnotation {}

--- a/src/Mapping/Driver/AbstractAnnotationDriver.php
+++ b/src/Mapping/Driver/AbstractAnnotationDriver.php
@@ -114,9 +114,7 @@ abstract class AbstractAnnotationDriver implements AttributeDriverInterface
      *
      * @return void
      */
-    public function validateFullMetadata(ClassMetadata $meta, array $config)
-    {
-    }
+    public function validateFullMetadata(ClassMetadata $meta, array $config) {}
 
     /**
      * Checks if $field type is valid

--- a/src/Mapping/Driver/AnnotationDriverInterface.php
+++ b/src/Mapping/Driver/AnnotationDriverInterface.php
@@ -17,6 +17,4 @@ namespace Gedmo\Mapping\Driver;
  *
  * @deprecated since gedmo/doctrine-extensions 3.16, will be removed in version 4.0.
  */
-interface AnnotationDriverInterface extends AttributeDriverInterface
-{
-}
+interface AnnotationDriverInterface extends AttributeDriverInterface {}

--- a/src/Mapping/Driver/AttributeAnnotationReader.php
+++ b/src/Mapping/Driver/AttributeAnnotationReader.php
@@ -23,15 +23,10 @@ use Gedmo\Mapping\Annotation\Annotation;
  */
 final class AttributeAnnotationReader implements Reader
 {
-    private Reader $annotationReader;
-
-    private AttributeReader $attributeReader;
-
-    public function __construct(AttributeReader $attributeReader, Reader $annotationReader)
-    {
-        $this->attributeReader = $attributeReader;
-        $this->annotationReader = $annotationReader;
-    }
+    public function __construct(
+        private readonly AttributeReader $attributeReader,
+        private readonly Reader $annotationReader,
+    ) {}
 
     /**
      * @phpstan-param \ReflectionClass<object> $class

--- a/src/Mapping/Driver/Chain.php
+++ b/src/Mapping/Driver/Chain.php
@@ -78,7 +78,7 @@ class Chain implements Driver
     public function readExtendedMetadata($meta, array &$config)
     {
         foreach ($this->_drivers as $namespace => $driver) {
-            if (0 === strpos($meta->getName(), $namespace)) {
+            if (str_starts_with($meta->getName(), $namespace)) {
                 $extendedMetadata = $driver->readExtendedMetadata($meta, $config);
 
                 if (\is_array($extendedMetadata)) {

--- a/src/Mapping/Event/Adapter/ORM.php
+++ b/src/Mapping/Event/Adapter/ORM.php
@@ -105,7 +105,7 @@ class ORM implements AdapterInterface
             'Calling "%s()" on event args of class "%s" that does not implement "getObjectManager()" is deprecated since gedmo/doctrine-extensions 3.14'
             .' and will throw a "%s" error in version 4.0.',
             __METHOD__,
-            get_class($this->args),
+            $this->args::class,
             \Error::class
         );
 
@@ -131,7 +131,7 @@ class ORM implements AdapterInterface
             'Calling "%s()" on event args of class "%s" that does not imeplement "getObject()" is deprecated since gedmo/doctrine-extensions 3.14'
             .' and will throw a "%s" error in version 4.0.',
             __METHOD__,
-            get_class($this->args),
+            $this->args::class,
             \Error::class
         );
 

--- a/src/ReferenceIntegrity/Mapping/Driver/Annotation.php
+++ b/src/ReferenceIntegrity/Mapping/Driver/Annotation.php
@@ -18,6 +18,4 @@ use Gedmo\Mapping\Driver\AnnotationDriverInterface;
  *
  * @internal
  */
-class Annotation extends Attribute implements AnnotationDriverInterface
-{
-}
+class Annotation extends Attribute implements AnnotationDriverInterface {}

--- a/src/ReferenceIntegrity/ReferenceIntegrityListener.php
+++ b/src/ReferenceIntegrity/ReferenceIntegrityListener.php
@@ -71,7 +71,7 @@ class ReferenceIntegrityListener extends MappedEventSubscriber
         $ea = $this->getEventAdapter($args);
         $om = $ea->getObjectManager();
         $object = $ea->getObject();
-        $class = get_class($object);
+        $class = $object::class;
         $meta = $om->getClassMetadata($class);
 
         if ($config = $this->getConfiguration($om, $meta->getName())) {

--- a/src/References/Mapping/Driver/Annotation.php
+++ b/src/References/Mapping/Driver/Annotation.php
@@ -18,6 +18,4 @@ use Gedmo\Mapping\Driver\AnnotationDriverInterface;
  *
  * @internal
  */
-class Annotation extends Attribute implements AnnotationDriverInterface
-{
-}
+class Annotation extends Attribute implements AnnotationDriverInterface {}

--- a/src/References/Mapping/Event/Adapter/ODM.php
+++ b/src/References/Mapping/Event/Adapter/ODM.php
@@ -35,7 +35,7 @@ final class ODM extends BaseAdapterODM implements ReferencesAdapter
             if ($object instanceof PersistenceProxy) {
                 $id = $om->getUnitOfWork()->getEntityIdentifier($object);
             } else {
-                $meta = $om->getClassMetadata(get_class($object));
+                $meta = $om->getClassMetadata($object::class);
                 $id = [];
                 foreach ($meta->getIdentifier() as $name) {
                     $id[$name] = $meta->getFieldValue($object, $name);
@@ -69,7 +69,7 @@ final class ODM extends BaseAdapterODM implements ReferencesAdapter
 
     public function extractIdentifier($om, $object, $single = true)
     {
-        $meta = $om->getClassMetadata(get_class($object));
+        $meta = $om->getClassMetadata($object::class);
         if ($object instanceof GhostObjectInterface) {
             $id = $om->getUnitOfWork()->getDocumentIdentifier($object);
         } else {

--- a/src/References/Mapping/Event/Adapter/ORM.php
+++ b/src/References/Mapping/Event/Adapter/ORM.php
@@ -34,7 +34,7 @@ final class ORM extends BaseAdapterORM implements ReferencesAdapter
         }
 
         if ($om instanceof MongoDocumentManager) {
-            $meta = $om->getClassMetadata(get_class($object));
+            $meta = $om->getClassMetadata($object::class);
             if ($object instanceof GhostObjectInterface) {
                 $id = $om->getUnitOfWork()->getDocumentIdentifier($object);
             } else {
@@ -49,7 +49,7 @@ final class ORM extends BaseAdapterORM implements ReferencesAdapter
         }
 
         if ($om instanceof PhpcrDocumentManager) {
-            $meta = $om->getClassMetadata(get_class($object));
+            $meta = $om->getClassMetadata($object::class);
             assert(1 === count($meta->getIdentifier()));
             $id = $meta->getFieldValue($object, $meta->getIdentifier()[0]);
 
@@ -82,7 +82,7 @@ final class ORM extends BaseAdapterORM implements ReferencesAdapter
         if ($object instanceof PersistenceProxy) {
             $id = $om->getUnitOfWork()->getEntityIdentifier($object);
         } else {
-            $meta = $om->getClassMetadata(get_class($object));
+            $meta = $om->getClassMetadata($object::class);
             $id = [];
             foreach ($meta->getIdentifier() as $name) {
                 $id[$name] = $meta->getFieldValue($object, $name);
@@ -110,7 +110,7 @@ final class ORM extends BaseAdapterORM implements ReferencesAdapter
     private function throwIfNotDocumentManager($dm): void
     {
         if (!($dm instanceof MongoDocumentManager) && !($dm instanceof PhpcrDocumentManager)) {
-            throw new InvalidArgumentException(sprintf('Expected a %s or %s instance but got "%s"', MongoDocumentManager::class, 'Doctrine\ODM\PHPCR\DocumentManager', is_object($dm) ? get_class($dm) : gettype($dm)));
+            throw new InvalidArgumentException(sprintf('Expected a %s or %s instance but got "%s"', MongoDocumentManager::class, 'Doctrine\ODM\PHPCR\DocumentManager', get_debug_type($dm)));
         }
     }
 }

--- a/src/References/ReferencesListener.php
+++ b/src/References/ReferencesListener.php
@@ -47,18 +47,11 @@ use Gedmo\References\Mapping\Event\ReferencesAdapter;
 class ReferencesListener extends MappedEventSubscriber
 {
     /**
-     * @var array<string, ObjectManager>
-     */
-    private array $managers;
-
-    /**
      * @param array<string, ObjectManager> $managers
      */
-    public function __construct(array $managers = [])
+    public function __construct(private array $managers = [])
     {
         parent::__construct();
-
-        $this->managers = $managers;
     }
 
     /**
@@ -87,13 +80,12 @@ class ReferencesListener extends MappedEventSubscriber
         $ea = $this->getEventAdapter($eventArgs);
         $om = $ea->getObjectManager();
         $object = $ea->getObject();
-        $meta = $om->getClassMetadata(get_class($object));
+        $meta = $om->getClassMetadata($object::class);
         $config = $this->getConfiguration($om, $meta->getName());
 
         if (isset($config['referenceOne'])) {
             foreach ($config['referenceOne'] as $mapping) {
                 $property = $meta->reflClass->getProperty($mapping['field']);
-                $property->setAccessible(true);
                 if (isset($mapping['identifier'])) {
                     $referencedObjectId = $meta->getFieldValue($object, $mapping['identifier']);
                     if (null !== $referencedObjectId) {
@@ -113,7 +105,6 @@ class ReferencesListener extends MappedEventSubscriber
         if (isset($config['referenceMany'])) {
             foreach ($config['referenceMany'] as $mapping) {
                 $property = $meta->reflClass->getProperty($mapping['field']);
-                $property->setAccessible(true);
                 if (isset($mapping['mappedBy'])) {
                     $id = $ea->extractIdentifier($om, $object);
                     $manager = $this->getManager($mapping['type']);
@@ -212,13 +203,12 @@ class ReferencesListener extends MappedEventSubscriber
         $ea = $this->getEventAdapter($eventArgs);
         $om = $ea->getObjectManager();
         $object = $ea->getObject();
-        $meta = $om->getClassMetadata(get_class($object));
+        $meta = $om->getClassMetadata($object::class);
         $config = $this->getConfiguration($om, $meta->getName());
 
         if (isset($config['referenceManyEmbed'])) {
             foreach ($config['referenceManyEmbed'] as $mapping) {
                 $property = $meta->reflClass->getProperty($mapping['field']);
-                $property->setAccessible(true);
 
                 $id = $ea->extractIdentifier($om, $object);
                 $manager = $this->getManager('document');
@@ -259,14 +249,13 @@ class ReferencesListener extends MappedEventSubscriber
         $ea = $this->getEventAdapter($eventArgs);
         $om = $ea->getObjectManager();
         $object = $ea->getObject();
-        $meta = $om->getClassMetadata(get_class($object));
+        $meta = $om->getClassMetadata($object::class);
         $config = $this->getConfiguration($om, $meta->getName());
 
         if (isset($config['referenceOne'])) {
             foreach ($config['referenceOne'] as $mapping) {
                 if (isset($mapping['identifier'])) {
                     $property = $meta->reflClass->getProperty($mapping['field']);
-                    $property->setAccessible(true);
                     $referencedObject = $property->getValue($object);
 
                     if (is_object($referencedObject)) {

--- a/src/Sluggable/Handler/InversedRelativeSlugHandler.php
+++ b/src/Sluggable/Handler/InversedRelativeSlugHandler.php
@@ -43,26 +43,22 @@ class InversedRelativeSlugHandler implements SlugHandlerInterface
         $this->sluggable = $sluggable;
     }
 
-    public function onChangeDecision(SluggableAdapter $ea, array &$config, $object, &$slug, &$needToChangeSlug)
-    {
-    }
+    public function onChangeDecision(SluggableAdapter $ea, array &$config, $object, &$slug, &$needToChangeSlug) {}
 
-    public function postSlugBuild(SluggableAdapter $ea, array &$config, $object, &$slug)
-    {
-    }
+    public function postSlugBuild(SluggableAdapter $ea, array &$config, $object, &$slug) {}
 
     /**
      * @param ClassMetadata<object> $meta
      */
     public static function validate(array $options, ClassMetadata $meta)
     {
-        if (!isset($options['relationClass']) || !strlen($options['relationClass'])) {
+        if (!isset($options['relationClass']) || !strlen((string) $options['relationClass'])) {
             throw new InvalidMappingException("'relationClass' option must be specified for object slug mapping - {$meta->getName()}");
         }
-        if (!isset($options['mappedBy']) || !strlen($options['mappedBy'])) {
+        if (!isset($options['mappedBy']) || !strlen((string) $options['mappedBy'])) {
             throw new InvalidMappingException("'mappedBy' option must be specified for object slug mapping - {$meta->getName()}");
         }
-        if (!isset($options['inverseSlugField']) || !strlen($options['inverseSlugField'])) {
+        if (!isset($options['inverseSlugField']) || !strlen((string) $options['inverseSlugField'])) {
             throw new InvalidMappingException("'inverseSlugField' option must be specified for object slug mapping - {$meta->getName()}");
         }
     }

--- a/src/Sluggable/Handler/RelativeSlugHandler.php
+++ b/src/Sluggable/Handler/RelativeSlugHandler.php
@@ -78,7 +78,7 @@ class RelativeSlugHandler implements SlugHandlerInterface
     public function postSlugBuild(SluggableAdapter $ea, array &$config, $object, &$slug)
     {
         $this->originalTransliterator = $this->sluggable->getTransliterator();
-        $this->sluggable->setTransliterator([$this, 'transliterate']);
+        $this->sluggable->setTransliterator($this->transliterate(...));
     }
 
     /**
@@ -91,9 +91,7 @@ class RelativeSlugHandler implements SlugHandlerInterface
         }
     }
 
-    public function onSlugCompletion(SluggableAdapter $ea, array &$config, $object, &$slug)
-    {
-    }
+    public function onSlugCompletion(SluggableAdapter $ea, array &$config, $object, &$slug) {}
 
     /**
      * Transliterates the slug and prefixes the slug

--- a/src/Sluggable/Mapping/Driver/Yaml.php
+++ b/src/Sluggable/Mapping/Driver/Yaml.php
@@ -107,7 +107,7 @@ class Yaml extends File implements Driver
                 $handlers = [];
                 if (isset($slug['handlers'])) {
                     foreach ($slug['handlers'] as $handlerClass => $options) {
-                        if (!strlen($handlerClass)) {
+                        if (!strlen((string) $handlerClass)) {
                             throw new InvalidMappingException("SlugHandler class: {$handlerClass} should be a valid class name in entity - {$meta->getName()}");
                         }
                         $handlers[$handlerClass] = $options;

--- a/src/Sluggable/Mapping/Event/Adapter/ODM.php
+++ b/src/Sluggable/Mapping/Event/Adapter/ODM.php
@@ -37,7 +37,7 @@ final class ODM extends BaseAdapterODM implements SluggableAdapter
             if (is_object($ubase = $wrapped->getPropertyValue($config['unique_base']))) {
                 $qb->field($config['unique_base'].'.$id')->equals(new \MongoId($ubase->getId()));
             } elseif ($ubase) {
-                $qb->where('/^'.preg_quote($ubase, '/').'/.test(this.'.$config['unique_base'].')');
+                $qb->where('/^'.preg_quote((string) $ubase, '/').'/.test(this.'.$config['unique_base'].')');
             } else {
                 $qb->field($config['unique_base'])->equals(null);
             }
@@ -73,7 +73,7 @@ final class ODM extends BaseAdapterODM implements SluggableAdapter
 
         foreach ($result as $targetObject) {
             ++$count;
-            $slug = preg_replace("@^{$target}@smi", $replacement.$config['pathSeparator'], $targetObject[$config['slug']]);
+            $slug = preg_replace("@^{$target}@smi", $replacement.$config['pathSeparator'], (string) $targetObject[$config['slug']]);
             $dm
                 ->createQueryBuilder()
                 ->updateMany($config['useObjectClass'])
@@ -109,7 +109,7 @@ final class ODM extends BaseAdapterODM implements SluggableAdapter
 
         foreach ($result as $targetObject) {
             ++$count;
-            $slug = preg_replace("@^{$replacement}@smi", $target, $targetObject[$config['slug']]);
+            $slug = preg_replace("@^{$replacement}@smi", $target, (string) $targetObject[$config['slug']]);
             $dm
                 ->createQueryBuilder()
                 ->updateMany($config['useObjectClass'])

--- a/src/Sluggable/SluggableListener.php
+++ b/src/Sluggable/SluggableListener.php
@@ -273,7 +273,7 @@ class SluggableListener extends MappedEventSubscriber
         $ea = $this->getEventAdapter($args);
         $om = $ea->getObjectManager();
         $object = $ea->getObject();
-        $meta = $om->getClassMetadata(get_class($object));
+        $meta = $om->getClassMetadata($object::class);
 
         if ($config = $this->getConfiguration($om, $meta->getName())) {
             foreach ($config['slugs'] as $slugField => $options) {
@@ -307,7 +307,7 @@ class SluggableListener extends MappedEventSubscriber
         // of prePersist in case if record will be changed before flushing this will
         // ensure correct result. No additional overhead is encountered
         foreach ($ea->getScheduledObjectInsertions($uow) as $object) {
-            $meta = $om->getClassMetadata(get_class($object));
+            $meta = $om->getClassMetadata($object::class);
             if ($this->getConfiguration($om, $meta->getName())) {
                 // generate first to exclude this object from similar persisted slugs result
                 $this->generateSlug($ea, $object);
@@ -317,7 +317,7 @@ class SluggableListener extends MappedEventSubscriber
         // we use onFlush and not preUpdate event to let other
         // event listeners be nested together
         foreach ($ea->getScheduledObjectUpdates($uow) as $object) {
-            $meta = $om->getClassMetadata(get_class($object));
+            $meta = $om->getClassMetadata($object::class);
             if ($this->getConfiguration($om, $meta->getName()) && !$uow->isScheduledForInsert($object)) {
                 $this->generateSlug($ea, $object);
                 $this->persisted[$ea->getRootObjectClass($meta)][] = $object;
@@ -352,7 +352,7 @@ class SluggableListener extends MappedEventSubscriber
     private function generateSlug(SluggableAdapter $ea, object $object): void
     {
         $om = $ea->getObjectManager();
-        $meta = $om->getClassMetadata(get_class($object));
+        $meta = $om->getClassMetadata($object::class);
         $uow = $om->getUnitOfWork();
         $changeSet = $ea->getObjectChangeSet($uow, $object);
         $isInsert = $uow->isScheduledForInsert($object);
@@ -365,7 +365,7 @@ class SluggableListener extends MappedEventSubscriber
             $slug = $meta->getFieldValue($object, $slugField);
 
             // if slug should not be updated, skip it
-            if (!$options['updatable'] && !$isInsert && (!isset($changeSet[$slugField]) || 0 === strpos($slug, '__sluggable_placeholder__'))) {
+            if (!$options['updatable'] && !$isInsert && (!isset($changeSet[$slugField]) || str_starts_with((string) $slug, '__sluggable_placeholder__'))) {
                 continue;
             }
             // must fetch the old slug from changeset, since $object holds the new version
@@ -373,7 +373,7 @@ class SluggableListener extends MappedEventSubscriber
             $needToChangeSlug = false;
 
             // if slug is null, regenerate it, or needs an update
-            if (null === $slug || 0 === strpos($slug, '__sluggable_placeholder__') || !isset($changeSet[$slugField])) {
+            if (null === $slug || str_starts_with($slug, '__sluggable_placeholder__') || !isset($changeSet[$slugField])) {
                 $slug = '';
 
                 foreach ($options['fields'] as $sluggableField) {
@@ -458,11 +458,11 @@ class SluggableListener extends MappedEventSubscriber
 
                 // cut slug if exceeded in length
                 $length = $mapping->length ?? $mapping['length'] ?? null;
-                if (null !== $length && strlen($slug) > $length) {
-                    $slug = substr($slug, 0, $length);
+                if (null !== $length && strlen((string) $slug) > $length) {
+                    $slug = substr((string) $slug, 0, $length);
                 }
 
-                if (($mapping->nullable ?? $mapping['nullable'] ?? false) && 0 === strlen($slug)) {
+                if (($mapping->nullable ?? $mapping['nullable'] ?? false) && 0 === strlen((string) $slug)) {
                     $slug = null;
                 }
 
@@ -502,12 +502,12 @@ class SluggableListener extends MappedEventSubscriber
     /**
      * Generates the unique slug
      *
-     * @param SlugConfiguration $config
+     * @phpstan-param SlugConfiguration $config
      */
     private function makeUniqueSlug(SluggableAdapter $ea, object $object, string $preferredSlug, bool $recursing, array $config): string
     {
         $om = $ea->getObjectManager();
-        $meta = $om->getClassMetadata(get_class($object));
+        $meta = $om->getClassMetadata($object::class);
         $similarPersisted = [];
         // extract unique base
         $base = false;
@@ -524,7 +524,7 @@ class SluggableListener extends MappedEventSubscriber
                 }
                 $slug = $meta->getFieldValue($obj, $config['slug']);
                 $quotedPreferredSlug = preg_quote($preferredSlug);
-                if (preg_match("@^{$quotedPreferredSlug}.*@smi", $slug)) {
+                if (preg_match("@^{$quotedPreferredSlug}.*@smi", (string) $slug)) {
                     $similarPersisted[] = [$config['slug'] => $slug];
                 }
             }
@@ -540,7 +540,7 @@ class SluggableListener extends MappedEventSubscriber
             $quotedSeparator = preg_quote($config['separator']);
             $quotedPreferredSlug = preg_quote($preferredSlug);
             foreach ($result as $key => $similar) {
-                if (!preg_match("@{$quotedPreferredSlug}($|{$quotedSeparator}[\d]+$)@smi", $similar[$config['slug']])) {
+                if (!preg_match("@{$quotedPreferredSlug}($|{$quotedSeparator}[\d]+$)@smi", (string) $similar[$config['slug']])) {
                     unset($result[$key]);
                 }
             }
@@ -572,7 +572,7 @@ class SluggableListener extends MappedEventSubscriber
                     $length - (strlen($uniqueSuffix) + strlen($config['separator']))
                 );
                 $this->exponent = strlen($uniqueSuffix) - 1;
-                if (substr($generatedSlug, -strlen($config['separator'])) == $config['separator']) {
+                if (str_ends_with($generatedSlug, $config['separator'])) {
                     $generatedSlug = substr($generatedSlug, 0, strlen($generatedSlug) - strlen($config['separator']));
                 }
                 $generatedSlug = $this->makeUniqueSlug($ea, $object, $generatedSlug, true, $config);

--- a/src/Sluggable/Util/Urlizer.php
+++ b/src/Sluggable/Util/Urlizer.php
@@ -23,6 +23,4 @@ if (!class_exists(Transliterator::class)) {
  *
  * @final since gedmo/doctrine-extensions 3.11
  */
-class Urlizer extends Transliterator
-{
-}
+class Urlizer extends Transliterator {}

--- a/src/SoftDeleteable/Event/PostSoftDeleteEventArgs.php
+++ b/src/SoftDeleteable/Event/PostSoftDeleteEventArgs.php
@@ -19,6 +19,4 @@ use Doctrine\Persistence\ObjectManager;
  *
  * @template-extends LifecycleEventArgs<TObjectManager>
  */
-final class PostSoftDeleteEventArgs extends LifecycleEventArgs
-{
-}
+final class PostSoftDeleteEventArgs extends LifecycleEventArgs {}

--- a/src/SoftDeleteable/Event/PreSoftDeleteEventArgs.php
+++ b/src/SoftDeleteable/Event/PreSoftDeleteEventArgs.php
@@ -19,6 +19,4 @@ use Doctrine\Persistence\ObjectManager;
  *
  * @template-extends LifecycleEventArgs<TObjectManager>
  */
-final class PreSoftDeleteEventArgs extends LifecycleEventArgs
-{
-}
+final class PreSoftDeleteEventArgs extends LifecycleEventArgs {}

--- a/src/SoftDeleteable/Filter/ODM/SoftDeleteableFilter.php
+++ b/src/SoftDeleteable/Filter/ODM/SoftDeleteableFilter.php
@@ -43,23 +43,23 @@ class SoftDeleteableFilter extends BsonFilter
      *
      * @phpstan-return array<string, array<int, array<string, array{'$gt': \DateTime}|null>>|null>
      */
-    public function addFilterCriteria(ClassMetadata $targetEntity): array
+    public function addFilterCriteria(ClassMetadata $class): array
     {
-        $class = $targetEntity->getName();
-        if (true === ($this->disabled[$class] ?? false)) {
+        $className = $class->getName();
+        if (true === ($this->disabled[$className] ?? false)) {
             return [];
         }
-        if (true === ($this->disabled[$targetEntity->rootDocumentName] ?? false)) {
+        if (true === ($this->disabled[$class->rootDocumentName] ?? false)) {
             return [];
         }
 
-        $config = $this->getListener()->getConfiguration($this->getDocumentManager(), $targetEntity->name);
+        $config = $this->getListener()->getConfiguration($this->getDocumentManager(), $class->name);
 
         if (!isset($config['softDeleteable']) || !$config['softDeleteable']) {
             return [];
         }
 
-        $column = $targetEntity->getFieldMapping($config['fieldName']);
+        $column = $class->getFieldMapping($config['fieldName']);
 
         if (isset($config['timeAware']) && $config['timeAware']) {
             return [

--- a/src/SoftDeleteable/Mapping/Driver/Annotation.php
+++ b/src/SoftDeleteable/Mapping/Driver/Annotation.php
@@ -18,6 +18,4 @@ use Gedmo\Mapping\Driver\AnnotationDriverInterface;
  *
  * @internal
  */
-class Annotation extends Attribute implements AnnotationDriverInterface
-{
-}
+class Annotation extends Attribute implements AnnotationDriverInterface {}

--- a/src/SoftDeleteable/Mapping/Event/Adapter/ODM.php
+++ b/src/SoftDeleteable/Mapping/Event/Adapter/ODM.php
@@ -35,7 +35,7 @@ final class ODM extends BaseAdapterODM implements SoftDeleteableAdapter, ClockAw
      */
     public function getDateValue($meta, $field)
     {
-        $datetime = $this->clock instanceof ClockInterface ? $this->clock->now() : new \DateTimeImmutable();
+        $datetime = $this->clock?->now() ?? new \DateTimeImmutable();
         $mapping = $meta->getFieldMapping($field);
         $type = $mapping['type'] ?? null;
 

--- a/src/SoftDeleteable/Mapping/Event/Adapter/ORM.php
+++ b/src/SoftDeleteable/Mapping/Event/Adapter/ORM.php
@@ -49,12 +49,10 @@ final class ORM extends BaseAdapterORM implements SoftDeleteableAdapter, ClockAw
      * Generates current timestamp for the specified mapping
      *
      * @param array<string, mixed>|FieldMapping $mapping
-     *
-     * @return \DateTimeInterface|int
      */
-    private function getRawDateValue($mapping)
+    private function getRawDateValue(array|FieldMapping $mapping): \DateTimeInterface|int
     {
-        $datetime = $this->clock instanceof ClockInterface ? $this->clock->now() : new \DateTimeImmutable();
+        $datetime = $this->clock?->now() ?? new \DateTimeImmutable();
         $type = $mapping instanceof FieldMapping ? $mapping->type : ($mapping['type'] ?? '');
 
         if ('integer' === $type) {

--- a/src/SoftDeleteable/Query/TreeWalker/Exec/MultiTableDeleteExecutor.php
+++ b/src/SoftDeleteable/Query/TreeWalker/Exec/MultiTableDeleteExecutor.php
@@ -54,11 +54,6 @@ class MultiTableDeleteExecutor extends BaseMultiTableDeleteExecutor
             }
         }
 
-        // @todo: Once the minimum supported ORM version is 2.17, this can always write to the `$this->sqlStatements` property
-        if (property_exists($this, 'sqlStatements')) {
-            $this->sqlStatements = $sqlStatements;
-        } else {
-            $this->_sqlStatements = $sqlStatements;
-        }
+        $this->sqlStatements = $sqlStatements;
     }
 }

--- a/src/SoftDeleteable/SoftDeleteableListener.php
+++ b/src/SoftDeleteable/SoftDeleteableListener.php
@@ -52,22 +52,19 @@ class SoftDeleteableListener extends MappedEventSubscriber
     public const POST_SOFT_DELETE = 'postSoftDelete';
 
     /**
-     * Whether the postFlush event should be handled.
-     */
-    private bool $handlePostFlushEvent;
-
-    /**
      * Objects soft-deleted on flush.
      *
      * @var array<object>
      */
     private array $softDeletedObjects = [];
 
-    public function __construct(bool $handlePostFlushEvent = false)
-    {
+    public function __construct(
+        /**
+         * Whether the postFlush event should be handled.
+         */
+        private bool $handlePostFlushEvent = false
+    ) {
         parent::__construct();
-
-        $this->handlePostFlushEvent = $handlePostFlushEvent;
     }
 
     /**
@@ -102,7 +99,7 @@ class SoftDeleteableListener extends MappedEventSubscriber
 
         // getScheduledDocumentDeletions
         foreach ($ea->getScheduledObjectDeletions($uow) as $object) {
-            $meta = $om->getClassMetadata(get_class($object));
+            $meta = $om->getClassMetadata($object::class);
             $config = $this->getConfiguration($om, $meta->getName());
 
             if (isset($config['softDeleteable']) && $config['softDeleteable']) {
@@ -227,7 +224,7 @@ class SoftDeleteableListener extends MappedEventSubscriber
                     'https://github.com/doctrine-extensions/DoctrineExtensions/pull/2649',
                     'Type-hinting to something different than "%s" in "%s::%s()" is deprecated.',
                     $eventClass,
-                    get_class($listener),
+                    $listener::class,
                     $reflMethod->getName()
                 );
 

--- a/src/Sortable/Mapping/Driver/Annotation.php
+++ b/src/Sortable/Mapping/Driver/Annotation.php
@@ -18,6 +18,4 @@ use Gedmo\Mapping\Driver\AnnotationDriverInterface;
  *
  * @internal
  */
-class Annotation extends Attribute implements AnnotationDriverInterface
-{
-}
+class Annotation extends Attribute implements AnnotationDriverInterface {}

--- a/src/Sortable/Mapping/Event/SortableAdapter.php
+++ b/src/Sortable/Mapping/Event/SortableAdapter.php
@@ -16,6 +16,4 @@ use Gedmo\Mapping\Event\AdapterInterface;
  *
  * @author Lukas Botsch <lukas.botsch@gmail.com>
  */
-interface SortableAdapter extends AdapterInterface
-{
-}
+interface SortableAdapter extends AdapterInterface {}

--- a/src/Sortable/SortableListener.php
+++ b/src/Sortable/SortableListener.php
@@ -124,7 +124,7 @@ class SortableListener extends MappedEventSubscriber
 
         // process all objects being deleted
         foreach ($ea->getScheduledObjectDeletions($uow) as $object) {
-            $meta = $om->getClassMetadata(get_class($object));
+            $meta = $om->getClassMetadata($object::class);
             if ($config = $this->getConfiguration($om, $meta->getName())) {
                 $this->processDeletion($ea, $config, $meta, $object);
             }
@@ -133,7 +133,7 @@ class SortableListener extends MappedEventSubscriber
         $updateValues = [];
         // process all objects being updated
         foreach ($ea->getScheduledObjectUpdates($uow) as $object) {
-            $meta = $om->getClassMetadata(get_class($object));
+            $meta = $om->getClassMetadata($object::class);
             if ($config = $this->getConfiguration($om, $meta->getName())) {
                 $position = $meta->getFieldValue($object, $config['position']);
                 $updateValues[$position] = [$ea, $config, $meta, $object];
@@ -146,7 +146,7 @@ class SortableListener extends MappedEventSubscriber
 
         // process all objects being inserted
         foreach ($ea->getScheduledObjectInsertions($uow) as $object) {
-            $meta = $om->getClassMetadata(get_class($object));
+            $meta = $om->getClassMetadata($object::class);
             if ($config = $this->getConfiguration($om, $meta->getName())) {
                 $this->processInsert($ea, $config, $meta, $object);
             }
@@ -167,7 +167,7 @@ class SortableListener extends MappedEventSubscriber
         $ea = $this->getEventAdapter($args);
         $om = $ea->getObjectManager();
         $object = $ea->getObject();
-        $meta = $om->getClassMetadata(get_class($object));
+        $meta = $om->getClassMetadata($object::class);
 
         if ($config = $this->getConfiguration($om, $meta->getName())) {
             // Get groups
@@ -706,7 +706,7 @@ class SortableListener extends MappedEventSubscriber
                 }
             }, $newDelta);
             $this->relocations[$hash]['deltas'][] = $newDelta;
-        } catch (\Exception $e) {
+        } catch (\Exception) {
         }
     }
 

--- a/src/Timestampable/Mapping/Driver/Annotation.php
+++ b/src/Timestampable/Mapping/Driver/Annotation.php
@@ -18,6 +18,4 @@ use Gedmo\Mapping\Driver\AnnotationDriverInterface;
  *
  * @internal
  */
-class Annotation extends Attribute implements AnnotationDriverInterface
-{
-}
+class Annotation extends Attribute implements AnnotationDriverInterface {}

--- a/src/Timestampable/Mapping/Event/Adapter/ODM.php
+++ b/src/Timestampable/Mapping/Event/Adapter/ODM.php
@@ -35,7 +35,7 @@ final class ODM extends BaseAdapterODM implements TimestampableAdapter, ClockAwa
      */
     public function getDateValue($meta, $field)
     {
-        $datetime = $this->clock instanceof ClockInterface ? $this->clock->now() : new \DateTimeImmutable();
+        $datetime = $this->clock?->now() ?? new \DateTimeImmutable();
         $mapping = $meta->getFieldMapping($field);
         $type = $mapping['type'] ?? null;
 

--- a/src/Timestampable/Mapping/Event/Adapter/ORM.php
+++ b/src/Timestampable/Mapping/Event/Adapter/ORM.php
@@ -49,12 +49,10 @@ final class ORM extends BaseAdapterORM implements TimestampableAdapter, ClockAwa
      * Generates current timestamp for the specified mapping
      *
      * @param array<string, mixed>|FieldMapping $mapping
-     *
-     * @return \DateTimeInterface|int
      */
-    private function getRawDateValue($mapping)
+    private function getRawDateValue(array|FieldMapping $mapping): \DateTimeInterface|int
     {
-        $datetime = $this->clock instanceof ClockInterface ? $this->clock->now() : new \DateTimeImmutable();
+        $datetime = $this->clock?->now() ?? new \DateTimeImmutable();
         $type = $mapping instanceof FieldMapping ? $mapping->type : ($mapping['type'] ?? '');
 
         if ('integer' === $type) {

--- a/src/Tool/ClassUtils.php
+++ b/src/Tool/ClassUtils.php
@@ -18,9 +18,7 @@ use Doctrine\Common\Util\ClassUtils as CommonClassUtils;
  */
 final class ClassUtils
 {
-    private function __construct()
-    {
-    }
+    private function __construct() {}
 
     /**
      * Gets the real class name of an object (even if it's a proxy).
@@ -39,6 +37,6 @@ final class ClassUtils
             return CommonClassUtils::getClass($object);
         }
 
-        return get_class($object);
+        return $object::class;
     }
 }

--- a/src/Tool/Wrapper/EntityWrapper.php
+++ b/src/Tool/Wrapper/EntityWrapper.php
@@ -32,7 +32,7 @@ class EntityWrapper extends AbstractWrapper
      *
      * @var array<string, mixed>|null
      */
-    private $identifier;
+    private ?array $identifier = null;
 
     /**
      * Wrap entity
@@ -43,7 +43,7 @@ class EntityWrapper extends AbstractWrapper
     {
         $this->om = $em;
         $this->object = $entity;
-        $this->meta = $em->getClassMetadata(get_class($this->object));
+        $this->meta = $em->getClassMetadata($this->object::class);
     }
 
     public function getPropertyValue($property)

--- a/src/Tool/Wrapper/MongoDocumentWrapper.php
+++ b/src/Tool/Wrapper/MongoDocumentWrapper.php
@@ -41,7 +41,7 @@ class MongoDocumentWrapper extends AbstractWrapper
     {
         $this->om = $dm;
         $this->object = $document;
-        $this->meta = $dm->getClassMetadata(get_class($this->object));
+        $this->meta = $dm->getClassMetadata($this->object::class);
     }
 
     public function getPropertyValue($property)

--- a/src/Translatable/Document/Repository/TranslationRepository.php
+++ b/src/Translatable/Document/Repository/TranslationRepository.php
@@ -64,7 +64,7 @@ class TranslationRepository extends DocumentRepository
      */
     public function translate($document, $field, $locale, $value)
     {
-        $meta = $this->dm->getClassMetadata(get_class($document));
+        $meta = $this->dm->getClassMetadata($document::class);
         $listener = $this->getTranslatableListener();
         $config = $listener->getConfiguration($this->dm, $meta->getName());
         if (!isset($config['fields']) || !in_array($field, $config['fields'], true)) {

--- a/src/Translatable/Entity/Repository/TranslationRepository.php
+++ b/src/Translatable/Entity/Repository/TranslationRepository.php
@@ -60,7 +60,7 @@ class TranslationRepository extends EntityRepository
      */
     public function translate($entity, $field, $locale, $value)
     {
-        $meta = $this->getEntityManager()->getClassMetadata(get_class($entity));
+        $meta = $this->getEntityManager()->getClassMetadata($entity::class);
         $listener = $this->getTranslatableListener();
         $config = $listener->getConfiguration($this->getEntityManager(), $meta->getName());
         if (!isset($config['fields']) || !in_array($field, $config['fields'], true)) {

--- a/src/Translatable/Mapping/Driver/Annotation.php
+++ b/src/Translatable/Mapping/Driver/Annotation.php
@@ -18,6 +18,4 @@ use Gedmo\Mapping\Driver\AnnotationDriverInterface;
  *
  * @internal
  */
-class Annotation extends Attribute implements AnnotationDriverInterface
-{
-}
+class Annotation extends Attribute implements AnnotationDriverInterface {}

--- a/src/Translatable/Mapping/Event/Adapter/ODM.php
+++ b/src/Translatable/Mapping/Event/Adapter/ODM.php
@@ -134,7 +134,7 @@ final class ODM extends BaseAdapterODM implements TranslatableAdapter
     public function insertTranslationRecord($translation)
     {
         $dm = $this->getObjectManager();
-        $meta = $dm->getClassMetadata(get_class($translation));
+        $meta = $dm->getClassMetadata($translation::class);
         $collection = $dm->getDocumentCollection($meta->getName());
         $data = [];
 

--- a/src/Translatable/Mapping/Event/Adapter/ORM.php
+++ b/src/Translatable/Mapping/Event/Adapter/ORM.php
@@ -191,7 +191,7 @@ final class ORM extends BaseAdapterORM implements TranslatableAdapter
     public function insertTranslationRecord($translation)
     {
         $em = $this->getObjectManager();
-        $meta = $em->getClassMetadata(get_class($translation));
+        $meta = $em->getClassMetadata($translation::class);
         $data = [];
 
         foreach ($meta->getReflectionProperties() as $fieldName => $reflProp) {
@@ -245,13 +245,9 @@ final class ORM extends BaseAdapterORM implements TranslatableAdapter
         $meta = $em->getClassMetadata($className);
         $type = Type::getType($meta->getTypeOfField('foreignKey'));
 
-        switch (Type::lookupName($type)) {
-            case Types::BIGINT:
-            case Types::INTEGER:
-            case Types::SMALLINT:
-                return (int) $key;
-            default:
-                return (string) $key;
-        }
+        return match (Type::lookupName($type)) {
+            Types::BIGINT, Types::INTEGER, Types::SMALLINT => (int) $key,
+            default => (string) $key,
+        };
     }
 }

--- a/src/Translator/TranslationProxy.php
+++ b/src/Translator/TranslationProxy.php
@@ -19,23 +19,10 @@ use Doctrine\Common\Collections\Collection;
 class TranslationProxy
 {
     /**
-     * @var string
-     */
-    protected $locale;
-    /**
-     * @var object
-     */
-    protected $translatable;
-    /**
      * @var string[]
      */
     protected $properties = [];
-    /**
-     * @var string
-     *
-     * @phpstan-var class-string<TranslationInterface>
-     */
-    protected $class;
+
     /**
      * @var Collection<int, TranslationInterface>
      */
@@ -54,16 +41,18 @@ class TranslationProxy
      *
      * @throws \InvalidArgumentException Translation class doesn't implement TranslationInterface
      */
-    public function __construct($translatable, $locale, array $properties, $class, Collection $coll)
-    {
-        $this->translatable = $translatable;
-        $this->locale = $locale;
+    public function __construct(
+        protected $translatable,
+        protected $locale,
+        array $properties,
+        protected $class,
+        Collection $coll
+    ) {
         $this->properties = $properties;
-        $this->class = $class;
         $this->coll = $coll;
 
-        if (!is_subclass_of($class, TranslationInterface::class)) {
-            throw new \InvalidArgumentException(sprintf('Translation class should implement %s, "%s" given', TranslationInterface::class, $class));
+        if (!is_subclass_of($this->class, TranslationInterface::class)) {
+            throw new \InvalidArgumentException(sprintf('Translation class should implement %s, "%s" given', TranslationInterface::class, $this->class));
         }
     }
 

--- a/src/Tree/Document/MongoDB/Repository/MaterializedPathRepository.php
+++ b/src/Tree/Document/MongoDB/Repository/MaterializedPathRepository.php
@@ -116,7 +116,7 @@ class MaterializedPathRepository extends AbstractTreeRepository
 
         if (is_a($node, $meta->getName())) {
             $node = new MongoDocumentWrapper($node, $this->dm);
-            $nodePath = preg_quote($node->getPropertyValue($config['path']));
+            $nodePath = preg_quote((string) $node->getPropertyValue($config['path']));
 
             if ($direct) {
                 $regex = sprintf(
@@ -149,7 +149,7 @@ class MaterializedPathRepository extends AbstractTreeRepository
     }
 
     /**
-     * G{@inheritdoc}
+     * {@inheritdoc}
      */
     public function getChildrenQuery($node = null, $direct = false, $sortByField = null, $direction = 'asc', $includeNode = false)
     {

--- a/src/Tree/Entity/Repository/ClosureTreeRepository.php
+++ b/src/Tree/Entity/Repository/ClosureTreeRepository.php
@@ -407,7 +407,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
             && isset($options['childSort']['field'], $options['childSort']['dir'])) {
             $q->addOrderBy(
                 'node.'.$options['childSort']['field'],
-                'asc' === strtolower($options['childSort']['dir']) ? 'asc' : 'desc'
+                'asc' === strtolower((string) $options['childSort']['dir']) ? 'asc' : 'desc'
             );
         }
 

--- a/src/Tree/Entity/Repository/MaterializedPathRepository.php
+++ b/src/Tree/Entity/Repository/MaterializedPathRepository.php
@@ -98,10 +98,10 @@ class MaterializedPathRepository extends AbstractTreeRepository
         $node = new EntityWrapper($node, $this->getEntityManager());
         $nodePath = $node->getPropertyValue($config['path']);
         $paths = [];
-        $nodePathLength = strlen($nodePath);
+        $nodePathLength = strlen((string) $nodePath);
         $separatorMatchOffset = 0;
         while ($separatorMatchOffset < $nodePathLength) {
-            $separatorPos = strpos($nodePath, $config['path_separator'], $separatorMatchOffset);
+            $separatorPos = strpos((string) $nodePath, $config['path_separator'], $separatorMatchOffset);
 
             if (false === $separatorPos || $separatorPos === $nodePathLength - 1) {
                 // last node, done
@@ -112,7 +112,7 @@ class MaterializedPathRepository extends AbstractTreeRepository
                 $separatorMatchOffset = 1;
             } else {
                 // add node
-                $paths[] = substr($nodePath, 0, $config['path_ends_with_separator'] ? $separatorPos + 1 : $separatorPos);
+                $paths[] = substr((string) $nodePath, 0, $config['path_ends_with_separator'] ? $separatorPos + 1 : $separatorPos);
                 $separatorMatchOffset = $separatorPos + 1;
             }
         }
@@ -254,7 +254,7 @@ class MaterializedPathRepository extends AbstractTreeRepository
         $nodes = $this->getNodesHierarchyQuery($node, $direct, $options, $includeNode)->getArrayResult();
         usort(
             $nodes,
-            static fn (array $a, array $b): int => strcmp($a[$path], $b[$path])
+            static fn (array $a, array $b): int => strcmp((string) $a[$path], (string) $b[$path])
         );
 
         return $nodes;

--- a/src/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/src/Tree/Entity/Repository/NestedTreeRepository.php
@@ -215,7 +215,7 @@ class NestedTreeRepository extends AbstractTreeRepository
             throw new InvalidArgumentException(sprintf('"stringMethod" option passed in argument 2 to %s must be a valid string.', __METHOD__));
         }
         if (!method_exists($node, $options['stringMethod'])) {
-            throw new InvalidArgumentException(sprintf('%s must implement method "%s".', get_class($node), $options['stringMethod']));
+            throw new InvalidArgumentException(sprintf('%s must implement method "%s".', $node::class, $options['stringMethod']));
         }
 
         $path = [];
@@ -1113,7 +1113,7 @@ class NestedTreeRepository extends AbstractTreeRepository
      */
     protected function doCallWithCompat($method, $args)
     {
-        if ('persistAs' === substr($method, 0, 9)) {
+        if (str_starts_with($method, 'persistAs')) {
             if (!isset($args[0])) {
                 throw new InvalidArgumentException('Node to persist must be available as first argument.');
             }
@@ -1122,7 +1122,7 @@ class NestedTreeRepository extends AbstractTreeRepository
             $meta = $this->getClassMetadata();
             $config = $this->listener->getConfiguration($this->getEntityManager(), $meta->getName());
             $position = substr($method, 9);
-            if ('Of' === substr($method, -2)) {
+            if (str_ends_with($method, 'Of')) {
                 if (!isset($args[1])) {
                     throw new InvalidArgumentException('If "Of" is specified you must provide parent or sibling as the second argument.');
                 }
@@ -1141,7 +1141,7 @@ class NestedTreeRepository extends AbstractTreeRepository
                             'Not implementing the "%s" interface from node "%s" is deprecated since gedmo/doctrine-extensions'
                             .' 3.13 and will throw a "%s" error in version 4.0.',
                             Node::class,
-                            \get_class($node),
+                            $node::class,
                             \TypeError::class
                         );
                     }

--- a/src/Tree/Hydrator/ORM/TreeObjectHydrator.php
+++ b/src/Tree/Hydrator/ORM/TreeObjectHydrator.php
@@ -24,6 +24,8 @@ use Gedmo\Tree\TreeListener;
  * @author Ilija Tovilo <ilija.tovilo@me.com>
  *
  * @final since gedmo/doctrine-extensions 3.11
+ *
+ * @phpstan-import-type TreeConfiguration from TreeListener
  */
 class TreeObjectHydrator extends ObjectHydrator
 {
@@ -32,23 +34,16 @@ class TreeObjectHydrator extends ObjectHydrator
 
     /**
      * @var array<string, mixed>
+     *
+     * @phpstan-var TreeConfiguration
      */
-    private $config = [];
+    private array $config = [];
 
-    /**
-     * @var string
-     */
-    private $idField;
+    private string $idField = '';
 
-    /**
-     * @var string
-     */
-    private $parentField;
+    private string $parentField = '';
 
-    /**
-     * @var string
-     */
-    private $childrenField;
+    private string $childrenField = '';
 
     /**
      * @param object $object
@@ -59,7 +54,7 @@ class TreeObjectHydrator extends ObjectHydrator
      */
     public function setPropertyValue($object, $property, $value)
     {
-        $meta = $this->getEntityManager()->getClassMetadata(get_class($object));
+        $meta = $this->getEntityManager()->getClassMetadata($object::class);
         $meta->setFieldValue($object, $property, $value);
     }
 
@@ -285,7 +280,7 @@ class TreeObjectHydrator extends ObjectHydrator
         $firstMappedEntity = array_values($data);
         $firstMappedEntity = $firstMappedEntity[0];
 
-        return $this->getEntityManager()->getClassMetadata(get_class($firstMappedEntity))->rootEntityName;
+        return $this->getEntityManager()->getClassMetadata($firstMappedEntity::class)->rootEntityName;
     }
 
     /**
@@ -296,7 +291,7 @@ class TreeObjectHydrator extends ObjectHydrator
      */
     protected function getPropertyValue($object, $property)
     {
-        $meta = $this->getEntityManager()->getClassMetadata(get_class($object));
+        $meta = $this->getEntityManager()->getClassMetadata($object::class);
 
         return $meta->getFieldValue($object, $property);
     }

--- a/src/Tree/Mapping/Driver/Annotation.php
+++ b/src/Tree/Mapping/Driver/Annotation.php
@@ -18,6 +18,4 @@ use Gedmo\Mapping\Driver\AnnotationDriverInterface;
  *
  * @internal
  */
-class Annotation extends Attribute implements AnnotationDriverInterface
-{
-}
+class Annotation extends Attribute implements AnnotationDriverInterface {}

--- a/src/Tree/Mapping/Driver/Attribute.php
+++ b/src/Tree/Mapping/Driver/Attribute.php
@@ -304,7 +304,7 @@ class Attribute extends AbstractAnnotationDriver
                     throw new InvalidMappingException("Tree does not support composite identifiers in class - {$meta->getName()}");
                 }
 
-                $method = 'validate'.ucfirst($config['strategy']).'TreeMetadata';
+                $method = 'validate'.ucfirst((string) $config['strategy']).'TreeMetadata';
                 $validator->$method($meta, $config);
             } else {
                 throw new InvalidMappingException("Cannot find Tree type for class: {$meta->getName()}");

--- a/src/Tree/Mapping/Driver/Xml.php
+++ b/src/Tree/Mapping/Driver/Xml.php
@@ -247,7 +247,7 @@ class Xml extends BaseXml
                 if (is_array($meta->getIdentifier()) && count($meta->getIdentifier()) > 1) {
                     throw new InvalidMappingException("Tree does not support composite identifiers in class - {$meta->getName()}");
                 }
-                $method = 'validate'.ucfirst($config['strategy']).'TreeMetadata';
+                $method = 'validate'.ucfirst((string) $config['strategy']).'TreeMetadata';
                 $validator->$method($meta, $config);
             } else {
                 throw new InvalidMappingException("Cannot find Tree type for class: {$meta->getName()}");

--- a/src/Tree/Mapping/Driver/Yaml.php
+++ b/src/Tree/Mapping/Driver/Yaml.php
@@ -128,7 +128,7 @@ class Yaml extends File implements Driver
                             $separator = '|';
                         }
 
-                        if (strlen($separator) > 1) {
+                        if (strlen((string) $separator) > 1) {
                             throw new InvalidMappingException("Tree Path field - [{$field}] Separator {$separator} is invalid. It must be only one character long.");
                         }
 
@@ -205,7 +205,7 @@ class Yaml extends File implements Driver
                 if (is_array($meta->getIdentifier()) && count($meta->getIdentifier()) > 1) {
                     throw new InvalidMappingException("Tree does not support composite identifiers in class - {$meta->getName()}");
                 }
-                $method = 'validate'.ucfirst($config['strategy']).'TreeMetadata';
+                $method = 'validate'.ucfirst((string) $config['strategy']).'TreeMetadata';
                 $validator->$method($meta, $config);
             } else {
                 throw new InvalidMappingException("Cannot find Tree type for class: {$meta->getName()}");

--- a/src/Tree/Mapping/Event/TreeAdapter.php
+++ b/src/Tree/Mapping/Event/TreeAdapter.php
@@ -16,6 +16,4 @@ use Gedmo\Mapping\Event\AdapterInterface;
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
-interface TreeAdapter extends AdapterInterface
-{
-}
+interface TreeAdapter extends AdapterInterface {}

--- a/src/Tree/RepositoryUtils.php
+++ b/src/Tree/RepositoryUtils.php
@@ -27,14 +27,8 @@ class RepositoryUtils implements RepositoryUtilsInterface
     /** @var ClassMetadata<T> */
     protected $meta;
 
-    /** @var TreeListener */
-    protected $listener;
-
     /** @var ObjectManager&(DocumentManager|EntityManagerInterface) */
     protected $om;
-
-    /** @var RepositoryInterface<T> */
-    protected $repo;
 
     /**
      * This index is used to hold the children of a node
@@ -50,12 +44,10 @@ class RepositoryUtils implements RepositoryUtilsInterface
      * @param TreeListener                                           $listener
      * @param RepositoryInterface<T>                                 $repo
      */
-    public function __construct(ObjectManager $om, ClassMetadata $meta, $listener, $repo)
+    public function __construct(ObjectManager $om, ClassMetadata $meta, protected $listener, protected $repo)
     {
         $this->om = $om;
         $this->meta = $meta;
-        $this->listener = $listener;
-        $this->repo = $repo;
     }
 
     /**

--- a/src/Tree/Strategy/AbstractMaterializedPath.php
+++ b/src/Tree/Strategy/AbstractMaterializedPath.php
@@ -95,7 +95,7 @@ abstract class AbstractMaterializedPath implements Strategy
 
     public function processScheduledInsertion($om, $node, AdapterInterface $ea)
     {
-        $meta = $om->getClassMetadata(get_class($node));
+        $meta = $om->getClassMetadata($node::class);
 
         // ID is always used in a path,
         // and if it is generated value from engine (like AUTO_INCREMENT),
@@ -109,7 +109,7 @@ abstract class AbstractMaterializedPath implements Strategy
 
     public function processScheduledUpdate($om, $node, AdapterInterface $ea)
     {
-        $meta = $om->getClassMetadata(get_class($node));
+        $meta = $om->getClassMetadata($node::class);
         $config = $this->listener->getConfiguration($om, $meta->getName());
         $uow = $om->getUnitOfWork();
         $changeSet = $ea->getObjectChangeSet($uow, $node);
@@ -177,13 +177,11 @@ abstract class AbstractMaterializedPath implements Strategy
         $this->processPreLockingActions($om, $node, self::ACTION_UPDATE);
     }
 
-    public function processMetadataLoad($om, $meta)
-    {
-    }
+    public function processMetadataLoad($om, $meta) {}
 
     public function processScheduledDelete($om, $node)
     {
-        $meta = $om->getClassMetadata(get_class($node));
+        $meta = $om->getClassMetadata($node::class);
         $config = $this->listener->getConfiguration($om, $meta->getName());
 
         $this->removeNode($om, $meta, $config, $node);
@@ -199,14 +197,14 @@ abstract class AbstractMaterializedPath implements Strategy
      */
     public function updateNode(ObjectManager $om, $node, AdapterInterface $ea)
     {
-        $meta = $om->getClassMetadata(get_class($node));
+        $meta = $om->getClassMetadata($node::class);
         $config = $this->listener->getConfiguration($om, $meta->getName());
         $uow = $om->getUnitOfWork();
         $parent = $meta->getFieldValue($node, $config['parent']);
         $path = (string) $meta->getFieldValue($node, $config['path_source']);
 
         // We need to avoid the presence of the path separator in the path source
-        if (false !== strpos($path, $config['path_separator'])) {
+        if (str_contains($path, $config['path_separator'])) {
             $msg = 'You can\'t use the Path separator ("%s") as a character for your PathSource field value.';
 
             throw new RuntimeException(sprintf($msg, $config['path_separator']));
@@ -240,7 +238,7 @@ abstract class AbstractMaterializedPath implements Strategy
 
             $parentPath = $meta->getFieldValue($parent, $config['path']);
             // if parent path not ends with separator
-            if ($parentPath[strlen($parentPath) - 1] !== $config['path_separator']) {
+            if ($parentPath[strlen((string) $parentPath) - 1] !== $config['path_separator']) {
                 // add separator
                 $path = $parentPath.$config['path_separator'].$path;
             } else {
@@ -316,7 +314,7 @@ abstract class AbstractMaterializedPath implements Strategy
      */
     public function updateChildren(ObjectManager $om, $node, AdapterInterface $ea, $originalPath)
     {
-        $meta = $om->getClassMetadata(get_class($node));
+        $meta = $om->getClassMetadata($node::class);
         $config = $this->listener->getConfiguration($om, $meta->getName());
         $children = $this->getChildren($om, $meta, $config, $originalPath);
 
@@ -336,7 +334,7 @@ abstract class AbstractMaterializedPath implements Strategy
      */
     public function processPreLockingActions($om, $node, $action)
     {
-        $meta = $om->getClassMetadata(get_class($node));
+        $meta = $om->getClassMetadata($node::class);
         $config = $this->listener->getConfiguration($om, $meta->getName());
 
         if ($config['activate_locking']) {
@@ -400,7 +398,7 @@ abstract class AbstractMaterializedPath implements Strategy
      */
     public function processPostEventsActions(ObjectManager $om, AdapterInterface $ea, $node, $action)
     {
-        $meta = $om->getClassMetadata(get_class($node));
+        $meta = $om->getClassMetadata($node::class);
         $config = $this->listener->getConfiguration($om, $meta->getName());
 
         if ($config['activate_locking']) {

--- a/src/Tree/Strategy/ODM/MongoDB/MaterializedPath.php
+++ b/src/Tree/Strategy/ODM/MongoDB/MaterializedPath.php
@@ -38,7 +38,7 @@ class MaterializedPath extends AbstractMaterializedPath
         // Remove node's children
         $results = $om->createQueryBuilder()
             ->find($meta->getName())
-            ->field($config['path'])->equals(new Regex('^'.preg_quote($wrapped->getPropertyValue($config['path'])).'.?+'))
+            ->field($config['path'])->equals(new Regex('^'.preg_quote((string) $wrapped->getPropertyValue($config['path'])).'.?+'))
             ->getQuery()
             ->getIterator();
 
@@ -69,7 +69,7 @@ class MaterializedPath extends AbstractMaterializedPath
         $uow = $om->getUnitOfWork();
 
         foreach ($this->rootsOfTreesWhichNeedsLocking as $root) {
-            $meta = $om->getClassMetadata(get_class($root));
+            $meta = $om->getClassMetadata($root::class);
             $config = $this->listener->getConfiguration($om, $meta->getName());
             $lockTimeValue = new UTCDateTime();
             $meta->setFieldValue($root, $config['lock_time'], $lockTimeValue);
@@ -86,7 +86,7 @@ class MaterializedPath extends AbstractMaterializedPath
         $uow = $om->getUnitOfWork();
 
         foreach ($this->rootsOfTreesWhichNeedsLocking as $oid => $root) {
-            $meta = $om->getClassMetadata(get_class($root));
+            $meta = $om->getClassMetadata($root::class);
             $config = $this->listener->getConfiguration($om, $meta->getName());
             $lockTimeValue = null;
             $meta->setFieldValue($root, $config['lock_time'], $lockTimeValue);

--- a/src/Tree/Strategy/ORM/Closure.php
+++ b/src/Tree/Strategy/ORM/Closure.php
@@ -242,7 +242,7 @@ class Closure implements Strategy
 
         if (!$hasTheUserExplicitlyDefinedMapping) {
             $metadataFactory = $em->getMetadataFactory();
-            $getCache = \Closure::bind(static fn (AbstractClassMetadataFactory $metadataFactory): ?CacheItemPoolInterface => $metadataFactory->getCache(), null, \get_class($metadataFactory));
+            $getCache = \Closure::bind(static fn (AbstractClassMetadataFactory $metadataFactory): ?CacheItemPoolInterface => $metadataFactory->getCache(), null, $metadataFactory::class);
 
             $metadataCache = $getCache($metadataFactory);
 
@@ -258,35 +258,25 @@ class Closure implements Strategy
         }
     }
 
-    public function onFlushEnd($em, AdapterInterface $ea)
-    {
-    }
+    public function onFlushEnd($em, AdapterInterface $ea) {}
 
     public function processPrePersist($em, $node)
     {
         $this->pendingChildNodeInserts[spl_object_id($em)][spl_object_id($node)] = $node;
     }
 
-    public function processPreUpdate($em, $node)
-    {
-    }
+    public function processPreUpdate($em, $node) {}
 
-    public function processPreRemove($em, $node)
-    {
-    }
+    public function processPreRemove($em, $node) {}
 
-    public function processScheduledInsertion($em, $node, AdapterInterface $ea)
-    {
-    }
+    public function processScheduledInsertion($em, $node, AdapterInterface $ea) {}
 
-    public function processScheduledDelete($em, $entity)
-    {
-    }
+    public function processScheduledDelete($em, $entity) {}
 
     public function processPostUpdate($em, $entity, AdapterInterface $ea)
     {
         \assert($em instanceof EntityManagerInterface);
-        $meta = $em->getClassMetadata(get_class($entity));
+        $meta = $em->getClassMetadata($entity::class);
         $config = $this->listener->getConfiguration($em, $meta->getName());
 
         // Process TreeLevel field value
@@ -295,9 +285,7 @@ class Closure implements Strategy
         }
     }
 
-    public function processPostRemove($em, $entity, AdapterInterface $ea)
-    {
-    }
+    public function processPostRemove($em, $entity, AdapterInterface $ea) {}
 
     /**
      * @param EntityManagerInterface $em
@@ -308,7 +296,7 @@ class Closure implements Strategy
         $emHash = spl_object_id($em);
 
         while ($node = array_shift($this->pendingChildNodeInserts[$emHash])) {
-            $meta = $em->getClassMetadata(get_class($node));
+            $meta = $em->getClassMetadata($node::class);
             $config = $this->listener->getConfiguration($em, $meta->getName());
 
             $identifier = $meta->getSingleIdentifierFieldName();
@@ -394,7 +382,7 @@ class Closure implements Strategy
      */
     public function processScheduledUpdate($em, $node, AdapterInterface $ea)
     {
-        $meta = $em->getClassMetadata(get_class($node));
+        $meta = $em->getClassMetadata($node::class);
         $config = $this->listener->getConfiguration($em, $meta->getName());
         $uow = $em->getUnitOfWork();
         $changeSet = $uow->getEntityChangeSet($node);
@@ -527,7 +515,7 @@ class Closure implements Strategy
 
             assert(null !== $first);
 
-            $meta = $em->getClassMetadata(get_class($first));
+            $meta = $em->getClassMetadata($first::class);
             unset($first);
             $identifier = $meta->getIdentifier();
             $mapping = $meta->getFieldMapping($identifier[0]);

--- a/src/Tree/Strategy/ORM/MaterializedPath.php
+++ b/src/Tree/Strategy/ORM/MaterializedPath.php
@@ -32,7 +32,7 @@ class MaterializedPath extends AbstractMaterializedPath
     {
         $wrapped = AbstractWrapper::wrap($node, $om);
 
-        $path = addcslashes($wrapped->getPropertyValue($config['path']), '%');
+        $path = addcslashes((string) $wrapped->getPropertyValue($config['path']), '%');
 
         $separator = $config['path_ends_with_separator'] ? null : $config['path_separator'];
 

--- a/src/Tree/Strategy/ORM/Nested.php
+++ b/src/Tree/Strategy/ORM/Nested.php
@@ -125,7 +125,7 @@ class Nested implements Strategy
     public function processScheduledInsertion($em, $node, AdapterInterface $ea)
     {
         /** @var ClassMetadata<object> $meta */
-        $meta = $em->getClassMetadata(get_class($node));
+        $meta = $em->getClassMetadata($node::class);
         $config = $this->listener->getConfiguration($em, $meta->getName());
 
         $meta->setFieldValue($node, $config['left'], 0);
@@ -145,7 +145,7 @@ class Nested implements Strategy
      */
     public function processScheduledUpdate($em, $node, AdapterInterface $ea)
     {
-        $meta = $em->getClassMetadata(get_class($node));
+        $meta = $em->getClassMetadata($node::class);
         $config = $this->listener->getConfiguration($em, $meta->getName());
         $uow = $em->getUnitOfWork();
 
@@ -186,7 +186,7 @@ class Nested implements Strategy
      */
     public function processPostPersist($em, $node, AdapterInterface $ea)
     {
-        $meta = $em->getClassMetadata(get_class($node));
+        $meta = $em->getClassMetadata($node::class);
 
         $config = $this->listener->getConfiguration($em, $meta->getName());
         $parent = $meta->getFieldValue($node, $config['parent']);
@@ -198,7 +198,7 @@ class Nested implements Strategy
      */
     public function processScheduledDelete($em, $node)
     {
-        $meta = $em->getClassMetadata(get_class($node));
+        $meta = $em->getClassMetadata($node::class);
         $config = $this->listener->getConfiguration($em, $meta->getName());
         $uow = $em->getUnitOfWork();
 
@@ -238,29 +238,17 @@ class Nested implements Strategy
         $this->treeEdges = [];
     }
 
-    public function processPreRemove($em, $node)
-    {
-    }
+    public function processPreRemove($em, $node) {}
 
-    public function processPrePersist($em, $node)
-    {
-    }
+    public function processPrePersist($em, $node) {}
 
-    public function processPreUpdate($em, $node)
-    {
-    }
+    public function processPreUpdate($em, $node) {}
 
-    public function processMetadataLoad($em, $meta)
-    {
-    }
+    public function processMetadataLoad($em, $meta) {}
 
-    public function processPostUpdate($em, $entity, AdapterInterface $ea)
-    {
-    }
+    public function processPostUpdate($em, $entity, AdapterInterface $ea) {}
 
-    public function processPostRemove($em, $entity, AdapterInterface $ea)
-    {
-    }
+    public function processPostRemove($em, $entity, AdapterInterface $ea) {}
 
     /**
      * Update the $node with a different $parent destination
@@ -624,7 +612,7 @@ class Nested implements Strategy
 
                 assert(null !== $node);
 
-                $nodeMeta = $em->getClassMetadata(get_class($node));
+                $nodeMeta = $em->getClassMetadata($node::class);
 
                 /** @phpstan-ignore-next-line function.alreadyNarrowedType Property introduced in ORM 3.4 */
                 if (property_exists($nodeMeta, 'propertyAccessors')) {
@@ -724,7 +712,7 @@ class Nested implements Strategy
 
                 assert(null !== $node);
 
-                $nodeMeta = $em->getClassMetadata(get_class($node));
+                $nodeMeta = $em->getClassMetadata($node::class);
 
                 /** @phpstan-ignore-next-line function.alreadyNarrowedType Property introduced in ORM 3.4 */
                 if (property_exists($nodeMeta, 'propertyAccessors')) {

--- a/src/Tree/TreeListener.php
+++ b/src/Tree/TreeListener.php
@@ -154,7 +154,7 @@ class TreeListener extends MappedEventSubscriber
 
         // check all scheduled updates for TreeNodes
         foreach ($ea->getScheduledObjectInsertions($uow) as $object) {
-            $meta = $om->getClassMetadata(get_class($object));
+            $meta = $om->getClassMetadata($object::class);
             if ($this->getConfiguration($om, $meta->getName())) {
                 $this->usedClassesOnFlush[$meta->getName()] = null;
                 $this->getStrategy($om, $meta->getName())->processScheduledInsertion($om, $object, $ea);
@@ -163,7 +163,7 @@ class TreeListener extends MappedEventSubscriber
         }
 
         foreach ($ea->getScheduledObjectUpdates($uow) as $object) {
-            $meta = $om->getClassMetadata(get_class($object));
+            $meta = $om->getClassMetadata($object::class);
             if ($this->getConfiguration($om, $meta->getName())) {
                 $this->usedClassesOnFlush[$meta->getName()] = null;
                 $this->getStrategy($om, $meta->getName())->processScheduledUpdate($om, $object, $ea);
@@ -171,7 +171,7 @@ class TreeListener extends MappedEventSubscriber
         }
 
         foreach ($ea->getScheduledObjectDeletions($uow) as $object) {
-            $meta = $om->getClassMetadata(get_class($object));
+            $meta = $om->getClassMetadata($object::class);
             if ($this->getConfiguration($om, $meta->getName())) {
                 $this->usedClassesOnFlush[$meta->getName()] = null;
                 $this->getStrategy($om, $meta->getName())->processScheduledDelete($om, $object);
@@ -197,7 +197,7 @@ class TreeListener extends MappedEventSubscriber
         $ea = $this->getEventAdapter($args);
         $om = $ea->getObjectManager();
         $object = $ea->getObject();
-        $meta = $om->getClassMetadata(get_class($object));
+        $meta = $om->getClassMetadata($object::class);
 
         if ($this->getConfiguration($om, $meta->getName())) {
             $this->getStrategy($om, $meta->getName())->processPreRemove($om, $object);
@@ -218,7 +218,7 @@ class TreeListener extends MappedEventSubscriber
         $ea = $this->getEventAdapter($args);
         $om = $ea->getObjectManager();
         $object = $ea->getObject();
-        $meta = $om->getClassMetadata(get_class($object));
+        $meta = $om->getClassMetadata($object::class);
 
         if ($this->getConfiguration($om, $meta->getName())) {
             $this->getStrategy($om, $meta->getName())->processPrePersist($om, $object);
@@ -239,7 +239,7 @@ class TreeListener extends MappedEventSubscriber
         $ea = $this->getEventAdapter($args);
         $om = $ea->getObjectManager();
         $object = $ea->getObject();
-        $meta = $om->getClassMetadata(get_class($object));
+        $meta = $om->getClassMetadata($object::class);
 
         if ($this->getConfiguration($om, $meta->getName())) {
             $this->getStrategy($om, $meta->getName())->processPreUpdate($om, $object);
@@ -261,7 +261,7 @@ class TreeListener extends MappedEventSubscriber
         $ea = $this->getEventAdapter($args);
         $om = $ea->getObjectManager();
         $object = $ea->getObject();
-        $meta = $om->getClassMetadata(get_class($object));
+        $meta = $om->getClassMetadata($object::class);
 
         if ($this->getConfiguration($om, $meta->getName())) {
             $this->getStrategy($om, $meta->getName())->processPostPersist($om, $object, $ea);
@@ -283,7 +283,7 @@ class TreeListener extends MappedEventSubscriber
         $ea = $this->getEventAdapter($args);
         $om = $ea->getObjectManager();
         $object = $ea->getObject();
-        $meta = $om->getClassMetadata(get_class($object));
+        $meta = $om->getClassMetadata($object::class);
 
         if ($this->getConfiguration($om, $meta->getName())) {
             $this->getStrategy($om, $meta->getName())->processPostUpdate($om, $object, $ea);
@@ -305,7 +305,7 @@ class TreeListener extends MappedEventSubscriber
         $ea = $this->getEventAdapter($args);
         $om = $ea->getObjectManager();
         $object = $ea->getObject();
-        $meta = $om->getClassMetadata(get_class($object));
+        $meta = $om->getClassMetadata($object::class);
 
         if ($this->getConfiguration($om, $meta->getName())) {
             $this->getStrategy($om, $meta->getName())->processPostRemove($om, $object, $ea);

--- a/src/Uploadable/Event/UploadableBaseEventArgs.php
+++ b/src/Uploadable/Event/UploadableBaseEventArgs.php
@@ -21,60 +21,27 @@ use Gedmo\Uploadable\UploadableListener;
  *
  * @author Gustavo Falco <comfortablynumb84@gmail.com>
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ *
+ * @phpstan-import-type UploadableConfiguration from UploadableListener
  */
 abstract class UploadableBaseEventArgs extends EventArgs
 {
     /**
-     * The instance of the Uploadable listener that fired this event
-     */
-    private UploadableListener $uploadableListener;
-
-    private EntityManagerInterface $em;
-
-    /**
-     * @todo Check if this property must be removed, as it is not used.
-     */
-    private array $config = [];
-
-    /**
-     * The Uploadable entity
+     * @param UploadableListener         $uploadableListener     The instance of the Uploadable listener that fired this event
+     * @param array<string, mixed>       $extensionConfiguration
+     * @param object                     $entity                 The Uploadable entity
+     * @param 'INSERT'|'UPDATE'|'DELETE' $action
      *
-     * @var object
+     * @phpstan-param UploadableConfiguration $extensionConfiguration
      */
-    private $entity;
-
-    /**
-     * The configuration of the Uploadable extension for this entity class
-     *
-     * @todo Check if this property must be removed, as it is never set.
-     *
-     * @var array
-     */
-    private $extensionConfiguration;
-
-    private FileInfoInterface $fileInfo;
-
-    /**
-     * Is the file being created, updated or removed?
-     * This value can be: CREATE, UPDATE or DELETE
-     *
-     * @var string
-     */
-    private $action;
-
-    /**
-     * @param object $entity
-     * @param string $action
-     */
-    public function __construct(UploadableListener $listener, EntityManagerInterface $em, array $config, FileInfoInterface $fileInfo, $entity, $action)
-    {
-        $this->uploadableListener = $listener;
-        $this->em = $em;
-        $this->config = $config;
-        $this->fileInfo = $fileInfo;
-        $this->entity = $entity;
-        $this->action = $action;
-    }
+    public function __construct(
+        private readonly UploadableListener $uploadableListener,
+        private readonly EntityManagerInterface $em,
+        private readonly array $extensionConfiguration,
+        private readonly FileInfoInterface $fileInfo,
+        private $entity,
+        private $action
+    ) {}
 
     /**
      * Retrieve the associated listener
@@ -143,7 +110,9 @@ abstract class UploadableBaseEventArgs extends EventArgs
     /**
      * Retrieve associated Uploadable extension configuration
      *
-     * @return array
+     * @return array<string, mixed>
+     *
+     * @phpstan-return UploadableConfiguration
      */
     public function getExtensionConfiguration()
     {
@@ -161,9 +130,9 @@ abstract class UploadableBaseEventArgs extends EventArgs
     }
 
     /**
-     * Retrieve the action being performed to the entity: CREATE, UPDATE or DELETE
+     * Retrieve the action being performed to the object
      *
-     * @return string
+     * @return 'INSERT'|'UPDATE'|'DELETE'
      */
     public function getAction()
     {

--- a/src/Uploadable/Event/UploadablePostFileProcessEventArgs.php
+++ b/src/Uploadable/Event/UploadablePostFileProcessEventArgs.php
@@ -17,6 +17,4 @@ namespace Gedmo\Uploadable\Event;
  *
  * @final since gedmo/doctrine-extensions 3.11
  */
-class UploadablePostFileProcessEventArgs extends UploadableBaseEventArgs
-{
-}
+class UploadablePostFileProcessEventArgs extends UploadableBaseEventArgs {}

--- a/src/Uploadable/Event/UploadablePreFileProcessEventArgs.php
+++ b/src/Uploadable/Event/UploadablePreFileProcessEventArgs.php
@@ -17,6 +17,4 @@ namespace Gedmo\Uploadable\Event;
  *
  * @final since gedmo/doctrine-extensions 3.11
  */
-class UploadablePreFileProcessEventArgs extends UploadableBaseEventArgs
-{
-}
+class UploadablePreFileProcessEventArgs extends UploadableBaseEventArgs {}

--- a/src/Uploadable/Events.php
+++ b/src/Uploadable/Events.php
@@ -34,7 +34,5 @@ final class Events
      */
     public const uploadablePostFileProcess = 'uploadablePostFileProcess';
 
-    private function __construct()
-    {
-    }
+    private function __construct() {}
 }

--- a/src/Uploadable/Mapping/Driver/Annotation.php
+++ b/src/Uploadable/Mapping/Driver/Annotation.php
@@ -21,6 +21,4 @@ use Gedmo\Mapping\Driver\AnnotationDriverInterface;
  *
  * @internal
  */
-class Annotation extends Attribute implements AnnotationDriverInterface
-{
-}
+class Annotation extends Attribute implements AnnotationDriverInterface {}

--- a/src/Uploadable/Mapping/Validator.php
+++ b/src/Uploadable/Mapping/Validator.php
@@ -176,7 +176,7 @@ class Validator
             return;
         }
 
-        if (!is_dir($path) && !@mkdir($path, 0777, true)) {
+        if (!is_dir($path) && !@mkdir($path, 0o777, true)) {
             throw new UploadableInvalidPathException(sprintf('Unable to create "%s" directory.', $path));
         }
 
@@ -221,10 +221,10 @@ class Validator
             throw new InvalidMappingException(sprintf($msg, $meta->getName()));
         }
 
-        $config['allowedTypes'] = $config['allowedTypes'] ? (false !== strpos($config['allowedTypes'], ',') ?
-            explode(',', $config['allowedTypes']) : [$config['allowedTypes']]) : false;
-        $config['disallowedTypes'] = $config['disallowedTypes'] ? (false !== strpos($config['disallowedTypes'], ',') ?
-            explode(',', $config['disallowedTypes']) : [$config['disallowedTypes']]) : false;
+        $config['allowedTypes'] = $config['allowedTypes'] ? (str_contains((string) $config['allowedTypes'], ',') ?
+            explode(',', (string) $config['allowedTypes']) : [$config['allowedTypes']]) : false;
+        $config['disallowedTypes'] = $config['disallowedTypes'] ? (str_contains((string) $config['disallowedTypes'], ',') ?
+            explode(',', (string) $config['disallowedTypes']) : [$config['disallowedTypes']]) : false;
 
         if ($config['fileNameField']) {
             self::validateFileNameField($meta, $config['fileNameField']);

--- a/tests/Gedmo/Blameable/Fixture/Document/Article.php
+++ b/tests/Gedmo/Blameable/Fixture/Document/Article.php
@@ -23,11 +23,9 @@ class Article
 {
     /**
      * @ODM\Id
-     *
-     * @var string|null
      */
     #[ODM\Id]
-    private $id;
+    private ?string $id = null;
 
     /**
      * @ODM\Field(type="string")

--- a/tests/Gedmo/Blameable/Fixture/Document/Type.php
+++ b/tests/Gedmo/Blameable/Fixture/Document/Type.php
@@ -22,11 +22,9 @@ class Type
 {
     /**
      * @ODM\Id
-     *
-     * @var string|null
      */
     #[ODM\Id]
-    private $id;
+    private ?string $id = null;
 
     /**
      * @ODM\Field(type="string")

--- a/tests/Gedmo/Blameable/Fixture/Document/User.php
+++ b/tests/Gedmo/Blameable/Fixture/Document/User.php
@@ -22,11 +22,9 @@ class User
 {
     /**
      * @ODM\Id
-     *
-     * @var string|null
      */
     #[ODM\Id]
-    private $id;
+    private ?string $id = null;
 
     /**
      * @ODM\Field(type="string")

--- a/tests/Gedmo/Blameable/Fixture/Entity/Article.php
+++ b/tests/Gedmo/Blameable/Fixture/Entity/Article.php
@@ -25,8 +25,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Article implements Blameable
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -34,7 +32,7 @@ class Article implements Blameable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=128)

--- a/tests/Gedmo/Blameable/Fixture/Entity/Comment.php
+++ b/tests/Gedmo/Blameable/Fixture/Entity/Comment.php
@@ -23,8 +23,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Comment implements Blameable
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -32,7 +30,7 @@ class Comment implements Blameable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="message", type="text")
@@ -53,26 +51,22 @@ class Comment implements Blameable
     private ?int $status = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="closed", type="string", nullable=true)
      *
      * @Gedmo\Blameable(on="change", field="status", value=1)
      */
     #[ORM\Column(name: 'closed', type: Types::STRING, nullable: true)]
     #[Gedmo\Blameable(on: 'change', field: 'status', value: 1)]
-    private $closed;
+    private ?string $closed = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="modified", type="string")
      *
      * @Gedmo\Blameable(on="update")
      */
     #[ORM\Column(name: 'modified', type: Types::STRING)]
     #[Gedmo\Blameable(on: 'update')]
-    private $modified;
+    private ?string $modified = null;
 
     public function setArticle(?Article $article): void
     {

--- a/tests/Gedmo/Blameable/Fixture/Entity/Company.php
+++ b/tests/Gedmo/Blameable/Fixture/Entity/Company.php
@@ -25,8 +25,6 @@ use Symfony\Component\Uid\UuidV6;
 class Company implements Blameable
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -34,7 +32,7 @@ class Company implements Blameable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="name", type="string", length=128)
@@ -43,15 +41,13 @@ class Company implements Blameable
     private ?string $name = null;
 
     /**
-     * @var UuidV6|string|null
-     *
      * @Gedmo\Blameable(on="create")
      *
      * @ORM\Column(name="created", type="uuid")
      */
     #[ORM\Column(name: 'created', type: 'uuid')]
     #[Gedmo\Blameable(on: 'create')]
-    private $created;
+    private UuidV6|string|null $created = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Blameable/Fixture/Entity/MappedSupperClass.php
+++ b/tests/Gedmo/Blameable/Fixture/Entity/MappedSupperClass.php
@@ -22,50 +22,39 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class MappedSupperClass
 {
     /**
-     * @var int|null
-     *
-     * @ORM\Column(name="id", type="integer")
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
      */
     #[ORM\Id]
-    #[ORM\GeneratedValue(strategy: 'AUTO')]
-    #[ORM\Column(name: 'id', type: Types::INTEGER)]
-    protected $id;
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    protected ?int $id = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Locale
      */
     #[Gedmo\Locale]
-    protected $locale;
+    protected ?string $locale = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      *
      * @ORM\Column(name="name", type="string", length=191)
      */
     #[Gedmo\Translatable]
     #[ORM\Column(name: 'name', type: Types::STRING, length: 191)]
-    protected $name;
+    protected ?string $name = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="created_by", type="string")
      *
      * @Gedmo\Blameable(on="create")
      */
     #[ORM\Column(name: 'created_by', type: Types::STRING)]
     #[Gedmo\Blameable(on: 'create')]
-    protected $createdBy;
+    protected ?string $createdBy = null;
 
-    /**
-     * @codeCoverageIgnore
-     */
     public function getId(): ?int
     {
         return $this->id;

--- a/tests/Gedmo/Blameable/Fixture/Entity/Type.php
+++ b/tests/Gedmo/Blameable/Fixture/Entity/Type.php
@@ -23,8 +23,6 @@ use Doctrine\ORM\Mapping as ORM;
 class Type
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -32,7 +30,7 @@ class Type
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=128)

--- a/tests/Gedmo/Blameable/Fixture/Entity/UsingTrait.php
+++ b/tests/Gedmo/Blameable/Fixture/Entity/UsingTrait.php
@@ -21,15 +21,9 @@ use Gedmo\Blameable\Traits\BlameableEntity;
 #[ORM\Entity]
 class UsingTrait
 {
-    /*
-     * Hook Blameable behavior
-     * updates createdAt, updatedAt fields
-     */
     use BlameableEntity;
 
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -37,7 +31,7 @@ class UsingTrait
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(length=128)

--- a/tests/Gedmo/Blameable/Fixture/Entity/WithoutInterface.php
+++ b/tests/Gedmo/Blameable/Fixture/Entity/WithoutInterface.php
@@ -22,8 +22,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class WithoutInterface
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -31,7 +29,7 @@ class WithoutInterface
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(type="string", length=128)
@@ -40,26 +38,22 @@ class WithoutInterface
     private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Blameable(on="create")
      *
      * @ORM\Column(type="string")
      */
     #[ORM\Column(type: Types::STRING)]
     #[Gedmo\Blameable(on: 'create')]
-    private $created;
+    private ?string $created = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(type="string")
      *
      * @Gedmo\Blameable(on="update")
      */
     #[ORM\Column(type: Types::STRING)]
     #[Gedmo\Blameable(on: 'update')]
-    private $updated;
+    private ?string $updated = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/DoctrineExtensionsTest.php
+++ b/tests/Gedmo/DoctrineExtensionsTest.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 
 namespace Gedmo\Tests;
 
-use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\ODM\MongoDB\Mapping\Driver as DriverMongodbODM;
 use Doctrine\ORM\Mapping\Driver as DriverORM;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
@@ -23,9 +22,6 @@ use PHPUnit\Framework\TestCase;
  */
 final class DoctrineExtensionsTest extends TestCase
 {
-    /**
-     * @requires PHP >= 8.0
-     */
     public function testRegistersAttributeDriverForConcreteOrmEntitiesToChain(): void
     {
         $chain = new MappingDriverChain();
@@ -38,25 +34,6 @@ final class DoctrineExtensionsTest extends TestCase
         static::assertInstanceOf(DriverORM\AttributeDriver::class, $drivers['Gedmo'], 'The attribute driver should be registered to the chain on PHP 8');
     }
 
-    public function testRegistersAnnotationDriverForConcreteOrmEntitiesToChain(): void
-    {
-        if (\PHP_VERSION_ID >= 80000 || !class_exists(AnnotationReader::class)) {
-            static::markTestSkipped('Test only applies to PHP 7 and requires the doctrine/annotations package');
-        }
-
-        $chain = new MappingDriverChain();
-
-        DoctrineExtensions::registerMappingIntoDriverChainORM($chain);
-
-        $drivers = $chain->getDrivers();
-
-        static::assertArrayHasKey('Gedmo', $drivers);
-        static::assertInstanceOf(DriverORM\AnnotationDriver::class, $drivers['Gedmo'], 'The annotations driver should be registered to the chain on PHP 7');
-    }
-
-    /**
-     * @requires PHP >= 8.0
-     */
     public function testRegistersAttributeDriverForAbstractOrmSuperclassesToChain(): void
     {
         $chain = new MappingDriverChain();
@@ -69,25 +46,6 @@ final class DoctrineExtensionsTest extends TestCase
         static::assertInstanceOf(DriverORM\AttributeDriver::class, $drivers['Gedmo'], 'The attribute driver should be registered to the chain on PHP 8');
     }
 
-    public function testRegistersAnnotationDriverForAbstractOrmSuperclassesToChain(): void
-    {
-        if (\PHP_VERSION_ID >= 80000 || !class_exists(AnnotationReader::class)) {
-            static::markTestSkipped('Test only applies to PHP 7 and requires the doctrine/annotations package');
-        }
-
-        $chain = new MappingDriverChain();
-
-        DoctrineExtensions::registerAbstractMappingIntoDriverChainORM($chain);
-
-        $drivers = $chain->getDrivers();
-
-        static::assertArrayHasKey('Gedmo', $drivers);
-        static::assertInstanceOf(DriverORM\AnnotationDriver::class, $drivers['Gedmo'], 'The annotations driver should be registered to the chain on PHP 7');
-    }
-
-    /**
-     * @requires PHP >= 8.0
-     */
     public function testRegistersAttributeDriverForConcreteOdmDocumentsToChain(): void
     {
         if (!class_exists(DriverMongodbODM\AttributeDriver::class)) {
@@ -104,25 +62,6 @@ final class DoctrineExtensionsTest extends TestCase
         static::assertInstanceOf(DriverMongodbODM\AttributeDriver::class, $drivers['Gedmo'], 'The attribute driver should be registered to the chain on PHP 8');
     }
 
-    public function testRegistersAnnotationDriverForConcreteOdmDocumentsToChain(): void
-    {
-        if (\PHP_VERSION_ID >= 80000 || !class_exists(AnnotationReader::class)) {
-            static::markTestSkipped('Test only applies to PHP 7 and requires the doctrine/annotations package');
-        }
-
-        $chain = new MappingDriverChain();
-
-        DoctrineExtensions::registerMappingIntoDriverChainMongodbODM($chain);
-
-        $drivers = $chain->getDrivers();
-
-        static::assertArrayHasKey('Gedmo', $drivers);
-        static::assertInstanceOf(DriverMongodbODM\AnnotationDriver::class, $drivers['Gedmo'], 'The annotations driver should be registered to the chain on PHP 7');
-    }
-
-    /**
-     * @requires PHP >= 8.0
-     */
     public function testRegistersAttributeDriverForAbstractOdmSuperclassesToChain(): void
     {
         if (!class_exists(DriverMongodbODM\AttributeDriver::class)) {
@@ -137,21 +76,5 @@ final class DoctrineExtensionsTest extends TestCase
 
         static::assertArrayHasKey('Gedmo', $drivers);
         static::assertInstanceOf(DriverMongodbODM\AttributeDriver::class, $drivers['Gedmo'], 'The attribute driver should be registered to the chain on PHP 8');
-    }
-
-    public function testRegistersAnnotationDriverForAbstractOdmSuperclassesToChain(): void
-    {
-        if (\PHP_VERSION_ID >= 80000 || !class_exists(AnnotationReader::class)) {
-            static::markTestSkipped('Test only applies to PHP 7 and requires the doctrine/annotations package');
-        }
-
-        $chain = new MappingDriverChain();
-
-        DoctrineExtensions::registerAbstractMappingIntoDriverChainMongodbODM($chain);
-
-        $drivers = $chain->getDrivers();
-
-        static::assertArrayHasKey('Gedmo', $drivers);
-        static::assertInstanceOf(DriverMongodbODM\AnnotationDriver::class, $drivers['Gedmo'], 'The annotations driver should be registered to the chain on PHP 7');
     }
 }

--- a/tests/Gedmo/IpTraceable/ChangeTest.php
+++ b/tests/Gedmo/IpTraceable/ChangeTest.php
@@ -25,10 +25,7 @@ final class ChangeTest extends BaseTestCaseORM
 {
     private const TEST_IP = '34.234.1.10';
 
-    /**
-     * @var IpTraceableListener
-     */
-    protected $listener;
+    private IpTraceableListener $listener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/IpTraceable/Fixture/Article.php
+++ b/tests/Gedmo/IpTraceable/Fixture/Article.php
@@ -25,8 +25,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Article implements IpTraceable
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -34,7 +32,7 @@ class Article implements IpTraceable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=128)
@@ -48,7 +46,7 @@ class Article implements IpTraceable
      * @ORM\OneToMany(targetEntity="Gedmo\Tests\IpTraceable\Fixture\Comment", mappedBy="article")
      */
     #[ORM\OneToMany(targetEntity: Comment::class, mappedBy: 'article')]
-    private $comments;
+    private Collection $comments;
 
     /**
      * @Gedmo\IpTraceable(on="create")

--- a/tests/Gedmo/IpTraceable/Fixture/Comment.php
+++ b/tests/Gedmo/IpTraceable/Fixture/Comment.php
@@ -23,8 +23,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Comment implements IpTraceable
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -32,7 +30,7 @@ class Comment implements IpTraceable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="message", type="text")
@@ -53,26 +51,22 @@ class Comment implements IpTraceable
     private ?int $status = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="closed", type="string", length=45, nullable=true)
      *
      * @Gedmo\IpTraceable(on="change", field="status", value=1)
      */
     #[ORM\Column(name: 'closed', type: Types::STRING, length: 45, nullable: true)]
     #[Gedmo\IpTraceable(on: 'change', field: 'status', value: 1)]
-    private $closed;
+    private ?string $closed = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="modified", type="string", length=45)
      *
      * @Gedmo\IpTraceable(on="update")
      */
     #[ORM\Column(name: 'modified', type: Types::STRING, length: 45)]
     #[Gedmo\IpTraceable(on: 'update')]
-    private $modified;
+    private ?string $modified = null;
 
     public function setArticle(?Article $article): void
     {

--- a/tests/Gedmo/IpTraceable/Fixture/Document/Article.php
+++ b/tests/Gedmo/IpTraceable/Fixture/Document/Article.php
@@ -22,12 +22,10 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Article
 {
     /**
-     * @var string|null
-     *
      * @ODM\Id
      */
     #[ODM\Id]
-    private $id;
+    private ?string $id = null;
 
     /**
      * @ODM\Field(type="string")

--- a/tests/Gedmo/IpTraceable/Fixture/Document/Type.php
+++ b/tests/Gedmo/IpTraceable/Fixture/Document/Type.php
@@ -21,12 +21,10 @@ use Doctrine\ODM\MongoDB\Types\Type as MongoDBType;
 class Type
 {
     /**
-     * @var string|null
-     *
      * @ODM\Id
      */
     #[ODM\Id]
-    private $id;
+    private ?string $id = null;
 
     /**
      * @ODM\Field(type="string")

--- a/tests/Gedmo/IpTraceable/Fixture/MappedSupperClass.php
+++ b/tests/Gedmo/IpTraceable/Fixture/MappedSupperClass.php
@@ -22,50 +22,39 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class MappedSupperClass
 {
     /**
-     * @var int|null
-     *
-     * @ORM\Column(name="id", type="integer")
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
      */
     #[ORM\Id]
-    #[ORM\GeneratedValue(strategy: 'AUTO')]
-    #[ORM\Column(name: 'id', type: Types::INTEGER)]
-    protected $id;
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    protected ?int $id = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Locale
      */
     #[Gedmo\Locale]
-    protected $locale;
+    protected ?string $locale = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      *
      * @ORM\Column(name="name", type="string", length=191)
      */
     #[Gedmo\Translatable]
     #[ORM\Column(name: 'name', type: Types::STRING, length: 191)]
-    protected $name;
+    protected ?string $name = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="created_at", type="string", length=45)
      *
      * @Gedmo\IpTraceable(on="create")
      */
     #[ORM\Column(name: 'created_at', type: Types::STRING, length: 45)]
     #[Gedmo\IpTraceable(on: 'create')]
-    protected $createdFromIp;
+    protected ?string $createdFromIp = null;
 
-    /**
-     * @codeCoverageIgnore
-     */
     public function getId(): ?int
     {
         return $this->id;

--- a/tests/Gedmo/IpTraceable/Fixture/Type.php
+++ b/tests/Gedmo/IpTraceable/Fixture/Type.php
@@ -23,8 +23,6 @@ use Doctrine\ORM\Mapping as ORM;
 class Type
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -32,7 +30,7 @@ class Type
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=128)

--- a/tests/Gedmo/IpTraceable/Fixture/UsingTrait.php
+++ b/tests/Gedmo/IpTraceable/Fixture/UsingTrait.php
@@ -21,15 +21,9 @@ use Gedmo\IpTraceable\Traits\IpTraceableEntity;
 #[ORM\Entity]
 class UsingTrait
 {
-    /*
-     * Hook ipTraceable behavior
-     * updates createdFromIp, updatedFromIp fields
-     */
     use IpTraceableEntity;
 
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -37,7 +31,7 @@ class UsingTrait
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(length=128)

--- a/tests/Gedmo/IpTraceable/Fixture/WithoutInterface.php
+++ b/tests/Gedmo/IpTraceable/Fixture/WithoutInterface.php
@@ -22,8 +22,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class WithoutInterface
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -31,7 +29,7 @@ class WithoutInterface
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(type="string", length=128)
@@ -40,26 +38,22 @@ class WithoutInterface
     private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\IpTraceable(on="create")
      *
      * @ORM\Column(type="string", length=45)
      */
     #[ORM\Column(type: Types::STRING, length: 45)]
     #[Gedmo\IpTraceable(on: 'create')]
-    private $created;
+    private ?string $created = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(type="string", length=45)
      *
      * @Gedmo\IpTraceable(on="update")
      */
     #[ORM\Column(type: Types::STRING, length: 45)]
     #[Gedmo\IpTraceable(on: 'update')]
-    private $updated;
+    private ?string $updated = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Loggable/AttributeLoggableEntityTest.php
+++ b/tests/Gedmo/Loggable/AttributeLoggableEntityTest.php
@@ -18,8 +18,6 @@ use Gedmo\Tests\Loggable\LoggableEntityTest;
 /**
  * These are tests for loggable behavior with an attribute reader
  *
- * @requires PHP >= 8.0
- *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  */
 final class AttributeLoggableEntityTest extends LoggableEntityTest

--- a/tests/Gedmo/Loggable/Fixture/Document/Article.php
+++ b/tests/Gedmo/Loggable/Fixture/Document/Article.php
@@ -23,15 +23,13 @@ use Gedmo\Mapping\Annotation as Gedmo;
  */
 #[ODM\Document(collection: 'articles')]
 #[Gedmo\Loggable]
-class Article implements Loggable
+class Article implements Loggable, \Stringable
 {
     /**
-     * @var string|null
-     *
      * @ODM\Id
      */
     #[ODM\Id]
-    private $id;
+    private ?string $id = null;
 
     /**
      * @Gedmo\Versioned
@@ -51,9 +49,9 @@ class Article implements Loggable
     #[Gedmo\Versioned]
     private ?Author $author = null;
 
-    public function __toString()
+    public function __toString(): string
     {
-        return $this->title;
+        return (string) $this->title;
     }
 
     public function getId(): ?string

--- a/tests/Gedmo/Loggable/Fixture/Document/Author.php
+++ b/tests/Gedmo/Loggable/Fixture/Document/Author.php
@@ -23,7 +23,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
  */
 #[ODM\EmbeddedDocument]
 #[Gedmo\Loggable]
-class Author implements Loggable
+class Author implements Loggable, \Stringable
 {
     /**
      * @Gedmo\Versioned
@@ -43,7 +43,7 @@ class Author implements Loggable
     #[Gedmo\Versioned]
     private ?string $email = null;
 
-    public function __toString()
+    public function __toString(): string
     {
         return (string) $this->getName();
     }

--- a/tests/Gedmo/Loggable/Fixture/Document/Comment.php
+++ b/tests/Gedmo/Loggable/Fixture/Document/Comment.php
@@ -27,12 +27,10 @@ use Gedmo\Tests\Loggable\Fixture\Document\Log\Comment as CommentLog;
 class Comment implements Loggable
 {
     /**
-     * @var string|null
-     *
      * @ODM\Id
      */
     #[ODM\Id]
-    private $id;
+    private ?string $id = null;
 
     /**
      * @Gedmo\Versioned

--- a/tests/Gedmo/Loggable/Fixture/Document/Log/Comment.php
+++ b/tests/Gedmo/Loggable/Fixture/Document/Log/Comment.php
@@ -25,6 +25,4 @@ use Gedmo\Tests\Loggable\Fixture\Document\Comment as CommentDocument;
  * @phpstan-extends AbstractLogEntry<CommentDocument>
  */
 #[ODM\Document(collection: 'test_comment_log_entries', repositoryClass: LogEntryRepository::class)]
-class Comment extends AbstractLogEntry
-{
-}
+class Comment extends AbstractLogEntry {}

--- a/tests/Gedmo/Loggable/Fixture/Document/RelatedArticle.php
+++ b/tests/Gedmo/Loggable/Fixture/Document/RelatedArticle.php
@@ -28,12 +28,10 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class RelatedArticle implements Loggable
 {
     /**
-     * @var string|null
-     *
      * @ODM\Id
      */
     #[ODM\Id]
-    private $id;
+    private ?string $id = null;
 
     /**
      * @Gedmo\Versioned
@@ -59,7 +57,7 @@ class RelatedArticle implements Loggable
      * @ODM\ReferenceMany(targetDocument="Gedmo\Tests\Loggable\Fixture\Document\Comment", mappedBy="article")
      */
     #[ODM\ReferenceMany(targetDocument: Comment::class, mappedBy: 'article')]
-    private $comments;
+    private Collection $comments;
 
     public function __construct()
     {

--- a/tests/Gedmo/Loggable/Fixture/Entity/Address.php
+++ b/tests/Gedmo/Loggable/Fixture/Entity/Address.php
@@ -28,49 +28,41 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Address implements Loggable
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
-     * @ORM\Column(name="id", type="integer")
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
      */
     #[ORM\Id]
-    #[ORM\Column(name: 'id', type: Types::INTEGER)]
-    #[ORM\GeneratedValue(strategy: 'AUTO')]
-    protected $id;
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    protected ?int $id = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(type="string", length=191)
      *
      * @Gedmo\Versioned
      */
     #[ORM\Column(type: Types::STRING, length: 191)]
     #[Gedmo\Versioned]
-    protected $street;
+    protected ?string $street = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(type="string", length=191)
      *
      * @Gedmo\Versioned
      */
     #[ORM\Column(type: Types::STRING, length: 191)]
     #[Gedmo\Versioned]
-    protected $city;
+    protected ?string $city = null;
 
     /**
-     * @var Geo|null
-     *
      * @ORM\Embedded(class="Gedmo\Tests\Loggable\Fixture\Entity\Geo")
      *
      * @Gedmo\Versioned
      */
     #[ORM\Embedded(class: Geo::class)]
     #[Gedmo\Versioned]
-    protected $geo;
+    protected ?Geo $geo = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Loggable/Fixture/Entity/Article.php
+++ b/tests/Gedmo/Loggable/Fixture/Entity/Article.php
@@ -26,16 +26,14 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Article implements Loggable
 {
     /**
-     * @var int|null
-     *
-     * @ORM\Column(name="id", type="integer")
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="IDENTITY")
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
      */
     #[ORM\Id]
-    #[ORM\Column(name: 'id', type: Types::INTEGER)]
-    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
-    private $id;
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    private ?int $id = null;
 
     /**
      * @Gedmo\Versioned

--- a/tests/Gedmo/Loggable/Fixture/Entity/Comment.php
+++ b/tests/Gedmo/Loggable/Fixture/Entity/Comment.php
@@ -27,16 +27,14 @@ use Gedmo\Tests\Loggable\Fixture\Entity\Log\Comment as CommentLog;
 class Comment implements Loggable
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
      */
     #[ORM\Id]
-    #[ORM\Column(type: Types::INTEGER)]
     #[ORM\GeneratedValue]
-    private $id;
+    #[ORM\Column(type: Types::INTEGER)]
+    private ?int $id = null;
 
     /**
      * @Gedmo\Versioned

--- a/tests/Gedmo/Loggable/Fixture/Entity/Composite.php
+++ b/tests/Gedmo/Loggable/Fixture/Entity/Composite.php
@@ -23,22 +23,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Composite
 {
     /**
-     * @ORM\Id
-     * @ORM\Column(type="integer")
-     */
-    #[ORM\Id]
-    #[ORM\Column(name: 'one', type: Types::INTEGER)]
-    private int $one;
-
-    /**
-     * @ORM\Id
-     * @ORM\Column(type="integer")
-     */
-    #[ORM\Id]
-    #[ORM\Column(name: 'two', type: Types::INTEGER)]
-    private int $two;
-
-    /**
      * @ORM\Column(length=8)
      *
      * @Gedmo\Versioned
@@ -47,11 +31,22 @@ class Composite
     #[Gedmo\Versioned]
     private ?string $title = null;
 
-    public function __construct(int $one, int $two)
-    {
-        $this->one = $one;
-        $this->two = $two;
-    }
+    public function __construct(
+        /**
+         * @ORM\Id
+         * @ORM\Column(type="integer")
+         */
+        #[ORM\Id]
+        #[ORM\Column(name: 'one', type: Types::INTEGER)]
+        private int $one,
+        /**
+         * @ORM\Id
+         * @ORM\Column(type="integer")
+         */
+        #[ORM\Id]
+        #[ORM\Column(name: 'two', type: Types::INTEGER)]
+        private int $two
+    ) {}
 
     public function getOne(): int
     {

--- a/tests/Gedmo/Loggable/Fixture/Entity/CompositeRelation.php
+++ b/tests/Gedmo/Loggable/Fixture/Entity/CompositeRelation.php
@@ -23,22 +23,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class CompositeRelation
 {
     /**
-     * @ORM\Id
-     * @ORM\ManyToOne(targetEntity="Article")
-     */
-    #[ORM\Id]
-    #[ORM\ManyToOne(targetEntity: Article::class)]
-    private Article $articleOne;
-
-    /**
-     * @ORM\Id
-     * @ORM\ManyToOne(targetEntity="Article")
-     */
-    #[ORM\Id]
-    #[ORM\ManyToOne(targetEntity: Article::class)]
-    private Article $articleTwo;
-
-    /**
      * @ORM\Column(length=8)
      *
      * @Gedmo\Versioned
@@ -47,11 +31,22 @@ class CompositeRelation
     #[Gedmo\Versioned]
     private ?string $title = null;
 
-    public function __construct(Article $articleOne, Article $articleTwo)
-    {
-        $this->articleOne = $articleOne;
-        $this->articleTwo = $articleTwo;
-    }
+    public function __construct(
+        /**
+         * @ORM\Id
+         * @ORM\ManyToOne(targetEntity="Article")
+         */
+        #[ORM\Id]
+        #[ORM\ManyToOne(targetEntity: Article::class)]
+        private Article $articleOne,
+        /**
+         * @ORM\Id
+         * @ORM\ManyToOne(targetEntity="Article")
+         */
+        #[ORM\Id]
+        #[ORM\ManyToOne(targetEntity: Article::class)]
+        private Article $articleTwo
+    ) {}
 
     public function getArticleOne(): Article
     {

--- a/tests/Gedmo/Loggable/Fixture/Entity/Geo.php
+++ b/tests/Gedmo/Loggable/Fixture/Entity/Geo.php
@@ -26,9 +26,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Geo
 {
     /**
-     * @var string|null
-     *
-     * @phpstan-var numeric-string|null
+     * @var numeric-string|null
      *
      * @ORM\Column(type="decimal", precision=9, scale=6)
      *
@@ -36,12 +34,10 @@ class Geo
      */
     #[ORM\Column(type: Types::DECIMAL, precision: 9, scale: 6)]
     #[Gedmo\Versioned]
-    protected $latitude;
+    protected ?string $latitude = null;
 
     /**
-     * @var string|null
-     *
-     * @phpstan-var numeric-string|null
+     * @var numeric-string|null
      *
      * @ORM\Column(type="decimal", precision=9, scale=6)
      *
@@ -49,24 +45,22 @@ class Geo
      */
     #[ORM\Column(type: Types::DECIMAL, precision: 9, scale: 6)]
     #[Gedmo\Versioned]
-    protected $longitude;
+    protected ?string $longitude = null;
 
-    /**
-     * @var GeoLocation
-     *
-     * @ORM\Embedded(class="Gedmo\Tests\Loggable\Fixture\Entity\GeoLocation")
-     *
-     * @Gedmo\Versioned
-     */
-    #[ORM\Embedded(class: GeoLocation::class)]
-    #[Gedmo\Versioned]
-    protected $geoLocation;
-
-    public function __construct(float $latitude, float $longitude, GeoLocation $geoLocation)
-    {
+    public function __construct(
+        float $latitude,
+        float $longitude,
+        /**
+         * @ORM\Embedded(class="Gedmo\Tests\Loggable\Fixture\Entity\GeoLocation")
+         *
+         * @Gedmo\Versioned
+         */
+        #[ORM\Embedded(class: GeoLocation::class)]
+        #[Gedmo\Versioned]
+        protected GeoLocation $geoLocation
+    ) {
         $this->latitude = $this->parseFloatToString($latitude);
         $this->longitude = $this->parseFloatToString($longitude);
-        $this->geoLocation = $geoLocation;
     }
 
     public function getLatitude(): float
@@ -100,7 +94,7 @@ class Geo
     }
 
     /**
-     * @phpstan-return numeric-string
+     * @return numeric-string
      */
     private function parseFloatToString(float $number): string
     {

--- a/tests/Gedmo/Loggable/Fixture/Entity/GeoLocation.php
+++ b/tests/Gedmo/Loggable/Fixture/Entity/GeoLocation.php
@@ -25,21 +25,16 @@ use Gedmo\Mapping\Annotation as Gedmo;
 #[ORM\Embeddable]
 class GeoLocation
 {
-    /**
-     * @var string
-     *
-     * @ORM\Column(type="string")
-     *
-     * @Gedmo\Versioned
-     */
-    #[ORM\Column(type: Types::STRING)]
-    #[Gedmo\Versioned]
-    protected $location;
-
-    public function __construct(string $location)
-    {
-        $this->location = $location;
-    }
+    public function __construct(
+        /**
+         * @ORM\Column(type="string")
+         *
+         * @Gedmo\Versioned
+         */
+        #[ORM\Column(type: Types::STRING)]
+        #[Gedmo\Versioned]
+        protected string $location
+    ) {}
 
     public function getLocation(): string
     {

--- a/tests/Gedmo/Loggable/Fixture/Entity/Log/Comment.php
+++ b/tests/Gedmo/Loggable/Fixture/Entity/Log/Comment.php
@@ -24,6 +24,4 @@ use Gedmo\Tests\Loggable\Fixture\Document\Comment as CommentEntity;
  */
 #[ORM\Table(name: 'test_comment_log_entries')]
 #[ORM\Entity(repositoryClass: LogEntryRepository::class)]
-class Comment extends AbstractLogEntry
-{
-}
+class Comment extends AbstractLogEntry {}

--- a/tests/Gedmo/Loggable/Fixture/Entity/RelatedArticle.php
+++ b/tests/Gedmo/Loggable/Fixture/Entity/RelatedArticle.php
@@ -28,16 +28,14 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class RelatedArticle implements Loggable
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
      */
     #[ORM\Id]
+    #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    #[ORM\GeneratedValue()]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @Gedmo\Versioned
@@ -63,7 +61,7 @@ class RelatedArticle implements Loggable
      * @ORM\OneToMany(targetEntity="Comment", mappedBy="article")
      */
     #[ORM\OneToMany(targetEntity: Comment::class, mappedBy: 'article')]
-    private $comments;
+    private Collection $comments;
 
     public function __construct()
     {

--- a/tests/Gedmo/Loggable/LoggableDocumentTest.php
+++ b/tests/Gedmo/Loggable/LoggableDocumentTest.php
@@ -63,7 +63,7 @@ final class LoggableDocumentTest extends BaseTestCaseMongoODM
 
         static::assertNotNull($log);
         static::assertSame('create', $log->getAction());
-        static::assertSame(get_class($art0), $log->getObjectClass());
+        static::assertSame($art0::class, $log->getObjectClass());
         static::assertSame('jules', $log->getUsername());
         static::assertSame(1, $log->getVersion());
         $data = $log->getData();

--- a/tests/Gedmo/Loggable/LoggableEntityTest.php
+++ b/tests/Gedmo/Loggable/LoggableEntityTest.php
@@ -84,7 +84,7 @@ abstract class LoggableEntityTest extends BaseTestCaseORM
 
         static::assertNotNull($log);
         static::assertSame('create', $log->getAction());
-        static::assertSame(get_class($art0), $log->getObjectClass());
+        static::assertSame($art0::class, $log->getObjectClass());
         static::assertSame('jules', $log->getUsername());
         static::assertSame(1, $log->getVersion());
         $data = $log->getData();
@@ -132,7 +132,7 @@ abstract class LoggableEntityTest extends BaseTestCaseORM
 
         static::assertNotNull($log);
         static::assertSame('create', $log->getAction());
-        static::assertSame(get_class($art0), $log->getObjectClass());
+        static::assertSame($art0::class, $log->getObjectClass());
         static::assertSame('testactor', $log->getUsername());
         static::assertSame(1, $log->getVersion());
         $data = $log->getData();
@@ -225,7 +225,7 @@ abstract class LoggableEntityTest extends BaseTestCaseORM
 
         static::assertNotNull($log);
         static::assertSame('create', $log->getAction());
-        static::assertSame(get_class($cmp), $log->getObjectClass());
+        static::assertSame($cmp::class, $log->getObjectClass());
         static::assertSame('jules', $log->getUsername());
         static::assertSame(1, $log->getVersion());
         $data = $log->getData();
@@ -279,7 +279,7 @@ abstract class LoggableEntityTest extends BaseTestCaseORM
 
         static::assertNotNull($log);
         static::assertSame('create', $log->getAction());
-        static::assertSame(get_class($cmp0), $log->getObjectClass());
+        static::assertSame($cmp0::class, $log->getObjectClass());
         static::assertSame('jules', $log->getUsername());
         static::assertSame(1, $log->getVersion());
         $data = $log->getData();

--- a/tests/Gedmo/Mapping/Annotation/BaseClassAnnotationTestCase.php
+++ b/tests/Gedmo/Mapping/Annotation/BaseClassAnnotationTestCase.php
@@ -18,13 +18,9 @@ use PHPUnit\Framework\TestCase;
 abstract class BaseClassAnnotationTestCase extends TestCase
 {
     /**
-     * @requires PHP 8
-     *
      * @dataProvider getValidParameters
-     *
-     * @param mixed $expectedReturn
      */
-    public function testLoadFromAttribute(string $annotationProperty, $expectedReturn): void
+    public function testLoadFromAttribute(string $annotationProperty, mixed $expectedReturn): void
     {
         $annotation = $this->getClassAnnotation(true);
         static::assertSame($annotation->$annotationProperty, $expectedReturn);
@@ -32,10 +28,8 @@ abstract class BaseClassAnnotationTestCase extends TestCase
 
     /**
      * @dataProvider getValidParameters
-     *
-     * @param mixed $expectedReturn
      */
-    public function testLoadFromDoctrineAnnotation(string $annotationProperty, $expectedReturn): void
+    public function testLoadFromDoctrineAnnotation(string $annotationProperty, mixed $expectedReturn): void
     {
         $annotation = $this->getClassAnnotation(false);
         static::assertSame($annotation->$annotationProperty, $expectedReturn);

--- a/tests/Gedmo/Mapping/Annotation/BasePropertyAnnotationTestCase.php
+++ b/tests/Gedmo/Mapping/Annotation/BasePropertyAnnotationTestCase.php
@@ -18,13 +18,9 @@ use PHPUnit\Framework\TestCase;
 abstract class BasePropertyAnnotationTestCase extends TestCase
 {
     /**
-     * @requires PHP 8
-     *
      * @dataProvider getValidParameters
-     *
-     * @param mixed $expectedReturn
      */
-    public function testLoadFromAttribute(string $annotationProperty, string $classProperty, $expectedReturn): void
+    public function testLoadFromAttribute(string $annotationProperty, string $classProperty, mixed $expectedReturn): void
     {
         $annotation = $this->getMethodAnnotation($classProperty, true);
         static::assertSame($annotation->$annotationProperty, $expectedReturn);
@@ -32,10 +28,8 @@ abstract class BasePropertyAnnotationTestCase extends TestCase
 
     /**
      * @dataProvider getValidParameters
-     *
-     * @param mixed $expectedReturn
      */
-    public function testLoadFromDoctrineAnnotation(string $annotationProperty, string $classProperty, $expectedReturn): void
+    public function testLoadFromDoctrineAnnotation(string $annotationProperty, string $classProperty, mixed $expectedReturn): void
     {
         $annotation = $this->getMethodAnnotation($classProperty, false);
         static::assertSame($annotation->$annotationProperty, $expectedReturn);
@@ -44,7 +38,7 @@ abstract class BasePropertyAnnotationTestCase extends TestCase
     /**
      * @phpstan-return iterable<int, array{0: string, 1: string, 2: ?bool}>
      */
-    abstract public function getValidParameters(): iterable;
+    abstract public static function getValidParameters(): iterable;
 
     abstract protected function getAnnotationClass(): string;
 

--- a/tests/Gedmo/Mapping/Annotation/TranslatablePropertyTestCase.php
+++ b/tests/Gedmo/Mapping/Annotation/TranslatablePropertyTestCase.php
@@ -17,13 +17,11 @@ use Gedmo\Tests\Mapping\Fixture\Attribute\TranslatableModel as AttributeTranslat
 
 final class TranslatablePropertyTestCase extends BasePropertyAnnotationTestCase
 {
-    public function getValidParameters(): iterable
+    public static function getValidParameters(): \Generator
     {
-        return [
-            ['fallback', 'title', null],
-            ['fallback', 'titleFallbackTrue', true],
-            ['fallback', 'titleFallbackFalse', false],
-        ];
+        yield ['fallback', 'title', null];
+        yield ['fallback', 'titleFallbackTrue', true];
+        yield ['fallback', 'titleFallbackFalse', false];
     }
 
     protected function getAnnotationClass(): string

--- a/tests/Gedmo/Mapping/Annotation/TranslationEntityTestCase.php
+++ b/tests/Gedmo/Mapping/Annotation/TranslationEntityTestCase.php
@@ -17,11 +17,9 @@ use Gedmo\Tests\Mapping\Fixture\Attribute\TranslationEntityModel as AttributeTra
 
 final class TranslationEntityTestCase extends BaseClassAnnotationTestCase
 {
-    public static function getValidParameters(): iterable
+    public static function getValidParameters(): \Iterator
     {
-        return [
-            ['class', \stdClass::class],
-        ];
+        yield ['class', \stdClass::class];
     }
 
     protected function getAnnotationClass(): string

--- a/tests/Gedmo/Mapping/ExtensionODMTest.php
+++ b/tests/Gedmo/Mapping/ExtensionODMTest.php
@@ -67,7 +67,6 @@ final class ExtensionODMTest extends BaseTestCaseMongoODM
     {
         $mappedSubscriberClass = new \ReflectionClass(MappedEventSubscriber::class);
         $getEventAdapterMethod = $mappedSubscriberClass->getMethod('getEventAdapter');
-        $getEventAdapterMethod->setAccessible(true);
 
         $loadClassMetadataEventArgs = new LoadClassMetadataEventArgs(
             $this->dm->getClassMetadata(User::class),

--- a/tests/Gedmo/Mapping/ExtensionORMTest.php
+++ b/tests/Gedmo/Mapping/ExtensionORMTest.php
@@ -68,7 +68,6 @@ final class ExtensionORMTest extends BaseTestCaseORM
     {
         $mappedSubscriberClass = new \ReflectionClass(MappedEventSubscriber::class);
         $getEventAdapterMethod = $mappedSubscriberClass->getMethod('getEventAdapter');
-        $getEventAdapterMethod->setAccessible(true);
 
         $loadClassMetadataEventArgs = new LoadClassMetadataEventArgs(
             $this->em->getClassMetadata(User::class),

--- a/tests/Gedmo/Mapping/Fixture/Annotation/TranslatableModel.php
+++ b/tests/Gedmo/Mapping/Fixture/Annotation/TranslatableModel.php
@@ -16,23 +16,17 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class TranslatableModel
 {
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      */
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable(fallback=true)
      */
-    private $titleFallbackTrue;
+    private ?string $titleFallbackTrue = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable(fallback=false)
      */
-    private $titleFallbackFalse;
+    private ?string $titleFallbackFalse = null;
 }

--- a/tests/Gedmo/Mapping/Fixture/Annotation/TranslationEntityModel.php
+++ b/tests/Gedmo/Mapping/Fixture/Annotation/TranslationEntityModel.php
@@ -16,6 +16,4 @@ use Gedmo\Mapping\Annotation as Gedmo;
 /**
  * @Gedmo\TranslationEntity(class="stdClass")
  */
-class TranslationEntityModel
-{
-}
+class TranslationEntityModel {}

--- a/tests/Gedmo/Mapping/Fixture/Attribute/TranslationEntityModel.php
+++ b/tests/Gedmo/Mapping/Fixture/Attribute/TranslationEntityModel.php
@@ -14,6 +14,4 @@ namespace Gedmo\Tests\Mapping\Fixture\Attribute;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 #[Gedmo\TranslationEntity(class: \stdClass::class)]
-class TranslationEntityModel
-{
-}
+class TranslationEntityModel {}

--- a/tests/Gedmo/Mapping/Fixture/BaseCategory.php
+++ b/tests/Gedmo/Mapping/Fixture/BaseCategory.php
@@ -80,9 +80,6 @@ class BaseCategory
         $this->created = $created;
     }
 
-    /**
-     * @return \DateTime $created
-     */
     public function getCreated(): ?\DateTime
     {
         return $this->created;

--- a/tests/Gedmo/Mapping/Fixture/Category.php
+++ b/tests/Gedmo/Mapping/Fixture/Category.php
@@ -19,7 +19,6 @@ use Gedmo\Loggable\Entity\LogEntry;
 use Gedmo\Mapping\Annotation as Gedmo;
 use Gedmo\Sluggable\Handler\RelativeSlugHandler;
 use Gedmo\Sluggable\Handler\TreeSlugHandler;
-use Gedmo\Tests\Translatable\Fixture\CategoryTranslation;
 
 /**
  * @ORM\Entity
@@ -37,8 +36,6 @@ use Gedmo\Tests\Translatable\Fixture\CategoryTranslation;
 class Category extends BaseCategory
 {
     /**
-     * @var int
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -46,7 +43,7 @@ class Category extends BaseCategory
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(type="string", length=64)
@@ -89,7 +86,7 @@ class Category extends BaseCategory
      * @ORM\OneToMany(targetEntity="Gedmo\Tests\Mapping\Fixture\Category", mappedBy="parent")
      */
     #[ORM\OneToMany(targetEntity: self::class, mappedBy: 'parent')]
-    private $children;
+    private Collection $children;
 
     /**
      * @ORM\ManyToOne(targetEntity="Gedmo\Tests\Mapping\Fixture\Category", inversedBy="children")
@@ -98,27 +95,22 @@ class Category extends BaseCategory
      */
     #[ORM\ManyToOne(targetEntity: self::class, inversedBy: 'children')]
     #[Gedmo\TreeParent]
-    private ?Category $parent = null;
+    private ?self $parent = null;
 
     /**
-     * @var \DateTime
-     *
      * @ORM\Column(type="date")
      *
      * @Gedmo\Timestampable(on="change", field="title", value="Test")
      */
     #[ORM\Column(type: Types::DATE_MUTABLE)]
     #[Gedmo\Timestampable(on: 'change', field: 'title', value: 'Test')]
-    private $changed;
+    private ?\DateTime $changed = null;
 
     public function __construct()
     {
         $this->children = new ArrayCollection();
     }
 
-    /**
-     * @return int $id
-     */
     public function getId(): int
     {
         return $this->id;
@@ -139,9 +131,6 @@ class Category extends BaseCategory
         $this->slug = $slug;
     }
 
-    /**
-     * @return string $slug
-     */
     public function getSlug(): string
     {
         return $this->slug;
@@ -153,9 +142,9 @@ class Category extends BaseCategory
     }
 
     /**
-     * @return Collection<int, self> $children
+     * @return Collection<int, self>
      */
-    public function getChildren()
+    public function getChildren(): Collection
     {
         return $this->children;
     }
@@ -165,9 +154,6 @@ class Category extends BaseCategory
         $this->parent = $parent;
     }
 
-    /**
-     * @return self $parent
-     */
     public function getParent(): self
     {
         return $this->parent;

--- a/tests/Gedmo/Mapping/Fixture/CategoryTranslation.php
+++ b/tests/Gedmo/Mapping/Fixture/CategoryTranslation.php
@@ -9,30 +9,32 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Gedmo\Tests\Translator\Fixture;
+namespace Gedmo\Tests\Mapping\Fixture;
 
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Translator\Entity\Translation;
 
 /**
  * @ORM\Table(
- *     indexes={@ORM\Index(name="pers_translations_lookup_idx", columns={
+ *     indexes={@ORM\Index(name="translations_lookup_idx", columns={
  *         "locale", "translatable_id"
  *     })},
- *     uniqueConstraints={@ORM\UniqueConstraint(name="pers_lookup_unique_idx", columns={
+ *     uniqueConstraints={@ORM\UniqueConstraint(name="lookup_unique_idx", columns={
  *         "locale", "translatable_id", "property"
  *     })}
  * )
  * @ORM\Entity
  */
 #[ORM\Entity]
-#[ORM\Index(name: 'pers_translations_lookup_idx', columns: ['locale', 'translatable_id'])]
-#[ORM\UniqueConstraint(name: 'pers_lookup_unique_idx', columns: ['locale', 'translatable_id', 'property'])]
-class PersonCustomTranslation extends Translation
+#[ORM\Index(name: 'translations_lookup_idx', columns: ['locale', 'translatable_id'])]
+#[ORM\UniqueConstraint(name: 'lookup_unique_idx', columns: ['locale', 'translatable_id', 'property'])]
+class CategoryTranslation extends Translation
 {
     /**
-     * @ORM\ManyToOne(targetEntity="PersonCustom", inversedBy="translations")
+     * @var Category|null
+     *
+     * @ORM\ManyToOne(targetEntity="Person", inversedBy="translations")
      */
-    #[ORM\ManyToOne(targetEntity: PersonCustom::class, inversedBy: 'translations')]
+    #[ORM\ManyToOne(targetEntity: Category::class, inversedBy: 'translations')]
     protected $translatable;
 }

--- a/tests/Gedmo/Mapping/Fixture/Document/User.php
+++ b/tests/Gedmo/Mapping/Fixture/Document/User.php
@@ -22,12 +22,10 @@ use Gedmo\Tests\Mapping\Mock\Extension\Encoder\Mapping as Ext;
 class User
 {
     /**
-     * @var string|null
-     *
      * @ODM\Id
      */
     #[ODM\Id]
-    private $id;
+    private ?string $id = null;
 
     /**
      * @Ext\Encode(type="sha1", secret="xxx")

--- a/tests/Gedmo/Mapping/Fixture/Embedded.php
+++ b/tests/Gedmo/Mapping/Fixture/Embedded.php
@@ -25,10 +25,8 @@ use Doctrine\ORM\Mapping as ORM;
 class Embedded
 {
     /**
-     * @var string
-     *
      * @ORM\Column(type="string")
      */
     #[ORM\Column(type: Types::STRING)]
-    private $subtitle;
+    private ?string $subtitle = null;
 }

--- a/tests/Gedmo/Mapping/Fixture/Loggable.php
+++ b/tests/Gedmo/Mapping/Fixture/Loggable.php
@@ -24,8 +24,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Loggable
 {
     /**
-     * @var int
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -33,7 +31,7 @@ class Loggable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=64)

--- a/tests/Gedmo/Mapping/Fixture/LoggableComposite.php
+++ b/tests/Gedmo/Mapping/Fixture/LoggableComposite.php
@@ -24,24 +24,20 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class LoggableComposite
 {
     /**
-     * @var int
-     *
      * @ORM\Id
      * @ORM\Column(type="integer")
      */
     #[ORM\Id]
     #[ORM\Column(type: Types::INTEGER)]
-    private $one;
+    private ?int $one = null;
 
     /**
-     * @var int
-     *
      * @ORM\Id
      * @ORM\Column(type="integer")
      */
     #[ORM\Id]
     #[ORM\Column(type: Types::INTEGER)]
-    private $two;
+    private ?int $two = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=64)

--- a/tests/Gedmo/Mapping/Fixture/LoggableCompositeRelation.php
+++ b/tests/Gedmo/Mapping/Fixture/LoggableCompositeRelation.php
@@ -24,24 +24,20 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class LoggableCompositeRelation
 {
     /**
-     * @var Loggable
-     *
      * @ORM\Id
      * @ORM\ManyToOne(targetEntity="Loggable")
      */
     #[ORM\Id]
     #[ORM\ManyToOne(targetEntity: Loggable::class)]
-    private $one;
+    private ?Loggable $one = null;
 
     /**
-     * @var int
-     *
      * @ORM\Id
      * @ORM\Column(type="integer")
      */
     #[ORM\Id]
     #[ORM\Column(type: Types::INTEGER)]
-    private $two;
+    private ?int $two = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=64)

--- a/tests/Gedmo/Mapping/Fixture/LoggableWithEmbedded.php
+++ b/tests/Gedmo/Mapping/Fixture/LoggableWithEmbedded.php
@@ -26,8 +26,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class LoggableWithEmbedded
 {
     /**
-     * @var int
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -35,27 +33,23 @@ class LoggableWithEmbedded
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
-     * @var string
-     *
      * @ORM\Column(name="title", type="string")
      *
      * @Gedmo\Versioned
      */
     #[ORM\Column(name: 'title', type: Types::STRING)]
     #[Gedmo\Versioned]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var Embedded
-     *
      * @ORM\Embedded(class="Gedmo\Tests\Mapping\Fixture\Embedded")
      *
      * @Gedmo\Versioned
      */
     #[ORM\Embedded(class: Embedded::class)]
     #[Gedmo\Versioned]
-    private $embedded;
+    private ?Embedded $embedded = null;
 }

--- a/tests/Gedmo/Mapping/Fixture/MappedSuperClass.php
+++ b/tests/Gedmo/Mapping/Fixture/MappedSuperClass.php
@@ -22,8 +22,6 @@ use Gedmo\Tests\Mapping\Mock\Extension\Encoder\Mapping as Ext;
 class MappedSuperClass
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -31,7 +29,7 @@ class MappedSuperClass
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(length=32)

--- a/tests/Gedmo/Mapping/Fixture/Sluggable.php
+++ b/tests/Gedmo/Mapping/Fixture/Sluggable.php
@@ -24,8 +24,6 @@ use Gedmo\Sluggable\Handler\TreeSlugHandler;
 class Sluggable
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -33,7 +31,7 @@ class Sluggable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=64)
@@ -54,8 +52,6 @@ class Sluggable
     private ?string $ean = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Slug(handlers={
      *     @Gedmo\SlugHandler(class="Gedmo\Sluggable\Handler\TreeSlugHandler", options={
      *         @Gedmo\SlugHandlerOption(name="parentRelationField", value="parent"),
@@ -74,23 +70,19 @@ class Sluggable
     #[Gedmo\SlugHandler(class: TreeSlugHandler::class, options: ['parentRelationField' => 'parent', 'separator' => '/'])]
     #[Gedmo\SlugHandler(class: RelativeSlugHandler::class, options: ['relationField' => 'parent', 'relationSlugField' => 'test', 'separator' => '-'])]
     #[ORM\Column(name: 'slug', type: Types::STRING, length: 64, unique: true)]
-    private $slug;
+    private ?string $slug = null;
 
     /**
-     * @var Sluggable|null
-     *
      * @ORM\ManyToOne(targetEntity="Sluggable")
      */
     #[ORM\ManyToOne(targetEntity: self::class)]
-    private $parent;
+    private ?self $parent = null;
 
     /**
-     * @var User|null
-     *
      * @ORM\ManyToOne(targetEntity="User")
      */
     #[ORM\ManyToOne(targetEntity: User::class)]
-    private $user;
+    private ?User $user = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Mapping/Fixture/SoftDeleteable.php
+++ b/tests/Gedmo/Mapping/Fixture/SoftDeleteable.php
@@ -25,8 +25,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class SoftDeleteable
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -34,24 +32,19 @@ class SoftDeleteable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     private ?string $title = null;
 
     private ?string $code = null;
 
-    /**
-     * @var string|null
-     */
-    private $slug;
+    private ?string $slug = null;
 
     /**
-     * @var \DateTime|null
-     *
      * @ORM\Column(name="deleted_at", type="datetime", nullable=true)
      */
     #[ORM\Column(name: 'deleted_at', type: Types::DATETIME_MUTABLE, nullable: true)]
-    private $deletedAt;
+    private ?\DateTime $deletedAt = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Mapping/Fixture/Sortable.php
+++ b/tests/Gedmo/Mapping/Fixture/Sortable.php
@@ -26,8 +26,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Sortable
 {
     /**
-     * @var int
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -35,48 +33,40 @@ class Sortable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
-     * @var string
-     *
      * @ORM\Column(type="string", length=128)
      */
     #[ORM\Column(type: Types::STRING, length: 128)]
-    private $title;
+    private ?string $title = null;
 
     /**
-     * @var int
-     *
      * @ORM\Column(type="integer")
      *
      * @Gedmo\SortablePosition
      */
     #[ORM\Column(type: Types::INTEGER)]
     #[Gedmo\SortablePosition]
-    private $position;
+    private ?int $position = null;
 
     /**
-     * @var string
-     *
      * @ORM\Column(type="string", length=128)
      *
      * @Gedmo\SortableGroup
      */
     #[ORM\Column(type: Types::STRING, length: 128)]
     #[Gedmo\SortableGroup]
-    private $grouping;
+    private ?string $grouping = null;
 
     /**
-     * @var SortableGroup
-     *
      * @ORM\ManyToOne(targetEntity="Sluggable")
      *
      * @Gedmo\SortableGroup
      */
     #[ORM\ManyToOne(targetEntity: SortableGroup::class)]
     #[Gedmo\SortableGroup]
-    private $sortable_group;
+    private ?SortableGroup $sortable_group = null;
 
     /**
      * @var Collection<int, SortableGroup>

--- a/tests/Gedmo/Mapping/Fixture/SortableGroup.php
+++ b/tests/Gedmo/Mapping/Fixture/SortableGroup.php
@@ -23,8 +23,6 @@ use Doctrine\ORM\Mapping as ORM;
 class SortableGroup
 {
     /**
-     * @var int
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -32,13 +30,11 @@ class SortableGroup
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
-     * @var string
-     *
      * @ORM\Column(type="string", length=64)
      */
     #[ORM\Column(type: Types::STRING, length: 64)]
-    private $name;
+    private ?string $name = null;
 }

--- a/tests/Gedmo/Mapping/Fixture/Unmapped/Timestampable.php
+++ b/tests/Gedmo/Mapping/Fixture/Unmapped/Timestampable.php
@@ -15,16 +15,11 @@ use Gedmo\Mapping\Annotation\Timestampable as Tmsp;
 
 class Timestampable
 {
-    /**
-     * @var int
-     */
-    private $id;
+    private ?int $id = null;
 
     /**
-     * @var \DateTime
-     *
      * @Tmsp(on="create")
      */
     #[Tmsp(on: 'create')]
-    private $created;
+    private ?\DateTime $created = null;
 }

--- a/tests/Gedmo/Mapping/Fixture/Uploadable.php
+++ b/tests/Gedmo/Mapping/Fixture/Uploadable.php
@@ -26,8 +26,6 @@ use Gedmo\Uploadable\Mapping\Validator;
 class Uploadable
 {
     /**
-     * @var int
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -35,18 +33,16 @@ class Uploadable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
-     * @var string
-     *
      * @ORM\Column(name="mime", type="string")
      *
      * @Gedmo\UploadableFileMimeType
      */
     #[ORM\Column(name: 'mime', type: Types::STRING)]
     #[Gedmo\UploadableFileMimeType]
-    private $mimeType;
+    private ?string $mimeType = null;
 
     /**
      * @var array<string, mixed>
@@ -54,33 +50,27 @@ class Uploadable
     private $fileInfo;
 
     /**
-     * @var float
-     *
      * @ORM\Column(name="size", type="decimal", precision=10, scale=2)
      *
      * @Gedmo\UploadableFileSize
      */
     #[ORM\Column(name: 'size', type: Types::DECIMAL, precision: 10, scale: 2)]
     #[Gedmo\UploadableFileSize]
-    private $size;
+    private ?float $size = null;
 
     /**
-     * @var string
-     *
      * @ORM\Column(name="path", type="string")
      *
      * @Gedmo\UploadableFilePath
      */
     #[ORM\Column(name: 'path', type: Types::STRING)]
     #[Gedmo\UploadableFilePath]
-    private $path;
+    private ?string $path = null;
 
     public function getPath(): string
     {
         return $this->path;
     }
 
-    public function callbackMethod(): void
-    {
-    }
+    public function callbackMethod(): void {}
 }

--- a/tests/Gedmo/Mapping/Fixture/User.php
+++ b/tests/Gedmo/Mapping/Fixture/User.php
@@ -34,8 +34,6 @@ use Gedmo\Tests\Translatable\Fixture\PersonTranslation;
 class User
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -43,7 +41,7 @@ class User
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @Ext\Encode(type="sha1", secret="xxx")
@@ -85,12 +83,10 @@ class User
     private ?string $company = null;
 
     /**
-     * @var string
-     *
      * @Gedmo\Locale
      */
     #[Gedmo\Locale]
-    private $localeField;
+    private ?string $localeField = null;
 
     public function setName(?string $name): void
     {

--- a/tests/Gedmo/Mapping/Fixture/Xml/ClosureTree.php
+++ b/tests/Gedmo/Mapping/Fixture/Xml/ClosureTree.php
@@ -13,23 +13,11 @@ namespace Gedmo\Tests\Mapping\Fixture\Xml;
 
 class ClosureTree
 {
-    /**
-     * @var int
-     */
-    private $id;
+    private ?int $id = null;
 
-    /**
-     * @var string
-     */
-    private $name;
+    private ?string $name = null;
 
-    /**
-     * @var ClosureTree|null
-     */
-    private $parent;
+    private ?self $parent = null;
 
-    /**
-     * @var int
-     */
-    private $level;
+    private ?int $level = null;
 }

--- a/tests/Gedmo/Mapping/Fixture/Xml/Embedded.php
+++ b/tests/Gedmo/Mapping/Fixture/Xml/Embedded.php
@@ -18,8 +18,5 @@ namespace Gedmo\Tests\Mapping\Fixture\Xml;
  */
 class Embedded
 {
-    /**
-     * @var string
-     */
-    private $subtitle;
+    private ?string $subtitle = null;
 }

--- a/tests/Gedmo/Mapping/Fixture/Xml/EmbeddedTranslatable.php
+++ b/tests/Gedmo/Mapping/Fixture/Xml/EmbeddedTranslatable.php
@@ -13,8 +13,5 @@ namespace Gedmo\Tests\Mapping\Fixture\Xml;
 
 class EmbeddedTranslatable
 {
-    /**
-     * @var string
-     */
-    private $subtitle;
+    private ?string $subtitle = null;
 }

--- a/tests/Gedmo/Mapping/Fixture/Xml/Loggable.php
+++ b/tests/Gedmo/Mapping/Fixture/Xml/Loggable.php
@@ -13,18 +13,9 @@ namespace Gedmo\Tests\Mapping\Fixture\Xml;
 
 class Loggable
 {
-    /**
-     * @var int
-     */
-    private $id;
+    private ?int $id = null;
 
-    /**
-     * @var string
-     */
-    private $title;
+    private ?string $title = null;
 
-    /**
-     * @var Status
-     */
-    private $status;
+    private ?Status $status = null;
 }

--- a/tests/Gedmo/Mapping/Fixture/Xml/LoggableComposite.php
+++ b/tests/Gedmo/Mapping/Fixture/Xml/LoggableComposite.php
@@ -11,18 +11,9 @@ namespace Gedmo\Tests\Mapping\Fixture\Xml;
 
 class LoggableComposite
 {
-    /**
-     * @var int
-     */
-    private $one;
+    private ?int $one = null;
 
-    /**
-     * @var int
-     */
-    private $two;
+    private ?int $two = null;
 
-    /**
-     * @var string
-     */
-    private $title;
+    private ?string $title = null;
 }

--- a/tests/Gedmo/Mapping/Fixture/Xml/LoggableCompositeRelation.php
+++ b/tests/Gedmo/Mapping/Fixture/Xml/LoggableCompositeRelation.php
@@ -11,18 +11,9 @@ namespace Gedmo\Tests\Mapping\Fixture\Xml;
 
 class LoggableCompositeRelation
 {
-    /**
-     * @var Loggable
-     */
-    private $one;
+    private ?Loggable $one = null;
 
-    /**
-     * @var int
-     */
-    private $two;
+    private ?int $two = null;
 
-    /**
-     * @var string
-     */
-    private $title;
+    private ?string $title = null;
 }

--- a/tests/Gedmo/Mapping/Fixture/Xml/LoggableWithEmbedded.php
+++ b/tests/Gedmo/Mapping/Fixture/Xml/LoggableWithEmbedded.php
@@ -13,23 +13,11 @@ namespace Gedmo\Tests\Mapping\Fixture\Xml;
 
 class LoggableWithEmbedded
 {
-    /**
-     * @var int
-     */
-    private $id;
+    private ?int $id = null;
 
-    /**
-     * @var string
-     */
-    private $title;
+    private ?string $title = null;
 
-    /**
-     * @var Status
-     */
-    private $status;
+    private ?Status $status = null;
 
-    /**
-     * @var Embedded
-     */
-    private $embedded;
+    private ?Embedded $embedded = null;
 }

--- a/tests/Gedmo/Mapping/Fixture/Xml/MaterializedPathTree.php
+++ b/tests/Gedmo/Mapping/Fixture/Xml/MaterializedPathTree.php
@@ -13,38 +13,17 @@ namespace Gedmo\Tests\Mapping\Fixture\Xml;
 
 class MaterializedPathTree
 {
-    /**
-     * @var int
-     */
-    private $id;
+    private ?int $id = null;
 
-    /**
-     * @var string
-     */
-    private $title;
+    private ?string $title = null;
 
-    /**
-     * @var string
-     */
-    private $path;
+    private ?string $path = null;
 
-    /**
-     * @var \DateTime|null
-     */
-    private $lockTime;
+    private ?\DateTime $lockTime = null;
 
-    /**
-     * @var string
-     */
-    private $pathHash;
+    private ?string $pathHash = null;
 
-    /**
-     * @var MaterializedPathTree
-     */
-    private $parent;
+    private ?MaterializedPathTree $parent = null;
 
-    /**
-     * @var int
-     */
-    private $level;
+    private ?int $level = null;
 }

--- a/tests/Gedmo/Mapping/Fixture/Xml/NestedTree.php
+++ b/tests/Gedmo/Mapping/Fixture/Xml/NestedTree.php
@@ -13,38 +13,17 @@ namespace Gedmo\Tests\Mapping\Fixture\Xml;
 
 class NestedTree
 {
-    /**
-     * @var int
-     */
-    private $id;
+    private ?int $id = null;
 
-    /**
-     * @var string
-     */
-    private $name;
+    private ?string $name = null;
 
-    /**
-     * @var NestedTree
-     */
-    private $parent;
+    private ?NestedTree $parent = null;
 
-    /**
-     * @var int
-     */
-    private $root;
+    private ?int $root = null;
 
-    /**
-     * @var int
-     */
-    private $level;
+    private ?int $level = null;
 
-    /**
-     * @var int
-     */
-    private $left;
+    private ?int $left = null;
 
-    /**
-     * @var int
-     */
-    private $right;
+    private ?int $right = null;
 }

--- a/tests/Gedmo/Mapping/Fixture/Xml/References.php
+++ b/tests/Gedmo/Mapping/Fixture/Xml/References.php
@@ -15,18 +15,12 @@ use Gedmo\Tests\Mapping\Fixture\Document\User;
 
 class References
 {
-    /**
-     * @var int
-     */
-    private $id;
+    private ?int $id = null;
 
-    /**
-     * @var string
-     */
-    private $name;
+    private ?string $name = null;
 
     /**
      * @var User[]
      */
-    private $users;
+    private array $users = [];
 }

--- a/tests/Gedmo/Mapping/Fixture/Xml/Sluggable.php
+++ b/tests/Gedmo/Mapping/Fixture/Xml/Sluggable.php
@@ -13,33 +13,15 @@ namespace Gedmo\Tests\Mapping\Fixture\Xml;
 
 class Sluggable
 {
-    /**
-     * @var int
-     */
-    private $id;
+    private ?int $id = null;
 
-    /**
-     * @var string
-     */
-    private $title;
+    private ?string $title = null;
 
-    /**
-     * @var string
-     */
-    private $code;
+    private ?string $code = null;
 
-    /**
-     * @var string
-     */
-    private $ean;
+    private ?string $ean = null;
 
-    /**
-     * @var string
-     */
-    private $slug;
+    private ?string $slug = null;
 
-    /**
-     * @var Sluggable
-     */
-    private $parent;
+    private ?Sluggable $parent = null;
 }

--- a/tests/Gedmo/Mapping/Fixture/Xml/SoftDeleteable.php
+++ b/tests/Gedmo/Mapping/Fixture/Xml/SoftDeleteable.php
@@ -13,13 +13,7 @@ namespace Gedmo\Tests\Mapping\Fixture\Xml;
 
 class SoftDeleteable
 {
-    /**
-     * @var int
-     */
-    private $id;
+    private ?int $id = null;
 
-    /**
-     * @var \DateTime|null
-     */
-    private $deletedAt;
+    private ?\DateTime $deletedAt = null;
 }

--- a/tests/Gedmo/Mapping/Fixture/Xml/Sortable.php
+++ b/tests/Gedmo/Mapping/Fixture/Xml/Sortable.php
@@ -16,33 +16,18 @@ use Gedmo\Tests\Mapping\Fixture\SortableGroup;
 
 class Sortable
 {
-    /**
-     * @var int
-     */
-    private $id;
+    private ?int $id = null;
 
-    /**
-     * @var string
-     */
-    private $title;
+    private ?string $title = null;
 
-    /**
-     * @var int
-     */
-    private $position;
+    private ?int $position = null;
 
-    /**
-     * @var string
-     */
-    private $grouping;
+    private ?string $grouping = null;
 
-    /**
-     * @var SortableGroup
-     */
-    private $sortable_group;
+    private ?SortableGroup $sortable_group = null;
 
     /**
      * @var Collection<int, SortableGroup>
      */
-    private $sortable_groups;
+    private Collection $sortable_groups;
 }

--- a/tests/Gedmo/Mapping/Fixture/Xml/Status.php
+++ b/tests/Gedmo/Mapping/Fixture/Xml/Status.php
@@ -13,13 +13,7 @@ namespace Gedmo\Tests\Mapping\Fixture\Xml;
 
 class Status
 {
-    /**
-     * @var int
-     */
-    private $id;
+    private ?int $id = null;
 
-    /**
-     * @var string
-     */
-    private $title;
+    private ?string $title = null;
 }

--- a/tests/Gedmo/Mapping/Fixture/Xml/Timestampable.php
+++ b/tests/Gedmo/Mapping/Fixture/Xml/Timestampable.php
@@ -13,28 +13,13 @@ namespace Gedmo\Tests\Mapping\Fixture\Xml;
 
 class Timestampable
 {
-    /**
-     * @var int
-     */
-    private $id;
+    private ?int $id = null;
 
-    /**
-     * @var \DateTime
-     */
-    private $created;
+    private ?\DateTime $created = null;
 
-    /**
-     * @var \DateTime
-     */
-    private $updated;
+    private ?\DateTime $updated = null;
 
-    /**
-     * @var \DateTime
-     */
-    private $published;
+    private ?\DateTime $published = null;
 
-    /**
-     * @var Status
-     */
-    private $status;
+    private ?Status $status = null;
 }

--- a/tests/Gedmo/Mapping/Fixture/Xml/Translatable.php
+++ b/tests/Gedmo/Mapping/Fixture/Xml/Translatable.php
@@ -13,33 +13,15 @@ namespace Gedmo\Tests\Mapping\Fixture\Xml;
 
 class Translatable
 {
-    /**
-     * @var int
-     */
-    private $id;
+    private ?int $id = null;
 
-    /**
-     * @var string
-     */
-    private $title;
+    private ?string $title = null;
 
-    /**
-     * @var string
-     */
-    private $content;
+    private ?string $content = null;
 
-    /**
-     * @var string
-     */
-    private $locale;
+    private ?string $locale = null;
 
-    /**
-     * @var string
-     */
-    private $author;
+    private ?string $author = null;
 
-    /**
-     * @var int
-     */
-    private $views;
+    private ?int $views = null;
 }

--- a/tests/Gedmo/Mapping/Fixture/Xml/TranslatableWithEmbedded.php
+++ b/tests/Gedmo/Mapping/Fixture/Xml/TranslatableWithEmbedded.php
@@ -13,38 +13,17 @@ namespace Gedmo\Tests\Mapping\Fixture\Xml;
 
 class TranslatableWithEmbedded
 {
-    /**
-     * @var int
-     */
-    private $id;
+    private ?int $id = null;
 
-    /**
-     * @var string
-     */
-    private $title;
+    private ?string $title = null;
 
-    /**
-     * @var string
-     */
-    private $content;
+    private ?string $content = null;
 
-    /**
-     * @var string
-     */
-    private $locale;
+    private ?string $locale = null;
 
-    /**
-     * @var string
-     */
-    private $author;
+    private ?string $author = null;
 
-    /**
-     * @var int
-     */
-    private $views;
+    private ?int $views = null;
 
-    /**
-     * @var EmbeddedTranslatable
-     */
-    private $embedded;
+    private ?EmbeddedTranslatable $embedded = null;
 }

--- a/tests/Gedmo/Mapping/Fixture/Xml/Uploadable.php
+++ b/tests/Gedmo/Mapping/Fixture/Xml/Uploadable.php
@@ -13,37 +13,23 @@ namespace Gedmo\Tests\Mapping\Fixture\Xml;
 
 class Uploadable
 {
-    /**
-     * @var int
-     */
-    private $id;
+    private ?int $id = null;
 
-    /**
-     * @var string
-     */
-    private $mimeType;
+    private ?string $mimeType = null;
 
     /**
      * @var array<string, mixed>
      */
-    private $fileInfo;
+    private array $fileInfo = [];
 
-    /**
-     * @var float
-     */
-    private $size;
+    private ?float $size = null;
 
-    /**
-     * @var string
-     */
-    private $path;
+    private ?string $path = null;
 
-    public function getPath(): string
+    public function getPath(): ?string
     {
         return $this->path;
     }
 
-    public function callbackMethod(): void
-    {
-    }
+    public function callbackMethod(): void {}
 }

--- a/tests/Gedmo/Mapping/Fixture/Xml/User.php
+++ b/tests/Gedmo/Mapping/Fixture/Xml/User.php
@@ -13,10 +13,7 @@ namespace Gedmo\Tests\Mapping\Fixture\Xml;
 
 class User
 {
-    /**
-     * @var int
-     */
-    private $id;
+    private ?int $id = null;
 
     private ?string $password = null;
 
@@ -24,12 +21,9 @@ class User
 
     private ?string $company = null;
 
-    /**
-     * @var string
-     */
-    private $localeField;
+    private ?string $localeField = null;
 
-    public function getId(): int
+    public function getId(): ?int
     {
         return $this->id;
     }
@@ -39,7 +33,7 @@ class User
         $this->password = $password;
     }
 
-    public function getPassword(): string
+    public function getPassword(): ?string
     {
         return $this->password;
     }
@@ -49,7 +43,7 @@ class User
         $this->username = $username;
     }
 
-    public function getUsername(): string
+    public function getUsername(): ?string
     {
         return $this->username;
     }
@@ -59,7 +53,7 @@ class User
         $this->company = $company;
     }
 
-    public function getCompany(): string
+    public function getCompany(): ?string
     {
         return $this->company;
     }

--- a/tests/Gedmo/Mapping/Fixture/Yaml/BaseCategory.php
+++ b/tests/Gedmo/Mapping/Fixture/Yaml/BaseCategory.php
@@ -30,9 +30,6 @@ class BaseCategory
         $this->created = $created;
     }
 
-    /**
-     * @return \DateTime $created
-     */
     public function getCreated(): ?\DateTime
     {
         return $this->created;

--- a/tests/Gedmo/Mapping/Fixture/Yaml/Category.php
+++ b/tests/Gedmo/Mapping/Fixture/Yaml/Category.php
@@ -16,10 +16,7 @@ use Doctrine\Common\Collections\Collection;
 
 class Category extends BaseCategory
 {
-    /**
-     * @var int
-     */
-    private $id;
+    private ?int $id = null;
 
     private ?string $title = null;
 
@@ -28,24 +25,18 @@ class Category extends BaseCategory
     /**
      * @var Collection<int, self>
      */
-    private $children;
+    private Collection $children;
 
-    private ?Category $parent = null;
+    private ?self $parent = null;
 
-    /**
-     * @var \DateTime
-     */
-    private $changed;
+    private ?\DateTime $changed = null;
 
     public function __construct()
     {
         $this->children = new ArrayCollection();
     }
 
-    /**
-     * @return int $id
-     */
-    public function getId(): int
+    public function getId(): ?int
     {
         return $this->id;
     }
@@ -65,9 +56,6 @@ class Category extends BaseCategory
         $this->slug = $slug;
     }
 
-    /**
-     * @return string $slug
-     */
     public function getSlug(): string
     {
         return $this->slug;
@@ -81,7 +69,7 @@ class Category extends BaseCategory
     /**
      * @return Collection<int, self> $children
      */
-    public function getChildren()
+    public function getChildren(): Collection
     {
         return $this->children;
     }
@@ -91,9 +79,6 @@ class Category extends BaseCategory
         $this->parent = $parent;
     }
 
-    /**
-     * @return self $parent
-     */
     public function getParent(): self
     {
         return $this->parent;

--- a/tests/Gedmo/Mapping/Fixture/Yaml/ClosureCategory.php
+++ b/tests/Gedmo/Mapping/Fixture/Yaml/ClosureCategory.php
@@ -16,19 +16,16 @@ use Doctrine\Common\Collections\Collection;
 
 class ClosureCategory
 {
-    /**
-     * @var int
-     */
-    private $id;
+    private ?int $id = null;
 
     private ?string $title = null;
 
     /**
      * @var Collection<int, ClosureCategory>
      */
-    private $children;
+    private Collection $children;
 
-    private ?ClosureCategory $parent = null;
+    private ?self $parent = null;
 
     private ?int $level = null;
 

--- a/tests/Gedmo/Mapping/Fixture/Yaml/Embedded.php
+++ b/tests/Gedmo/Mapping/Fixture/Yaml/Embedded.php
@@ -18,8 +18,5 @@ namespace Gedmo\Tests\Mapping\Fixture\Yaml;
  */
 class Embedded
 {
-    /**
-     * @var string
-     */
-    private $subtitle;
+    private ?string $subtitle = null;
 }

--- a/tests/Gedmo/Mapping/Fixture/Yaml/Loggable.php
+++ b/tests/Gedmo/Mapping/Fixture/Yaml/Loggable.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Doctrine Behavioral Extensions package.
  * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
@@ -11,13 +13,7 @@ namespace Gedmo\Tests\Mapping\Fixture\Yaml;
 
 class Loggable
 {
-    /**
-     * @var int
-     */
-    private $id;
+    private ?int $id = null;
 
-    /**
-     * @var string
-     */
-    private $title;
+    private ?string $title = null;
 }

--- a/tests/Gedmo/Mapping/Fixture/Yaml/LoggableComposite.php
+++ b/tests/Gedmo/Mapping/Fixture/Yaml/LoggableComposite.php
@@ -11,18 +11,9 @@ namespace Gedmo\Tests\Mapping\Fixture\Yaml;
 
 class LoggableComposite
 {
-    /**
-     * @var int
-     */
-    private $one;
+    private ?int $one = null;
 
-    /**
-     * @var int
-     */
-    private $two;
+    private ?int $two = null;
 
-    /**
-     * @var string
-     */
-    private $title;
+    private ?string $title = null;
 }

--- a/tests/Gedmo/Mapping/Fixture/Yaml/LoggableCompositeRelation.php
+++ b/tests/Gedmo/Mapping/Fixture/Yaml/LoggableCompositeRelation.php
@@ -11,18 +11,9 @@ namespace Gedmo\Tests\Mapping\Fixture\Yaml;
 
 class LoggableCompositeRelation
 {
-    /**
-     * @var Loggable
-     */
-    private $one;
+    private ?Loggable $one = null;
 
-    /**
-     * @var int
-     */
-    private $two;
+    private ?int $two = null;
 
-    /**
-     * @var string
-     */
-    private $title;
+    private ?string $title = null;
 }

--- a/tests/Gedmo/Mapping/Fixture/Yaml/LoggableWithEmbedded.php
+++ b/tests/Gedmo/Mapping/Fixture/Yaml/LoggableWithEmbedded.php
@@ -13,18 +13,9 @@ namespace Gedmo\Tests\Mapping\Fixture\Yaml;
 
 class LoggableWithEmbedded
 {
-    /**
-     * @var int
-     */
-    private $id;
+    private ?int $id = null;
 
-    /**
-     * @var string
-     */
-    private $title;
+    private ?string $title = null;
 
-    /**
-     * @var Embedded
-     */
-    private $embedded;
+    private ?Embedded $embedded = null;
 }

--- a/tests/Gedmo/Mapping/Fixture/Yaml/MaterializedPathCategory.php
+++ b/tests/Gedmo/Mapping/Fixture/Yaml/MaterializedPathCategory.php
@@ -16,10 +16,7 @@ use Doctrine\Common\Collections\Collection;
 
 class MaterializedPathCategory
 {
-    /**
-     * @var int
-     */
-    private $id;
+    private ?int $id = null;
 
     private ?string $title = null;
 
@@ -30,7 +27,7 @@ class MaterializedPathCategory
     /**
      * @var Collection<int, Category>
      */
-    private $children;
+    private Collection $children;
 
     private ?MaterializedPathCategory $parent = null;
 

--- a/tests/Gedmo/Mapping/Fixture/Yaml/Referenced.php
+++ b/tests/Gedmo/Mapping/Fixture/Yaml/Referenced.php
@@ -13,13 +13,7 @@ namespace Gedmo\Tests\Mapping\Fixture\Yaml;
 
 class Referenced
 {
-    /**
-     * @var int
-     */
-    private $id;
+    private ?int $id = null;
 
-    /**
-     * @var Referencer
-     */
-    private $referencer;
+    private ?Referencer $referencer = null;
 }

--- a/tests/Gedmo/Mapping/Fixture/Yaml/Referencer.php
+++ b/tests/Gedmo/Mapping/Fixture/Yaml/Referencer.php
@@ -15,13 +15,10 @@ use Doctrine\Common\Collections\Collection;
 
 class Referencer
 {
-    /**
-     * @var int
-     */
-    private $id;
+    private ?int $id = null;
 
     /**
      * @var Collection<int, Referenced>
      */
-    private $referencedDocuments;
+    private Collection $referencedDocuments;
 }

--- a/tests/Gedmo/Mapping/Fixture/Yaml/SoftDeleteable.php
+++ b/tests/Gedmo/Mapping/Fixture/Yaml/SoftDeleteable.php
@@ -13,13 +13,7 @@ namespace Gedmo\Tests\Mapping\Fixture\Yaml;
 
 class SoftDeleteable
 {
-    /**
-     * @var int
-     */
-    private $id;
+    private ?int $id = null;
 
-    /**
-     * @var \DateTime|null
-     */
-    private $deletedAt;
+    private ?\DateTime $deletedAt = null;
 }

--- a/tests/Gedmo/Mapping/Fixture/Yaml/Sortable.php
+++ b/tests/Gedmo/Mapping/Fixture/Yaml/Sortable.php
@@ -16,33 +16,18 @@ use Gedmo\Tests\Mapping\Fixture\SortableGroup;
 
 class Sortable
 {
-    /**
-     * @var int
-     */
-    private $id;
+    private ?int $id = null;
 
-    /**
-     * @var string
-     */
-    private $title;
+    private ?string $title = null;
 
-    /**
-     * @var int
-     */
-    private $position;
+    private ?int $position = null;
 
-    /**
-     * @var string
-     */
-    private $grouping;
+    private ?string $grouping = null;
 
-    /**
-     * @var SortableGroup
-     */
-    private $sortable_group;
+    private ?SortableGroup $sortable_group = null;
 
     /**
      * @var Collection<int, SortableGroup>
      */
-    private $sortable_groups;
+    private Collection $sortable_groups;
 }

--- a/tests/Gedmo/Mapping/Fixture/Yaml/Uploadable.php
+++ b/tests/Gedmo/Mapping/Fixture/Yaml/Uploadable.php
@@ -13,37 +13,23 @@ namespace Gedmo\Tests\Mapping\Fixture\Yaml;
 
 class Uploadable
 {
-    /**
-     * @var int
-     */
-    private $id;
+    private ?int $id = null;
 
-    /**
-     * @var string
-     */
-    private $mimeType;
+    private ?string $mimeType = null;
 
     /**
      * @var array<string, mixed>
      */
-    private $fileInfo;
+    private array $fileInfo = [];
 
-    /**
-     * @var float
-     */
-    private $size;
+    private ?float $size = null;
 
-    /**
-     * @var string
-     */
-    private $path;
+    private ?string $path = null;
 
-    public function getPath(): string
+    public function getPath(): ?string
     {
         return $this->path;
     }
 
-    public function callbackMethod(): void
-    {
-    }
+    public function callbackMethod(): void {}
 }

--- a/tests/Gedmo/Mapping/Fixture/Yaml/User.php
+++ b/tests/Gedmo/Mapping/Fixture/Yaml/User.php
@@ -13,10 +13,7 @@ namespace Gedmo\Tests\Mapping\Fixture\Yaml;
 
 class User
 {
-    /**
-     * @var int
-     */
-    private $id;
+    private ?int $id = null;
 
     private ?string $password = null;
 
@@ -24,12 +21,9 @@ class User
 
     private ?string $company = null;
 
-    /**
-     * @var string
-     */
-    private $localeField;
+    private ?string $localeField = null;
 
-    public function getId(): int
+    public function getId(): ?int
     {
         return $this->id;
     }
@@ -39,7 +33,7 @@ class User
         $this->password = $password;
     }
 
-    public function getPassword(): string
+    public function getPassword(): ?string
     {
         return $this->password;
     }
@@ -49,7 +43,7 @@ class User
         $this->username = $username;
     }
 
-    public function getUsername(): string
+    public function getUsername(): ?string
     {
         return $this->username;
     }
@@ -59,7 +53,7 @@ class User
         $this->company = $company;
     }
 
-    public function getCompany(): string
+    public function getCompany(): ?string
     {
         return $this->company;
     }

--- a/tests/Gedmo/Mapping/LoggableORMMappingTest.php
+++ b/tests/Gedmo/Mapping/LoggableORMMappingTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace Gedmo\Tests\Mapping;
 
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
 use Gedmo\Loggable\Entity\LogEntry;
 use Gedmo\Loggable\LoggableListener;
@@ -57,11 +56,7 @@ final class LoggableORMMappingTest extends ORMMappingTestCase
      */
     public static function dataLoggableObject(): \Generator
     {
-        if (PHP_VERSION_ID >= 80000) {
-            yield 'Model with attributes' => [AnnotatedLoggable::class];
-        } elseif (class_exists(AnnotationDriver::class)) {
-            yield 'Model with annotations' => [AnnotatedLoggable::class];
-        }
+        yield 'Model with attributes' => [AnnotatedLoggable::class];
 
         if (class_exists(YamlDriver::class)) {
             yield 'Model with YAML mapping' => [YamlLoggable::class];
@@ -117,11 +112,7 @@ final class LoggableORMMappingTest extends ORMMappingTestCase
     {
         yield 'Model with XML mapping' => [XmlLoggableComposite::class];
 
-        if (PHP_VERSION_ID >= 80000) {
-            yield 'Model with attributes' => [AnnotatedLoggableComposite::class];
-        } elseif (class_exists(AnnotationDriver::class)) {
-            yield 'Model with annotations' => [AnnotatedLoggableComposite::class];
-        }
+        yield 'Model with attributes' => [AnnotatedLoggableComposite::class];
 
         if (class_exists(YamlDriver::class)) {
             yield 'Model with YAML mapping' => [YamlLoggableComposite::class];
@@ -160,11 +151,7 @@ final class LoggableORMMappingTest extends ORMMappingTestCase
     {
         yield 'Model with XML mapping' => [XmlLoggableCompositeRelation::class];
 
-        if (PHP_VERSION_ID >= 80000) {
-            yield 'Model with attributes' => [AnnotatedLoggableCompositeRelation::class];
-        } elseif (class_exists(AnnotationDriver::class)) {
-            yield 'Model with annotations' => [AnnotatedLoggableCompositeRelation::class];
-        }
+        yield 'Model with attributes' => [AnnotatedLoggableCompositeRelation::class];
 
         if (class_exists(YamlDriver::class)) {
             yield 'Model with YAML mapping' => [YamlLoggableCompositeRelation::class];
@@ -206,11 +193,7 @@ final class LoggableORMMappingTest extends ORMMappingTestCase
      */
     public static function dataLoggableObjectWithEmbedded(): \Generator
     {
-        if (PHP_VERSION_ID >= 80000) {
-            yield 'Model with attributes' => [AnnotatedLoggableWithEmbedded::class];
-        } elseif (class_exists(AnnotationDriver::class)) {
-            yield 'Model with annotations' => [AnnotatedLoggableWithEmbedded::class];
-        }
+        yield 'Model with attributes' => [AnnotatedLoggableWithEmbedded::class];
     }
 
     /**

--- a/tests/Gedmo/Mapping/MappingEventSubscriberTest.php
+++ b/tests/Gedmo/Mapping/MappingEventSubscriberTest.php
@@ -11,9 +11,7 @@ declare(strict_types=1);
 
 namespace Gedmo\Tests\Mapping;
 
-use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\Persistence\Mapping\AbstractClassMetadataFactory;
 use Gedmo\Mapping\ExtensionMetadataFactory;
@@ -33,11 +31,7 @@ final class MappingEventSubscriberTest extends ORMMappingTestCase
 
         $config = $this->getBasicConfiguration();
 
-        if (PHP_VERSION_ID >= 80000) {
-            $config->setMetadataDriverImpl(new AttributeDriver([]));
-        } else {
-            $config->setMetadataDriverImpl(new AnnotationDriver(new AnnotationReader()));
-        }
+        $config->setMetadataDriverImpl(new AttributeDriver([]));
 
         $this->em = $this->getBasicEntityManager($config);
     }
@@ -45,7 +39,7 @@ final class MappingEventSubscriberTest extends ORMMappingTestCase
     public function testGetMetadataFactoryCacheFromDoctrineForSluggable(): void
     {
         $metadataFactory = $this->em->getMetadataFactory();
-        $getCache = \Closure::bind(static fn (AbstractClassMetadataFactory $metadataFactory): ?CacheItemPoolInterface => $metadataFactory->getCache(), null, \get_class($metadataFactory));
+        $getCache = \Closure::bind(static fn (AbstractClassMetadataFactory $metadataFactory): ?CacheItemPoolInterface => $metadataFactory->getCache(), null, $metadataFactory::class);
 
         $cache = $getCache($metadataFactory);
 
@@ -63,7 +57,7 @@ final class MappingEventSubscriberTest extends ORMMappingTestCase
     public function testGetMetadataFactoryCacheFromDoctrineForSuperClassExtension(): void
     {
         $metadataFactory = $this->em->getMetadataFactory();
-        $getCache = \Closure::bind(static fn (AbstractClassMetadataFactory $metadataFactory): ?CacheItemPoolInterface => $metadataFactory->getCache(), null, \get_class($metadataFactory));
+        $getCache = \Closure::bind(static fn (AbstractClassMetadataFactory $metadataFactory): ?CacheItemPoolInterface => $metadataFactory->getCache(), null, $metadataFactory::class);
 
         /** @var CacheItemPoolInterface $cache */
         $cache = $getCache($metadataFactory);
@@ -87,11 +81,7 @@ final class MappingEventSubscriberTest extends ORMMappingTestCase
         // Create new configuration to use new array cache
         $config = $this->getBasicConfiguration();
 
-        if (PHP_VERSION_ID >= 80000) {
-            $config->setMetadataDriverImpl(new AttributeDriver([]));
-        } else {
-            $config->setMetadataDriverImpl(new AnnotationDriver(new AnnotationReader()));
-        }
+        $config->setMetadataDriverImpl(new AttributeDriver([]));
 
         $this->em = $this->getBasicEntityManager($config);
 

--- a/tests/Gedmo/Mapping/MappingTest.php
+++ b/tests/Gedmo/Mapping/MappingTest.php
@@ -15,7 +15,6 @@ use Doctrine\Common\EventManager;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Tools\SchemaTool;
 use Gedmo\Sluggable\SluggableListener;
@@ -49,11 +48,7 @@ final class MappingTest extends TestCase
             $config->setProxyNamespace('Gedmo\Mapping\Proxy');
         }
 
-        if (PHP_VERSION_ID >= 80000) {
-            $config->setMetadataDriverImpl(new AttributeDriver([]));
-        } else {
-            $config->setMetadataDriverImpl(new AnnotationDriver($_ENV['annotation_reader']));
-        }
+        $config->setMetadataDriverImpl(new AttributeDriver([]));
 
         $conn = [
             'driver' => 'pdo_sqlite',

--- a/tests/Gedmo/Mapping/MetadataFactory/CustomDriverTest.php
+++ b/tests/Gedmo/Mapping/MetadataFactory/CustomDriverTest.php
@@ -11,12 +11,12 @@ declare(strict_types=1);
 
 namespace Gedmo\Tests\Mapping\MetadataFactory;
 
-use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata as ORMClassMetadata;
 use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
@@ -55,13 +55,9 @@ final class CustomDriverTest extends TestCase
         ];
 
         $evm = new EventManager();
-        $this->timestampable = new TimestampableListener();
 
-        if (PHP_VERSION >= 80000) {
-            $this->timestampable->setAnnotationReader(new AttributeReader());
-        } elseif (class_exists(AnnotationReader::class)) {
-            $this->timestampable->setAnnotationReader($_ENV['annotation_reader']);
-        }
+        $this->timestampable = new TimestampableListener();
+        $this->timestampable->setAnnotationReader(new AttributeReader());
 
         $evm->addEventSubscriber($this->timestampable);
         $connection = DriverManager::getConnection($conn, $config);
@@ -81,7 +77,7 @@ final class CustomDriverTest extends TestCase
             $this->em,
             Timestampable::class
         );
-        static::assertTrue(isset($conf['create']));
+        static::assertArrayHasKey('create', $conf);
 
         $test = new Timestampable();
         $this->em->persist($test);
@@ -113,9 +109,7 @@ class CustomDriver implements MappingDriver
             $id['columnName'] = 'id';
             $id['id'] = true;
 
-            $metadata->setIdGeneratorType(
-                constant('Doctrine\ORM\Mapping\ClassMetadata::GENERATOR_TYPE_AUTO')
-            );
+            $metadata->setIdGeneratorType(ORMClassMetadata::GENERATOR_TYPE_AUTO);
 
             $metadata->mapField($id);
 

--- a/tests/Gedmo/Mapping/MetadataFactory/ForcedMetadataTest.php
+++ b/tests/Gedmo/Mapping/MetadataFactory/ForcedMetadataTest.php
@@ -19,7 +19,6 @@ use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Id\IdentityGenerator;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Tools\SchemaTool;
 use Gedmo\Mapping\Driver\AttributeReader;
@@ -50,19 +49,11 @@ final class ForcedMetadataTest extends TestCase
             $config->setProxyNamespace('Gedmo\Mapping\Proxy');
         }
 
-        if (PHP_VERSION_ID >= 80000) {
-            $config->setMetadataDriverImpl(new AttributeDriver([]));
-        } else {
-            $config->setMetadataDriverImpl(new AnnotationDriver($_ENV['annotation_reader']));
-        }
+        $config->setMetadataDriverImpl(new AttributeDriver([]));
 
         $this->timestampable = new TimestampableListener();
 
-        if (PHP_VERSION_ID >= 80000) {
-            $this->timestampable->setAnnotationReader(new AttributeReader());
-        } else {
-            $this->timestampable->setAnnotationReader($_ENV['annotation_reader']);
-        }
+        $this->timestampable->setAnnotationReader(new AttributeReader());
 
         $evm = new EventManager();
         $evm->addEventSubscriber($this->timestampable);
@@ -86,7 +77,7 @@ final class ForcedMetadataTest extends TestCase
         );
 
         // @todo: This assertion fails when run in isolation
-        static::assertTrue(isset($conf['create']));
+        static::assertArrayHasKey('create', $conf);
 
         $test = new Timestampable();
         $this->em->persist($test);

--- a/tests/Gedmo/Mapping/Mock/Extension/Encoder/EncoderListener.php
+++ b/tests/Gedmo/Mapping/Mock/Extension/Encoder/EncoderListener.php
@@ -53,7 +53,7 @@ class EncoderListener extends MappedEventSubscriber
 
         // check all pending updates
         foreach ($ea->getScheduledObjectUpdates($uow) as $object) {
-            $meta = $om->getClassMetadata(get_class($object));
+            $meta = $om->getClassMetadata($object::class);
             // if it has our metadata lets encode the properties
             if ($config = $this->getConfiguration($om, $meta->getName())) {
                 $this->encode($ea, $object, $config);
@@ -61,7 +61,7 @@ class EncoderListener extends MappedEventSubscriber
         }
         // check all pending insertions
         foreach ($ea->getScheduledObjectInsertions($uow) as $object) {
-            $meta = $om->getClassMetadata(get_class($object));
+            $meta = $om->getClassMetadata($object::class);
             // if it has our metadata lets encode the properties
             if ($config = $this->getConfiguration($om, $meta->getName())) {
                 $this->encode($ea, $object, $config);
@@ -81,7 +81,7 @@ class EncoderListener extends MappedEventSubscriber
     private function encode(EventAdapterInterface $ea, object $object, array $config): void
     {
         $om = $ea->getObjectManager();
-        $meta = $om->getClassMetadata(get_class($object));
+        $meta = $om->getClassMetadata($object::class);
         $uow = $om->getUnitOfWork();
         foreach ($config['encode'] as $field => $options) {
             $value = $meta->getReflectionProperty($field)->getValue($object);

--- a/tests/Gedmo/Mapping/Mock/Extension/Encoder/Mapping/Driver/Annotation.php
+++ b/tests/Gedmo/Mapping/Mock/Extension/Encoder/Mapping/Driver/Annotation.php
@@ -13,6 +13,4 @@ namespace Gedmo\Tests\Mapping\Mock\Extension\Encoder\Mapping\Driver;
 
 use Gedmo\Mapping\Driver\AnnotationDriverInterface;
 
-class Annotation extends Attribute implements AnnotationDriverInterface
-{
-}
+class Annotation extends Attribute implements AnnotationDriverInterface {}

--- a/tests/Gedmo/Mapping/Mock/Extension/Encoder/Mapping/Driver/Attribute.php
+++ b/tests/Gedmo/Mapping/Mock/Extension/Encoder/Mapping/Driver/Attribute.php
@@ -16,7 +16,12 @@ use Gedmo\Tests\Mapping\Mock\Extension\Encoder\Mapping\Encode;
 
 class Attribute extends AbstractAnnotationDriver
 {
-    public function readExtendedMetadata($meta, array &$config)
+    /**
+     * @param array<string, mixed> $config
+     *
+     * @return array<string, mixed>
+     */
+    public function readExtendedMetadata($meta, array &$config): array
     {
         $class = $meta->getReflectionClass();
 

--- a/tests/Gedmo/Mapping/Mock/Extension/Encoder/Mapping/Encode.php
+++ b/tests/Gedmo/Mapping/Mock/Extension/Encoder/Mapping/Encode.php
@@ -21,19 +21,5 @@ use Gedmo\Mapping\Annotation\Annotation as GedmoAnnotation;
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class Encode implements GedmoAnnotation
 {
-    /**
-     * @var string
-     */
-    public $type = 'md5';
-
-    /**
-     * @var string|null
-     */
-    public $secret;
-
-    public function __construct(string $type = 'md5', ?string $secret = null)
-    {
-        $this->type = $type;
-        $this->secret = $secret;
-    }
+    public function __construct(public string $type = 'md5', public ?string $secret = null) {}
 }

--- a/tests/Gedmo/Mapping/Mock/Extension/Encoder/Mapping/Event/Adapter/ODM.php
+++ b/tests/Gedmo/Mapping/Mock/Extension/Encoder/Mapping/Event/Adapter/ODM.php
@@ -13,6 +13,4 @@ namespace Gedmo\Tests\Mapping\Mock\Extension\Encoder\Mapping\Event\Adapter;
 
 use Gedmo\Mapping\Event\Adapter\ODM as BaseAdapterODM;
 
-final class ODM extends BaseAdapterODM
-{
-}
+final class ODM extends BaseAdapterODM {}

--- a/tests/Gedmo/Mapping/Mock/Extension/Encoder/Mapping/Event/Adapter/ORM.php
+++ b/tests/Gedmo/Mapping/Mock/Extension/Encoder/Mapping/Event/Adapter/ORM.php
@@ -13,6 +13,4 @@ namespace Gedmo\Tests\Mapping\Mock\Extension\Encoder\Mapping\Event\Adapter;
 
 use Gedmo\Mapping\Event\Adapter\ORM as BaseAdapterORM;
 
-final class ORM extends BaseAdapterORM
-{
-}
+final class ORM extends BaseAdapterORM {}

--- a/tests/Gedmo/Mapping/Mock/Mapping/Event/Adapter/ORM.php
+++ b/tests/Gedmo/Mapping/Mock/Mapping/Event/Adapter/ORM.php
@@ -13,6 +13,4 @@ namespace Gedmo\Tests\Mapping\Mock\Mapping\Event\Adapter;
 
 use Gedmo\Mapping\Event\Adapter\ORM as EventAdapterORM;
 
-class ORM extends EventAdapterORM
-{
-}
+class ORM extends EventAdapterORM {}

--- a/tests/Gedmo/Mapping/MultiManagerMappingTest.php
+++ b/tests/Gedmo/Mapping/MultiManagerMappingTest.php
@@ -11,10 +11,8 @@ declare(strict_types=1);
 
 namespace Gedmo\Tests\Mapping;
 
-use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
@@ -46,18 +44,9 @@ final class MultiManagerMappingTest extends BaseTestCaseOM
             ArticleEntity::class,
         ]);
 
-        // EM with XML and annotation/attribute mapping
-        if (PHP_VERSION_ID >= 80000) {
-            $annotationDriver = new AttributeDriver([]);
-
-            $annotationDriver2 = new AttributeDriver([]);
-        } else {
-            $reader = new AnnotationReader();
-            $annotationDriver = new AnnotationDriver($reader);
-
-            $reader = new AnnotationReader();
-            $annotationDriver2 = new AnnotationDriver($reader);
-        }
+        // EM with XML and attribute mapping
+        $annotationDriver = new AttributeDriver([]);
+        $annotationDriver2 = new AttributeDriver([]);
 
         $xmlDriver = new XmlDriver(__DIR__.'/Driver/Xml', XmlDriver::DEFAULT_FILE_EXTENSION, false);
 

--- a/tests/Gedmo/Mapping/ORMMappingTestCase.php
+++ b/tests/Gedmo/Mapping/ORMMappingTestCase.php
@@ -11,13 +11,11 @@ declare(strict_types=1);
 
 namespace Gedmo\Tests\Mapping;
 
-use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
@@ -57,7 +55,7 @@ abstract class ORMMappingTestCase extends TestCase
 
     final protected function getBasicEntityManager(?Configuration $config = null, ?Connection $connection = null, ?EventManager $evm = null): EntityManager
     {
-        if (null === $config) {
+        if (!$config instanceof Configuration) {
             $config = $this->getBasicConfiguration();
             $config->setMetadataDriverImpl($this->createChainedMappingDriver());
         }
@@ -80,11 +78,7 @@ abstract class ORMMappingTestCase extends TestCase
             $chain->addDriver(new YamlDriver(__DIR__.'/Driver/Yaml'), 'Gedmo\Tests\Mapping\Fixture\Yaml');
         }
 
-        if (PHP_VERSION_ID >= 80000) {
-            $chain->addDriver(new AttributeDriver([]), 'Gedmo\Tests\Mapping\Fixture');
-        } elseif (class_exists(AnnotationDriver::class) && class_exists(AnnotationReader::class)) {
-            $chain->addDriver(new AnnotationDriver(new AnnotationReader()), 'Gedmo\Tests\Mapping\Fixture');
-        }
+        $chain->addDriver(new AttributeDriver([]), 'Gedmo\Tests\Mapping\Fixture');
 
         return $chain;
     }

--- a/tests/Gedmo/Mapping/SluggableMappingTest.php
+++ b/tests/Gedmo/Mapping/SluggableMappingTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace Gedmo\Tests\Mapping;
 
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
 use Gedmo\Mapping\ExtensionMetadataFactory;
 use Gedmo\Sluggable\Handler\RelativeSlugHandler;
@@ -49,11 +48,7 @@ final class SluggableMappingTest extends ORMMappingTestCase
     {
         yield 'Model with XML mapping' => [XmlSluggable::class];
 
-        if (PHP_VERSION_ID >= 80000) {
-            yield 'Model with attributes' => [AnnotatedSluggable::class];
-        } elseif (class_exists(AnnotationDriver::class)) {
-            yield 'Model with annotations' => [AnnotatedSluggable::class];
-        }
+        yield 'Model with attributes' => [AnnotatedSluggable::class];
     }
 
     /**

--- a/tests/Gedmo/Mapping/SoftDeleteableMappingTest.php
+++ b/tests/Gedmo/Mapping/SoftDeleteableMappingTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace Gedmo\Tests\Mapping;
 
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
 use Gedmo\Mapping\ExtensionMetadataFactory;
 use Gedmo\SoftDeleteable\SoftDeleteableListener;
@@ -48,11 +47,7 @@ final class SoftDeleteableMappingTest extends ORMMappingTestCase
     {
         yield 'Model with XML mapping' => [XmlSoftDeleteable::class];
 
-        if (PHP_VERSION_ID >= 80000) {
-            yield 'Model with attributes' => [AnnotatedSoftDeleteable::class];
-        } elseif (class_exists(AnnotationDriver::class)) {
-            yield 'Model with annotations' => [AnnotatedSoftDeleteable::class];
-        }
+        yield 'Model with attributes' => [AnnotatedSoftDeleteable::class];
 
         if (class_exists(YamlDriver::class)) {
             yield 'Model with YAML mapping' => [YamlSoftDeleteable::class];

--- a/tests/Gedmo/Mapping/SortableMappingTest.php
+++ b/tests/Gedmo/Mapping/SortableMappingTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace Gedmo\Tests\Mapping;
 
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
 use Gedmo\Mapping\ExtensionMetadataFactory;
 use Gedmo\Sortable\SortableListener;
@@ -47,11 +46,7 @@ final class SortableMappingTest extends ORMMappingTestCase
     {
         yield 'Model with XML mapping' => [XmlSortable::class];
 
-        if (PHP_VERSION_ID >= 80000) {
-            yield 'Model with attributes' => [AnnotatedSortable::class];
-        } elseif (class_exists(AnnotationDriver::class)) {
-            yield 'Model with annotations' => [AnnotatedSortable::class];
-        }
+        yield 'Model with attributes' => [AnnotatedSortable::class];
 
         if (class_exists(YamlDriver::class)) {
             yield 'Model with YAML mapping' => [YamlSortable::class];

--- a/tests/Gedmo/Mapping/TimestampableMappingTest.php
+++ b/tests/Gedmo/Mapping/TimestampableMappingTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace Gedmo\Tests\Mapping;
 
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
 use Gedmo\Mapping\ExtensionMetadataFactory;
 use Gedmo\Tests\Mapping\Fixture\Category as AnnotatedCategory;
@@ -47,11 +46,7 @@ final class TimestampableMappingTest extends ORMMappingTestCase
      */
     public static function dataTimestampableObject(): \Generator
     {
-        if (PHP_VERSION_ID >= 80000) {
-            yield 'Model with attributes' => [AnnotatedCategory::class];
-        } elseif (class_exists(AnnotationDriver::class)) {
-            yield 'Model with annotations' => [AnnotatedCategory::class];
-        }
+        yield 'Model with attributes' => [AnnotatedCategory::class];
 
         if (class_exists(YamlDriver::class)) {
             yield 'Model with YAML mapping' => [YamlCategory::class];

--- a/tests/Gedmo/Mapping/TranslatableMappingTest.php
+++ b/tests/Gedmo/Mapping/TranslatableMappingTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace Gedmo\Tests\Mapping;
 
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
 use Gedmo\Mapping\ExtensionMetadataFactory;
 use Gedmo\Tests\Mapping\Fixture\User as AnnotatedUser;
@@ -49,11 +48,7 @@ final class TranslatableMappingTest extends ORMMappingTestCase
     {
         yield 'Model with XML mapping' => [XmlUser::class];
 
-        if (PHP_VERSION_ID >= 80000) {
-            yield 'Model with attributes' => [AnnotatedUser::class];
-        } elseif (class_exists(AnnotationDriver::class)) {
-            yield 'Model with annotations' => [AnnotatedUser::class];
-        }
+        yield 'Model with attributes' => [AnnotatedUser::class];
 
         if (class_exists(YamlDriver::class)) {
             yield 'Model with YAML mapping' => [YamlUser::class];

--- a/tests/Gedmo/Mapping/TreeMappingTest.php
+++ b/tests/Gedmo/Mapping/TreeMappingTest.php
@@ -11,9 +11,7 @@ declare(strict_types=1);
 
 namespace Gedmo\Tests\Mapping;
 
-use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
@@ -53,11 +51,7 @@ final class TreeMappingTest extends ORMMappingTestCase
         // TODO - The ORM's YAML mapping is deprecated and removed in 3.0
         $chain->addDriver(new YamlDriver(__DIR__.'/Driver/Yaml'), 'Gedmo\Tests\Mapping\Fixture\Yaml');
 
-        if (PHP_VERSION_ID >= 80000) {
-            $annotationOrAttributeDriver = new AttributeDriver([]);
-        } else {
-            $annotationOrAttributeDriver = new AnnotationDriver(new AnnotationReader());
-        }
+        $annotationOrAttributeDriver = new AttributeDriver([]);
 
         $chain->addDriver($annotationOrAttributeDriver, 'Gedmo\Tests\Tree\Fixture');
         $chain->addDriver($annotationOrAttributeDriver, 'Gedmo\Tree');

--- a/tests/Gedmo/Mapping/UploadableMappingTest.php
+++ b/tests/Gedmo/Mapping/UploadableMappingTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace Gedmo\Tests\Mapping;
 
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
 use Gedmo\Mapping\ExtensionMetadataFactory;
 use Gedmo\Tests\Mapping\Fixture\Uploadable as AnnotatedUploadable;
@@ -52,11 +51,7 @@ final class UploadableMappingTest extends ORMMappingTestCase
     {
         yield 'Model with XML mapping' => [XmlUploadable::class];
 
-        if (PHP_VERSION_ID >= 80000) {
-            yield 'Model with attributes' => [AnnotatedUploadable::class];
-        } elseif (class_exists(AnnotationDriver::class)) {
-            yield 'Model with annotations' => [AnnotatedUploadable::class];
-        }
+        yield 'Model with attributes' => [AnnotatedUploadable::class];
 
         if (class_exists(YamlDriver::class)) {
             yield 'Model with YAML mapping' => [YamlUploadable::class];

--- a/tests/Gedmo/Mapping/Xml/ClosureTreeMappingTest.php
+++ b/tests/Gedmo/Mapping/Xml/ClosureTreeMappingTest.php
@@ -11,10 +11,8 @@ declare(strict_types=1);
 
 namespace Gedmo\Tests\Mapping\Xml;
 
-use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\EventManager;
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
@@ -38,11 +36,7 @@ final class ClosureTreeMappingTest extends BaseTestCaseOM
     {
         parent::setUp();
 
-        if (PHP_VERSION_ID >= 80000) {
-            $annotationDriver = new AttributeDriver([]);
-        } else {
-            $annotationDriver = new AnnotationDriver(new AnnotationReader());
-        }
+        $annotationDriver = new AttributeDriver([]);
 
         $xmlDriver = new XmlDriver(__DIR__.'/../Driver/Xml', XmlDriver::DEFAULT_FILE_EXTENSION, false);
 

--- a/tests/Gedmo/Mapping/Xml/MaterializedPathTreeMappingTest.php
+++ b/tests/Gedmo/Mapping/Xml/MaterializedPathTreeMappingTest.php
@@ -11,10 +11,8 @@ declare(strict_types=1);
 
 namespace Gedmo\Tests\Mapping\Xml;
 
-use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\EventManager;
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
@@ -38,11 +36,7 @@ final class MaterializedPathTreeMappingTest extends BaseTestCaseOM
     {
         parent::setUp();
 
-        if (PHP_VERSION_ID >= 80000) {
-            $annotationDriver = new AttributeDriver([]);
-        } else {
-            $annotationDriver = new AnnotationDriver(new AnnotationReader());
-        }
+        $annotationDriver = new AttributeDriver([]);
 
         $xmlDriver = new XmlDriver(__DIR__.'/../Driver/Xml', XmlDriver::DEFAULT_FILE_EXTENSION, false);
 

--- a/tests/Gedmo/Mapping/Xml/ReferencesMappingTest.php
+++ b/tests/Gedmo/Mapping/Xml/ReferencesMappingTest.php
@@ -11,10 +11,8 @@ declare(strict_types=1);
 
 namespace Gedmo\Tests\Mapping\Xml;
 
-use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\EventManager;
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
@@ -35,11 +33,7 @@ final class ReferencesMappingTest extends BaseTestCaseOM
     {
         parent::setUp();
 
-        if (PHP_VERSION_ID >= 80000) {
-            $annotationDriver = new AttributeDriver([]);
-        } else {
-            $annotationDriver = new AnnotationDriver(new AnnotationReader());
-        }
+        $annotationDriver = new AttributeDriver([]);
 
         $xmlDriver = new XmlDriver(__DIR__.'/../Driver/Xml', XmlDriver::DEFAULT_FILE_EXTENSION, false);
 

--- a/tests/Gedmo/Mapping/Xml/TranslatableMappingTest.php
+++ b/tests/Gedmo/Mapping/Xml/TranslatableMappingTest.php
@@ -11,10 +11,8 @@ declare(strict_types=1);
 
 namespace Gedmo\Tests\Mapping\Xml;
 
-use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\EventManager;
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
@@ -39,11 +37,7 @@ final class TranslatableMappingTest extends BaseTestCaseOM
     {
         parent::setUp();
 
-        if (PHP_VERSION_ID >= 80000) {
-            $annotationDriver = new AttributeDriver([]);
-        } else {
-            $annotationDriver = new AnnotationDriver(new AnnotationReader());
-        }
+        $annotationDriver = new AttributeDriver([]);
 
         $xmlDriver = new XmlDriver(__DIR__.'/../Driver/Xml', XmlDriver::DEFAULT_FILE_EXTENSION, false);
 

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyNullify/Article.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyNullify/Article.php
@@ -21,12 +21,10 @@ use Doctrine\ODM\MongoDB\Types\Type as MongoDBType;
 class Article
 {
     /**
-     * @var string|null
-     *
      * @ODM\Id
      */
     #[ODM\Id]
-    private $id;
+    private ?string $id = null;
 
     /**
      * @ODM\Field(type="string")

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyNullify/Type.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyNullify/Type.php
@@ -32,15 +32,13 @@ class Type
      */
     #[ODM\ReferenceMany(targetDocument: Article::class, mappedBy: 'type')]
     #[Gedmo\ReferenceIntegrity(value: 'nullify')]
-    protected $articles;
+    protected Collection $articles;
 
     /**
-     * @var string|null
-     *
      * @ODM\Id
      */
     #[ODM\Id]
-    private $id;
+    private ?string $id = null;
 
     /**
      * @ODM\Field(type="string")

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyPull/Article.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyPull/Article.php
@@ -23,12 +23,10 @@ use Doctrine\ODM\MongoDB\Types\Type as MongoDBType;
 class Article
 {
     /**
-     * @var string|null
-     *
      * @ODM\Id
      */
     #[ODM\Id]
-    private $id;
+    private ?string $id = null;
 
     /**
      * @ODM\Field(type="string")
@@ -42,7 +40,7 @@ class Article
      * @ODM\ReferenceMany(targetDocument="Gedmo\Tests\ReferenceIntegrity\Fixture\Document\ManyPull\Type", inversedBy="articles")
      */
     #[ODM\ReferenceMany(targetDocument: Type::class, inversedBy: 'articles')]
-    private $types;
+    private Collection $types;
 
     public function __construct()
     {

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyPull/Type.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyPull/Type.php
@@ -32,15 +32,13 @@ class Type
      */
     #[ODM\ReferenceMany(targetDocument: Article::class, mappedBy: 'types')]
     #[Gedmo\ReferenceIntegrity(value: 'pull')]
-    protected $articles;
+    protected Collection $articles;
 
     /**
-     * @var string|null
-     *
      * @ODM\Id
      */
     #[ODM\Id]
-    private $id;
+    private ?string $id = null;
 
     /**
      * @ODM\Field(type="string")

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyRestrict/Article.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyRestrict/Article.php
@@ -21,12 +21,10 @@ use Doctrine\ODM\MongoDB\Types\Type as MongoDBType;
 class Article
 {
     /**
-     * @var string|null
-     *
      * @ODM\Id
      */
     #[ODM\Id]
-    private $id;
+    private ?string $id = null;
 
     /**
      * @ODM\Field(type="string")

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyRestrict/Type.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyRestrict/Type.php
@@ -32,15 +32,13 @@ class Type
      */
     #[ODM\ReferenceMany(targetDocument: Article::class, mappedBy: 'type')]
     #[Gedmo\ReferenceIntegrity(value: 'restrict')]
-    protected $articles;
+    protected Collection $articles;
 
     /**
-     * @var string|null
-     *
      * @ODM\Id
      */
     #[ODM\Id]
-    private $id;
+    private ?string $id = null;
 
     /**
      * @ODM\Field(type="string")

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OneNullify/Article.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OneNullify/Article.php
@@ -21,12 +21,10 @@ use Doctrine\ODM\MongoDB\Types\Type as MongoDBType;
 class Article
 {
     /**
-     * @var string|null
-     *
      * @ODM\Id
      */
     #[ODM\Id]
-    private $id;
+    private ?string $id = null;
 
     /**
      * @ODM\Field(type="string")

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OneNullify/Type.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OneNullify/Type.php
@@ -22,23 +22,19 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Type
 {
     /**
-     * @var Article
-     *
      * @ODM\ReferenceOne(targetDocument="Gedmo\Tests\ReferenceIntegrity\Fixture\Document\OneNullify\Article", mappedBy="type")
      *
      * @Gedmo\ReferenceIntegrity("nullify")
      */
     #[ODM\ReferenceOne(targetDocument: Article::class, mappedBy: 'type')]
     #[Gedmo\ReferenceIntegrity(value: 'nullify')]
-    protected $article;
+    protected ?Article $article = null;
 
     /**
-     * @var string|null
-     *
      * @ODM\Id
      */
     #[ODM\Id]
-    private $id;
+    private ?string $id = null;
 
     /**
      * @ODM\Field(type="string")

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OnePull/Article.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OnePull/Article.php
@@ -23,12 +23,10 @@ use Doctrine\ODM\MongoDB\Types\Type as MongoDBType;
 class Article
 {
     /**
-     * @var string|null
-     *
      * @ODM\Id
      */
     #[ODM\Id]
-    private $id;
+    private ?string $id = null;
 
     /**
      * @ODM\Field(type="string")
@@ -42,7 +40,7 @@ class Article
      * @ODM\ReferenceMany(targetDocument="Gedmo\Tests\ReferenceIntegrity\Fixture\Document\OnePull\Type", inversedBy="articles")
      */
     #[ODM\ReferenceMany(targetDocument: Type::class, inversedBy: 'articles')]
-    private $types;
+    private Collection $types;
 
     public function __construct()
     {

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OnePull/Type.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OnePull/Type.php
@@ -22,23 +22,19 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Type
 {
     /**
-     * @var Article|null
-     *
      * @ODM\ReferenceOne(targetDocument="Gedmo\Tests\ReferenceIntegrity\Fixture\Document\OnePull\Article", mappedBy="types")
      *
      * @Gedmo\ReferenceIntegrity("pull")
      */
     #[ODM\ReferenceOne(targetDocument: Article::class, mappedBy: 'types')]
     #[Gedmo\ReferenceIntegrity(value: 'pull')]
-    protected $article;
+    protected ?Article $article = null;
 
     /**
-     * @var string|null
-     *
      * @ODM\Id
      */
     #[ODM\Id]
-    private $id;
+    private ?string $id = null;
 
     /**
      * @ODM\Field(type="string")

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OneRestrict/Article.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OneRestrict/Article.php
@@ -21,12 +21,10 @@ use Doctrine\ODM\MongoDB\Types\Type as MongoDBType;
 class Article
 {
     /**
-     * @var string|null
-     *
      * @ODM\Id
      */
     #[ODM\Id]
-    private $id;
+    private ?string $id = null;
 
     /**
      * @ODM\Field(type="string")

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OneRestrict/Type.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OneRestrict/Type.php
@@ -22,23 +22,19 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Type
 {
     /**
-     * @var Article|null
-     *
      * @ODM\ReferenceOne(targetDocument="Gedmo\Tests\ReferenceIntegrity\Fixture\Document\OneRestrict\Article", mappedBy="type")
      *
      * @Gedmo\ReferenceIntegrity("restrict")
      */
     #[ODM\ReferenceOne(targetDocument: Article::class, mappedBy: 'type')]
     #[Gedmo\ReferenceIntegrity(value: 'restrict')]
-    protected $article;
+    protected ?Article $article = null;
 
     /**
-     * @var string|null
-     *
      * @ODM\Id
      */
     #[ODM\Id]
-    private $id;
+    private ?string $id = null;
 
     /**
      * @ODM\Field(type="string")

--- a/tests/Gedmo/ReferenceIntegrity/ReferenceIntegrityDocumentTest.php
+++ b/tests/Gedmo/ReferenceIntegrity/ReferenceIntegrityDocumentTest.php
@@ -59,7 +59,7 @@ final class ReferenceIntegrityDocumentTest extends BaseTestCaseMongoODM
         $type = $this->dm->getRepository(TypeOneNullify::class)
             ->findOneBy(['title' => 'One Nullify Type']);
 
-        static::assertNotNull($type);
+        static::assertInstanceOf(TypeOneNullify::class, $type);
         static::assertIsObject($type);
 
         $this->dm->remove($type);
@@ -67,12 +67,12 @@ final class ReferenceIntegrityDocumentTest extends BaseTestCaseMongoODM
 
         $type = $this->dm->getRepository(TypeOneNullify::class)
             ->findOneBy(['title' => 'One Nullify Type']);
-        static::assertNull($type);
+        static::assertNotInstanceOf(TypeOneNullify::class, $type);
 
         $article = $this->dm->getRepository(ArticleOneNullify::class)
             ->findOneBy(['title' => 'One Nullify Article']);
 
-        static::assertNull($article->getType());
+        static::assertNotInstanceOf(TypeOneNullify::class, $article->getType());
 
         $this->dm->clear();
     }
@@ -82,7 +82,7 @@ final class ReferenceIntegrityDocumentTest extends BaseTestCaseMongoODM
         $type = $this->dm->getRepository(TypeManyNullify::class)
             ->findOneBy(['title' => 'Many Nullify Type']);
 
-        static::assertNotNull($type);
+        static::assertInstanceOf(TypeManyNullify::class, $type);
         static::assertIsObject($type);
 
         $this->dm->remove($type);
@@ -90,12 +90,12 @@ final class ReferenceIntegrityDocumentTest extends BaseTestCaseMongoODM
 
         $type = $this->dm->getRepository(TypeManyNullify::class)
             ->findOneBy(['title' => 'Many Nullify Type']);
-        static::assertNull($type);
+        static::assertNotInstanceOf(TypeManyNullify::class, $type);
 
         $article = $this->dm->getRepository(ArticleManyNullify::class)
             ->findOneBy(['title' => 'Many Nullify Article']);
 
-        static::assertNull($article->getType());
+        static::assertNotInstanceOf(TypeManyNullify::class, $article->getType());
 
         $this->dm->clear();
     }
@@ -107,10 +107,10 @@ final class ReferenceIntegrityDocumentTest extends BaseTestCaseMongoODM
         $type2 = $this->dm->getRepository(TypeOnePull::class)
             ->findOneBy(['title' => 'One Pull Type 2']);
 
-        static::assertNotNull($type1);
+        static::assertInstanceOf(TypeOnePull::class, $type1);
         static::assertIsObject($type1);
 
-        static::assertNotNull($type2);
+        static::assertInstanceOf(TypeOnePull::class, $type2);
         static::assertIsObject($type2);
 
         $this->dm->remove($type2);
@@ -118,7 +118,7 @@ final class ReferenceIntegrityDocumentTest extends BaseTestCaseMongoODM
 
         $type2 = $this->dm->getRepository(TypeOnePull::class)
             ->findOneBy(['title' => 'One Pull Type 2']);
-        static::assertNull($type2);
+        static::assertNotInstanceOf(TypeOnePull::class, $type2);
 
         $article = $this->dm->getRepository(ArticleOnePull::class)
             ->findOneBy(['title' => 'One Pull Article']);
@@ -137,10 +137,10 @@ final class ReferenceIntegrityDocumentTest extends BaseTestCaseMongoODM
         $type2 = $this->dm->getRepository(TypeOnePull::class)
             ->findOneBy(['title' => 'Many Pull Type 2']);
 
-        static::assertNotNull($type1);
+        static::assertInstanceOf(TypeOnePull::class, $type1);
         static::assertIsObject($type1);
 
-        static::assertNotNull($type2);
+        static::assertInstanceOf(TypeOnePull::class, $type2);
         static::assertIsObject($type2);
 
         $this->dm->remove($type2);
@@ -148,7 +148,7 @@ final class ReferenceIntegrityDocumentTest extends BaseTestCaseMongoODM
 
         $type2 = $this->dm->getRepository(TypeManyPull::class)
             ->findOneBy(['title' => 'Many Pull Type 2']);
-        static::assertNull($type2);
+        static::assertNotInstanceOf(TypeManyPull::class, $type2);
 
         $article = $this->dm->getRepository(ArticleManyPull::class)
             ->findOneBy(['title' => 'Many Pull Article']);
@@ -166,7 +166,7 @@ final class ReferenceIntegrityDocumentTest extends BaseTestCaseMongoODM
         $type = $this->dm->getRepository(TypeOneRestrict::class)
             ->findOneBy(['title' => 'One Restrict Type']);
 
-        static::assertNotNull($type);
+        static::assertInstanceOf(TypeOneRestrict::class, $type);
         static::assertIsObject($type);
 
         $this->dm->remove($type);
@@ -179,7 +179,7 @@ final class ReferenceIntegrityDocumentTest extends BaseTestCaseMongoODM
         $type = $this->dm->getRepository(Type::class)
             ->findOneBy(['title' => 'Many Restrict Type']);
 
-        static::assertNotNull($type);
+        static::assertInstanceOf(Type::class, $type);
         static::assertIsObject($type);
 
         $this->dm->remove($type);

--- a/tests/Gedmo/References/Fixture/ODM/MongoDB/Metadata.php
+++ b/tests/Gedmo/References/Fixture/ODM/MongoDB/Metadata.php
@@ -24,12 +24,10 @@ use Gedmo\Tests\References\Fixture\ORM\Category;
 class Metadata
 {
     /**
-     * @var string|null
-     *
      * @ODM\Field(type="string")
      */
     #[ODM\Field(type: Type::STRING)]
-    private $name;
+    private ?string $name = null;
 
     /**
      * @Gedmo\ReferenceOne(type="entity", class="Gedmo\Tests\References\Fixture\ORM\Category", identifier="categoryId")

--- a/tests/Gedmo/References/Fixture/ODM/MongoDB/Product.php
+++ b/tests/Gedmo/References/Fixture/ODM/MongoDB/Product.php
@@ -42,7 +42,7 @@ class Product
      * @Gedmo\ReferenceMany(type="entity", class="Gedmo\Tests\References\Fixture\ORM\StockItem", mappedBy="product")
      */
     #[Gedmo\ReferenceMany(type: 'entity', class: StockItem::class, mappedBy: 'product')]
-    private $stockItems;
+    private Collection $stockItems;
 
     /**
      * @var Collection<int, Metadata>
@@ -50,7 +50,7 @@ class Product
      * @ODM\EmbedMany(targetDocument="Gedmo\Tests\References\Fixture\ODM\MongoDB\Metadata")
      */
     #[ODM\EmbedMany(targetDocument: Metadata::class)]
-    private $metadatas;
+    private Collection $metadatas;
 
     public function __construct()
     {

--- a/tests/Gedmo/References/Fixture/ORM/Category.php
+++ b/tests/Gedmo/References/Fixture/ORM/Category.php
@@ -25,16 +25,14 @@ use Gedmo\Tests\References\Fixture\ODM\MongoDB\Product;
 class Category
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="IDENTITY")
+     * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
      */
     #[ORM\Id]
-    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="name", type="string", length=128)

--- a/tests/Gedmo/References/Fixture/ORM/StockItem.php
+++ b/tests/Gedmo/References/Fixture/ORM/StockItem.php
@@ -23,16 +23,14 @@ use Gedmo\Tests\References\Fixture\ODM\MongoDB\Product;
 class StockItem
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="IDENTITY")
+     * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
      */
     #[ORM\Id]
-    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column

--- a/tests/Gedmo/References/ReferencesListenerTest.php
+++ b/tests/Gedmo/References/ReferencesListenerTest.php
@@ -94,7 +94,7 @@ final class ReferencesListenerTest extends BaseTestCaseOM
         $this->em->flush();
         $this->em->clear();
 
-        $stockItem = $this->em->find(get_class($stockItem), $stockItem->getId());
+        $stockItem = $this->em->find($stockItem::class, $stockItem->getId());
 
         static::assertSame($product, $stockItem->getProduct());
     }
@@ -125,19 +125,19 @@ final class ReferencesListenerTest extends BaseTestCaseOM
         $this->em->persist($stockItem);
         $this->em->flush();
 
-        $product = $this->dm->find(get_class($product), $product->getId());
+        $product = $this->dm->find($product::class, $product->getId());
 
         static::assertInstanceOf(Collection::class, $product->getStockItems());
-        static::assertSame(2, $product->getStockItems()->count());
+        static::assertCount(2, $product->getStockItems());
 
         $first = $product->getStockItems()->first();
 
-        static::assertInstanceOf(get_class($stockItem), $first);
+        static::assertInstanceOf($stockItem::class, $first);
         static::assertSame('APP-TV', $first->getSku());
 
         $last = $product->getStockItems()->last();
 
-        static::assertInstanceOf(get_class($stockItem), $last);
+        static::assertInstanceOf($stockItem::class, $last);
         static::assertSame('AMZN-APP-TV', $last->getSku());
     }
 

--- a/tests/Gedmo/Sluggable/CustomTransliteratorTest.php
+++ b/tests/Gedmo/Sluggable/CustomTransliteratorTest.php
@@ -41,7 +41,7 @@ final class CustomTransliteratorTest extends BaseTestCaseORM
     {
         $evm = new EventManager();
         $sluggableListener = new SluggableListener();
-        $sluggableListener->setTransliterator([Transliterator::class, 'transliterate']);
+        $sluggableListener->setTransliterator(Transliterator::transliterate(...));
         $evm->addEventSubscriber($sluggableListener);
 
         $this->getDefaultMockSqliteEntityManager($evm);

--- a/tests/Gedmo/Sluggable/Fixture/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Article.php
@@ -23,8 +23,6 @@ use Gedmo\Sluggable\Sluggable;
 class Article implements Sluggable
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -32,7 +30,7 @@ class Article implements Sluggable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=64)

--- a/tests/Gedmo/Sluggable/Fixture/ArticleWithoutFields.php
+++ b/tests/Gedmo/Sluggable/Fixture/ArticleWithoutFields.php
@@ -23,8 +23,6 @@ use Gedmo\Sluggable\Sluggable;
 class ArticleWithoutFields implements Sluggable
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -32,7 +30,7 @@ class ArticleWithoutFields implements Sluggable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @Gedmo\Slug(separator="-", updatable=true)

--- a/tests/Gedmo/Sluggable/Fixture/Comment.php
+++ b/tests/Gedmo/Sluggable/Fixture/Comment.php
@@ -21,8 +21,6 @@ use Doctrine\ORM\Mapping as ORM;
 class Comment
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -30,7 +28,7 @@ class Comment
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(type="text")

--- a/tests/Gedmo/Sluggable/Fixture/ConfigurationArticle.php
+++ b/tests/Gedmo/Sluggable/Fixture/ConfigurationArticle.php
@@ -23,8 +23,6 @@ use Gedmo\Sluggable\Sluggable;
 class ConfigurationArticle implements Sluggable
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -32,7 +30,7 @@ class ConfigurationArticle implements Sluggable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=64)

--- a/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDate.php
+++ b/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDate.php
@@ -23,8 +23,6 @@ use Gedmo\Sluggable\Sluggable;
 class ArticleDate implements Sluggable
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -32,7 +30,7 @@ class ArticleDate implements Sluggable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=64)

--- a/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateImmutable.php
+++ b/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateImmutable.php
@@ -23,8 +23,6 @@ use Gedmo\Sluggable\Sluggable;
 class ArticleDateImmutable implements Sluggable
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -32,7 +30,7 @@ class ArticleDateImmutable implements Sluggable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=64)

--- a/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateTime.php
+++ b/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateTime.php
@@ -23,8 +23,6 @@ use Gedmo\Sluggable\Sluggable;
 class ArticleDateTime implements Sluggable
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -32,7 +30,7 @@ class ArticleDateTime implements Sluggable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=64)

--- a/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateTimeImmutable.php
+++ b/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateTimeImmutable.php
@@ -23,8 +23,6 @@ use Gedmo\Sluggable\Sluggable;
 class ArticleDateTimeImmutable implements Sluggable
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -32,7 +30,7 @@ class ArticleDateTimeImmutable implements Sluggable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=64)

--- a/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateTimeTz.php
+++ b/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateTimeTz.php
@@ -23,8 +23,6 @@ use Gedmo\Sluggable\Sluggable;
 class ArticleDateTimeTz implements Sluggable
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -32,7 +30,7 @@ class ArticleDateTimeTz implements Sluggable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=64)

--- a/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateTimeTzImmutable.php
+++ b/tests/Gedmo/Sluggable/Fixture/DateTimeTypes/ArticleDateTimeTzImmutable.php
@@ -23,8 +23,6 @@ use Gedmo\Sluggable\Sluggable;
 class ArticleDateTimeTzImmutable implements Sluggable
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -32,7 +30,7 @@ class ArticleDateTimeTzImmutable implements Sluggable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=64)

--- a/tests/Gedmo/Sluggable/Fixture/Document/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Document/Article.php
@@ -22,12 +22,10 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Article
 {
     /**
-     * @var string|null
-     *
      * @ODM\Id
      */
     #[ODM\Id]
-    private $id;
+    private ?string $id = null;
 
     /**
      * @ODM\Field(type="string")

--- a/tests/Gedmo/Sluggable/Fixture/Document/Handler/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Document/Handler/Article.php
@@ -23,12 +23,10 @@ use Gedmo\Sluggable\Handler\InversedRelativeSlugHandler;
 class Article
 {
     /**
-     * @var string|null
-     *
      * @ODM\Id
      */
     #[ODM\Id]
-    private $id;
+    private ?string $id = null;
 
     /**
      * @ODM\Field(type="string")

--- a/tests/Gedmo/Sluggable/Fixture/Document/Handler/RelativeSlug.php
+++ b/tests/Gedmo/Sluggable/Fixture/Document/Handler/RelativeSlug.php
@@ -23,12 +23,10 @@ use Gedmo\Sluggable\Handler\RelativeSlugHandler;
 class RelativeSlug
 {
     /**
-     * @var string|null
-     *
      * @ODM\Id
      */
     #[ODM\Id]
-    private $id;
+    private ?string $id = null;
 
     /**
      * @ODM\Field(type="string")

--- a/tests/Gedmo/Sluggable/Fixture/Document/Handler/TreeSlug.php
+++ b/tests/Gedmo/Sluggable/Fixture/Document/Handler/TreeSlug.php
@@ -23,12 +23,10 @@ use Gedmo\Sluggable\Handler\TreeSlugHandler;
 class TreeSlug
 {
     /**
-     * @var string|null
-     *
      * @ODM\Id
      */
     #[ODM\Id]
-    private $id;
+    private ?string $id = null;
 
     /**
      * @ODM\Field(type="string")
@@ -37,8 +35,6 @@ class TreeSlug
     private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Slug(handlers={
      *     @Gedmo\SlugHandler(class="Gedmo\Sluggable\Handler\TreeSlugHandler", options={
      *         @Gedmo\SlugHandlerOption(name="parentRelationField", value="parent"),
@@ -51,7 +47,7 @@ class TreeSlug
     #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title'])]
     #[Gedmo\SlugHandler(class: TreeSlugHandler::class, options: ['parentRelationField' => 'parent', 'separator' => '/'])]
     #[ODM\Field(type: Type::STRING)]
-    private $alias;
+    private ?string $alias = null;
 
     /**
      * @ODM\ReferenceOne(targetDocument="Gedmo\Tests\Sluggable\Fixture\Document\Handler\TreeSlug")

--- a/tests/Gedmo/Sluggable/Fixture/Handler/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Handler/Article.php
@@ -24,8 +24,6 @@ use Gedmo\Sluggable\Sluggable;
 class Article implements Sluggable
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -33,7 +31,7 @@ class Article implements Sluggable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=64)
@@ -48,8 +46,6 @@ class Article implements Sluggable
     private ?string $code = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Slug(handlers={
      *     @Gedmo\SlugHandler(class="Gedmo\Sluggable\Handler\InversedRelativeSlugHandler", options={
      *         @Gedmo\SlugHandlerOption(name="relationClass", value="Gedmo\Tests\Sluggable\Fixture\Handler\ArticleRelativeSlug"),
@@ -63,7 +59,7 @@ class Article implements Sluggable
     #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title', 'code'])]
     #[Gedmo\SlugHandler(class: InversedRelativeSlugHandler::class, options: ['relationClass' => ArticleRelativeSlug::class, 'mappedBy' => 'article', 'inverseSlugField' => 'slug'])]
     #[ORM\Column(name: 'slug', type: Types::STRING, length: 64, unique: true)]
-    private $slug;
+    private ?string $slug = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Sluggable/Fixture/Handler/ArticleRelativeSlug.php
+++ b/tests/Gedmo/Sluggable/Fixture/Handler/ArticleRelativeSlug.php
@@ -23,8 +23,6 @@ use Gedmo\Sluggable\Handler\RelativeSlugHandler;
 class ArticleRelativeSlug
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -32,7 +30,7 @@ class ArticleRelativeSlug
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(length=64)
@@ -41,8 +39,6 @@ class ArticleRelativeSlug
     private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Slug(handlers={
      *     @Gedmo\SlugHandler(class="Gedmo\Sluggable\Handler\RelativeSlugHandler", options={
      *         @Gedmo\SlugHandlerOption(name="relationField", value="article"),
@@ -56,7 +52,7 @@ class ArticleRelativeSlug
     #[Gedmo\Slug(separator: '-', updatable: true, fields: ['title'])]
     #[Gedmo\SlugHandler(class: RelativeSlugHandler::class, options: ['relationField' => 'article', 'relationSlugField' => 'slug', 'separator' => '/'])]
     #[ORM\Column(name: 'slug', type: Types::STRING, length: 64, unique: true)]
-    private $slug;
+    private ?string $slug = null;
 
     /**
      * @ORM\ManyToOne(targetEntity="Article")

--- a/tests/Gedmo/Sluggable/Fixture/Handler/Company.php
+++ b/tests/Gedmo/Sluggable/Fixture/Handler/Company.php
@@ -23,8 +23,6 @@ use Gedmo\Sluggable\Handler\InversedRelativeSlugHandler;
 class Company
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -32,7 +30,7 @@ class Company
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(length=64)

--- a/tests/Gedmo/Sluggable/Fixture/Handler/TreeSlug.php
+++ b/tests/Gedmo/Sluggable/Fixture/Handler/TreeSlug.php
@@ -30,8 +30,6 @@ use Gedmo\Tree\Node;
 class TreeSlug implements Node
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -39,7 +37,7 @@ class TreeSlug implements Node
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=64)
@@ -48,8 +46,6 @@ class TreeSlug implements Node
     private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Slug(fields={"title"}, handlers={
      *     @Gedmo\SlugHandler(class="Gedmo\Sluggable\Handler\TreeSlugHandler", options={
      *         @Gedmo\SlugHandlerOption(name="parentRelationField", value="parent"),
@@ -62,7 +58,7 @@ class TreeSlug implements Node
     #[Gedmo\Slug(fields: ['title'], separator: '-', updatable: true)]
     #[Gedmo\SlugHandler(class: TreeSlugHandler::class, options: ['parentRelationField' => 'parent', 'separator' => '/'])]
     #[ORM\Column(name: 'slug', type: Types::STRING, length: 64, unique: true)]
-    private $slug;
+    private ?string $slug = null;
 
     /**
      * @Gedmo\TreeParent
@@ -81,48 +77,40 @@ class TreeSlug implements Node
     private Collection $children;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeLeft
      *
      * @ORM\Column(type="integer")
      */
     #[ORM\Column(type: Types::INTEGER)]
     #[Gedmo\TreeLeft]
-    private $lft;
+    private ?int $lft = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeRight
      *
      * @ORM\Column(type="integer")
      */
     #[ORM\Column(type: Types::INTEGER)]
     #[Gedmo\TreeRight]
-    private $rgt;
+    private ?int $rgt = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeRoot
      *
      * @ORM\Column(type="integer")
      */
     #[ORM\Column(type: Types::INTEGER)]
     #[Gedmo\TreeRoot]
-    private $root;
+    private ?int $root = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeLevel
      *
      * @ORM\Column(name="lvl", type="integer")
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER)]
     #[Gedmo\TreeLevel]
-    private $level;
+    private ?int $level = null;
 
     private ?Node $sibling = null;
 

--- a/tests/Gedmo/Sluggable/Fixture/Handler/TreeSlugPrefixSuffix.php
+++ b/tests/Gedmo/Sluggable/Fixture/Handler/TreeSlugPrefixSuffix.php
@@ -29,8 +29,6 @@ use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
 class TreeSlugPrefixSuffix
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -38,7 +36,7 @@ class TreeSlugPrefixSuffix
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=64)
@@ -47,8 +45,6 @@ class TreeSlugPrefixSuffix
     private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Slug(fields={"title"}, handlers={
      *     @Gedmo\SlugHandler(class="Gedmo\Sluggable\Handler\TreeSlugHandler", options={
      *         @Gedmo\SlugHandlerOption(name="parentRelationField", value="parent"),
@@ -63,7 +59,7 @@ class TreeSlugPrefixSuffix
     #[Gedmo\Slug(fields: ['title'], separator: '-', updatable: true)]
     #[Gedmo\SlugHandler(class: TreeSlugHandler::class, options: ['parentRelationField' => 'parent', 'separator' => '/', 'prefix' => 'prefix.', 'suffix' => '.suffix'])]
     #[ORM\Column(name: 'slug', type: Types::STRING, length: 64, unique: true)]
-    private $slug;
+    private ?string $slug = null;
 
     /**
      * @Gedmo\TreeParent
@@ -82,48 +78,40 @@ class TreeSlugPrefixSuffix
     private Collection $children;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeLeft
      *
      * @ORM\Column(type="integer")
      */
     #[ORM\Column(type: Types::INTEGER)]
     #[Gedmo\TreeLeft]
-    private $lft;
+    private ?int $lft = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeRight
      *
      * @ORM\Column(type="integer")
      */
     #[ORM\Column(type: Types::INTEGER)]
     #[Gedmo\TreeRight]
-    private $rgt;
+    private ?int $rgt = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeRoot
      *
      * @ORM\Column(type="integer")
      */
     #[ORM\Column(type: Types::INTEGER)]
     #[Gedmo\TreeRoot]
-    private $root;
+    private ?int $root = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeLevel
      *
      * @ORM\Column(name="lvl", type="integer")
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER)]
     #[Gedmo\TreeLevel]
-    private $level;
+    private ?int $level = null;
 
     public function __construct()
     {

--- a/tests/Gedmo/Sluggable/Fixture/Handler/User.php
+++ b/tests/Gedmo/Sluggable/Fixture/Handler/User.php
@@ -23,8 +23,6 @@ use Gedmo\Sluggable\Handler\RelativeSlugHandler;
 class User
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -32,7 +30,7 @@ class User
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(length=64)

--- a/tests/Gedmo/Sluggable/Fixture/Inheritance/Vehicle.php
+++ b/tests/Gedmo/Sluggable/Fixture/Inheritance/Vehicle.php
@@ -31,8 +31,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Vehicle
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -40,7 +38,7 @@ class Vehicle
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(length=128)

--- a/tests/Gedmo/Sluggable/Fixture/Inheritance2/SportCar.php
+++ b/tests/Gedmo/Sluggable/Fixture/Inheritance2/SportCar.php
@@ -17,6 +17,4 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Entity
  */
 #[ORM\Entity]
-class SportCar extends Car
-{
-}
+class SportCar extends Car {}

--- a/tests/Gedmo/Sluggable/Fixture/Inheritance2/Vehicle.php
+++ b/tests/Gedmo/Sluggable/Fixture/Inheritance2/Vehicle.php
@@ -28,8 +28,6 @@ use Gedmo\Tests\Translatable\Fixture\Sport;
 abstract class Vehicle
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -37,7 +35,7 @@ abstract class Vehicle
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Sluggable/Fixture/Issue100/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue100/Article.php
@@ -24,8 +24,6 @@ use Gedmo\Translatable\Translatable;
 class Article implements Sluggable, Translatable
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -33,7 +31,7 @@ class Article implements Sluggable, Translatable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @Gedmo\Translatable

--- a/tests/Gedmo/Sluggable/Fixture/Issue104/Bus.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue104/Bus.php
@@ -21,8 +21,6 @@ use Doctrine\ORM\Mapping as ORM;
 class Bus
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -30,7 +28,7 @@ class Bus
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(length=128)

--- a/tests/Gedmo/Sluggable/Fixture/Issue104/Vehicle.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue104/Vehicle.php
@@ -30,8 +30,6 @@ class Vehicle
     protected $title;
 
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -39,7 +37,7 @@ class Vehicle
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @var string|null

--- a/tests/Gedmo/Sluggable/Fixture/Issue1058/Page.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue1058/Page.php
@@ -22,8 +22,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Page
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -31,7 +29,7 @@ class Page
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=64)

--- a/tests/Gedmo/Sluggable/Fixture/Issue1058/User.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue1058/User.php
@@ -21,8 +21,6 @@ use Doctrine\ORM\Mapping as ORM;
 class User
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -30,7 +28,7 @@ class User
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Sluggable/Fixture/Issue116/Country.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue116/Country.php
@@ -24,8 +24,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Country
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -33,15 +31,13 @@ class Country
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(type="string", length=10, nullable=true)
      */
     #[ORM\Column(type: Types::STRING, length: 10, nullable: true)]
-    private $languageCode;
+    private ?string $languageCode = null;
 
     /**
      * @ORM\Column(type="string", length=50)
@@ -50,15 +46,13 @@ class Country
     private ?string $originalName = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(type="string", length=50)
      *
      * @Gedmo\Slug(separator="-", fields={"originalName"})
      */
     #[ORM\Column(type: Types::STRING, length: 50)]
     #[Gedmo\Slug(separator: '-', fields: ['originalName'])]
-    private $alias;
+    private ?string $alias = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Sluggable/Fixture/Issue1177/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue1177/Article.php
@@ -23,8 +23,6 @@ use Gedmo\Sluggable\Sluggable;
 class Article implements Sluggable
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -32,7 +30,7 @@ class Article implements Sluggable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=64)

--- a/tests/Gedmo/Sluggable/Fixture/Issue1240/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue1240/Article.php
@@ -23,8 +23,6 @@ use Gedmo\Sluggable\Sluggable;
 class Article implements Sluggable
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -32,7 +30,7 @@ class Article implements Sluggable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=64)

--- a/tests/Gedmo/Sluggable/Fixture/Issue131/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue131/Article.php
@@ -22,8 +22,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Article
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -31,7 +29,7 @@ class Article
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(length=64)

--- a/tests/Gedmo/Sluggable/Fixture/Issue449/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue449/Article.php
@@ -26,8 +26,6 @@ use Gedmo\Sluggable\Sluggable;
 class Article implements Sluggable
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -35,7 +33,7 @@ class Article implements Sluggable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=64)

--- a/tests/Gedmo/Sluggable/Fixture/Issue633/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue633/Article.php
@@ -22,8 +22,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Article
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -31,7 +29,7 @@ class Article
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="code", type="string", length=16)

--- a/tests/Gedmo/Sluggable/Fixture/Issue827/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue827/Article.php
@@ -22,8 +22,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Article
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -31,7 +29,7 @@ class Article
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", length=64)

--- a/tests/Gedmo/Sluggable/Fixture/Issue827/Category.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue827/Category.php
@@ -24,8 +24,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Category
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -33,7 +31,7 @@ class Category
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", length=64)

--- a/tests/Gedmo/Sluggable/Fixture/Issue827/Comment.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue827/Comment.php
@@ -22,8 +22,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Comment
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -31,7 +29,7 @@ class Comment
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", length=64)

--- a/tests/Gedmo/Sluggable/Fixture/Issue939/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue939/Article.php
@@ -22,8 +22,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Article
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -31,7 +29,7 @@ class Article
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", length=64)

--- a/tests/Gedmo/Sluggable/Fixture/Issue939/Category.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue939/Category.php
@@ -24,8 +24,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Category
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -33,7 +31,7 @@ class Category
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", length=64)

--- a/tests/Gedmo/Sluggable/Fixture/Issue939/SluggableListener.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue939/SluggableListener.php
@@ -32,8 +32,8 @@ final class SluggableListener extends BaseSluggableListener
         $this->originalTransliterator = $this->getTransliterator();
         $this->originalUrlizer = $this->getUrlizer();
 
-        $this->setTransliterator([$this, 'transliterator']);
-        $this->setUrlizer([$this, 'urlizer']);
+        $this->setTransliterator($this->transliterator(...));
+        $this->setUrlizer($this->urlizer(...));
     }
 
     public function transliterator(string $slug, string $separator, object $object): string

--- a/tests/Gedmo/Sluggable/Fixture/MappedSuperclass/Car.php
+++ b/tests/Gedmo/Sluggable/Fixture/MappedSuperclass/Car.php
@@ -21,8 +21,6 @@ use Doctrine\ORM\Mapping as ORM;
 class Car extends Vehicle
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -30,7 +28,7 @@ class Car extends Vehicle
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(length=128)

--- a/tests/Gedmo/Sluggable/Fixture/Page.php
+++ b/tests/Gedmo/Sluggable/Fixture/Page.php
@@ -24,8 +24,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Page
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -33,7 +31,7 @@ class Page
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(type="string", length=191)
@@ -42,15 +40,13 @@ class Page
     private ?string $content = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Slug(style="camel", separator="_", fields={"content"})
      *
      * @ORM\Column(type="string", length=128)
      */
     #[Gedmo\Slug(style: 'camel', separator: '_', fields: ['content'])]
     #[ORM\Column(type: Types::STRING, length: 128)]
-    private $slug;
+    private ?string $slug = null;
 
     /**
      * @var Collection<int, TranslatableArticle>
@@ -58,7 +54,7 @@ class Page
      * @ORM\OneToMany(targetEntity="TranslatableArticle", mappedBy="page")
      */
     #[ORM\OneToMany(targetEntity: TranslatableArticle::class, mappedBy: 'page')]
-    private $articles;
+    private Collection $articles;
 
     public function __construct()
     {

--- a/tests/Gedmo/Sluggable/Fixture/Position.php
+++ b/tests/Gedmo/Sluggable/Fixture/Position.php
@@ -22,8 +22,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Position
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -31,7 +29,7 @@ class Position
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @var string|null

--- a/tests/Gedmo/Sluggable/Fixture/Prefix.php
+++ b/tests/Gedmo/Sluggable/Fixture/Prefix.php
@@ -25,8 +25,6 @@ use Gedmo\Sluggable\Sluggable;
 class Prefix implements Sluggable
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -34,7 +32,7 @@ class Prefix implements Sluggable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=64)

--- a/tests/Gedmo/Sluggable/Fixture/PrefixWithTreeHandler.php
+++ b/tests/Gedmo/Sluggable/Fixture/PrefixWithTreeHandler.php
@@ -30,8 +30,6 @@ use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
 class PrefixWithTreeHandler implements Sluggable
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -39,7 +37,7 @@ class PrefixWithTreeHandler implements Sluggable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=64)

--- a/tests/Gedmo/Sluggable/Fixture/Suffix.php
+++ b/tests/Gedmo/Sluggable/Fixture/Suffix.php
@@ -25,8 +25,6 @@ use Gedmo\Sluggable\Sluggable;
 class Suffix implements Sluggable
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -34,7 +32,7 @@ class Suffix implements Sluggable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=64)

--- a/tests/Gedmo/Sluggable/Fixture/SuffixWithTreeHandler.php
+++ b/tests/Gedmo/Sluggable/Fixture/SuffixWithTreeHandler.php
@@ -30,8 +30,6 @@ use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
 class SuffixWithTreeHandler implements Sluggable
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -39,7 +37,7 @@ class SuffixWithTreeHandler implements Sluggable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=64)

--- a/tests/Gedmo/Sluggable/Fixture/TransArticleManySlug.php
+++ b/tests/Gedmo/Sluggable/Fixture/TransArticleManySlug.php
@@ -24,8 +24,6 @@ use Gedmo\Translatable\Translatable;
 class TransArticleManySlug implements Sluggable, Translatable
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -33,7 +31,7 @@ class TransArticleManySlug implements Sluggable, Translatable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     private ?int $page = null;
 
@@ -53,15 +51,13 @@ class TransArticleManySlug implements Sluggable, Translatable
     private ?string $uniqueTitle = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Slug(fields={"uniqueTitle"})
      *
      * @ORM\Column(type="string", length=128)
      */
     #[Gedmo\Slug(fields: ['uniqueTitle'])]
     #[ORM\Column(type: Types::STRING, length: 128)]
-    private $uniqueSlug;
+    private ?string $uniqueSlug = null;
 
     /**
      * @Gedmo\Translatable
@@ -73,8 +69,6 @@ class TransArticleManySlug implements Sluggable, Translatable
     private ?string $code = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @Gedmo\Slug(fields={"title", "code"})
      *
@@ -83,7 +77,7 @@ class TransArticleManySlug implements Sluggable, Translatable
     #[ORM\Column(type: Types::STRING, length: 128)]
     #[Gedmo\Slug(fields: ['title', 'code'])]
     #[Gedmo\Translatable]
-    private $slug;
+    private ?string $slug = null;
 
     /**
      * @Gedmo\Locale

--- a/tests/Gedmo/Sluggable/Fixture/TranslatableArticle.php
+++ b/tests/Gedmo/Sluggable/Fixture/TranslatableArticle.php
@@ -26,8 +26,6 @@ use Gedmo\Translatable\Translatable;
 class TranslatableArticle implements Sluggable, Translatable
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -35,7 +33,7 @@ class TranslatableArticle implements Sluggable, Translatable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @Gedmo\Translatable
@@ -56,8 +54,6 @@ class TranslatableArticle implements Sluggable, Translatable
     private ?string $code = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @Gedmo\Slug(fields={"title", "code"})
      *
@@ -66,7 +62,7 @@ class TranslatableArticle implements Sluggable, Translatable
     #[ORM\Column(type: Types::STRING, length: 128)]
     #[Gedmo\Translatable]
     #[Gedmo\Slug(fields: ['title', 'code'])]
-    private $slug;
+    private ?string $slug = null;
 
     /**
      * @var Collection<int, Comment>
@@ -74,7 +70,7 @@ class TranslatableArticle implements Sluggable, Translatable
      * @ORM\OneToMany(targetEntity="Comment", mappedBy="article")
      */
     #[ORM\OneToMany(targetEntity: Comment::class, mappedBy: 'article')]
-    private $comments;
+    private Collection $comments;
 
     /**
      * @ORM\ManyToOne(targetEntity="Page", inversedBy="articles")

--- a/tests/Gedmo/Sluggable/Issue/Issue116Test.php
+++ b/tests/Gedmo/Sluggable/Issue/Issue116Test.php
@@ -12,10 +12,6 @@ declare(strict_types=1);
 namespace Gedmo\Tests\Sluggable\Issue;
 
 use Doctrine\Common\EventManager;
-use Doctrine\ORM\Mapping\Driver\AttributeDriver;
-use Doctrine\ORM\Mapping\Driver\YamlDriver;
-use Doctrine\Persistence\Mapping\Driver\MappingDriver;
-use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Gedmo\Sluggable\SluggableListener;
 use Gedmo\Tests\Sluggable\Fixture\Issue116\Country;
 use Gedmo\Tests\Tool\BaseTestCaseORM;
@@ -46,22 +42,6 @@ final class Issue116Test extends BaseTestCaseORM
         $this->em->flush();
 
         static::assertSame('new-zealand', $country->getAlias());
-    }
-
-    protected function getMetadataDriverImplementation(): MappingDriver
-    {
-        $chain = new MappingDriverChain();
-
-        if (PHP_VERSION_ID >= 80000) {
-            $chain->addDriver(new AttributeDriver([]), 'Gedmo\Tests\Sluggable\Fixture\Issue116');
-        } else {
-            $chain->addDriver(
-                new YamlDriver([__DIR__.'/../Fixture/Issue116/Mapping']),
-                'Gedmo\Tests\Sluggable\Fixture\Issue116'
-            );
-        }
-
-        return $chain;
     }
 
     protected function getUsedEntityFixtures(): array

--- a/tests/Gedmo/Sluggable/SluggableConfigurationTest.php
+++ b/tests/Gedmo/Sluggable/SluggableConfigurationTest.php
@@ -71,7 +71,7 @@ final class SluggableConfigurationTest extends BaseTestCaseORM
         $this->em->clear();
 
         $shorten = $article->getSlug();
-        static::assertSame(32, strlen($shorten));
+        static::assertSame(32, strlen((string) $shorten));
     }
 
     public function testNonUpdatableSlug(): void

--- a/tests/Gedmo/Sluggable/SluggableTest.php
+++ b/tests/Gedmo/Sluggable/SluggableTest.php
@@ -85,7 +85,7 @@ final class SluggableTest extends BaseTestCaseORM
             $this->em->clear();
 
             $shorten = $article->getSlug();
-            static::assertSame(64, strlen($shorten));
+            static::assertSame(64, strlen((string) $shorten));
             $expected = 'the-title-the-title-the-title-the-title-the-title-the-title-the-';
             $expected = substr($expected, 0, 64 - (strlen($uniqueSuffix) + 1)).'-'.$uniqueSuffix;
             static::assertSame($shorten, $expected);

--- a/tests/Gedmo/SoftDeleteable/CarbonTest.php
+++ b/tests/Gedmo/SoftDeleteable/CarbonTest.php
@@ -68,16 +68,16 @@ final class CarbonTest extends BaseTestCaseORM
 
         $art = $repo->findOneBy([$field => $value]);
 
-        static::assertNull($art->getDeletedAt());
-        static::assertNull($comment->getDeletedAt());
+        static::assertNotInstanceOf(\DateTime::class, $art->getDeletedAt());
+        static::assertNotInstanceOf(\DateTime::class, $comment->getDeletedAt());
 
         $this->em->remove($art);
         $this->em->flush();
 
         $art = $repo->findOneBy([$field => $value]);
-        static::assertNull($art);
+        static::assertNotInstanceOf(Article::class, $art);
         $comment = $commentRepo->findOneBy([$commentField => $commentValue]);
-        static::assertNull($comment);
+        static::assertNotInstanceOf(Comment::class, $comment);
 
         // Now we deactivate the filter so we test if the entity appears in the result
         $this->em->getFilters()->disable(self::SOFT_DELETEABLE_FILTER_NAME);

--- a/tests/Gedmo/SoftDeleteable/Fixture/Document/User.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Document/User.php
@@ -32,12 +32,10 @@ class User
     #[ODM\Field(type: Type::DATE)]
     protected $deletedAt;
     /**
-     * @var string|null
-     *
      * @ODM\Id
      */
     #[ODM\Id]
-    private $id;
+    private ?string $id = null;
 
     /**
      * @ODM\Field(type="string")

--- a/tests/Gedmo/SoftDeleteable/Fixture/Document/UserTimeAware.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Document/UserTimeAware.php
@@ -32,12 +32,10 @@ class UserTimeAware
     #[ODM\Field(type: Type::DATE)]
     protected $deletedAt;
     /**
-     * @var string|null
-     *
      * @ODM\Id
      */
     #[ODM\Id]
-    private $id;
+    private ?string $id = null;
 
     /**
      * @ODM\Field(type="string")

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/Address.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/Address.php
@@ -25,8 +25,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Address
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -34,7 +32,7 @@ class Address
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(length=128)

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/Article.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/Article.php
@@ -27,8 +27,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Article
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="IDENTITY")
      * @ORM\Column(type="integer")
@@ -36,7 +34,7 @@ class Article
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string")
@@ -56,7 +54,7 @@ class Article
      * @ORM\OneToMany(targetEntity="Comment", mappedBy="article", cascade={"persist", "remove"})
      */
     #[ORM\OneToMany(targetEntity: Comment::class, mappedBy: 'article', cascade: ['persist', 'remove'])]
-    private $comments;
+    private Collection $comments;
 
     /**
      * @ORM\ManyToOne(targetEntity="Author", cascade={"persist"}, inversedBy="articles")

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/Comment.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/Comment.php
@@ -25,8 +25,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Comment
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="IDENTITY")
      * @ORM\Column(type="integer")
@@ -34,7 +32,7 @@ class Comment
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="comment", type="string")
@@ -49,12 +47,10 @@ class Comment
     private ?\DateTime $deletedAt = null;
 
     /**
-     * @var Article|null
-     *
      * @ORM\ManyToOne(targetEntity="Article", inversedBy="comments")
      */
     #[ORM\ManyToOne(targetEntity: Article::class, inversedBy: 'comments')]
-    private $article;
+    private ?Article $article = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/MappedSuperclass.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/MappedSuperclass.php
@@ -25,8 +25,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class MappedSuperclass
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="IDENTITY")
      * @ORM\Column(type="integer")
@@ -34,7 +32,7 @@ class MappedSuperclass
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="deletedAt", type="datetime", nullable=true)

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/MegaPage.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/MegaPage.php
@@ -17,6 +17,4 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Entity
  */
 #[ORM\Entity]
-class MegaPage extends Page
-{
-}
+class MegaPage extends Page {}

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/Module.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/Module.php
@@ -25,8 +25,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Module
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="IDENTITY")
      * @ORM\Column(type="integer")
@@ -34,7 +32,7 @@ class Module
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string")

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/OtherArticle.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/OtherArticle.php
@@ -27,8 +27,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class OtherArticle
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="IDENTITY")
      * @ORM\Column(type="integer")
@@ -36,7 +34,7 @@ class OtherArticle
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string")
@@ -56,7 +54,7 @@ class OtherArticle
      * @ORM\OneToMany(targetEntity="OtherComment", mappedBy="article")
      */
     #[ORM\OneToMany(targetEntity: OtherComment::class, mappedBy: 'article')]
-    private $comments;
+    private Collection $comments;
 
     public function __construct()
     {

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/OtherComment.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/OtherComment.php
@@ -21,8 +21,6 @@ use Doctrine\ORM\Mapping as ORM;
 class OtherComment
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="IDENTITY")
      * @ORM\Column(type="integer")
@@ -30,7 +28,7 @@ class OtherComment
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="comment", type="string")

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/Page.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/Page.php
@@ -33,8 +33,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Page
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="IDENTITY")
      * @ORM\Column(type="integer")
@@ -42,7 +40,7 @@ class Page
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string")
@@ -62,7 +60,7 @@ class Page
      * @ORM\OneToMany(targetEntity="Module", mappedBy="page", cascade={"persist", "remove"})
      */
     #[ORM\OneToMany(targetEntity: Module::class, mappedBy: 'page', cascade: ['persist', 'remove'])]
-    private $modules;
+    private Collection $modules;
 
     public function __construct()
     {

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/Person.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/Person.php
@@ -25,8 +25,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Person
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -34,7 +32,7 @@ class Person
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(length=32)

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/User.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/User.php
@@ -25,8 +25,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class User
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="IDENTITY")
      * @ORM\Column(type="integer")
@@ -34,7 +32,7 @@ class User
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string")

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/UserNoHardDelete.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/UserNoHardDelete.php
@@ -25,8 +25,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class UserNoHardDelete
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="IDENTITY")
      * @ORM\Column(type="integer")
@@ -34,7 +32,7 @@ class UserNoHardDelete
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string")

--- a/tests/Gedmo/SoftDeleteable/Fixture/Listener/WithLifecycleEventArgsFromODMTypeListener.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Listener/WithLifecycleEventArgsFromODMTypeListener.php
@@ -17,13 +17,9 @@ use Gedmo\SoftDeleteable\SoftDeleteableListener;
 
 final class WithLifecycleEventArgsFromODMTypeListener implements EventSubscriber
 {
-    public function preSoftDelete(LifecycleEventArgs $args): void
-    {
-    }
+    public function preSoftDelete(LifecycleEventArgs $args): void {}
 
-    public function postSoftDelete(LifecycleEventArgs $args): void
-    {
-    }
+    public function postSoftDelete(LifecycleEventArgs $args): void {}
 
     public function getSubscribedEvents(): array
     {

--- a/tests/Gedmo/SoftDeleteable/Fixture/Listener/WithLifecycleEventArgsFromORMTypeListener.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Listener/WithLifecycleEventArgsFromORMTypeListener.php
@@ -17,13 +17,9 @@ use Gedmo\SoftDeleteable\SoftDeleteableListener;
 
 final class WithLifecycleEventArgsFromORMTypeListener implements EventSubscriber
 {
-    public function preSoftDelete(LifecycleEventArgs $args): void
-    {
-    }
+    public function preSoftDelete(LifecycleEventArgs $args): void {}
 
-    public function postSoftDelete(LifecycleEventArgs $args): void
-    {
-    }
+    public function postSoftDelete(LifecycleEventArgs $args): void {}
 
     public function getSubscribedEvents(): array
     {

--- a/tests/Gedmo/SoftDeleteable/Fixture/Listener/WithPreAndPostSoftDeleteEventArgsTypeListener.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Listener/WithPreAndPostSoftDeleteEventArgsTypeListener.php
@@ -20,14 +20,10 @@ use Gedmo\SoftDeleteable\SoftDeleteableListener;
 final class WithPreAndPostSoftDeleteEventArgsTypeListener implements EventSubscriber
 {
     /** @param PreSoftDeleteEventArgs<ObjectManager> $args */
-    public function preSoftDelete(PreSoftDeleteEventArgs $args): void
-    {
-    }
+    public function preSoftDelete(PreSoftDeleteEventArgs $args): void {}
 
     /** @param PostSoftDeleteEventArgs<ObjectManager> $args */
-    public function postSoftDelete(PostSoftDeleteEventArgs $args): void
-    {
-    }
+    public function postSoftDelete(PostSoftDeleteEventArgs $args): void {}
 
     public function getSubscribedEvents(): array
     {

--- a/tests/Gedmo/SoftDeleteable/Fixture/Listener/WithoutTypeListener.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Listener/WithoutTypeListener.php
@@ -20,14 +20,10 @@ use Gedmo\SoftDeleteable\SoftDeleteableListener;
 final class WithoutTypeListener implements EventSubscriber
 {
     /** @param PreSoftDeleteEventArgs<ObjectManager> $args */
-    public function preSoftDelete($args): void
-    {
-    }
+    public function preSoftDelete($args): void {}
 
     /** @param PostSoftDeleteEventArgs<ObjectManager> $args */
-    public function postSoftDelete($args): void
-    {
-    }
+    public function postSoftDelete($args): void {}
 
     public function getSubscribedEvents(): array
     {

--- a/tests/Gedmo/SoftDeleteable/HardRelationTest.php
+++ b/tests/Gedmo/SoftDeleteable/HardRelationTest.php
@@ -50,7 +50,7 @@ final class HardRelationTest extends BaseTestCaseORM
         $this->em->clear();
 
         $person = $this->em->getRepository(Person::class)->findOneBy(['id' => $person->getId()]);
-        static::assertNull($person, 'Softdelete should cascade to hard relation entity');
+        static::assertNotInstanceOf(Person::class, $person, 'Softdelete should cascade to hard relation entity');
     }
 
     public function testShouldCascadeToInversedRelationAsWell(): void
@@ -72,7 +72,7 @@ final class HardRelationTest extends BaseTestCaseORM
         $this->em->clear();
 
         $address = $this->em->getRepository(Address::class)->findOneBy(['id' => $address->getId()]);
-        static::assertNull($address, 'Softdelete should cascade to hard relation entity');
+        static::assertNotInstanceOf(Address::class, $address, 'Softdelete should cascade to hard relation entity');
     }
 
     public function testShouldHandleTimeAwareSoftDeleteable(): void
@@ -91,7 +91,7 @@ final class HardRelationTest extends BaseTestCaseORM
         $this->em->clear();
 
         $person = $this->em->getRepository(Person::class)->findOneBy(['id' => $person->getId()]);
-        static::assertNotNull($person, 'Should not be softdeleted');
+        static::assertInstanceOf(Person::class, $person, 'Should not be softdeleted');
 
         $person->setDeletedAt(new \DateTime(date('Y-m-d H:i:s', time() - 15 * 3600))); // in an hour
         $this->em->persist($person);
@@ -99,7 +99,7 @@ final class HardRelationTest extends BaseTestCaseORM
         $this->em->clear();
 
         $person = $this->em->getRepository(Person::class)->findOneBy(['id' => $person->getId()]);
-        static::assertNull($person, 'Should be softdeleted');
+        static::assertNotInstanceOf(Person::class, $person, 'Should be softdeleted');
     }
 
     protected function getUsedEntityFixtures(): array

--- a/tests/Gedmo/SoftDeleteable/SoftDeletableDocumentTraitTest.php
+++ b/tests/Gedmo/SoftDeleteable/SoftDeletableDocumentTraitTest.php
@@ -21,17 +21,12 @@ use PHPUnit\Framework\TestCase;
  */
 final class SoftDeletableDocumentTraitTest extends TestCase
 {
-    /**
-     * @var UsingTrait
-     */
-    protected $entity;
-
     public function testGetSetDeletedAt(): void
     {
         $time = new \DateTime();
         $entity = new UsingTrait();
 
-        static::assertNull($entity->getDeletedAt(), 'deletedAt defaults to null');
+        static::assertNotInstanceOf(\DateTime::class, $entity->getDeletedAt(), 'deletedAt defaults to null');
         static::assertFalse($entity->isDeleted(), 'isDeleted defaults to false');
         static::assertSame($entity, $entity->setDeletedAt($time), 'Setter has a fluid interface');
         static::assertSame($time, $entity->getDeletedAt(), 'Getter returns a DateTime Object');

--- a/tests/Gedmo/SoftDeleteable/SoftDeletableEntityTraitTest.php
+++ b/tests/Gedmo/SoftDeleteable/SoftDeletableEntityTraitTest.php
@@ -21,17 +21,12 @@ use PHPUnit\Framework\TestCase;
  */
 final class SoftDeletableEntityTraitTest extends TestCase
 {
-    /**
-     * @var UsingTrait
-     */
-    protected $entity;
-
     public function testGetSetDeletedAt(): void
     {
         $time = new \DateTime();
         $entity = new UsingTrait();
 
-        static::assertNull($entity->getDeletedAt(), 'deletedAt defaults to null');
+        static::assertNotInstanceOf(\DateTime::class, $entity->getDeletedAt(), 'deletedAt defaults to null');
         static::assertFalse($entity->isDeleted(), 'isDeleted defaults to false');
         static::assertSame($entity, $entity->setDeletedAt($time), 'Setter has a fluid interface');
         static::assertSame($time, $entity->getDeletedAt(), 'Getter returns a DateTime Object');

--- a/tests/Gedmo/SoftDeleteable/SoftDeleteableDocumentTest.php
+++ b/tests/Gedmo/SoftDeleteable/SoftDeleteableDocumentTest.php
@@ -62,14 +62,14 @@ final class SoftDeleteableDocumentTest extends BaseTestCaseMongoODM
 
         $user = $repo->findOneBy(['username' => $username]);
 
-        static::assertNull($user->getDeletedAt());
+        static::assertNotInstanceOf(\DateTime::class, $user->getDeletedAt());
 
         $this->dm->remove($user);
         $this->dm->flush();
 
         $user = $repo->findOneBy(['username' => $username]);
 
-        static::assertNull($user);
+        static::assertNotInstanceOf(User::class, $user);
     }
 
     /**
@@ -92,18 +92,18 @@ final class SoftDeleteableDocumentTest extends BaseTestCaseMongoODM
 
         $user = $repo->findOneBy(['username' => $username]);
 
-        static::assertNull($user->getDeletedAt());
+        static::assertNotInstanceOf(\DateTime::class, $user->getDeletedAt());
         $this->dm->remove($user);
         $this->dm->flush();
 
         $user = $repo->findOneBy(['username' => $username]);
 
-        static::assertNotNull($user->getDeletedAt());
+        static::assertInstanceOf(\DateTime::class, $user->getDeletedAt());
 
         $filter->enableForDocument(User::class);
 
         $user = $repo->findOneBy(['username' => $username]);
-        static::assertNull($user);
+        static::assertNotInstanceOf(User::class, $user);
     }
 
     /**
@@ -144,7 +144,7 @@ final class SoftDeleteableDocumentTest extends BaseTestCaseMongoODM
 
         $user = $repo->findOneBy(['username' => $username]);
 
-        static::assertNull($user);
+        static::assertNotInstanceOf(UserTimeAware::class, $user);
         $this->dm->flush();
     }
 
@@ -177,7 +177,7 @@ final class SoftDeleteableDocumentTest extends BaseTestCaseMongoODM
 
         $user = $repo->findOneBy(['username' => 'test_user']);
 
-        static::assertNull($user->getDeletedAt());
+        static::assertNotInstanceOf(\DateTime::class, $user->getDeletedAt());
 
         $this->dm->remove($user);
         $this->dm->flush();

--- a/tests/Gedmo/Sortable/Fixture/AbstractNode.php
+++ b/tests/Gedmo/Sortable/Fixture/AbstractNode.php
@@ -22,8 +22,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class AbstractNode
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -31,37 +29,31 @@ class AbstractNode
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    protected $id;
+    protected ?int $id = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(type="string", length=191)
      */
     #[ORM\Column(type: Types::STRING, length: 191)]
-    protected $name;
+    protected ?string $name = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\SortableGroup
      *
      * @ORM\Column(type="string", length=191)
      */
     #[Gedmo\SortableGroup]
     #[ORM\Column(type: Types::STRING, length: 191)]
-    protected $path;
+    protected ?string $path = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\SortablePosition
      *
      * @ORM\Column(type="integer")
      */
     #[Gedmo\SortablePosition]
     #[ORM\Column(type: Types::INTEGER)]
-    protected $position;
+    protected ?int $position = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Sortable/Fixture/Author.php
+++ b/tests/Gedmo/Sortable/Fixture/Author.php
@@ -23,8 +23,6 @@ use Gedmo\Sortable\Entity\Repository\SortableRepository;
 class Author
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -32,7 +30,7 @@ class Author
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="name", type="string")

--- a/tests/Gedmo/Sortable/Fixture/Category.php
+++ b/tests/Gedmo/Sortable/Fixture/Category.php
@@ -23,8 +23,6 @@ use Doctrine\ORM\Mapping as ORM;
 class Category
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -32,7 +30,7 @@ class Category
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(type="string", length=191)

--- a/tests/Gedmo/Sortable/Fixture/Customer.php
+++ b/tests/Gedmo/Sortable/Fixture/Customer.php
@@ -21,8 +21,6 @@ use Doctrine\ORM\Mapping as ORM;
 class Customer
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -30,7 +28,7 @@ class Customer
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="name", type="string")

--- a/tests/Gedmo/Sortable/Fixture/CustomerType.php
+++ b/tests/Gedmo/Sortable/Fixture/CustomerType.php
@@ -29,8 +29,6 @@ use Gedmo\Sortable\Entity\Repository\SortableRepository;
 class CustomerType
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -38,7 +36,7 @@ class CustomerType
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="name", type="string")

--- a/tests/Gedmo/Sortable/Fixture/Document/Article.php
+++ b/tests/Gedmo/Sortable/Fixture/Document/Article.php
@@ -33,12 +33,10 @@ class Article
     protected $position;
 
     /**
-     * @var string|null
-     *
      * @ODM\Id
      */
     #[ODM\Id]
-    private $id;
+    private ?string $id = null;
 
     /**
      * @ODM\Field(type="string")

--- a/tests/Gedmo/Sortable/Fixture/Document/Category.php
+++ b/tests/Gedmo/Sortable/Fixture/Document/Category.php
@@ -21,12 +21,10 @@ use Doctrine\ODM\MongoDB\Types\Type as MongoDBType;
 class Category
 {
     /**
-     * @var string|null
-     *
      * @ODM\Id
      */
     #[ODM\Id]
-    private $id;
+    private ?string $id = null;
 
     /**
      * @ODM\Field(type="string")

--- a/tests/Gedmo/Sortable/Fixture/Document/Kid.php
+++ b/tests/Gedmo/Sortable/Fixture/Document/Kid.php
@@ -44,12 +44,10 @@ class Kid
     protected $birthdate;
 
     /**
-     * @var string|null
-     *
      * @ODM\Id
      */
     #[ODM\Id]
-    private $id;
+    private ?string $id = null;
 
     /**
      * @ODM\Field(type="string")

--- a/tests/Gedmo/Sortable/Fixture/Document/Post.php
+++ b/tests/Gedmo/Sortable/Fixture/Document/Post.php
@@ -44,12 +44,10 @@ class Post
     protected $category;
 
     /**
-     * @var string|null
-     *
      * @ODM\Id
      */
     #[ODM\Id]
-    private $id;
+    private ?string $id = null;
 
     /**
      * @ODM\Field(type="string")

--- a/tests/Gedmo/Sortable/Fixture/Event.php
+++ b/tests/Gedmo/Sortable/Fixture/Event.php
@@ -23,8 +23,6 @@ use Gedmo\Sortable\Entity\Repository\SortableRepository;
 class Event
 {
     /**
-     * @var int
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -32,7 +30,7 @@ class Event
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @Gedmo\SortableGroup

--- a/tests/Gedmo/Sortable/Fixture/Item.php
+++ b/tests/Gedmo/Sortable/Fixture/Item.php
@@ -23,8 +23,6 @@ use Gedmo\Sortable\Entity\Repository\SortableRepository;
 class Item
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -32,7 +30,7 @@ class Item
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(type="string", length=191)

--- a/tests/Gedmo/Sortable/Fixture/Node.php
+++ b/tests/Gedmo/Sortable/Fixture/Node.php
@@ -20,6 +20,4 @@ use Gedmo\Sortable\Entity\Repository\SortableRepository;
  * @ORM\Entity(repositoryClass="Gedmo\Sortable\Entity\Repository\SortableRepository")
  */
 #[ORM\Entity(repositoryClass: SortableRepository::class)]
-class Node extends AbstractNode
-{
-}
+class Node extends AbstractNode {}

--- a/tests/Gedmo/Sortable/Fixture/NotifyNode.php
+++ b/tests/Gedmo/Sortable/Fixture/NotifyNode.php
@@ -31,18 +31,16 @@ class NotifyNode extends AbstractNode implements NotifyPropertyChanged
      *
      * @var PropertyChangedListener[]
      */
-    private $_propertyChangedListeners = [];
+    private array $propertyChangedListeners = [];
 
     /**
      * Adds a listener that wants to be notified about property changes.
      *
      * @see \Doctrine\Common\NotifyPropertyChanged::addPropertyChangedListener()
-     *
-     * @return void
      */
-    public function addPropertyChangedListener(PropertyChangedListener $listener)
+    public function addPropertyChangedListener(PropertyChangedListener $listener): void
     {
-        $this->_propertyChangedListeners[] = $listener;
+        $this->propertyChangedListeners[] = $listener;
     }
 
     public function setName(?string $name): void
@@ -62,21 +60,15 @@ class NotifyNode extends AbstractNode implements NotifyPropertyChanged
 
     /**
      * Notify property change event to listeners
-     *
-     * @param mixed $oldValue
-     * @param mixed $newValue
      */
-    protected function triggerPropertyChanged(string $propName, $oldValue, $newValue): void
+    protected function triggerPropertyChanged(string $propName, mixed $oldValue, mixed $newValue): void
     {
-        foreach ($this->_propertyChangedListeners as $listener) {
+        foreach ($this->propertyChangedListeners as $listener) {
             $listener->propertyChanged($this, $propName, $oldValue, $newValue);
         }
     }
 
-    /**
-     * @param mixed $newValue
-     */
-    protected function setProperty(string $property, $newValue): void
+    protected function setProperty(string $property, mixed $newValue): void
     {
         $oldValue = $this->{$property};
         if ($oldValue !== $newValue) {

--- a/tests/Gedmo/Sortable/Fixture/Paper.php
+++ b/tests/Gedmo/Sortable/Fixture/Paper.php
@@ -23,8 +23,6 @@ use Doctrine\ORM\Mapping as ORM;
 class Paper
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -32,7 +30,7 @@ class Paper
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="name", type="string")

--- a/tests/Gedmo/Sortable/Fixture/SimpleListItem.php
+++ b/tests/Gedmo/Sortable/Fixture/SimpleListItem.php
@@ -23,8 +23,6 @@ use Gedmo\Sortable\Entity\Repository\SortableRepository;
 class SimpleListItem
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -32,7 +30,7 @@ class SimpleListItem
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(type="string", length=191)

--- a/tests/Gedmo/Sortable/Fixture/Transport/Bus.php
+++ b/tests/Gedmo/Sortable/Fixture/Transport/Bus.php
@@ -17,6 +17,4 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Entity
  */
 #[ORM\Entity]
-class Bus extends Vehicle
-{
-}
+class Bus extends Vehicle {}

--- a/tests/Gedmo/Sortable/Fixture/Transport/Engine.php
+++ b/tests/Gedmo/Sortable/Fixture/Transport/Engine.php
@@ -21,8 +21,6 @@ use Doctrine\ORM\Mapping as ORM;
 class Engine
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -30,7 +28,7 @@ class Engine
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(length=32)

--- a/tests/Gedmo/Sortable/Fixture/Transport/Reservation.php
+++ b/tests/Gedmo/Sortable/Fixture/Transport/Reservation.php
@@ -22,8 +22,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Reservation
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -31,7 +29,7 @@ class Reservation
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\ManyToOne(targetEntity="Bus")

--- a/tests/Gedmo/Sortable/Fixture/Transport/Vehicle.php
+++ b/tests/Gedmo/Sortable/Fixture/Transport/Vehicle.php
@@ -32,8 +32,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Vehicle
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -41,7 +39,7 @@ class Vehicle
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @Gedmo\SortableGroup

--- a/tests/Gedmo/Sortable/SortableGroupTest.php
+++ b/tests/Gedmo/Sortable/SortableGroupTest.php
@@ -123,15 +123,15 @@ final class SortableGroupTest extends BaseTestCaseORM
 
         for ($i = 0; $i < self::SEATS; ++$i) {
             $reservation = $repo->findOneBy(['name' => 'Bratislava Today '.$i]);
-            static::assertNotNull($reservation);
+            static::assertInstanceOf(Reservation::class, $reservation);
             static::assertSame($i, $reservation->getSeat());
 
             $reservation = $repo->findOneBy(['name' => 'Bratislava Tomorrow '.$i]);
-            static::assertNotNull($reservation);
+            static::assertInstanceOf(Reservation::class, $reservation);
             static::assertSame($i, $reservation->getSeat());
 
             $reservation = $repo->findOneBy(['name' => 'Prague Today '.$i]);
-            static::assertNotNull($reservation);
+            static::assertInstanceOf(Reservation::class, $reservation);
             static::assertSame($i, $reservation->getSeat());
         }
 
@@ -150,7 +150,7 @@ final class SortableGroupTest extends BaseTestCaseORM
         static::assertCount(self::SEATS - 1, $bratislavaToday);
         // Test seat numbers
         // Should be [ 0, 1 ]
-        $seats = array_map(static fn ($r) => $r->getSeat(), $bratislavaToday);
+        $seats = array_map(static fn ($r): ?int => $r->getSeat(), $bratislavaToday);
         static::assertSame(range(0, self::SEATS - 2), $seats, 'Should be seats [ 0, 1 ] to Bratislava Today');
 
         // Bratislava Tomorrow should have 4 seats
@@ -161,7 +161,7 @@ final class SortableGroupTest extends BaseTestCaseORM
         static::assertCount(self::SEATS + 1, $bratislavaTomorrow);
         // Test seat numbers
         // Should be [ 0, 1, 2, 3 ]
-        $seats = array_map(static fn ($r) => $r->getSeat(), $bratislavaTomorrow);
+        $seats = array_map(static fn ($r): ?int => $r->getSeat(), $bratislavaTomorrow);
         static::assertSame(range(0, self::SEATS), $seats, 'Should be seats [ 0, 1, 2, 3 ] to Bratislava Tomorrow');
 
         // Prague Today should have 3 seats
@@ -171,7 +171,7 @@ final class SortableGroupTest extends BaseTestCaseORM
         ], ['seat' => 'asc']);
         static::assertCount(self::SEATS, $pragueToday);
         // Test seat numbers
-        $seats = array_map(static fn ($r) => $r->getSeat(), $pragueToday);
+        $seats = array_map(static fn ($r): ?int => $r->getSeat(), $pragueToday);
         static::assertSame(range(0, self::SEATS - 1), $seats, 'Should be seats [ 0, 1, 2 ] to Prague Today');
     }
 

--- a/tests/Gedmo/Sortable/SortableTest.php
+++ b/tests/Gedmo/Sortable/SortableTest.php
@@ -71,12 +71,12 @@ final class SortableTest extends BaseTestCaseORM
 
         for ($i = 0; $i <= 8; ++$i) {
             $node = $repo->findOneBy(['position' => $i]);
-            static::assertNotNull($node);
+            static::assertInstanceOf(Node::class, $node);
             static::assertSame('Node'.($i + 2), $node->getName());
         }
 
         $node = $repo->findOneBy(['position' => 9]);
-        static::assertNotNull($node);
+        static::assertInstanceOf(Node::class, $node);
         static::assertSame('Node1', $node->getName());
     }
 
@@ -140,8 +140,9 @@ final class SortableTest extends BaseTestCaseORM
         static::assertSame('Node4', $nodes[2]->getName());
         static::assertSame('Node2', $nodes[3]->getName());
         static::assertSame('Node5', $nodes[4]->getName());
+        $counter = count($nodes);
 
-        for ($i = 0; $i < count($nodes); ++$i) {
+        for ($i = 0; $i < $counter; ++$i) {
             static::assertSame($i, $nodes[$i]->getPosition());
         }
     }
@@ -185,8 +186,9 @@ final class SortableTest extends BaseTestCaseORM
         static::assertSame('Node5', $nodes[2]->getName());
         static::assertSame('Node2', $nodes[3]->getName());
         static::assertSame('Node3', $nodes[4]->getName());
+        $counter = count($nodes);
 
-        for ($i = 0; $i < count($nodes); ++$i) {
+        for ($i = 0; $i < $counter; ++$i) {
             static::assertSame($i, $nodes[$i]->getPosition());
         }
     }
@@ -229,8 +231,9 @@ final class SortableTest extends BaseTestCaseORM
         static::assertSame('Node2', $nodes[2]->getName());
         static::assertSame('Node3', $nodes[3]->getName());
         static::assertSame('Node5', $nodes[4]->getName());
+        $counter = count($nodes);
 
-        for ($i = 0; $i < count($nodes); ++$i) {
+        for ($i = 0; $i < $counter; ++$i) {
             static::assertSame($i, $nodes[$i]->getPosition());
         }
     }
@@ -419,7 +422,7 @@ final class SortableTest extends BaseTestCaseORM
             $this->em->flush();
 
             static::fail('Foreign key constraint violation exception not thrown.');
-        } catch (ForeignKeyConstraintViolationException $e) {
+        } catch (ForeignKeyConstraintViolationException) {
             $customerTypes = $repo->findAll();
 
             static::assertCount(3, $customerTypes);

--- a/tests/Gedmo/TestActorProvider.php
+++ b/tests/Gedmo/TestActorProvider.php
@@ -15,27 +15,9 @@ use Gedmo\Tool\ActorProviderInterface;
 
 final class TestActorProvider implements ActorProviderInterface
 {
-    /**
-     * @var object|string|null
-     */
-    private $actor;
+    public function __construct(private readonly string|object|null $actor) {}
 
-    /**
-     * @param object|string|null $actor
-     */
-    public function __construct($actor)
-    {
-        if (!is_string($actor) && !is_object($actor) && null !== $actor) {
-            throw new \TypeError(sprintf('The actor must be a string, an object, or null, "%s" given.', gettype($actor)));
-        }
-
-        $this->actor = $actor;
-    }
-
-    /**
-     * @return object|string|null
-     */
-    public function getActor()
+    public function getActor(): string|object|null
     {
         return $this->actor;
     }

--- a/tests/Gedmo/TestIpAddressProvider.php
+++ b/tests/Gedmo/TestIpAddressProvider.php
@@ -15,12 +15,7 @@ use Gedmo\Tool\IpAddressProviderInterface;
 
 final class TestIpAddressProvider implements IpAddressProviderInterface
 {
-    private ?string $address;
-
-    public function __construct(?string $address)
-    {
-        $this->address = $address;
-    }
+    public function __construct(private readonly ?string $address) {}
 
     public function getAddress(): ?string
     {

--- a/tests/Gedmo/Timestampable/AttributeChangeTest.php
+++ b/tests/Gedmo/Timestampable/AttributeChangeTest.php
@@ -24,16 +24,11 @@ use Gedmo\Tests\Tool\BaseTestCaseORM;
  *
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  *
- * @requires PHP >= 8.0
- *
  * @todo This test requires {@see ChangeTest} to have been run first to load the {@see TimestampableListenerStub}
  */
 final class AttributeChangeTest extends BaseTestCaseORM
 {
-    /**
-     * @var TimestampableListenerStub
-     */
-    protected $listener;
+    protected TimestampableListenerStub $listener;
 
     protected function setUp(): void
     {
@@ -69,14 +64,8 @@ final class AttributeChangeTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
         // Changed.
-        static::assertSame(
-            $currentDate->format('Y-m-d H:i:s'),
-            $test->getChtitle()->format('Y-m-d H:i:s')
-        );
-        static::assertSame(
-            $currentDate->format('Y-m-d H:i:s'),
-            $test->getClosed()->format('Y-m-d H:i:s')
-        );
+        static::assertSame($currentDate->format('Y-m-d H:i:s'), $test->getChtitle()->format('Y-m-d H:i:s'));
+        static::assertSame($currentDate->format('Y-m-d H:i:s'), $test->getClosed()->format('Y-m-d H:i:s'));
 
         $anotherDate = \DateTime::createFromFormat('Y-m-d H:i:s', '2000-01-01 00:00:00');
         $this->listener->eventAdapter->setDateValue($anotherDate);
@@ -88,14 +77,8 @@ final class AttributeChangeTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
         // Not Changed.
-        static::assertSame(
-            $currentDate->format('Y-m-d H:i:s'),
-            $test->getChtitle()->format('Y-m-d H:i:s')
-        );
-        static::assertSame(
-            $currentDate->format('Y-m-d H:i:s'),
-            $test->getClosed()->format('Y-m-d H:i:s')
-        );
+        static::assertSame($currentDate->format('Y-m-d H:i:s'), $test->getChtitle()->format('Y-m-d H:i:s'));
+        static::assertSame($currentDate->format('Y-m-d H:i:s'), $test->getClosed()->format('Y-m-d H:i:s'));
 
         $test = $this->em->getRepository(TitledArticle::class)->findOneBy(['title' => 'New Title']);
         $test->setState('Published');
@@ -103,10 +86,7 @@ final class AttributeChangeTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
         // Changed.
-        static::assertSame(
-            $anotherDate->format('Y-m-d H:i:s'),
-            $test->getClosed()->format('Y-m-d H:i:s')
-        );
+        static::assertSame($anotherDate->format('Y-m-d H:i:s'), $test->getClosed()->format('Y-m-d H:i:s'));
     }
 
     protected function getUsedEntityFixtures(): array

--- a/tests/Gedmo/Timestampable/ChangeTest.php
+++ b/tests/Gedmo/Timestampable/ChangeTest.php
@@ -66,14 +66,8 @@ final class ChangeTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
         // Changed
-        static::assertSame(
-            $currentDate->format('Y-m-d H:i:s'),
-            $test->getChtitle()->format('Y-m-d H:i:s')
-        );
-        static::assertSame(
-            $currentDate->format('Y-m-d H:i:s'),
-            $test->getClosed()->format('Y-m-d H:i:s')
-        );
+        static::assertSame($currentDate->format('Y-m-d H:i:s'), $test->getChtitle()->format('Y-m-d H:i:s'));
+        static::assertSame($currentDate->format('Y-m-d H:i:s'), $test->getClosed()->format('Y-m-d H:i:s'));
 
         $anotherDate = \DateTime::createFromFormat('Y-m-d H:i:s', '2000-01-01 00:00:00');
         $this->listener->eventAdapter->setDateValue($anotherDate);
@@ -85,14 +79,8 @@ final class ChangeTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
         // Not Changed
-        static::assertSame(
-            $currentDate->format('Y-m-d H:i:s'),
-            $test->getChtitle()->format('Y-m-d H:i:s')
-        );
-        static::assertSame(
-            $currentDate->format('Y-m-d H:i:s'),
-            $test->getClosed()->format('Y-m-d H:i:s')
-        );
+        static::assertSame($currentDate->format('Y-m-d H:i:s'), $test->getChtitle()->format('Y-m-d H:i:s'));
+        static::assertSame($currentDate->format('Y-m-d H:i:s'), $test->getClosed()->format('Y-m-d H:i:s'));
 
         $test = $this->em->getRepository(TitledArticle::class)->findOneBy(['title' => 'New Title']);
         $test->setState('Published');
@@ -100,10 +88,7 @@ final class ChangeTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
         // Changed
-        static::assertSame(
-            $anotherDate->format('Y-m-d H:i:s'),
-            $test->getClosed()->format('Y-m-d H:i:s')
-        );
+        static::assertSame($anotherDate->format('Y-m-d H:i:s'), $test->getClosed()->format('Y-m-d H:i:s'));
     }
 
     protected function getUsedEntityFixtures(): array
@@ -137,13 +122,12 @@ final class EventAdapterORMStub extends BaseAdapterORM implements TimestampableA
  */
 final class TimestampableListenerStub extends AbstractTrackingListener
 {
-    /**
-     * @var EventAdapterORMStub
-     */
-    public $eventAdapter;
+    public ?EventAdapterORMStub $eventAdapter = null;
 
     protected function getEventAdapter(EventArgs $args)
     {
+        \assert($this->eventAdapter instanceof EventAdapterORMStub);
+
         $this->eventAdapter->setEventArgs($args);
 
         return $this->eventAdapter;
@@ -153,12 +137,12 @@ final class TimestampableListenerStub extends AbstractTrackingListener
      * @param ClassMetadata<object> $meta
      * @param EventAdapterORMStub   $eventAdapter
      */
-    protected function getFieldValue($meta, $field, $eventAdapter)
+    protected function getFieldValue($meta, $field, $eventAdapter): ?\DateTime
     {
         return $eventAdapter->getDateValue($meta, $field);
     }
 
-    protected function getNamespace()
+    protected function getNamespace(): string
     {
         return 'Gedmo\Timestampable';
     }

--- a/tests/Gedmo/Timestampable/Fixture/Article.php
+++ b/tests/Gedmo/Timestampable/Fixture/Article.php
@@ -25,8 +25,6 @@ use Gedmo\Timestampable\Timestampable;
 class Article implements Timestampable
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -34,7 +32,7 @@ class Article implements Timestampable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=128)
@@ -54,7 +52,7 @@ class Article implements Timestampable
      * @ORM\OneToMany(targetEntity="Gedmo\Tests\Timestampable\Fixture\Comment", mappedBy="article")
      */
     #[ORM\OneToMany(targetEntity: Comment::class, mappedBy: 'article')]
-    private $comments;
+    private Collection $comments;
 
     /**
      * @ORM\Embedded(class="Gedmo\Tests\Timestampable\Fixture\Author")
@@ -97,16 +95,15 @@ class Article implements Timestampable
     #[ORM\Column(name: 'content_changed', type: Types::DATETIME_MUTABLE, nullable: true)]
     #[Gedmo\Timestampable(on: 'change', field: ['title', 'body'])]
     private ?\DateTime $contentChanged = null;
+
     /**
-     * @var \DateTime|null
-     *
      * @ORM\Column(name="author_changed", type="datetime", nullable=true)
      *
      * @Gedmo\Timestampable(on="change", field={"author.name", "author.email"})
      */
     #[ORM\Column(name: 'author_changed', type: Types::DATETIME_MUTABLE, nullable: true)]
     #[Gedmo\Timestampable(on: 'change', field: ['author.name', 'author.email'])]
-    private $authorChanged;
+    private ?\DateTime $authorChanged = null;
 
     /**
      * @ORM\ManyToOne(targetEntity="Type", inversedBy="articles")
@@ -123,15 +120,13 @@ class Article implements Timestampable
     /**
      * We use the value "10" as string here in order to check the behavior of `AbstractTrackingListener`
      *
-     * @var \DateTimeInterface|null
-     *
      * @ORM\Column(name="reached_relevant_level", type="datetime", nullable=true)
      *
      * @Gedmo\Timestampable(on="change", field="level", value="10")
      */
     #[ORM\Column(name: 'reached_relevant_level', type: Types::DATE_MUTABLE, nullable: true)]
     #[Gedmo\Timestampable(on: 'change', field: 'level', value: '10')]
-    private $reachedRelevantLevel;
+    private ?\DateTime $reachedRelevantLevel = null;
 
     public function __construct()
     {
@@ -247,7 +242,7 @@ class Article implements Timestampable
         return $this->level;
     }
 
-    public function getReachedRelevantLevel(): ?\DateTimeInterface
+    public function getReachedRelevantLevel(): ?\DateTime
     {
         return $this->reachedRelevantLevel;
     }

--- a/tests/Gedmo/Timestampable/Fixture/ArticleCarbon.php
+++ b/tests/Gedmo/Timestampable/Fixture/ArticleCarbon.php
@@ -49,11 +49,11 @@ class ArticleCarbon implements Timestampable
     private ?string $body = null;
 
     /**
-     * @var Collection<int, Comment>
+     * @var Collection<int, CommentCarbon>
      *
-     * @ORM\OneToMany(targetEntity="Gedmo\Tests\Timestampable\Fixture\Comment", mappedBy="article")
+     * @ORM\OneToMany(targetEntity="Gedmo\Tests\Timestampable\Fixture\CommentCarbon", mappedBy="article")
      */
-    #[ORM\OneToMany(targetEntity: Comment::class, mappedBy: 'article')]
+    #[ORM\OneToMany(targetEntity: CommentCarbon::class, mappedBy: 'article')]
     private Collection $comments;
 
     /**
@@ -63,55 +63,47 @@ class ArticleCarbon implements Timestampable
     private ?Author $author = null;
 
     /**
-     * @var \DateTime|Carbon|null
-     *
      * @Gedmo\Timestampable(on="create")
      *
      * @ORM\Column(name="created", type="date")
      */
     #[Gedmo\Timestampable(on: 'create')]
     #[ORM\Column(name: 'created', type: Types::DATE_MUTABLE)]
-    private $created;
+    private ?Carbon $created = null;
 
     /**
-     * @var \DateTime|CarbonImmutable|null
-     *
-     * @ORM\Column(name="updated", type="datetime")
+     * @ORM\Column(name="updated", type="datetime_immutable")
      *
      * @Gedmo\Timestampable
      */
-    #[ORM\Column(name: 'updated', type: Types::DATETIME_MUTABLE)]
+    #[ORM\Column(name: 'updated', type: Types::DATETIME_IMMUTABLE)]
     #[Gedmo\Timestampable]
-    private $updated;
+    private ?CarbonImmutable $updated = null;
 
     /**
-     * @var \DateTime|CarbonImmutable|null
-     *
-     * @ORM\Column(name="published", type="datetime", nullable=true)
+     * @ORM\Column(name="published", type="datetime_immutable", nullable=true)
      *
      * @Gedmo\Timestampable(on="change", field="type.title", value="Published")
      */
-    #[ORM\Column(name: 'published', type: Types::DATETIME_MUTABLE, nullable: true)]
+    #[ORM\Column(name: 'published', type: Types::DATETIME_IMMUTABLE, nullable: true)]
     #[Gedmo\Timestampable(on: 'change', field: 'type.title', value: 'Published')]
-    private $published;
+    private ?CarbonImmutable $published = null;
 
     /**
-     * @var \DateTime|CarbonImmutable|null
-     *
-     * @ORM\Column(name="content_changed", type="datetime", nullable=true)
+     * @ORM\Column(name="content_changed", type="datetime_immutable", nullable=true)
      *
      * @Gedmo\Timestampable(on="change", field={"title", "body"})
      */
-    #[ORM\Column(name: 'content_changed', type: Types::DATETIME_MUTABLE, nullable: true)]
+    #[ORM\Column(name: 'content_changed', type: Types::DATETIME_IMMUTABLE, nullable: true)]
     #[Gedmo\Timestampable(on: 'change', field: ['title', 'body'])]
-    private $contentChanged;
+    private ?CarbonImmutable $contentChanged = null;
 
     /**
-     * @ORM\Column(name="author_changed", type="datetime", nullable=true)
+     * @ORM\Column(name="author_changed", type="datetime_immutable", nullable=true)
      *
      * @Gedmo\Timestampable(on="change", field={"author.name", "author.email"})
      */
-    #[ORM\Column(name: 'author_changed', type: Types::DATETIME_MUTABLE, nullable: true)]
+    #[ORM\Column(name: 'author_changed', type: Types::DATETIME_IMMUTABLE, nullable: true)]
     #[Gedmo\Timestampable(on: 'change', field: ['author.name', 'author.email'])]
     private ?CarbonImmutable $authorChanged = null;
 
@@ -136,7 +128,7 @@ class ArticleCarbon implements Timestampable
      */
     #[ORM\Column(name: 'reached_relevant_level', type: Types::DATE_MUTABLE, nullable: true)]
     #[Gedmo\Timestampable(on: 'change', field: 'level', value: '10')]
-    private ?\DateTimeInterface $reachedRelevantLevel = null;
+    private ?Carbon $reachedRelevantLevel = null;
 
     public function __construct()
     {
@@ -173,14 +165,14 @@ class ArticleCarbon implements Timestampable
         return $this->body;
     }
 
-    public function addComment(Comment $comment): void
+    public function addComment(CommentCarbon $comment): void
     {
         $comment->setArticle($this);
         $this->comments[] = $comment;
     }
 
     /**
-     * @return Collection<int, Comment>
+     * @return Collection<int, CommentCarbon>
      */
     public function getComments(): Collection
     {
@@ -202,8 +194,7 @@ class ArticleCarbon implements Timestampable
         return $this->created;
     }
 
-    /** @param CarbonImmutable|\DateTime $created */
-    public function setCreated($created): void
+    public function setCreated(Carbon $created): void
     {
         $this->created = $created;
     }
@@ -213,8 +204,7 @@ class ArticleCarbon implements Timestampable
         return $this->published;
     }
 
-    /** @param CarbonImmutable|\DateTime $published */
-    public function setPublished($published): void
+    public function setPublished(CarbonImmutable $published): void
     {
         $this->published = $published;
     }
@@ -224,14 +214,12 @@ class ArticleCarbon implements Timestampable
         return $this->updated;
     }
 
-    /** @param CarbonImmutable|\DateTime $updated */
-    public function setUpdated($updated): void
+    public function setUpdated(CarbonImmutable $updated): void
     {
         $this->updated = $updated;
     }
 
-    /** @param CarbonImmutable|\DateTime $contentChanged */
-    public function setContentChanged($contentChanged): void
+    public function setContentChanged(CarbonImmutable $contentChanged): void
     {
         $this->contentChanged = $contentChanged;
     }
@@ -256,7 +244,7 @@ class ArticleCarbon implements Timestampable
         return $this->level;
     }
 
-    public function getReachedRelevantLevel(): ?\DateTimeInterface
+    public function getReachedRelevantLevel(): ?Carbon
     {
         return $this->reachedRelevantLevel;
     }

--- a/tests/Gedmo/Timestampable/Fixture/Comment.php
+++ b/tests/Gedmo/Timestampable/Fixture/Comment.php
@@ -23,8 +23,6 @@ use Gedmo\Timestampable\Timestampable;
 class Comment implements Timestampable
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -32,7 +30,7 @@ class Comment implements Timestampable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="message", type="text")
@@ -41,12 +39,10 @@ class Comment implements Timestampable
     private ?string $message = null;
 
     /**
-     * @var Article|null
-     *
      * @ORM\ManyToOne(targetEntity="Gedmo\Tests\Timestampable\Fixture\Article", inversedBy="comments")
      */
     #[ORM\ManyToOne(targetEntity: Article::class, inversedBy: 'comments')]
-    private $article;
+    private ?Article $article = null;
 
     /**
      * @ORM\Column(type="integer")
@@ -55,31 +51,24 @@ class Comment implements Timestampable
     private ?int $status = null;
 
     /**
-     * @var \DateTime|null
-     *
      * @ORM\Column(name="closed", type="datetime", nullable=true)
      *
      * @Gedmo\Timestampable(on="change", field="status", value=1)
      */
     #[ORM\Column(name: 'closed', type: Types::DATETIME_MUTABLE, nullable: true)]
     #[Gedmo\Timestampable(on: 'change', field: 'status', value: 1)]
-    private $closed;
+    private ?\DateTime $closed = null;
 
     /**
-     * @var \DateTime|null
-     *
      * @ORM\Column(name="modified", type="time")
      *
      * @Gedmo\Timestampable(on="update")
      */
     #[ORM\Column(name: 'modified', type: Types::TIME_MUTABLE)]
     #[Gedmo\Timestampable(on: 'update')]
-    private $modified;
+    private ?\DateTime $modified = null;
 
-    /**
-     * @param Article|ArticleCarbon $article
-     */
-    public function setArticle(?Timestampable $article): void
+    public function setArticle(Article $article): void
     {
         $this->article = $article;
     }

--- a/tests/Gedmo/Timestampable/Fixture/CommentCarbon.php
+++ b/tests/Gedmo/Timestampable/Fixture/CommentCarbon.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 
 namespace Gedmo\Tests\Timestampable\Fixture;
 
-use Carbon\CarbonImmutable;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
@@ -24,8 +23,6 @@ use Gedmo\Timestampable\Timestampable;
 class CommentCarbon implements Timestampable
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -33,7 +30,7 @@ class CommentCarbon implements Timestampable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="message", type="text")
@@ -54,26 +51,22 @@ class CommentCarbon implements Timestampable
     private ?int $status = null;
 
     /**
-     * @var CarbonImmutable|null
-     *
      * @ORM\Column(name="closed", type="datetime", nullable=true)
      *
      * @Gedmo\Timestampable(on="change", field="status", value=1)
      */
     #[ORM\Column(name: 'closed', type: Types::DATETIME_MUTABLE, nullable: true)]
     #[Gedmo\Timestampable(on: 'change', field: 'status', value: 1)]
-    private $closed;
+    private ?\DateTime $closed = null;
 
     /**
-     * @var \DateTime|null
-     *
      * @ORM\Column(name="modified", type="time")
      *
      * @Gedmo\Timestampable(on="update")
      */
     #[ORM\Column(name: 'modified', type: Types::TIME_MUTABLE)]
     #[Gedmo\Timestampable(on: 'update')]
-    private $modified;
+    private ?\DateTime $modified = null;
 
     public function setArticle(?ArticleCarbon $article): void
     {
@@ -110,7 +103,7 @@ class CommentCarbon implements Timestampable
         return $this->modified;
     }
 
-    public function getClosed(): ?CarbonImmutable
+    public function getClosed(): ?\DateTime
     {
         return $this->closed;
     }

--- a/tests/Gedmo/Timestampable/Fixture/Document/Article.php
+++ b/tests/Gedmo/Timestampable/Fixture/Document/Article.php
@@ -23,12 +23,10 @@ use MongoDB\BSON\Timestamp;
 class Article
 {
     /**
-     * @var string|null
-     *
      * @ODM\Id
      */
     #[ODM\Id]
-    private $id;
+    private ?string $id = null;
 
     /**
      * @ODM\Field(type="string")

--- a/tests/Gedmo/Timestampable/Fixture/Document/Type.php
+++ b/tests/Gedmo/Timestampable/Fixture/Document/Type.php
@@ -21,12 +21,10 @@ use Doctrine\ODM\MongoDB\Types\Type as MongoDBType;
 class Type
 {
     /**
-     * @var string|null
-     *
      * @ODM\Id
      */
     #[ODM\Id]
-    private $id;
+    private ?string $id = null;
 
     /**
      * @ODM\Field(type="string")

--- a/tests/Gedmo/Timestampable/Fixture/MappedSupperClass.php
+++ b/tests/Gedmo/Timestampable/Fixture/MappedSupperClass.php
@@ -22,50 +22,39 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class MappedSupperClass
 {
     /**
-     * @var int|null
-     *
-     * @ORM\Column(name="id", type="integer")
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
-     */
-    #[ORM\Column(name: 'id', type: Types::INTEGER)]
-    #[ORM\Id]
-    #[ORM\GeneratedValue(strategy: 'AUTO')]
-    protected $id;
-
-    /**
-     * @var string|null
-     *
      * @Gedmo\Locale
      */
     #[Gedmo\Locale]
-    protected $locale;
+    protected ?string $locale = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      *
      * @ORM\Column(name="name", type="string", length=191)
      */
     #[Gedmo\Translatable]
     #[ORM\Column(name: 'name', type: Types::STRING, length: 191)]
-    protected $name;
+    protected ?string $name = null;
 
     /**
-     * @var \DateTime|null
-     *
      * @ORM\Column(name="created_at", type="datetime")
      *
      * @Gedmo\Timestampable(on="create")
      */
     #[ORM\Column(name: 'created_at', type: Types::DATETIME_MUTABLE)]
     #[Gedmo\Timestampable(on: 'create')]
-    protected $createdAt;
+    protected ?\DateTime $createdAt = null;
 
     /**
-     * @codeCoverageIgnore
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
      */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    private ?int $id = null;
+
     public function getId(): ?int
     {
         return $this->id;

--- a/tests/Gedmo/Timestampable/Fixture/Type.php
+++ b/tests/Gedmo/Timestampable/Fixture/Type.php
@@ -23,8 +23,6 @@ use Doctrine\ORM\Mapping as ORM;
 class Type
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -32,7 +30,7 @@ class Type
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=128)

--- a/tests/Gedmo/Timestampable/Fixture/UsingTrait.php
+++ b/tests/Gedmo/Timestampable/Fixture/UsingTrait.php
@@ -28,8 +28,6 @@ class UsingTrait
     use TimestampableEntity;
 
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -37,7 +35,7 @@ class UsingTrait
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(length=128)

--- a/tests/Gedmo/Timestampable/Fixture/WithoutInterface.php
+++ b/tests/Gedmo/Timestampable/Fixture/WithoutInterface.php
@@ -22,8 +22,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class WithoutInterface
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -31,7 +29,7 @@ class WithoutInterface
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(type="string", length=128)
@@ -40,26 +38,22 @@ class WithoutInterface
     private ?string $title = null;
 
     /**
-     * @var \DateTime|null
-     *
      * @Gedmo\Timestampable(on="create")
      *
      * @ORM\Column(type="date")
      */
     #[Gedmo\Timestampable(on: 'create')]
     #[ORM\Column(type: Types::DATE_MUTABLE)]
-    private $created;
+    private ?\DateTime $created = null;
 
     /**
-     * @var \DateTime|null
-     *
      * @ORM\Column(type="datetime")
      *
      * @Gedmo\Timestampable(on="update")
      */
     #[ORM\Column(type: Types::DATETIME_MUTABLE)]
     #[Gedmo\Timestampable(on: 'update')]
-    private $updated;
+    private ?\DateTime $updated = null;
 
     public function getId(): ?int
     {

--- a/tests/Gedmo/Timestampable/NoInterfaceTest.php
+++ b/tests/Gedmo/Timestampable/NoInterfaceTest.php
@@ -44,14 +44,8 @@ final class NoInterfaceTest extends BaseTestCaseORM
         $this->em->clear();
 
         $test = $this->em->getRepository(WithoutInterface::class)->findOneBy(['title' => 'Test']);
-        static::assertSame(
-            $date->format('Y-m-d 00:00:00'),
-            $test->getCreated()->format('Y-m-d H:i:s')
-        );
-        static::assertSame(
-            $date->format('Y-m-d H:i'),
-            $test->getUpdated()->format('Y-m-d H:i')
-        );
+        static::assertSame($date->format('Y-m-d 00:00:00'), $test->getCreated()->format('Y-m-d H:i:s'));
+        static::assertSame($date->format('Y-m-d H:i'), $test->getUpdated()->format('Y-m-d H:i'));
     }
 
     protected function getUsedEntityFixtures(): array

--- a/tests/Gedmo/Timestampable/TimestampableDocumentTest.php
+++ b/tests/Gedmo/Timestampable/TimestampableDocumentTest.php
@@ -43,10 +43,7 @@ final class TimestampableDocumentTest extends BaseTestCaseMongoODM
         $now = time();
         $created = $article->getCreated()->getTimestamp();
         static::assertTrue($created > $now - 5 && $created < $now + 5); // 5 seconds interval if lag
-        static::assertSame(
-            $date->format('Y-m-d H:i'),
-            $article->getUpdated()->format('Y-m-d H:i')
-        );
+        static::assertSame($date->format('Y-m-d H:i'), $article->getUpdated()->format('Y-m-d H:i'));
 
         $published = new Type();
         $published->setIdentifier('published');
@@ -60,10 +57,7 @@ final class TimestampableDocumentTest extends BaseTestCaseMongoODM
 
         $article = $repo->findOneBy(['title' => 'Timestampable Article']);
         $date = new \DateTime();
-        static::assertSame(
-            $date->format('Y-m-d H:i'),
-            $article->getPublished()->format('Y-m-d H:i')
-        );
+        static::assertSame($date->format('Y-m-d H:i'), $article->getPublished()->format('Y-m-d H:i'));
     }
 
     public function testForcedValues(): void
@@ -80,14 +74,8 @@ final class TimestampableDocumentTest extends BaseTestCaseMongoODM
 
         $repo = $this->dm->getRepository(Article::class);
         $sport = $repo->findOneBy(['title' => 'sport forced']);
-        static::assertSame(
-            $created,
-            $sport->getCreated()->getTimestamp()
-        );
-        static::assertSame(
-            '2000-01-01 12:00:00',
-            $sport->getUpdated()->format('Y-m-d H:i:s')
-        );
+        static::assertSame($created, $sport->getCreated()->getTimestamp());
+        static::assertSame('2000-01-01 12:00:00', $sport->getUpdated()->format('Y-m-d H:i:s'));
 
         $published = new Type();
         $published->setIdentifier('published');
@@ -101,10 +89,7 @@ final class TimestampableDocumentTest extends BaseTestCaseMongoODM
         $this->dm->clear();
 
         $sport = $repo->findOneBy(['title' => 'sport forced']);
-        static::assertSame(
-            '2000-01-01 12:00:00',
-            $sport->getPublished()->format('Y-m-d H:i:s')
-        );
+        static::assertSame('2000-01-01 12:00:00', $sport->getPublished()->format('Y-m-d H:i:s'));
     }
 
     public function testShouldHandleOnChangeWithBooleanValue(): void
@@ -112,13 +97,13 @@ final class TimestampableDocumentTest extends BaseTestCaseMongoODM
         $repo = $this->dm->getRepository(Article::class);
         $article = $repo->findOneBy(['title' => 'Timestampable Article']);
 
-        static::assertNull($article->getReady());
+        static::assertNotInstanceOf(\DateTime::class, $article->getReady());
 
         $article->setIsReady(true);
         $this->dm->persist($article);
         $this->dm->flush();
 
-        static::assertNotNull($article->getReady());
+        static::assertInstanceOf(\DateTime::class, $article->getReady());
     }
 
     private function populate(): void

--- a/tests/Gedmo/Timestampable/TimestampableEmbeddedDocumentTest.php
+++ b/tests/Gedmo/Timestampable/TimestampableEmbeddedDocumentTest.php
@@ -54,28 +54,16 @@ final class TimestampableEmbeddedDocumentTest extends BaseTestCaseMongoODM
 
         $bookFromRepo = $repo->findOneBy(['title' => 'Cats & Dogs']);
 
-        static::assertNotNull($bookFromRepo);
+        static::assertInstanceOf(Book::class, $bookFromRepo);
 
         $date = new \DateTime();
 
-        static::assertSame(
-            $date->format('Y-m-d H:i'),
-            $book->getTags()->get(0)->getCreated()->format('Y-m-d H:i')
-        );
+        static::assertSame($date->format('Y-m-d H:i'), $book->getTags()->get(0)->getCreated()->format('Y-m-d H:i'));
 
-        static::assertSame(
-            $date->format('Y-m-d H:i'),
-            $book->getTags()->get(1)->getCreated()->format('Y-m-d H:i')
-        );
+        static::assertSame($date->format('Y-m-d H:i'), $book->getTags()->get(1)->getCreated()->format('Y-m-d H:i'));
 
-        static::assertSame(
-            $date->format('Y-m-d H:i'),
-            $book->getTags()->get(0)->getUpdated()->format('Y-m-d H:i')
-        );
+        static::assertSame($date->format('Y-m-d H:i'), $book->getTags()->get(0)->getUpdated()->format('Y-m-d H:i'));
 
-        static::assertSame(
-            $date->format('Y-m-d H:i'),
-            $book->getTags()->get(1)->getUpdated()->format('Y-m-d H:i')
-        );
+        static::assertSame($date->format('Y-m-d H:i'), $book->getTags()->get(1)->getUpdated()->format('Y-m-d H:i'));
     }
 }

--- a/tests/Gedmo/Timestampable/TimestampableTest.php
+++ b/tests/Gedmo/Timestampable/TimestampableTest.php
@@ -116,19 +116,19 @@ final class TimestampableTest extends BaseTestCaseORM
         $this->em->flush();
 
         $sport = $this->em->getRepository(Article::class)->findOneBy(['title' => 'Sport']);
-        static::assertNotNull($sc = $sport->getCreated());
-        static::assertNotNull($su = $sport->getUpdated());
-        static::assertNull($sport->getContentChanged());
-        static::assertNull($sport->getPublished());
-        static::assertNull($sport->getAuthorChanged());
+        static::assertInstanceOf(\DateTime::class, $sc = $sport->getCreated());
+        static::assertInstanceOf(\DateTime::class, $su = $sport->getUpdated());
+        static::assertNotInstanceOf(\DateTime::class, $sport->getContentChanged());
+        static::assertNotInstanceOf(\DateTime::class, $sport->getPublished());
+        static::assertNotInstanceOf(\DateTime::class, $sport->getAuthorChanged());
 
         $author = $sport->getAuthor();
         $author->setName('New author');
         $sport->setAuthor($author);
 
         $sportComment = $this->em->getRepository(Comment::class)->findOneBy(['message' => 'hello']);
-        static::assertNotNull($sportComment->getModified());
-        static::assertNull($sportComment->getClosed());
+        static::assertInstanceOf(\DateTime::class, $sportComment->getModified());
+        static::assertNotInstanceOf(\DateTime::class, $sportComment->getClosed());
 
         $sportComment->setStatus(1);
         $published = new Type();
@@ -141,9 +141,9 @@ final class TimestampableTest extends BaseTestCaseORM
         $this->em->flush();
 
         $sportComment = $this->em->getRepository(Comment::class)->findOneBy(['message' => 'hello']);
-        static::assertNotNull($scc = $sportComment->getClosed());
-        static::assertNotNull($sp = $sport->getPublished());
-        static::assertNotNull($sa = $sport->getAuthorChanged());
+        static::assertInstanceOf(\DateTime::class, $scc = $sportComment->getClosed());
+        static::assertInstanceOf(\DateTime::class, $sp = $sport->getPublished());
+        static::assertInstanceOf(\DateTime::class, $sa = $sport->getAuthorChanged());
 
         $sport->setTitle('Updated');
         $this->em->persist($sport);
@@ -188,18 +188,9 @@ final class TimestampableTest extends BaseTestCaseORM
 
         $repo = $this->em->getRepository(Article::class);
         $sport = $repo->findOneBy(['title' => 'sport forced']);
-        static::assertSame(
-            '2000-01-01',
-            $sport->getCreated()->format('Y-m-d')
-        );
-        static::assertSame(
-            '2000-01-01 12:00:00',
-            $sport->getUpdated()->format('Y-m-d H:i:s')
-        );
-        static::assertSame(
-            '2000-01-01 12:00:00',
-            $sport->getContentChanged()->format('Y-m-d H:i:s')
-        );
+        static::assertSame('2000-01-01', $sport->getCreated()->format('Y-m-d'));
+        static::assertSame('2000-01-01 12:00:00', $sport->getUpdated()->format('Y-m-d H:i:s'));
+        static::assertSame('2000-01-01 12:00:00', $sport->getContentChanged()->format('Y-m-d H:i:s'));
 
         $published = new Type();
         $published->setTitle('Published');
@@ -211,10 +202,7 @@ final class TimestampableTest extends BaseTestCaseORM
         $this->em->flush();
 
         $sport = $repo->findOneBy(['title' => 'sport forced']);
-        static::assertSame(
-            '2000-01-01 12:00:00',
-            $sport->getPublished()->format('Y-m-d H:i:s')
-        );
+        static::assertSame('2000-01-01 12:00:00', $sport->getPublished()->format('Y-m-d H:i:s'));
 
         $this->em->clear();
     }
@@ -241,7 +229,7 @@ final class TimestampableTest extends BaseTestCaseORM
         $art->setType($type);
         $this->em->flush(); // in v2.4.x will work on insert too
 
-        static::assertNotNull($art->getPublished());
+        static::assertInstanceOf(\DateTime::class, $art->getPublished());
     }
 
     /**
@@ -253,7 +241,7 @@ final class TimestampableTest extends BaseTestCaseORM
         $timespampable->setTitle('My article');
         $timespampable->setBody('My article body.');
 
-        static::assertNull($timespampable->getReachedRelevantLevel());
+        static::assertNotInstanceOf(\DateTimeInterface::class, $timespampable->getReachedRelevantLevel());
         $timespampable->setLevel(8);
 
         $this->em->persist($timespampable);
@@ -262,7 +250,7 @@ final class TimestampableTest extends BaseTestCaseORM
         $repo = $this->em->getRepository(Article::class);
         $found = $repo->findOneBy(['body' => 'My article body.']);
 
-        static::assertNull($found->getReachedRelevantLevel());
+        static::assertNotInstanceOf(\DateTimeInterface::class, $found->getReachedRelevantLevel());
 
         $timespampable->setLevel(9);
 
@@ -271,7 +259,7 @@ final class TimestampableTest extends BaseTestCaseORM
 
         $found = $repo->findOneBy(['body' => 'My article body.']);
 
-        static::assertNull($found->getReachedRelevantLevel());
+        static::assertNotInstanceOf(\DateTimeInterface::class, $found->getReachedRelevantLevel());
 
         $timespampable->setLevel(10);
 

--- a/tests/Gedmo/Timestampable/TraitUsageTest.php
+++ b/tests/Gedmo/Timestampable/TraitUsageTest.php
@@ -41,8 +41,8 @@ final class TraitUsageTest extends BaseTestCaseORM
         $this->em->persist($sport);
         $this->em->flush();
 
-        static::assertNotNull($sport->getCreatedAt());
-        static::assertNotNull($sport->getUpdatedAt());
+        static::assertInstanceOf(\DateTime::class, $sport->getCreatedAt());
+        static::assertInstanceOf(\DateTime::class, $sport->getUpdatedAt());
     }
 
     public function testTraitMethodthShouldReturnObject(): void

--- a/tests/Gedmo/Tool/BaseTestCaseMongoODM.php
+++ b/tests/Gedmo/Tool/BaseTestCaseMongoODM.php
@@ -99,11 +99,7 @@ abstract class BaseTestCaseMongoODM extends TestCase
      */
     protected function getMetadataDriverImplementation(): MappingDriver
     {
-        if (PHP_VERSION_ID >= 80000) {
-            return new AttributeDriver();
-        }
-
-        return new AnnotationDriver($_ENV['annotation_reader']);
+        return new AttributeDriver();
     }
 
     /**
@@ -145,7 +141,7 @@ abstract class BaseTestCaseMongoODM extends TestCase
 
     private function getMetadataDefaultDriverImplementation(): MappingDriver
     {
-        if (PHP_VERSION_ID >= 80000 && class_exists(AttributeDriver::class)) {
+        if (class_exists(AttributeDriver::class)) {
             return new AttributeDriver([]);
         }
 

--- a/tests/Gedmo/Tool/BaseTestCaseORM.php
+++ b/tests/Gedmo/Tool/BaseTestCaseORM.php
@@ -17,7 +17,6 @@ use Doctrine\DBAL\Logging\Middleware;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
@@ -77,11 +76,7 @@ abstract class BaseTestCaseORM extends TestCase
      */
     protected function getMetadataDriverImplementation(): MappingDriver
     {
-        if (PHP_VERSION_ID >= 80000) {
-            return new AttributeDriver([]);
-        }
-
-        return new AnnotationDriver($_ENV['annotation_reader']);
+        return new AttributeDriver([]);
     }
 
     /**

--- a/tests/Gedmo/Translatable/AttributeEntityTranslationTableTest.php
+++ b/tests/Gedmo/Translatable/AttributeEntityTranslationTableTest.php
@@ -23,8 +23,6 @@ use Gedmo\Translatable\TranslatableListener;
  * These are tests for translatable behavior
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
- *
- * @requires PHP >= 8.0
  */
 final class AttributeEntityTranslationTableTest extends BaseTestCaseORM
 {

--- a/tests/Gedmo/Translatable/Fixture/Article.php
+++ b/tests/Gedmo/Translatable/Fixture/Article.php
@@ -25,8 +25,6 @@ use Gedmo\Translatable\Translatable;
 class Article implements Translatable
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -34,7 +32,7 @@ class Article implements Translatable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @Gedmo\Translatable
@@ -88,7 +86,7 @@ class Article implements Translatable
      * @ORM\OneToMany(targetEntity="Comment", mappedBy="article")
      */
     #[ORM\OneToMany(targetEntity: Comment::class, mappedBy: 'article')]
-    private $comments;
+    private Collection $comments;
 
     public function __construct()
     {

--- a/tests/Gedmo/Translatable/Fixture/Attribute/PersonTranslation.php
+++ b/tests/Gedmo/Translatable/Fixture/Attribute/PersonTranslation.php
@@ -19,6 +19,4 @@ use Gedmo\Translatable\Entity\Repository\TranslationRepository;
 #[ORM\Table(name: 'ext_translations')]
 #[ORM\Index(name: 'translations_lookup_idx', columns: ['locale', 'object_Class', 'foreign_key'])]
 #[ORM\UniqueConstraint(name: 'lookup_unique_idx', columns: ['locale', 'object_Class', 'foreign_key', 'field'])]
-class PersonTranslation extends AbstractTranslation
-{
-}
+class PersonTranslation extends AbstractTranslation {}

--- a/tests/Gedmo/Translatable/Fixture/Comment.php
+++ b/tests/Gedmo/Translatable/Fixture/Comment.php
@@ -22,8 +22,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Comment
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -31,7 +29,7 @@ class Comment
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @Gedmo\Translatable

--- a/tests/Gedmo/Translatable/Fixture/Company.php
+++ b/tests/Gedmo/Translatable/Fixture/Company.php
@@ -23,8 +23,6 @@ use Gedmo\Translatable\Translatable;
 class Company implements Translatable
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -32,7 +30,7 @@ class Company implements Translatable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=128)

--- a/tests/Gedmo/Translatable/Fixture/CompanyEmbedLink.php
+++ b/tests/Gedmo/Translatable/Fixture/CompanyEmbedLink.php
@@ -22,26 +22,22 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class CompanyEmbedLink
 {
     /**
-     * @var string
-     *
      * @ORM\Column(name="website", type="string", length=191, nullable=true)
      *
      * @Gedmo\Translatable
      */
     #[Gedmo\Translatable]
     #[ORM\Column(name: 'website', type: Types::STRING, length: 191, nullable: true)]
-    protected $website;
+    protected ?string $website = null;
 
     /**
-     * @var string
-     *
      * @ORM\Column(name="facebook", type="string", length=191, nullable=true)
      *
      * @Gedmo\Translatable
      */
     #[Gedmo\Translatable]
     #[ORM\Column(name: 'facebook', type: Types::STRING, length: 191, nullable: true)]
-    protected $facebook;
+    protected ?string $facebook = null;
 
     public function getWebsite(): string
     {

--- a/tests/Gedmo/Translatable/Fixture/Document/Personal/Article.php
+++ b/tests/Gedmo/Translatable/Fixture/Document/Personal/Article.php
@@ -27,12 +27,10 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Article
 {
     /**
-     * @var string|null
-     *
      * @MongoODM\Id
      */
     #[MongoODM\Id]
-    private $id;
+    private ?string $id = null;
 
     /**
      * @Gedmo\Translatable
@@ -49,14 +47,11 @@ class Article
      * @MongoODM\ReferenceMany(targetDocument="Gedmo\Tests\Translatable\Fixture\Document\Personal\ArticleTranslation", mappedBy="object")
      */
     #[MongoODM\ReferenceMany(targetDocument: ArticleTranslation::class, mappedBy: 'object')]
-    private $translations;
+    private Collection $translations;
 
     private ?string $code = null;
 
-    /**
-     * @var string
-     */
-    private $slug;
+    private ?string $slug = null;
 
     public function __construct()
     {

--- a/tests/Gedmo/Translatable/Fixture/File.php
+++ b/tests/Gedmo/Translatable/Fixture/File.php
@@ -28,8 +28,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class File
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -37,7 +35,7 @@ class File
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @Gedmo\Translatable

--- a/tests/Gedmo/Translatable/Fixture/Issue1123/BaseEntity.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue1123/BaseEntity.php
@@ -32,8 +32,6 @@ use Doctrine\ORM\Mapping as ORM;
 abstract class BaseEntity
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -41,5 +39,5 @@ abstract class BaseEntity
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    protected $id;
+    protected ?int $id = null;
 }

--- a/tests/Gedmo/Translatable/Fixture/Issue114/Article.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue114/Article.php
@@ -22,8 +22,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Article
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -31,7 +29,7 @@ class Article
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @Gedmo\Translatable

--- a/tests/Gedmo/Translatable/Fixture/Issue114/Category.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue114/Category.php
@@ -24,8 +24,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Category
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -33,7 +31,7 @@ class Category
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @Gedmo\Translatable
@@ -50,7 +48,7 @@ class Category
      * @ORM\OneToMany(targetEntity="Article", mappedBy="category", cascade={"persist", "remove"})
      */
     #[ORM\OneToMany(targetEntity: Article::class, mappedBy: 'category', cascade: ['persist', 'remove'])]
-    private $articles;
+    private Collection $articles;
 
     public function __construct()
     {

--- a/tests/Gedmo/Translatable/Fixture/Issue138/Article.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue138/Article.php
@@ -22,8 +22,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Article
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -31,7 +29,7 @@ class Article
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @Gedmo\Translatable

--- a/tests/Gedmo/Translatable/Fixture/Issue173/Article.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue173/Article.php
@@ -22,8 +22,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Article
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -31,7 +29,7 @@ class Article
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @Gedmo\Translatable

--- a/tests/Gedmo/Translatable/Fixture/Issue173/Category.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue173/Category.php
@@ -24,8 +24,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Category
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -33,7 +31,7 @@ class Category
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @Gedmo\Translatable
@@ -50,7 +48,7 @@ class Category
      * @ORM\OneToMany(targetEntity="Article", mappedBy="category", cascade={"persist", "remove"})
      */
     #[ORM\OneToMany(targetEntity: Article::class, mappedBy: 'category', cascade: ['persist', 'remove'])]
-    private $articles;
+    private Collection $articles;
 
     /**
      * @var Collection<int, Product>
@@ -58,7 +56,7 @@ class Category
      * @ORM\OneToMany(targetEntity="Product", mappedBy="category", cascade={"persist", "remove"})
      */
     #[ORM\OneToMany(targetEntity: Product::class, mappedBy: 'category', cascade: ['persist', 'remove'])]
-    private $products;
+    private Collection $products;
 
     public function __construct()
     {

--- a/tests/Gedmo/Translatable/Fixture/Issue173/Product.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue173/Product.php
@@ -22,8 +22,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Product
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -31,7 +29,7 @@ class Product
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @Gedmo\Translatable

--- a/tests/Gedmo/Translatable/Fixture/Issue2152/EntityWithTranslatableBoolean.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue2152/EntityWithTranslatableBoolean.php
@@ -27,13 +27,11 @@ class EntityWithTranslatableBoolean
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
-     *
-     * @var int
      */
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @Gedmo\Translatable

--- a/tests/Gedmo/Translatable/Fixture/Issue2167/Article.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue2167/Article.php
@@ -22,8 +22,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Article
 {
     /**
-     * @var int
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -31,7 +29,7 @@ class Article
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @Gedmo\Translatable

--- a/tests/Gedmo/Translatable/Fixture/Issue75/Article.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue75/Article.php
@@ -24,8 +24,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Article
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -33,7 +31,7 @@ class Article
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @Gedmo\Translatable
@@ -57,7 +55,7 @@ class Article
     #[ORM\JoinTable(name: 'article_images')]
     #[ORM\JoinColumn(name: 'image_id', referencedColumnName: 'id')]
     #[ORM\InverseJoinColumn(name: 'article_id', referencedColumnName: 'id')]
-    private $images;
+    private Collection $images;
 
     /**
      * @var Collection<int, File>
@@ -65,7 +63,7 @@ class Article
      * @ORM\ManyToMany(targetEntity="File")
      */
     #[ORM\ManyToMany(targetEntity: File::class)]
-    private $files;
+    private Collection $files;
 
     public function __construct()
     {

--- a/tests/Gedmo/Translatable/Fixture/Issue75/File.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue75/File.php
@@ -22,8 +22,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class File
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -31,7 +29,7 @@ class File
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @Gedmo\Translatable

--- a/tests/Gedmo/Translatable/Fixture/Issue75/Image.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue75/Image.php
@@ -24,8 +24,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Image
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -33,7 +31,7 @@ class Image
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @Gedmo\Translatable
@@ -50,7 +48,7 @@ class Image
      * @ORM\ManyToMany(targetEntity="Article", mappedBy="images")
      */
     #[ORM\ManyToMany(targetEntity: Article::class, mappedBy: 'images')]
-    private $articles;
+    private Collection $articles;
 
     public function __construct()
     {

--- a/tests/Gedmo/Translatable/Fixture/Issue922/Post.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue922/Post.php
@@ -22,8 +22,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Post
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -31,7 +29,7 @@ class Post
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @Gedmo\Translatable

--- a/tests/Gedmo/Translatable/Fixture/MixedValue.php
+++ b/tests/Gedmo/Translatable/Fixture/MixedValue.php
@@ -22,8 +22,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class MixedValue
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -31,7 +29,7 @@ class MixedValue
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @Gedmo\Translatable

--- a/tests/Gedmo/Translatable/Fixture/Person.php
+++ b/tests/Gedmo/Translatable/Fixture/Person.php
@@ -25,8 +25,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Person
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -34,7 +32,7 @@ class Person
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @Gedmo\Translatable

--- a/tests/Gedmo/Translatable/Fixture/PersonTranslation.php
+++ b/tests/Gedmo/Translatable/Fixture/PersonTranslation.php
@@ -31,6 +31,4 @@ use Gedmo\Translatable\Entity\Repository\TranslationRepository;
 #[ORM\Table(name: 'ext_translations')]
 #[ORM\Index(name: 'translations_lookup_idx', columns: ['locale', 'object_Class', 'foreign_key'])]
 #[ORM\UniqueConstraint(name: 'lookup_unique_idx', columns: ['locale', 'object_Class', 'foreign_key', 'field'])]
-class PersonTranslation extends AbstractTranslation
-{
-}
+class PersonTranslation extends AbstractTranslation {}

--- a/tests/Gedmo/Translatable/Fixture/Personal/Article.php
+++ b/tests/Gedmo/Translatable/Fixture/Personal/Article.php
@@ -27,8 +27,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Article
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -36,7 +34,7 @@ class Article
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @Gedmo\Translatable
@@ -53,7 +51,7 @@ class Article
      * @ORM\OneToMany(targetEntity="PersonalArticleTranslation", mappedBy="object")
      */
     #[ORM\OneToMany(targetEntity: PersonalArticleTranslation::class, mappedBy: 'object')]
-    private $translations;
+    private Collection $translations;
 
     public function __construct()
     {

--- a/tests/Gedmo/Translatable/Fixture/Sport.php
+++ b/tests/Gedmo/Translatable/Fixture/Sport.php
@@ -22,8 +22,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Sport
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -31,7 +29,7 @@ class Sport
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @Gedmo\Translatable

--- a/tests/Gedmo/Translatable/Fixture/TemplatedArticle.php
+++ b/tests/Gedmo/Translatable/Fixture/TemplatedArticle.php
@@ -23,8 +23,6 @@ use Gedmo\Tests\Translatable\Fixture\Template\ArticleTemplate;
 class TemplatedArticle extends ArticleTemplate
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -32,7 +30,7 @@ class TemplatedArticle extends ArticleTemplate
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @Gedmo\Translatable

--- a/tests/Gedmo/Translatable/PersonalTranslationTest.php
+++ b/tests/Gedmo/Translatable/PersonalTranslationTest.php
@@ -93,7 +93,7 @@ final class PersonalTranslationTest extends BaseTestCaseORM
     public function testShouldCascadeDeletionsByForeignKeyConstraints(): void
     {
         // Uses normalized comparison due to case differences between versions
-        if ('doctrine\dbal\platforms\sqliteplatform' === strtolower(get_class($this->em->getConnection()->getDatabasePlatform()))) {
+        if ('doctrine\dbal\platforms\sqliteplatform' === strtolower($this->em->getConnection()->getDatabasePlatform()::class)) {
             static::markTestSkipped('Foreign key constraints do not map in SQLite.');
         }
 

--- a/tests/Gedmo/Translatable/TranslatableTest.php
+++ b/tests/Gedmo/Translatable/TranslatableTest.php
@@ -159,7 +159,7 @@ final class TranslatableTest extends BaseTestCaseORM
 
         $comments = $article->getComments();
         foreach ($comments as $comment) {
-            $number = preg_replace("@[^\d]+@", '', $comment->getSubject());
+            $number = preg_replace("@[^\d]+@", '', (string) $comment->getSubject());
             $comment->setTranslatableLocale('de_de');
             $comment->setSubject("subject{$number} in de");
             $comment->setMessage("message{$number} in de");
@@ -188,7 +188,7 @@ final class TranslatableTest extends BaseTestCaseORM
             static::assertCount(1, $translations);
             static::assertArrayHasKey('de_de', $translations);
 
-            $number = preg_replace("@[^\d]+@", '', $comment->getSubject());
+            $number = preg_replace("@[^\d]+@", '', (string) $comment->getSubject());
             static::assertArrayHasKey('subject', $translations['de_de']);
             $expected = "subject{$number} in de";
             static::assertSame($expected, $translations['de_de']['subject']);
@@ -204,7 +204,7 @@ final class TranslatableTest extends BaseTestCaseORM
 
         $comments = $article->getComments();
         foreach ($comments as $comment) {
-            $number = preg_replace("@[^\d]+@", '', $comment->getSubject());
+            $number = preg_replace("@[^\d]+@", '', (string) $comment->getSubject());
 
             static::assertSame("subject{$number} in en", $comment->getSubject());
             static::assertSame("message{$number} in en", $comment->getMessage());

--- a/tests/Gedmo/Translator/Fixture/Person.php
+++ b/tests/Gedmo/Translator/Fixture/Person.php
@@ -25,32 +25,24 @@ use Gedmo\Translator\TranslationProxy;
 class Person
 {
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="name", type="string", length=128)
      */
     #[ORM\Column(name: 'name', type: Types::STRING, length: 128)]
-    public $name;
+    public ?string $name = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="desc", type="string", length=128)
      */
     #[ORM\Column(name: 'desc', type: Types::STRING, length: 128)]
-    public $description;
+    public ?string $description = null;
 
     /**
-     * @var string|null
-     *
      * @ORM\Column(name="last_name", type="string", length=128, nullable=true)
      */
     #[ORM\Column(name: 'last_name', type: Types::STRING, length: 128, nullable: true)]
-    public $lastName;
+    public ?string $lastName = null;
 
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -58,7 +50,7 @@ class Person
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @var Collection<int, TranslationInterface>
@@ -124,10 +116,7 @@ class Person
         return $this->parent;
     }
 
-    /**
-     * @return self|TranslationProxy
-     */
-    public function translate(string $locale = 'en')
+    public function translate(string $locale = 'en'): self|TranslationProxy
     {
         if ('en' === $locale) {
             return $this;

--- a/tests/Gedmo/Translator/Fixture/PersonCustom.php
+++ b/tests/Gedmo/Translator/Fixture/PersonCustom.php
@@ -24,8 +24,6 @@ use Gedmo\Translator\TranslationInterface;
 class PersonCustom
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -33,7 +31,7 @@ class PersonCustom
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="name", type="string", length=128)
@@ -85,10 +83,7 @@ class PersonCustom
         return $this->description;
     }
 
-    /**
-     * @return self|CustomProxy
-     */
-    public function translate(?string $locale = null)
+    public function translate(?string $locale = null): self|CustomProxy
     {
         if (null === $locale) {
             return $this;

--- a/tests/Gedmo/Translator/Fixture/PersonTranslation.php
+++ b/tests/Gedmo/Translator/Fixture/PersonTranslation.php
@@ -31,8 +31,6 @@ use Gedmo\Translator\Entity\Translation;
 class PersonTranslation extends Translation
 {
     /**
-     * @var Person|null
-     *
      * @ORM\ManyToOne(targetEntity="Person", inversedBy="translations")
      */
     #[ORM\ManyToOne(targetEntity: Person::class, inversedBy: 'translations')]

--- a/tests/Gedmo/Tree/ClosureTreeRepositoryTest.php
+++ b/tests/Gedmo/Tree/ClosureTreeRepositoryTest.php
@@ -211,7 +211,7 @@ final class ClosureTreeRepositoryTest extends BaseTestCaseORM
 
         $vegitables = $repo->findOneBy(['title' => 'Vegitables']);
         static::assertSame(2, $repo->childCount($vegitables, true));
-        static::assertNull($vegitables->getParent());
+        static::assertNotInstanceOf(Category::class, $vegitables->getParent());
 
         $repo->removeFromTree($lemons);
         static::assertCount(5, $repo->children(null, true));
@@ -241,7 +241,7 @@ final class ClosureTreeRepositoryTest extends BaseTestCaseORM
         $config = $this->listener->getConfiguration($this->em, $meta->getName());
         $qb = $repo->getNodesHierarchyQueryBuilder($roots[0], false, $config);
 
-        static::assertFalse(strpos($qb->getQuery()->getDql(), '(SELECT MAX('));
+        static::assertStringNotContainsString('(SELECT MAX(', (string) $qb->getQuery()->getDql());
     }
 
     public function testNotHavingLevelPropertyUsesASubqueryInSelectInGetNodesHierarchy(): void
@@ -254,7 +254,7 @@ final class ClosureTreeRepositoryTest extends BaseTestCaseORM
         $config = $this->listener->getConfiguration($this->em, $meta->getName());
         $qb = $repo->getNodesHierarchyQueryBuilder($roots[0], false, $config);
 
-        static::assertTrue((bool) strpos($qb->getQuery()->getDql(), '(SELECT MAX('));
+        static::assertTrue((bool) strpos((string) $qb->getQuery()->getDql(), '(SELECT MAX('));
     }
 
     public function testChangeChildrenIndex(): void
@@ -475,7 +475,7 @@ final class ClosureTreeRepositoryTest extends BaseTestCaseORM
             array_merge($sortOption, ['decorate' => true]),
             $includeNode
         );
-        $getTreeHtml = static function ($includeNode) {
+        $getTreeHtml = static function ($includeNode): string {
             $baseHtml = '<li>Boring Food<ul><li>Vegitables<ul><li>Cabbages</li><li>Carrots</li></ul></li></ul></li><li>Fruits<ul><li>Berries<ul><li>Strawberries</li></ul></li><li>Lemons</li><li>Oranges</li></ul></li><li>Milk<ul><li>Cheese<ul><li>Mould cheese</li></ul></li></ul></li></ul>';
 
             return $includeNode ? '<ul><li>Food<ul>'.$baseHtml.'</li></ul>' : '<ul>'.$baseHtml;

--- a/tests/Gedmo/Tree/ClosureTreeTest.php
+++ b/tests/Gedmo/Tree/ClosureTreeTest.php
@@ -325,9 +325,9 @@ final class ClosureTreeTest extends BaseTestCaseORM
     }
 
     /**
-     * @return array<string, array<int, Category>>
+     * @return \Generator<string, array<int, Category>>
      */
-    public static function provideNodeOrders(): array
+    public static function provideNodeOrders(): \Generator
     {
         $grandpa = new Category();
         $grandpa->setTitle('grandpa');
@@ -340,14 +340,12 @@ final class ClosureTreeTest extends BaseTestCaseORM
         $son->setTitle('son');
         $son->setParent($father);
 
-        return [
-            'order-123' => [$grandpa, $father, $son],
-            'order-132' => [$grandpa, $son, $father],
-            'order-213' => [$father, $grandpa, $son],
-            'order-231' => [$father, $son, $grandpa],
-            'order-312' => [$son, $grandpa, $father],
-            'order-321' => [$son, $father, $grandpa],
-        ];
+        yield 'order-123' => [$grandpa, $father, $son];
+        yield 'order-132' => [$grandpa, $son, $father];
+        yield 'order-213' => [$father, $grandpa, $son];
+        yield 'order-231' => [$father, $son, $grandpa];
+        yield 'order-312' => [$son, $grandpa, $father];
+        yield 'order-321' => [$son, $father, $grandpa];
     }
 
     protected function getUsedEntityFixtures(): array

--- a/tests/Gedmo/Tree/Fixture/ANode.php
+++ b/tests/Gedmo/Tree/Fixture/ANode.php
@@ -22,8 +22,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class ANode
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -31,29 +29,25 @@ class ANode
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeLeft
      *
      * @ORM\Column(type="integer", nullable=true)
      */
     #[ORM\Column(type: Types::INTEGER, nullable: true)]
     #[Gedmo\TreeLeft]
-    private $lft;
+    private ?int $lft = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeRight
      *
      * @ORM\Column(type="integer", nullable=true)
      */
     #[ORM\Column(type: Types::INTEGER, nullable: true)]
     #[Gedmo\TreeRight]
-    private $rgt;
+    private ?int $rgt = null;
 
     /**
      * @Gedmo\TreeParent

--- a/tests/Gedmo/Tree/Fixture/Article.php
+++ b/tests/Gedmo/Tree/Fixture/Article.php
@@ -23,8 +23,6 @@ use Doctrine\ORM\Mapping as ORM;
 class Article
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -32,7 +30,7 @@ class Article
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=128)
@@ -46,7 +44,7 @@ class Article
      * @ORM\OneToMany(targetEntity="Comment", mappedBy="article")
      */
     #[ORM\OneToMany(targetEntity: Comment::class, mappedBy: 'article')]
-    private $comments;
+    private Collection $comments;
 
     /**
      * @ORM\ManyToOne(targetEntity="Category", inversedBy="articles")

--- a/tests/Gedmo/Tree/Fixture/BaseNode.php
+++ b/tests/Gedmo/Tree/Fixture/BaseNode.php
@@ -42,15 +42,13 @@ class BaseNode extends ANode
     private Collection $children;
 
     /**
-     * @var \DateTime|null
-     *
      * @Gedmo\Timestampable(on="create")
      *
      * @ORM\Column(type="datetime")
      */
     #[ORM\Column(type: Types::DATETIME_MUTABLE)]
     #[Gedmo\Timestampable(on: 'create')]
-    private $created;
+    private ?\DateTime $created = null;
 
     /**
      * @ORM\Column(length=128, unique=true)
@@ -59,15 +57,13 @@ class BaseNode extends ANode
     private ?string $identifier = null;
 
     /**
-     * @var \DateTime|null
-     *
      * @ORM\Column(type="datetime")
      *
      * @Gedmo\Timestampable
      */
     #[ORM\Column(type: Types::DATETIME_MUTABLE)]
     #[Gedmo\Timestampable]
-    private $updated;
+    private ?\DateTime $updated = null;
 
     public function __construct()
     {

--- a/tests/Gedmo/Tree/Fixture/BehavioralCategory.php
+++ b/tests/Gedmo/Tree/Fixture/BehavioralCategory.php
@@ -28,8 +28,6 @@ use Gedmo\Tests\Tree\Fixture\Repository\BehavioralCategoryRepository;
 class BehavioralCategory
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -37,7 +35,7 @@ class BehavioralCategory
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @Gedmo\Translatable
@@ -49,26 +47,22 @@ class BehavioralCategory
     private ?string $title = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeLeft
      *
      * @ORM\Column(name="lft", type="integer", nullable=true)
      */
     #[ORM\Column(name: 'lft', type: Types::INTEGER, nullable: true)]
     #[Gedmo\TreeLeft]
-    private $lft;
+    private ?int $lft = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeRight
      *
      * @ORM\Column(name="rgt", type="integer", nullable=true)
      */
     #[ORM\Column(name: 'rgt', type: Types::INTEGER, nullable: true)]
     #[Gedmo\TreeRight]
-    private $rgt;
+    private ?int $rgt = null;
 
     /**
      * @Gedmo\TreeParent
@@ -92,8 +86,6 @@ class BehavioralCategory
     private Collection $children;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @Gedmo\Slug(fields={"title"})
      *
@@ -102,7 +94,7 @@ class BehavioralCategory
     #[ORM\Column(name: 'slug', type: Types::STRING, length: 128, unique: true)]
     #[Gedmo\Translatable]
     #[Gedmo\Slug(fields: ['title'])]
-    private $slug;
+    private ?string $slug = null;
 
     public function __construct()
     {

--- a/tests/Gedmo/Tree/Fixture/Category.php
+++ b/tests/Gedmo/Tree/Fixture/Category.php
@@ -29,8 +29,6 @@ use Gedmo\Tree\Node as NodeInterface;
 class Category implements NodeInterface
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -38,7 +36,7 @@ class Category implements NodeInterface
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=64)
@@ -47,26 +45,22 @@ class Category implements NodeInterface
     private ?string $title = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeLeft
      *
      * @ORM\Column(name="lft", type="integer")
      */
     #[ORM\Column(name: 'lft', type: Types::INTEGER)]
     #[Gedmo\TreeLeft]
-    private $lft;
+    private ?int $lft = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeRight
      *
      * @ORM\Column(name="rgt", type="integer")
      */
     #[ORM\Column(name: 'rgt', type: Types::INTEGER)]
     #[Gedmo\TreeRight]
-    private $rgt;
+    private ?int $rgt = null;
 
     /**
      * @Gedmo\TreeParent
@@ -82,15 +76,13 @@ class Category implements NodeInterface
     private ?Category $parentId = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeLevel
      *
      * @ORM\Column(name="lvl", type="integer")
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER)]
     #[Gedmo\TreeLevel]
-    private $level;
+    private ?int $level = null;
 
     /**
      * @var Collection<int, self>

--- a/tests/Gedmo/Tree/Fixture/CategoryUuid.php
+++ b/tests/Gedmo/Tree/Fixture/CategoryUuid.php
@@ -48,26 +48,22 @@ class CategoryUuid implements NodeInterface
     private ?string $title = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeLeft
      *
      * @ORM\Column(name="lft", type="integer")
      */
     #[ORM\Column(name: 'lft', type: Types::INTEGER)]
     #[Gedmo\TreeLeft]
-    private $lft;
+    private ?int $lft = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeRight
      *
      * @ORM\Column(name="rgt", type="integer")
      */
     #[ORM\Column(name: 'rgt', type: Types::INTEGER)]
     #[Gedmo\TreeRight]
-    private $rgt;
+    private ?int $rgt = null;
 
     /**
      * @Gedmo\TreeParent
@@ -83,26 +79,22 @@ class CategoryUuid implements NodeInterface
     private ?CategoryUuid $parentId = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeLevel
      *
      * @ORM\Column(name="lvl", type="integer")
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER)]
     #[Gedmo\TreeLevel]
-    private $level;
+    private ?int $level = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\TreeRoot
      *
      * @ORM\Column(name="root", type="string")
      */
     #[ORM\Column(name: 'root', type: Types::STRING)]
     #[Gedmo\TreeRoot]
-    private $root;
+    private ?string $root = null;
 
     /**
      * @var Collection<int, self>

--- a/tests/Gedmo/Tree/Fixture/Closure/Category.php
+++ b/tests/Gedmo/Tree/Fixture/Closure/Category.php
@@ -30,8 +30,6 @@ use Gedmo\Tree\Entity\Repository\ClosureTreeRepository;
 class Category
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -39,7 +37,7 @@ class Category
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=64)
@@ -70,7 +68,7 @@ class Category
     /**
      * @var Collection<int, CategoryClosure>
      */
-    private $closures;
+    private Collection $closures;
 
     public function __construct()
     {

--- a/tests/Gedmo/Tree/Fixture/Closure/CategoryClosureWithoutMapping.php
+++ b/tests/Gedmo/Tree/Fixture/Closure/CategoryClosureWithoutMapping.php
@@ -18,6 +18,4 @@ use Gedmo\Tree\Entity\MappedSuperclass\AbstractClosure;
  * @ORM\Entity
  */
 #[ORM\Entity]
-class CategoryClosureWithoutMapping extends AbstractClosure
-{
-}
+class CategoryClosureWithoutMapping extends AbstractClosure {}

--- a/tests/Gedmo/Tree/Fixture/Closure/CategoryWithoutLevel.php
+++ b/tests/Gedmo/Tree/Fixture/Closure/CategoryWithoutLevel.php
@@ -30,8 +30,6 @@ use Gedmo\Tree\Entity\Repository\ClosureTreeRepository;
 class CategoryWithoutLevel
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -39,7 +37,7 @@ class CategoryWithoutLevel
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=64)
@@ -61,7 +59,7 @@ class CategoryWithoutLevel
     /**
      * @var Collection<int, CategoryWithoutLevelClosure>
      */
-    private $closures;
+    private Collection $closures;
 
     public function __construct()
     {

--- a/tests/Gedmo/Tree/Fixture/Closure/News.php
+++ b/tests/Gedmo/Tree/Fixture/Closure/News.php
@@ -23,8 +23,6 @@ use Doctrine\ORM\Mapping as ORM;
 class News
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="IDENTITY")
      * @ORM\Column(type="integer")
@@ -32,25 +30,20 @@ class News
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
-    /**
-     * @ORM\Column(name="title", type="string", length=64)
-     */
-    #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
-    private string $title;
-
-    /**
-     * @ORM\OneToOne(targetEntity="Gedmo\Tests\Tree\Fixture\Closure\Category", cascade={"persist"})
-     * @ORM\JoinColumn(name="category_id", referencedColumnName="id")
-     */
-    #[ORM\OneToOne(targetEntity: Category::class, cascade: ['persist'])]
-    #[ORM\JoinColumn(name: 'category_id', referencedColumnName: 'id')]
-    private Category $category;
-
-    public function __construct(string $title, Category $category)
-    {
-        $this->title = $title;
-        $this->category = $category;
-    }
+    public function __construct(
+        /**
+         * @ORM\Column(name="title", type="string", length=64)
+         */
+        #[ORM\Column(name: 'title', type: Types::STRING, length: 64)]
+        private string $title,
+        /**
+         * @ORM\OneToOne(targetEntity="Gedmo\Tests\Tree\Fixture\Closure\Category", cascade={"persist"})
+         * @ORM\JoinColumn(name="category_id", referencedColumnName="id")
+         */
+        #[ORM\OneToOne(targetEntity: Category::class, cascade: ['persist'])]
+        #[ORM\JoinColumn(name: 'category_id', referencedColumnName: 'id')]
+        private Category $category
+    ) {}
 }

--- a/tests/Gedmo/Tree/Fixture/Closure/Person.php
+++ b/tests/Gedmo/Tree/Fixture/Closure/Person.php
@@ -36,8 +36,6 @@ use Gedmo\Tree\Entity\Repository\ClosureTreeRepository;
 abstract class Person
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -45,7 +43,7 @@ abstract class Person
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="full_name", type="string", length=64)

--- a/tests/Gedmo/Tree/Fixture/Comment.php
+++ b/tests/Gedmo/Tree/Fixture/Comment.php
@@ -21,8 +21,6 @@ use Doctrine\ORM\Mapping as ORM;
 class Comment
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -30,7 +28,7 @@ class Comment
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="message", type="text")

--- a/tests/Gedmo/Tree/Fixture/ForeignRootCategory.php
+++ b/tests/Gedmo/Tree/Fixture/ForeignRootCategory.php
@@ -28,8 +28,6 @@ use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
 class ForeignRootCategory
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -37,7 +35,7 @@ class ForeignRootCategory
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=64)
@@ -46,26 +44,22 @@ class ForeignRootCategory
     private ?string $title = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeLeft
      *
      * @ORM\Column(name="lft", type="integer")
      */
     #[ORM\Column(name: 'lft', type: Types::INTEGER)]
     #[Gedmo\TreeLeft]
-    private $lft;
+    private ?int $lft = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeRight
      *
      * @ORM\Column(name="rgt", type="integer")
      */
     #[ORM\Column(name: 'rgt', type: Types::INTEGER)]
     #[Gedmo\TreeRight]
-    private $rgt;
+    private ?int $rgt = null;
 
     /**
      * @Gedmo\TreeParent
@@ -81,26 +75,22 @@ class ForeignRootCategory
     private ?ForeignRootCategory $parent = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeRoot(identifierMethod="getRoot")
      *
      * @ORM\Column(type="integer")
      */
     #[ORM\Column(type: Types::INTEGER)]
     #[Gedmo\TreeRoot(identifierMethod: 'getRoot')]
-    private $root;
+    private ?int $root = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeLevel
      *
      * @ORM\Column(name="lvl", type="integer")
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER)]
     #[Gedmo\TreeLevel]
-    private $level;
+    private ?int $level = null;
 
     /**
      * @var Collection<int, self>
@@ -108,7 +98,7 @@ class ForeignRootCategory
      * @ORM\OneToMany(targetEntity="ForeignRootCategory", mappedBy="parent")
      */
     #[ORM\OneToMany(targetEntity: self::class, mappedBy: 'parent')]
-    private $children;
+    private Collection $children;
 
     public function __construct()
     {

--- a/tests/Gedmo/Tree/Fixture/Genealogy/Man.php
+++ b/tests/Gedmo/Tree/Fixture/Genealogy/Man.php
@@ -18,6 +18,4 @@ use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
  * @ORM\Entity(repositoryClass="Gedmo\Tree\Entity\Repository\NestedTreeRepository")
  */
 #[ORM\Entity(repositoryClass: NestedTreeRepository::class)]
-class Man extends Person
-{
-}
+class Man extends Person {}

--- a/tests/Gedmo/Tree/Fixture/Genealogy/Person.php
+++ b/tests/Gedmo/Tree/Fixture/Genealogy/Person.php
@@ -41,11 +41,9 @@ abstract class Person
      * @ORM\OneToMany(targetEntity="Person", mappedBy="parent")
      */
     #[ORM\OneToMany(targetEntity: self::class, mappedBy: 'parent')]
-    protected $children;
+    protected Collection $children;
 
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -53,7 +51,7 @@ abstract class Person
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @Gedmo\TreeParent
@@ -65,47 +63,39 @@ abstract class Person
     private ?Person $parent = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeLeft
      *
      * @ORM\Column(name="lft", type="integer")
      */
     #[ORM\Column(name: 'lft', type: Types::INTEGER)]
     #[Gedmo\TreeLeft]
-    private $lft;
+    private ?int $lft = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeRight
      *
      * @ORM\Column(name="rgt", type="integer")
      */
     #[ORM\Column(name: 'rgt', type: Types::INTEGER)]
     #[Gedmo\TreeRight]
-    private $rgt;
+    private ?int $rgt = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeLevel
      *
      * @ORM\Column(name="lvl", type="integer")
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER)]
     #[Gedmo\TreeLevel]
-    private $lvl;
+    private ?int $lvl = null;
 
-    /**
-     * @ORM\Column(name="name", type="string", length=191, nullable=false)
-     */
-    #[ORM\Column(name: 'name', type: Types::STRING, length: 191, nullable: false)]
-    private string $name;
-
-    public function __construct(string $name)
-    {
-        $this->name = $name;
+    public function __construct(
+        /**
+         * @ORM\Column(name="name", type="string", length=191, nullable=false)
+         */
+        #[ORM\Column(name: 'name', type: Types::STRING, length: 191, nullable: false)]
+        private string $name
+    ) {
         $this->children = new ArrayCollection();
     }
 

--- a/tests/Gedmo/Tree/Fixture/Genealogy/Woman.php
+++ b/tests/Gedmo/Tree/Fixture/Genealogy/Woman.php
@@ -18,6 +18,4 @@ use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
  * @ORM\Entity(repositoryClass="Gedmo\Tree\Entity\Repository\NestedTreeRepository")
  */
 #[ORM\Entity(repositoryClass: NestedTreeRepository::class)]
-class Woman extends Person
-{
-}
+class Woman extends Person {}

--- a/tests/Gedmo/Tree/Fixture/Issue2408/Category.php
+++ b/tests/Gedmo/Tree/Fixture/Issue2408/Category.php
@@ -30,8 +30,6 @@ use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
 class Category
 {
     /**
-     * @var int|null
-     *
      * @ORM\Column(name="id", type="integer")
      * @ORM\Id
      * @ORM\GeneratedValue
@@ -39,7 +37,7 @@ class Category
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=64)
@@ -48,41 +46,33 @@ class Category
     private ?string $title = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeLeft
      *
      * @ORM\Column(name="lft", type="integer")
      */
     #[ORM\Column(name: 'lft', type: Types::INTEGER)]
     #[Gedmo\TreeLeft]
-    private $lft;
+    private ?int $lft = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeRight
      *
      * @ORM\Column(name="rgt", type="integer")
      */
     #[ORM\Column(name: 'rgt', type: Types::INTEGER)]
     #[Gedmo\TreeRight]
-    private $rgt;
+    private ?int $rgt = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeLevel
      *
      * @ORM\Column(name="lvl", type="integer")
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER)]
     #[Gedmo\TreeLevel]
-    private $lvl;
+    private ?int $lvl = null;
 
     /**
-     * @var self|null
-     *
      * @Gedmo\TreeRoot
      *
      * @ORM\ManyToOne(targetEntity="Category")
@@ -91,7 +81,7 @@ class Category
     #[Gedmo\TreeRoot]
     #[ORM\ManyToOne(targetEntity: self::class)]
     #[ORM\JoinColumn(name: 'tree_root', referencedColumnName: 'id', onDelete: 'CASCADE')]
-    private $root;
+    private ?Category $root = null;
 
     /**
      * @Gedmo\TreeParent

--- a/tests/Gedmo/Tree/Fixture/Issue2517/Category.php
+++ b/tests/Gedmo/Tree/Fixture/Issue2517/Category.php
@@ -30,8 +30,6 @@ use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
 class Category
 {
     /**
-     * @var int|null
-     *
      * @ORM\Column(name="id", type="integer")
      * @ORM\Id
      * @ORM\GeneratedValue
@@ -39,7 +37,7 @@ class Category
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=64)
@@ -48,41 +46,33 @@ class Category
     private ?string $title = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeLeft
      *
      * @ORM\Column(name="lft", type="integer")
      */
     #[ORM\Column(name: 'lft', type: Types::INTEGER)]
     #[Gedmo\TreeLeft]
-    private $lft;
+    private ?int $lft = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeRight
      *
      * @ORM\Column(name="rgt", type="integer")
      */
     #[ORM\Column(name: 'rgt', type: Types::INTEGER)]
     #[Gedmo\TreeRight]
-    private $rgt;
+    private ?int $rgt = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeLevel
      *
      * @ORM\Column(name="lvl", type="integer")
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER)]
     #[Gedmo\TreeLevel]
-    private $lvl;
+    private ?int $lvl = null;
 
     /**
-     * @var self|null
-     *
      * @Gedmo\TreeRoot
      *
      * @ORM\ManyToOne(targetEntity="Category")
@@ -91,7 +81,7 @@ class Category
     #[Gedmo\TreeRoot]
     #[ORM\ManyToOne(targetEntity: self::class)]
     #[ORM\JoinColumn(name: 'tree_root', referencedColumnName: 'id', onDelete: 'CASCADE')]
-    private $root;
+    private ?Category $root = null;
 
     /**
      * @Gedmo\TreeParent

--- a/tests/Gedmo/Tree/Fixture/Issue2616/Category.php
+++ b/tests/Gedmo/Tree/Fixture/Issue2616/Category.php
@@ -9,6 +9,8 @@
 
 namespace Gedmo\Tests\Tree\Fixture\Issue2616;
 
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
@@ -29,32 +31,27 @@ class Category
      * @ORM\JoinColumn(name="parent_id", referencedColumnName="category_id", onDelete="cascade")
      *
      * @Gedmo\TreeParent
-     *
-     * @var Category|null
      */
     #[Gedmo\TreeParent]
     #[ORM\JoinColumn(name: 'parent_id', referencedColumnName: 'category_id', onDelete: 'cascade')]
     #[ORM\ManyToOne(targetEntity: self::class, inversedBy: 'children')]
-    protected $parent;
+    protected ?Category $parent = null;
 
     /**
      * @ORM\OneToMany(targetEntity="\Gedmo\Tests\Tree\Fixture\Issue2616\Category", mappedBy="parent", fetch="EXTRA_LAZY")
      *
-     * @var Category[]|null
+     * @var Collection<int, Category>
      */
     #[ORM\OneToMany(mappedBy: 'parent', targetEntity: self::class, fetch: 'EXTRA_LAZY')]
-    protected $children;
+    protected Collection $children;
 
     /**
      * @ORM\OneToOne(targetEntity="\Gedmo\Tests\Tree\Fixture\Issue2616\Page", mappedBy="category", cascade={"remove"})
-     *
-     * @var Page|null
      */
     #[ORM\OneToOne(targetEntity: Page::class, mappedBy: 'category', cascade: ['remove'])]
-    protected $page;
+    protected ?Page $page = null;
+
     /**
-     * @var int|null
-     *
      * @ORM\Column(name="category_id", type="integer")
      * @ORM\Id
      * @ORM\GeneratedValue
@@ -65,7 +62,7 @@ class Category
     #[ORM\Column(name: 'category_id', type: Types::INTEGER)]
     #[ORM\GeneratedValue]
     #[ORM\Id]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=64)
@@ -77,49 +74,41 @@ class Category
      * @Gedmo\TreeLevel
      *
      * @ORM\Column(name="level", type="integer", nullable=true)
-     *
-     * @var int|null
      */
     #[Gedmo\TreeLevel]
     #[ORM\Column(name: 'level', type: Types::INTEGER, nullable: true)]
-    private $level;
+    private ?int $level = null;
 
     /**
      * @Gedmo\TreePath(separator="/", endsWithSeparator=false)
      *
      * @ORM\Column(name="path", type="string", nullable=true)
-     *
-     * @var string|null
      */
     #[ORM\Column(name: 'path', type: Types::STRING, nullable: true)]
     #[Gedmo\TreePath(separator: '/', endsWithSeparator: false)]
-    private $path;
+    private ?string $path = null;
+
+    public function __construct()
+    {
+        $this->children = new ArrayCollection();
+    }
 
     public function getId(): ?int
     {
         return $this->id;
     }
 
-    /**
-     * @return Category|null
-     */
-    public function getParent()
+    public function getParent(): ?self
     {
         return $this->parent;
     }
 
-    /**
-     * @param Category|null $parent
-     */
-    public function setParent($parent): void
+    public function setParent(?self $parent): void
     {
         $this->parent = $parent;
     }
 
-    /**
-     * @return Page|null
-     */
-    public function getPage()
+    public function getPage(): ?Page
     {
         return $this->page;
     }
@@ -130,36 +119,22 @@ class Category
         $page->setCategory($this);
     }
 
-    /**
-     * @return int
-     */
-    public function getLevel()
+    public function getLevel(): ?int
     {
         return $this->level;
     }
 
-    /**
-     * @param int $level
-     */
-    public function setLevel($level): void
+    public function setLevel(?int $level): void
     {
         $this->level = $level;
     }
 
-    /**
-     * @return string|null
-     */
-    public function getPath()
+    public function getPath(): ?string
     {
         return $this->path;
     }
 
-    /**
-     * @param string $path
-     *
-     * @return void
-     */
-    public function setPath($path)
+    public function setPath(?string $path): void
     {
         $this->path = $path;
     }

--- a/tests/Gedmo/Tree/Fixture/Issue2616/Page.php
+++ b/tests/Gedmo/Tree/Fixture/Issue2616/Page.php
@@ -20,17 +20,13 @@ use Doctrine\ORM\Mapping as ORM;
 class Page
 {
     /**
-     * @var Category|null
-     *
      * @ORM\OneToOne(targetEntity="Category", inversedBy="page")
      * @ORM\JoinColumn(name="entity_id", referencedColumnName="category_id", nullable=false)
      */
     #[ORM\JoinColumn(name: 'entity_id', referencedColumnName: 'category_id', nullable: false)]
     #[ORM\OneToOne(targetEntity: Category::class, inversedBy: 'page')]
-    protected $category;
+    protected ?Category $category = null;
     /**
-     * @var int|null
-     *
      * @ORM\Column(name="page_id", type="integer")
      * @ORM\Id
      * @ORM\GeneratedValue
@@ -38,7 +34,7 @@ class Page
     #[ORM\Column(name: 'page_id', type: Types::INTEGER)]
     #[ORM\GeneratedValue]
     #[ORM\Id]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=64)

--- a/tests/Gedmo/Tree/Fixture/MPCategory.php
+++ b/tests/Gedmo/Tree/Fixture/MPCategory.php
@@ -28,8 +28,6 @@ use Gedmo\Tree\Entity\Repository\MaterializedPathRepository;
 class MPCategory
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -37,7 +35,7 @@ class MPCategory
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @Gedmo\TreePath
@@ -71,26 +69,22 @@ class MPCategory
     private ?MPCategory $parentId = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeLevel
      *
      * @ORM\Column(name="lvl", type="integer", nullable=true)
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER, nullable: true)]
     #[Gedmo\TreeLevel]
-    private $level;
+    private ?int $level = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\TreeRoot
      *
      * @ORM\Column(name="tree_root_value", type="string", nullable=true)
      */
     #[ORM\Column(name: 'tree_root_value', type: Types::STRING, nullable: true)]
     #[Gedmo\TreeRoot]
-    private $treeRootValue;
+    private ?string $treeRootValue = null;
 
     /**
      * @var Collection<int, self>

--- a/tests/Gedmo/Tree/Fixture/MPCategoryUuid.php
+++ b/tests/Gedmo/Tree/Fixture/MPCategoryUuid.php
@@ -68,26 +68,22 @@ class MPCategoryUuid
     private ?MPCategoryUuid $parentId = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeLevel
      *
      * @ORM\Column(name="lvl", type="integer", nullable=true)
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER, nullable: true)]
     #[Gedmo\TreeLevel]
-    private $level;
+    private ?int $level = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\TreeRoot
      *
      * @ORM\Column(name="tree_root_value", type="string", nullable=true)
      */
     #[ORM\Column(name: 'tree_root_value', type: Types::STRING, nullable: true)]
     #[Gedmo\TreeRoot]
-    private $treeRootValue;
+    private ?string $treeRootValue = null;
 
     /**
      * @var Collection<int, self>

--- a/tests/Gedmo/Tree/Fixture/MPCategoryWithRootAssociation.php
+++ b/tests/Gedmo/Tree/Fixture/MPCategoryWithRootAssociation.php
@@ -28,8 +28,6 @@ use Gedmo\Tree\Entity\Repository\MaterializedPathRepository;
 class MPCategoryWithRootAssociation
 {
     /**
-     * @var int|null
-     *
      * @Gedmo\TreePathSource
      *
      * @ORM\Id
@@ -40,7 +38,7 @@ class MPCategoryWithRootAssociation
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
     #[Gedmo\TreePathSource]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @Gedmo\TreePath
@@ -71,19 +69,15 @@ class MPCategoryWithRootAssociation
     private ?MPCategoryWithRootAssociation $parentId = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeLevel
      *
      * @ORM\Column(name="lvl", type="integer", nullable=true)
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER, nullable: true)]
     #[Gedmo\TreeLevel]
-    private $level;
+    private ?int $level = null;
 
     /**
-     * @var self|null
-     *
      * @Gedmo\TreeRoot
      *
      * @ORM\ManyToOne(targetEntity="MPCategoryWithRootAssociation")
@@ -94,7 +88,7 @@ class MPCategoryWithRootAssociation
     #[ORM\ManyToOne(targetEntity: self::class)]
     #[ORM\JoinColumn(name: 'tree_root_entity', referencedColumnName: 'id', onDelete: 'CASCADE')]
     #[Gedmo\TreeRoot]
-    private $treeRootEntity;
+    private ?MPCategoryWithRootAssociation $treeRootEntity = null;
 
     /**
      * @var Collection<int, self>

--- a/tests/Gedmo/Tree/Fixture/MPCategoryWithTrimmedSeparator.php
+++ b/tests/Gedmo/Tree/Fixture/MPCategoryWithTrimmedSeparator.php
@@ -28,8 +28,6 @@ use Gedmo\Tree\Entity\Repository\MaterializedPathRepository;
 class MPCategoryWithTrimmedSeparator
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -37,7 +35,7 @@ class MPCategoryWithTrimmedSeparator
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @Gedmo\TreePath(appendId=false, startsWithSeparator=false, endsWithSeparator=false)
@@ -71,15 +69,13 @@ class MPCategoryWithTrimmedSeparator
     private ?MPCategoryWithTrimmedSeparator $parentId = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeLevel
      *
      * @ORM\Column(name="lvl", type="integer", nullable=true)
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER, nullable: true)]
     #[Gedmo\TreeLevel]
-    private $level;
+    private ?int $level = null;
 
     /**
      * @var Collection<int, self>

--- a/tests/Gedmo/Tree/Fixture/MPFeaturesCategory.php
+++ b/tests/Gedmo/Tree/Fixture/MPFeaturesCategory.php
@@ -28,8 +28,6 @@ use Gedmo\Tree\Entity\Repository\MaterializedPathRepository;
 class MPFeaturesCategory
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -37,7 +35,7 @@ class MPFeaturesCategory
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @Gedmo\TreePath(appendId=false, startsWithSeparator=true, endsWithSeparator=false)
@@ -49,15 +47,13 @@ class MPFeaturesCategory
     private ?string $path = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\TreePathHash
      *
      * @ORM\Column(name="pathhash", type="string", length=32, nullable=true)
      */
     #[ORM\Column(name: 'pathhash', type: Types::STRING, length: 32, nullable: true)]
     #[Gedmo\TreePathHash]
-    private $pathHash;
+    private ?string $pathHash = null;
 
     /**
      * @Gedmo\TreePathSource
@@ -82,26 +78,22 @@ class MPFeaturesCategory
     private ?MPFeaturesCategory $parentId = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeLevel
      *
      * @ORM\Column(name="lvl", type="integer", nullable=true)
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER, nullable: true)]
     #[Gedmo\TreeLevel]
-    private $level;
+    private ?int $level = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\TreeRoot
      *
      * @ORM\Column(name="tree_root_value", type="string", nullable=true)
      */
     #[ORM\Column(name: 'tree_root_value', type: Types::STRING, nullable: true)]
     #[Gedmo\TreeRoot]
-    private $treeRootValue;
+    private ?string $treeRootValue = null;
 
     /**
      * @var Collection<int, self>

--- a/tests/Gedmo/Tree/Fixture/Mock/TreeListenerMock.php
+++ b/tests/Gedmo/Tree/Fixture/Mock/TreeListenerMock.php
@@ -23,17 +23,11 @@ use Gedmo\Tree\TreeListener;
  */
 final class TreeListenerMock extends TreeListener
 {
-    /**
-     * @var bool
-     */
-    public $releaseLocks = false;
+    public bool $releaseLocks = false;
 
-    /**
-     * @var MaterializedPathMock
-     */
-    protected $strategy;
+    protected ?MaterializedPathMock $strategy = null;
 
-    public function getStrategy(ObjectManager $om, $class)
+    public function getStrategy(ObjectManager $om, $class): MaterializedPathMock
     {
         if (null === $this->strategy) {
             $this->strategy = new MaterializedPathMock($this);

--- a/tests/Gedmo/Tree/Fixture/Node.php
+++ b/tests/Gedmo/Tree/Fixture/Node.php
@@ -32,8 +32,6 @@ class Node extends BaseNode
     private ?string $title = null;
 
     /**
-     * @var string|null
-     *
      * @Gedmo\Translatable
      * @Gedmo\Slug(fields={"title"})
      *
@@ -42,7 +40,7 @@ class Node extends BaseNode
     #[ORM\Column(name: 'slug', type: Types::STRING, length: 128)]
     #[Gedmo\Translatable]
     #[Gedmo\Slug(fields: ['title'])]
-    private $slug;
+    private ?string $slug = null;
 
     public function getSlug(): ?string
     {

--- a/tests/Gedmo/Tree/Fixture/Repository/BehavioralCategoryRepository.php
+++ b/tests/Gedmo/Tree/Fixture/Repository/BehavioralCategoryRepository.php
@@ -17,6 +17,4 @@ use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
 /**
  * @template-extends NestedTreeRepository<BehavioralCategory>
  */
-final class BehavioralCategoryRepository extends NestedTreeRepository
-{
-}
+final class BehavioralCategoryRepository extends NestedTreeRepository {}

--- a/tests/Gedmo/Tree/Fixture/Role.php
+++ b/tests/Gedmo/Tree/Fixture/Role.php
@@ -33,7 +33,7 @@ use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
 #[ORM\DiscriminatorColumn(name: 'discr', type: Types::STRING)]
 #[ORM\DiscriminatorMap(['user' => User::class, 'usergroup' => UserGroup::class, 'userldap' => UserLDAP::class])]
 #[Gedmo\Tree(type: 'nested')]
-abstract class Role
+abstract class Role implements \Stringable
 {
     /**
      * @var Collection<int, Role>
@@ -41,11 +41,9 @@ abstract class Role
      * @ORM\OneToMany(targetEntity="Role", mappedBy="parent")
      */
     #[ORM\OneToMany(targetEntity: self::class, mappedBy: 'parent')]
-    protected $children;
+    protected Collection $children;
 
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -53,7 +51,7 @@ abstract class Role
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @Gedmo\TreeParent
@@ -65,37 +63,31 @@ abstract class Role
     private ?UserGroup $parent = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeLeft
      *
      * @ORM\Column(name="lft", type="integer")
      */
     #[ORM\Column(name: 'lft', type: Types::INTEGER)]
     #[Gedmo\TreeLeft]
-    private $lft;
+    private ?int $lft = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeRight
      *
      * @ORM\Column(name="rgt", type="integer")
      */
     #[ORM\Column(name: 'rgt', type: Types::INTEGER)]
     #[Gedmo\TreeRight]
-    private $rgt;
+    private ?int $rgt = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeLevel
      *
      * @ORM\Column(name="lvl", type="integer")
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER)]
     #[Gedmo\TreeLevel]
-    private $lvl;
+    private ?int $lvl = null;
 
     /**
      * @ORM\Column(name="role", type="string", length=191, nullable=false)

--- a/tests/Gedmo/Tree/Fixture/RootAssociationCategory.php
+++ b/tests/Gedmo/Tree/Fixture/RootAssociationCategory.php
@@ -33,10 +33,9 @@ class RootAssociationCategory
      * @ORM\OneToMany(targetEntity="RootAssociationCategory", mappedBy="parent")
      */
     #[ORM\OneToMany(targetEntity: self::class, mappedBy: 'parent')]
-    protected $children;
+    protected Collection $children;
+
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -44,7 +43,7 @@ class RootAssociationCategory
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=64)
@@ -53,26 +52,22 @@ class RootAssociationCategory
     private ?string $title = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeLeft
      *
      * @ORM\Column(name="lft", type="integer")
      */
     #[ORM\Column(name: 'lft', type: Types::INTEGER)]
     #[Gedmo\TreeLeft]
-    private $lft;
+    private ?int $lft = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeRight
      *
      * @ORM\Column(name="rgt", type="integer")
      */
     #[ORM\Column(name: 'rgt', type: Types::INTEGER)]
     #[Gedmo\TreeRight]
-    private $rgt;
+    private ?int $rgt = null;
 
     /**
      * @Gedmo\TreeParent
@@ -88,8 +83,6 @@ class RootAssociationCategory
     private ?RootAssociationCategory $parent = null;
 
     /**
-     * @var self|null
-     *
      * @Gedmo\TreeRoot
      *
      * @ORM\ManyToOne(targetEntity="RootAssociationCategory")
@@ -100,18 +93,16 @@ class RootAssociationCategory
     #[ORM\ManyToOne(targetEntity: self::class)]
     #[ORM\JoinColumn(name: 'tree_root', referencedColumnName: 'id', onDelete: 'CASCADE')]
     #[Gedmo\TreeRoot]
-    private $root;
+    private ?RootAssociationCategory $root = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeLevel
      *
      * @ORM\Column(name="lvl", type="integer")
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER)]
     #[Gedmo\TreeLevel]
-    private $level;
+    private ?int $level = null;
 
     public function __construct()
     {

--- a/tests/Gedmo/Tree/Fixture/RootCategory.php
+++ b/tests/Gedmo/Tree/Fixture/RootCategory.php
@@ -34,10 +34,9 @@ class RootCategory implements Node
      * @ORM\OneToMany(targetEntity="RootCategory", mappedBy="parent")
      */
     #[ORM\OneToMany(targetEntity: self::class, mappedBy: 'parent')]
-    protected $children;
+    protected Collection $children;
+
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -45,7 +44,7 @@ class RootCategory implements Node
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", length=64)
@@ -54,26 +53,22 @@ class RootCategory implements Node
     private ?string $title = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeLeft
      *
      * @ORM\Column(name="lft", type="integer")
      */
     #[ORM\Column(name: 'lft', type: Types::INTEGER)]
     #[Gedmo\TreeLeft]
-    private $lft;
+    private ?int $lft = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeRight
      *
      * @ORM\Column(name="rgt", type="integer")
      */
     #[ORM\Column(name: 'rgt', type: Types::INTEGER)]
     #[Gedmo\TreeRight]
-    private $rgt;
+    private ?int $rgt = null;
 
     /**
      * @Gedmo\TreeParent
@@ -89,26 +84,22 @@ class RootCategory implements Node
     private ?RootCategory $parent = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeRoot
      *
      * @ORM\Column(type="integer")
      */
     #[ORM\Column(type: Types::INTEGER)]
     #[Gedmo\TreeRoot]
-    private $root;
+    private ?int $root = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeLevel(base=1)
      *
      * @ORM\Column(name="lvl", type="integer")
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER)]
     #[Gedmo\TreeLevel(base: 1)]
-    private $level;
+    private ?int $level = null;
 
     private ?Node $sibling = null;
 

--- a/tests/Gedmo/Tree/Fixture/Transport/Bus.php
+++ b/tests/Gedmo/Tree/Fixture/Transport/Bus.php
@@ -17,6 +17,4 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Entity
  */
 #[ORM\Entity]
-class Bus extends Vehicle
-{
-}
+class Bus extends Vehicle {}

--- a/tests/Gedmo/Tree/Fixture/Transport/Car.php
+++ b/tests/Gedmo/Tree/Fixture/Transport/Car.php
@@ -33,7 +33,7 @@ class Car extends Vehicle
      * @ORM\OneToMany(targetEntity="Car", mappedBy="parent")
      */
     #[ORM\OneToMany(targetEntity: self::class, mappedBy: 'parent')]
-    protected $children;
+    protected Collection $children;
 
     /**
      * @Gedmo\TreeParent
@@ -49,48 +49,40 @@ class Car extends Vehicle
     private ?Car $parent = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeLeft
      *
      * @ORM\Column(type="integer", nullable=true)
      */
     #[ORM\Column(type: Types::INTEGER, nullable: true)]
     #[Gedmo\TreeLeft]
-    private $lft;
+    private ?int $lft = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeRight
      *
      * @ORM\Column(type="integer", nullable=true)
      */
     #[ORM\Column(type: Types::INTEGER, nullable: true)]
     #[Gedmo\TreeRight]
-    private $rgt;
+    private ?int $rgt = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeRoot
      *
      * @ORM\Column(type="integer", nullable=true)
      */
     #[ORM\Column(type: Types::INTEGER, nullable: true)]
     #[Gedmo\TreeRoot]
-    private $root;
+    private ?int $root = null;
 
     /**
-     * @var int|null
-     *
      * @Gedmo\TreeLevel
      *
      * @ORM\Column(name="lvl", type="integer", nullable=true)
      */
     #[ORM\Column(name: 'lvl', type: Types::INTEGER, nullable: true)]
     #[Gedmo\TreeLevel]
-    private $classLevel;
+    private ?int $classLevel = null;
 
     public function __construct()
     {

--- a/tests/Gedmo/Tree/Fixture/Transport/Engine.php
+++ b/tests/Gedmo/Tree/Fixture/Transport/Engine.php
@@ -21,8 +21,6 @@ use Doctrine\ORM\Mapping as ORM;
 class Engine
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -30,7 +28,7 @@ class Engine
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(length=32)

--- a/tests/Gedmo/Tree/Fixture/Transport/Vehicle.php
+++ b/tests/Gedmo/Tree/Fixture/Transport/Vehicle.php
@@ -31,8 +31,6 @@ use Doctrine\ORM\Mapping as ORM;
 class Vehicle
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -40,7 +38,7 @@ class Vehicle
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\OneToOne(targetEntity="Engine")

--- a/tests/Gedmo/Tree/Issue/Issue2616Test.php
+++ b/tests/Gedmo/Tree/Issue/Issue2616Test.php
@@ -67,8 +67,8 @@ class Issue2616Test extends BaseTestCaseORM
         $this->em->remove($food);
         $this->em->flush();
 
-        static::assertNull($categoryRepo->findOneBy(['title' => 'Fruits']));
-        static::assertNull($categoryRepo->findOneBy(['title' => 'Vegetables']));
+        static::assertNotInstanceOf(Category::class, $categoryRepo->findOneBy(['title' => 'Fruits']));
+        static::assertNotInstanceOf(Category::class, $categoryRepo->findOneBy(['title' => 'Vegetables']));
 
         // Page should be removed as well, because children Fruits/Vegetables are removed and they have Page with cascade remove.
         static::assertEmpty($this->em->getRepository(Page::class)->findAll());

--- a/tests/Gedmo/Tree/MaterializedPathODMMongoDBRepositoryTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathODMMongoDBRepositoryTest.php
@@ -50,7 +50,7 @@ final class MaterializedPathODMMongoDBRepositoryTest extends BaseTestCaseMongoOD
         $result = $this->repo->getRootNodes('title');
 
         static::assertInstanceOf(Iterator::class, $result);
-        static::assertSame(3, \iterator_count($result));
+        static::assertCount(3, $result);
         $result->rewind();
 
         static::assertSame('Drinks', $result->current()->getTitle());
@@ -68,7 +68,7 @@ final class MaterializedPathODMMongoDBRepositoryTest extends BaseTestCaseMongoOD
         $result = $this->repo->getChildren($root, false, 'title', 'asc', true);
 
         static::assertInstanceOf(Iterator::class, $result);
-        static::assertSame(5, \iterator_count($result));
+        static::assertCount(5, $result);
         $result->rewind();
 
         static::assertSame('Carrots', $result->current()->getTitle());
@@ -85,7 +85,7 @@ final class MaterializedPathODMMongoDBRepositoryTest extends BaseTestCaseMongoOD
         $result = $this->repo->getChildren($root, false, 'title', 'asc', false);
 
         static::assertInstanceOf(Iterator::class, $result);
-        static::assertSame(4, \iterator_count($result));
+        static::assertCount(4, $result);
         $result->rewind();
         static::assertSame('Carrots', $result->current()->getTitle());
         $result->next();
@@ -99,7 +99,7 @@ final class MaterializedPathODMMongoDBRepositoryTest extends BaseTestCaseMongoOD
         $result = $this->repo->getChildren($root, true, 'title', 'asc', true);
 
         static::assertInstanceOf(Iterator::class, $result);
-        static::assertSame(3, \iterator_count($result));
+        static::assertCount(3, $result);
         $result->rewind();
         static::assertSame('Food', $result->current()->getTitle());
         $result->next();
@@ -111,7 +111,7 @@ final class MaterializedPathODMMongoDBRepositoryTest extends BaseTestCaseMongoOD
         $result = $this->repo->getChildren($root, true, 'title', 'asc', false);
         static::assertInstanceOf(Iterator::class, $result);
 
-        static::assertSame(2, \iterator_count($result));
+        static::assertCount(2, $result);
         $result->rewind();
         static::assertSame('Fruits', $result->current()->getTitle());
         $result->next();
@@ -121,7 +121,7 @@ final class MaterializedPathODMMongoDBRepositoryTest extends BaseTestCaseMongoOD
         $result = $this->repo->getChildren(null, false, 'title');
         static::assertInstanceOf(Iterator::class, $result);
 
-        static::assertSame(9, \iterator_count($result));
+        static::assertCount(9, $result);
         $result->rewind();
         static::assertSame('Best Whisky', $result->current()->getTitle());
         $result->next();
@@ -145,7 +145,7 @@ final class MaterializedPathODMMongoDBRepositoryTest extends BaseTestCaseMongoOD
         $result = $this->repo->getChildren(null, true, 'title');
         static::assertInstanceOf(Iterator::class, $result);
 
-        static::assertSame(3, \iterator_count($result));
+        static::assertCount(3, $result);
         $result->rewind();
         static::assertSame('Drinks', $result->current()->getTitle());
         $result->next();
@@ -158,7 +158,7 @@ final class MaterializedPathODMMongoDBRepositoryTest extends BaseTestCaseMongoOD
     {
         $tree = $this->repo->getTree();
 
-        static::assertSame(9, \iterator_count($tree));
+        static::assertCount(9, $tree);
         $tree->rewind();
         static::assertSame('Drinks', $tree->current()->getTitle());
         $tree->next();
@@ -183,7 +183,7 @@ final class MaterializedPathODMMongoDBRepositoryTest extends BaseTestCaseMongoOD
         static::assertInstanceOf(Iterator::class, $roots);
         $tree = $this->repo->getTree($roots->current());
 
-        static::assertSame(3, \iterator_count($tree));
+        static::assertCount(3, $tree);
         $tree->rewind();
         static::assertSame('Drinks', $tree->current()->getTitle());
         $tree->next();

--- a/tests/Gedmo/Tree/MaterializedPathODMMongoDBTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathODMMongoDBTest.php
@@ -23,18 +23,17 @@ use Gedmo\Tree\TreeListener;
  *
  * @author Gustavo Falco <comfortablynumb84@gmail.com>
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ *
+ * @phpstan-import-type TreeConfiguration from TreeListener
  */
 final class MaterializedPathODMMongoDBTest extends BaseTestCaseMongoODM
 {
     /**
-     * @var array<string, mixed>
+     * @phpstan-var TreeConfiguration
      */
-    protected $config;
+    private array $config;
 
-    /**
-     * @var TreeListener
-     */
-    protected $listener;
+    private TreeListener $listener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Tree/MaterializedPathODMMongoDBTreeLockingTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathODMMongoDBTreeLockingTest.php
@@ -25,15 +25,7 @@ use Gedmo\Tests\Tree\Fixture\Mock\TreeListenerMock;
  */
 final class MaterializedPathODMMongoDBTreeLockingTest extends BaseTestCaseMongoODM
 {
-    /**
-     * @var array<string, mixed>
-     */
-    protected $config;
-
-    /**
-     * @var TreeListenerMock
-     */
-    protected $listener;
+    private TreeListenerMock $listener;
 
     protected function setUp(): void
     {
@@ -45,9 +37,6 @@ final class MaterializedPathODMMongoDBTreeLockingTest extends BaseTestCaseMongoO
         $evm->addEventSubscriber($this->listener);
 
         $this->getDefaultDocumentManager($evm);
-
-        $meta = $this->dm->getClassMetadata(Article::class);
-        $this->config = $this->listener->getConfiguration($this->dm, $meta->getName());
     }
 
     public function testModifyingANodeWhileItsTreeIsLockedShouldThrowAnException(): void

--- a/tests/Gedmo/Tree/MaterializedPathORMFeaturesTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathORMFeaturesTest.php
@@ -21,18 +21,17 @@ use Gedmo\Tree\TreeListener;
  *
  * @author Gustavo Falco <comfortablynumb84@gmail.com>
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ *
+ * @phpstan-import-type TreeConfiguration from TreeListener
  */
 final class MaterializedPathORMFeaturesTest extends BaseTestCaseORM
 {
     /**
-     * @var array<string, mixed>
+     * @phpstan-var TreeConfiguration
      */
-    protected $config;
+    private array $config;
 
-    /**
-     * @var TreeListener
-     */
-    protected $listener;
+    private TreeListener $listener;
 
     protected function setUp(): void
     {
@@ -110,7 +109,7 @@ final class MaterializedPathORMFeaturesTest extends BaseTestCaseORM
     private function generatePath(array $sources): string
     {
         $path = '';
-        foreach ($sources as $p => $id) {
+        foreach (array_keys($sources) as $p) {
             $path .= $this->config['path_separator'].$p;
         }
 

--- a/tests/Gedmo/Tree/MaterializedPathORMRootAssociationTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathORMRootAssociationTest.php
@@ -21,18 +21,17 @@ use Gedmo\Tree\TreeListener;
  *
  * @author Gustavo Falco <comfortablynumb84@gmail.com>
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ *
+ * @phpstan-import-type TreeConfiguration from TreeListener
  */
 final class MaterializedPathORMRootAssociationTest extends BaseTestCaseORM
 {
     /**
-     * @var array<string, mixed>
+     * @phpstan-var TreeConfiguration
      */
-    protected $config;
+    private array $config;
 
-    /**
-     * @var TreeListener
-     */
-    protected $listener;
+    private TreeListener $listener;
 
     protected function setUp(): void
     {

--- a/tests/Gedmo/Tree/MaterializedPathORMTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathORMTest.php
@@ -22,18 +22,17 @@ use Gedmo\Tree\TreeListener;
  *
  * @author Gustavo Falco <comfortablynumb84@gmail.com>
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ *
+ * @phpstan-import-type TreeConfiguration from TreeListener
  */
 final class MaterializedPathORMTest extends BaseTestCaseORM
 {
     /**
-     * @var array<string, mixed>
+     * @phpstan-var TreeConfiguration
      */
-    protected $config;
+    private array $config;
 
-    /**
-     * @var TreeListener
-     */
-    protected $listener;
+    private TreeListener $listener;
 
     protected function setUp(): void
     {
@@ -169,7 +168,7 @@ final class MaterializedPathORMTest extends BaseTestCaseORM
 
     private function getTreeRootValueOfRootNode(MPCategory $category): string
     {
-        while (null !== $category->getParent()) {
+        while ($category->getParent() instanceof MPCategory) {
             $category = $category->getParent();
         }
 

--- a/tests/Gedmo/Tree/MaterializedPathUuidORMTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathUuidORMTest.php
@@ -23,15 +23,17 @@ use Symfony\Component\Uid\UuidV4;
  * @author Gustavo Falco <comfortablynumb84@gmail.com>
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  * @author Andrea Bergamasco <a.bergamasco@keesystem.com>
+ *
+ * @phpstan-import-type TreeConfiguration from TreeListener
  */
 final class MaterializedPathUuidORMTest extends BaseTestCaseORM
 {
     /**
-     * @var array<string, mixed>
+     * @phpstan-var TreeConfiguration
      */
-    protected array $config;
+    private array $config;
 
-    protected TreeListener $listener;
+    private TreeListener $listener;
 
     protected function setUp(): void
     {
@@ -53,16 +55,16 @@ final class MaterializedPathUuidORMTest extends BaseTestCaseORM
         // Insert
         $category = $this->createCategory();
         $category->setTitle('1');
-        static::assertNotNull($category->getId());
+        static::assertInstanceOf(UuidV4::class, $category->getId());
         $category2 = $this->createCategory();
         $category2->setTitle('2');
-        static::assertNotNull($category2->getId());
+        static::assertInstanceOf(UuidV4::class, $category2->getId());
         $category3 = $this->createCategory();
         $category3->setTitle('3');
-        static::assertNotNull($category3->getId());
+        static::assertInstanceOf(UuidV4::class, $category3->getId());
         $category4 = $this->createCategory();
         $category4->setTitle('4');
-        static::assertNotNull($category4->getId());
+        static::assertInstanceOf(UuidV4::class, $category4->getId());
 
         $category2->setParent($category);
         $category3->setParent($category2);
@@ -162,7 +164,7 @@ final class MaterializedPathUuidORMTest extends BaseTestCaseORM
 
     private function getTreeRootValueOfRootNode(MPCategoryUuid $category): string
     {
-        while (null !== $category->getParent()) {
+        while ($category->getParent() instanceof MPCategoryUuid) {
             $category = $category->getParent();
         }
 

--- a/tests/Gedmo/Tree/NestedTreeRootTest.php
+++ b/tests/Gedmo/Tree/NestedTreeRootTest.php
@@ -398,13 +398,13 @@ final class NestedTreeRootTest extends BaseTestCaseORM
         static::assertSame(4, $fact->getRight());
         static::assertSame(0, $fact->getLevel());
         static::assertSame(1, $fact->getRoot());
-        static::assertNull($fact->getParent());
+        static::assertNotInstanceOf(ForeignRootCategory::class, $fact->getParent());
 
         static::assertSame(5, $fiction->getLeft());
         static::assertSame(10, $fiction->getRight());
         static::assertSame(0, $fiction->getLevel());
         static::assertSame(1, $fiction->getRoot());
-        static::assertNull($fiction->getParent());
+        static::assertNotInstanceOf(ForeignRootCategory::class, $fiction->getParent());
 
         static::assertSame(6, $lotr->getLeft());
         static::assertSame(7, $lotr->getRight());
@@ -428,19 +428,19 @@ final class NestedTreeRootTest extends BaseTestCaseORM
         static::assertSame(2, $comedy->getRight());
         static::assertSame(0, $comedy->getLevel());
         static::assertSame(2, $comedy->getRoot());
-        static::assertNull($comedy->getParent());
+        static::assertNotInstanceOf(ForeignRootCategory::class, $comedy->getParent());
 
         static::assertSame(3, $horror->getLeft());
         static::assertSame(8, $horror->getRight());
         static::assertSame(0, $horror->getLevel());
         static::assertSame(2, $horror->getRoot());
-        static::assertNull($horror->getParent());
+        static::assertNotInstanceOf(ForeignRootCategory::class, $horror->getParent());
 
         static::assertSame(9, $action->getLeft());
         static::assertSame(10, $action->getRight());
         static::assertSame(0, $action->getLevel());
         static::assertSame(2, $action->getRoot());
-        static::assertNull($action->getParent());
+        static::assertNotInstanceOf(ForeignRootCategory::class, $action->getParent());
 
         static::assertSame(4, $dracula->getLeft());
         static::assertSame(5, $dracula->getRight());
@@ -473,7 +473,7 @@ final class NestedTreeRootTest extends BaseTestCaseORM
         static::assertSame(10, $horror->getRight());
         static::assertSame(0, $horror->getLevel());
         static::assertSame(2, $horror->getRoot());
-        static::assertNull($horror->getParent());
+        static::assertNotInstanceOf(ForeignRootCategory::class, $horror->getParent());
 
         static::assertSame(6, $dracula->getLeft());
         static::assertSame(7, $dracula->getRight());

--- a/tests/Gedmo/Tree/RepositoryTest.php
+++ b/tests/Gedmo/Tree/RepositoryTest.php
@@ -262,7 +262,7 @@ final class RepositoryTest extends BaseTestCaseORM
         $vegies = $this->em->getRepository(Category::class)
             ->findOneBy(['title' => 'Vegitables']);
 
-        static::assertNull($vegies);
+        static::assertNotInstanceOf(Category::class, $vegies);
 
         $node = $this->em->getRepository(Category::class)
             ->findOneBy(['title' => 'Fruits']);
@@ -294,7 +294,7 @@ final class RepositoryTest extends BaseTestCaseORM
         $this->em->clear();
 
         $food = $repo->findOneBy(['title' => 'Food']);
-        static::assertNull($food);
+        static::assertNotInstanceOf(Category::class, $food);
 
         $node = $repo->findOneBy(['title' => 'Fruits']);
         $left = $meta->getReflectionProperty('lft')->getValue($node);
@@ -302,7 +302,7 @@ final class RepositoryTest extends BaseTestCaseORM
 
         static::assertSame(1, $left);
         static::assertSame(2, $right);
-        static::assertNull($node->getParent());
+        static::assertNotInstanceOf(Category::class, $node->getParent());
 
         $node = $repo->findOneBy(['title' => 'Vegitables']);
         $left = $meta->getReflectionProperty('lft')->getValue($node);
@@ -310,7 +310,7 @@ final class RepositoryTest extends BaseTestCaseORM
 
         static::assertSame(3, $left);
         static::assertSame(12, $right);
-        static::assertNull($node->getParent());
+        static::assertNotInstanceOf(Category::class, $node->getParent());
     }
 
     public function testVerificationAndRecover(): void
@@ -372,7 +372,7 @@ final class RepositoryTest extends BaseTestCaseORM
 
         static::assertSame(3, $left);
         static::assertSame(12, $right);
-        static::assertNull($food->getParent());
+        static::assertNotInstanceOf(Category::class, $food->getParent());
 
         static::assertTrue($repo->verify());
     }

--- a/tests/Gedmo/Uploadable/Fixture/Entity/Article.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/Article.php
@@ -23,8 +23,6 @@ use Doctrine\ORM\Mapping as ORM;
 class Article
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="IDENTITY")
      * @ORM\Column(type="integer")
@@ -32,7 +30,7 @@ class Article
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string")
@@ -46,7 +44,7 @@ class Article
      * @ORM\OneToMany(targetEntity="File", mappedBy="article", cascade={"persist", "remove"})
      */
     #[ORM\OneToMany(targetEntity: File::class, mappedBy: 'article', cascade: ['persist', 'remove'])]
-    private $files;
+    private Collection $files;
 
     private ?string $filePath = null;
 

--- a/tests/Gedmo/Uploadable/Fixture/Entity/File.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/File.php
@@ -30,8 +30,6 @@ class File
     public $callbackWasCalled = false;
 
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="IDENTITY")
      * @ORM\Column(type="integer")
@@ -39,7 +37,7 @@ class File
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", nullable=true)

--- a/tests/Gedmo/Uploadable/Fixture/Entity/FileAppendNumber.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/FileAppendNumber.php
@@ -25,8 +25,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class FileAppendNumber
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="IDENTITY")
      * @ORM\Column(type="integer")
@@ -34,7 +32,7 @@ class FileAppendNumber
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", nullable=true)

--- a/tests/Gedmo/Uploadable/Fixture/Entity/FileAppendNumberRelative.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/FileAppendNumberRelative.php
@@ -26,8 +26,6 @@ use Gedmo\Uploadable\Mapping\Validator;
 class FileAppendNumberRelative
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="IDENTITY")
      * @ORM\Column(type="integer")
@@ -35,7 +33,7 @@ class FileAppendNumberRelative
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", nullable=true)

--- a/tests/Gedmo/Uploadable/Fixture/Entity/FileWithAllowedTypes.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/FileWithAllowedTypes.php
@@ -25,8 +25,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class FileWithAllowedTypes
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="IDENTITY")
      * @ORM\Column(type="integer")
@@ -34,7 +32,7 @@ class FileWithAllowedTypes
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", nullable=true)

--- a/tests/Gedmo/Uploadable/Fixture/Entity/FileWithAlphanumericName.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/FileWithAlphanumericName.php
@@ -26,8 +26,6 @@ use Gedmo\Uploadable\Mapping\Validator;
 class FileWithAlphanumericName
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="IDENTITY")
      * @ORM\Column(type="integer")
@@ -35,7 +33,7 @@ class FileWithAlphanumericName
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="path", type="string", nullable=true)

--- a/tests/Gedmo/Uploadable/Fixture/Entity/FileWithCustomFilenameGenerator.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/FileWithCustomFilenameGenerator.php
@@ -26,8 +26,6 @@ use Gedmo\Tests\Uploadable\FakeFilenameGenerator;
 class FileWithCustomFilenameGenerator
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="IDENTITY")
      * @ORM\Column(type="integer")
@@ -35,7 +33,7 @@ class FileWithCustomFilenameGenerator
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="path", type="string", nullable=true)

--- a/tests/Gedmo/Uploadable/Fixture/Entity/FileWithDisallowedTypes.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/FileWithDisallowedTypes.php
@@ -25,8 +25,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class FileWithDisallowedTypes
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="IDENTITY")
      * @ORM\Column(type="integer")
@@ -34,7 +32,7 @@ class FileWithDisallowedTypes
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", nullable=true)

--- a/tests/Gedmo/Uploadable/Fixture/Entity/FileWithMaxSize.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/FileWithMaxSize.php
@@ -24,14 +24,9 @@ use Gedmo\Mapping\Annotation as Gedmo;
 #[Gedmo\Uploadable(allowOverwrite: true, pathMethod: 'getPath', callback: 'callbackMethod', maxSize: '2')]
 class FileWithMaxSize
 {
-    /**
-     * @var bool
-     */
-    public $callbackWasCalled = false;
+    public bool $callbackWasCalled = false;
 
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="IDENTITY")
      * @ORM\Column(type="integer")
@@ -39,7 +34,7 @@ class FileWithMaxSize
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string", nullable=true)

--- a/tests/Gedmo/Uploadable/Fixture/Entity/FileWithSha1Name.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/FileWithSha1Name.php
@@ -26,8 +26,6 @@ use Gedmo\Uploadable\Mapping\Validator;
 class FileWithSha1Name
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="IDENTITY")
      * @ORM\Column(type="integer")
@@ -35,7 +33,7 @@ class FileWithSha1Name
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="path", type="string", nullable=true)

--- a/tests/Gedmo/Uploadable/Fixture/Entity/FileWithoutPath.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/FileWithoutPath.php
@@ -25,8 +25,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class FileWithoutPath
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="IDENTITY")
      * @ORM\Column(type="integer")
@@ -34,7 +32,7 @@ class FileWithoutPath
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="path", type="string", nullable=true)

--- a/tests/Gedmo/Uploadable/Fixture/Entity/Image.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/Image.php
@@ -25,8 +25,6 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Image
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="IDENTITY")
      * @ORM\Column(type="integer")
@@ -34,7 +32,7 @@ class Image
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(name="title", type="string")

--- a/tests/Gedmo/Uploadable/Mapping/ValidatorTest.php
+++ b/tests/Gedmo/Uploadable/Mapping/ValidatorTest.php
@@ -29,9 +29,9 @@ use PHPUnit\Framework\TestCase;
 final class ValidatorTest extends TestCase
 {
     /**
-     * @var ClassMetadata<object>&MockObject
+     * @var MockObject&ClassMetadata<object>
      */
-    protected $meta;
+    protected MockObject&ClassMetadata $meta;
 
     protected function setUp(): void
     {
@@ -52,7 +52,7 @@ final class ValidatorTest extends TestCase
         $this->expectException(InvalidMappingException::class);
         $this->meta->expects(static::once())
             ->method('getFieldMapping')
-            ->willReturnCallback(static function (string $fieldName) {
+            ->willReturnCallback(static function (string $fieldName): FieldMapping|array {
                 if (class_exists(FieldMapping::class)) {
                     return FieldMapping::fromMappingArray(['type' => 'someType', 'fieldName' => $fieldName, 'columnName' => $fieldName]);
                 }
@@ -129,7 +129,7 @@ final class ValidatorTest extends TestCase
             ->willReturn(new \ReflectionClass(new FakeEntity()));
         $this->meta
             ->method('getFieldMapping')
-            ->willReturnCallback(static function (string $fieldName) {
+            ->willReturnCallback(static function (string $fieldName): FieldMapping|array {
                 if (class_exists(FieldMapping::class)) {
                     return FieldMapping::fromMappingArray(['type' => 'someType', 'fieldName' => $fieldName, 'columnName' => $fieldName]);
                 }
@@ -164,7 +164,7 @@ final class ValidatorTest extends TestCase
             ->willReturn(new \ReflectionClass(new FakeEntity()));
         $this->meta
             ->method('getFieldMapping')
-            ->willReturnCallback(static function (string $fieldName) {
+            ->willReturnCallback(static function (string $fieldName): FieldMapping|array {
                 if (class_exists(FieldMapping::class)) {
                     return FieldMapping::fromMappingArray(['type' => 'someType', 'fieldName' => $fieldName, 'columnName' => $fieldName]);
                 }
@@ -198,7 +198,7 @@ final class ValidatorTest extends TestCase
             ->willReturn(new \ReflectionClass(new FakeEntity()));
         $this->meta
             ->method('getFieldMapping')
-            ->willReturnCallback(static function (string $fieldName) {
+            ->willReturnCallback(static function (string $fieldName): FieldMapping|array {
                 if (class_exists(FieldMapping::class)) {
                     return FieldMapping::fromMappingArray(['type' => 'string', 'fieldName' => $fieldName, 'columnName' => $fieldName]);
                 }
@@ -232,7 +232,7 @@ final class ValidatorTest extends TestCase
             ->willReturn(new \ReflectionClass(new FakeEntity()));
         $this->meta
             ->method('getFieldMapping')
-            ->willReturnCallback(static function (string $fieldName) {
+            ->willReturnCallback(static function (string $fieldName): FieldMapping|array {
                 if (class_exists(FieldMapping::class)) {
                     return FieldMapping::fromMappingArray(['type' => 'string', 'fieldName' => $fieldName, 'columnName' => $fieldName]);
                 }
@@ -310,6 +310,4 @@ final class ValidatorTest extends TestCase
     }
 }
 
-class FakeEntity
-{
-}
+class FakeEntity {}

--- a/tests/Gedmo/Uploadable/Stub/FileInfoStub.php
+++ b/tests/Gedmo/Uploadable/Stub/FileInfoStub.php
@@ -15,32 +15,32 @@ use Gedmo\Uploadable\FileInfo\FileInfoInterface;
 
 final class FileInfoStub implements FileInfoInterface
 {
-    public function getTmpName()
+    public function getTmpName(): never
     {
         throw new \BadMethodCallException('Not implemented.');
     }
 
-    public function getName()
+    public function getName(): never
     {
         throw new \BadMethodCallException('Not implemented.');
     }
 
-    public function getSize()
+    public function getSize(): never
     {
         throw new \BadMethodCallException('Not implemented.');
     }
 
-    public function getType()
+    public function getType(): never
     {
         throw new \BadMethodCallException('Not implemented.');
     }
 
-    public function getError()
+    public function getError(): never
     {
         throw new \BadMethodCallException('Not implemented.');
     }
 
-    public function isUploadedFile()
+    public function isUploadedFile(): never
     {
         throw new \BadMethodCallException('Not implemented.');
     }

--- a/tests/Gedmo/Uploadable/Stub/MimeTypeGuesserStub.php
+++ b/tests/Gedmo/Uploadable/Stub/MimeTypeGuesserStub.php
@@ -15,17 +15,9 @@ use Gedmo\Uploadable\MimeType\MimeTypeGuesserInterface;
 
 class MimeTypeGuesserStub implements MimeTypeGuesserInterface
 {
-    /**
-     * @var string|null
-     */
-    protected $mimeType;
+    public function __construct(protected ?string $mimeType) {}
 
-    public function __construct(?string $mimeType)
-    {
-        $this->mimeType = $mimeType;
-    }
-
-    public function guess($path): ?string
+    public function guess($filePath): ?string
     {
         return $this->mimeType;
     }

--- a/tests/Gedmo/Uploadable/Stub/UploadableListenerStub.php
+++ b/tests/Gedmo/Uploadable/Stub/UploadableListenerStub.php
@@ -15,10 +15,7 @@ use Gedmo\Uploadable\UploadableListener;
 
 final class UploadableListenerStub extends UploadableListener
 {
-    /**
-     * @var bool
-     */
-    public $returnFalseOnMoveUploadedFile = false;
+    public bool $returnFalseOnMoveUploadedFile = false;
 
     public function doMoveFile($source, $dest, $isUploadedFile = true): bool
     {

--- a/tests/Gedmo/Uploadable/UploadableEntityTest.php
+++ b/tests/Gedmo/Uploadable/UploadableEntityTest.php
@@ -320,6 +320,8 @@ final class UploadableEntityTest extends BaseTestCaseORM
     }
 
     /**
+     * @param class-string<UploadableException> $exceptionClass
+     *
      * @dataProvider uploadExceptionsProvider
      */
     public function testUploadExceptions(int $error, string $exceptionClass): void
@@ -363,7 +365,7 @@ final class UploadableEntityTest extends BaseTestCaseORM
 
         $this->em->refresh($file);
 
-        $sha1String = substr($file->getFilePath(), strrpos($file->getFilePath(), '/') + 1);
+        $sha1String = substr((string) $file->getFilePath(), strrpos((string) $file->getFilePath(), '/') + 1);
         $sha1String = str_replace('.txt', '', $sha1String);
 
         static::assertMatchesRegularExpression('/[a-z0-9]{40}/', $sha1String);
@@ -381,7 +383,7 @@ final class UploadableEntityTest extends BaseTestCaseORM
 
         $this->em->refresh($file);
 
-        $filename = substr($file->getFilePath(), strrpos($file->getFilePath(), '/') + 1);
+        $filename = substr((string) $file->getFilePath(), strrpos((string) $file->getFilePath(), '/') + 1);
 
         static::assertSame('test-3.txt', $filename);
     }
@@ -398,7 +400,7 @@ final class UploadableEntityTest extends BaseTestCaseORM
 
         $this->em->refresh($file);
 
-        $filename = substr($file->getFilePath(), strrpos($file->getFilePath(), '/') + 1);
+        $filename = substr((string) $file->getFilePath(), strrpos((string) $file->getFilePath(), '/') + 1);
 
         static::assertSame('123.txt', $filename);
     }
@@ -479,19 +481,17 @@ final class UploadableEntityTest extends BaseTestCaseORM
     }
 
     /**
-     * @return array<string, array<string, string>>
+     * @return \Iterator<string, array<string, string>>
      */
-    public static function dataProvider_testMoveFileUsingAppendNumberOptionAppendsNumberToFilenameIfItAlreadyExists(): array
+    public static function dataProvider_testMoveFileUsingAppendNumberOptionAppendsNumberToFilenameIfItAlreadyExists(): \Iterator
     {
-        return [
-            'With extension' => [
-                'Filename' => 'test.txt',
-                'Expected filename' => 'test-2.txt',
-            ],
-            'Without extension' => [
-                'Filename' => 'test',
-                'Expected filename' => 'test-2',
-            ],
+        yield 'With extension' => [
+            'Filename' => 'test.txt',
+            'Expected filename' => 'test-2.txt',
+        ];
+        yield 'Without extension' => [
+            'Filename' => 'test',
+            'Expected filename' => 'test-2',
         ];
     }
 
@@ -520,7 +520,7 @@ final class UploadableEntityTest extends BaseTestCaseORM
 
         $this->em->refresh($file2);
 
-        static::assertSame($expectedFilename, basename($file2->getFilePath()));
+        static::assertSame($expectedFilename, basename((string) $file2->getFilePath()));
     }
 
     public function testMoveFileUsingAppendNumberOptionAppendsNumberToFilenameIfItAlreadyExistsRelativePath(): void
@@ -663,11 +663,9 @@ final class UploadableEntityTest extends BaseTestCaseORM
     }
 
     /**
-     * @param mixed $class
-     *
      * @dataProvider invalidFileInfoClassesProvider
      */
-    public function testSetDefaultFileInfoClassThrowExceptionIfInvalidClassArePassed($class): void
+    public function testSetDefaultFileInfoClassThrowExceptionIfInvalidClassArePassed(mixed $class): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->listener->setDefaultFileInfoClass($class);
@@ -714,37 +712,31 @@ final class UploadableEntityTest extends BaseTestCaseORM
     // Data Providers
 
     /**
-     * @return list<array{mixed}>
+     * @return \Generator<array{mixed}>
      */
-    public static function invalidFileInfoClassesProvider(): array
+    public static function invalidFileInfoClassesProvider(): \Generator
     {
-        return [
-            [''],
-            [false],
-            [null],
-            ['FakeFileInfo'],
-            [[]],
-            [new \DateTime()],
-        ];
+        yield [''];
+        yield [false];
+        yield [null];
+        yield ['FakeFileInfo'];
+        yield [[]];
+        yield [new \DateTime()];
     }
 
     /**
-     * @return list<int, array{int, string}>
-     *
-     * @phpstan-return list<array{int, class-string<UploadableException>}>
+     * @phpstan-return \Generator<array{int, class-string<UploadableException>}>
      */
-    public static function uploadExceptionsProvider(): array
+    public static function uploadExceptionsProvider(): \Generator
     {
-        return [
-            [1, UploadableIniSizeException::class],
-            [2, UploadableFormSizeException::class],
-            [3, UploadablePartialException::class],
-            [4, UploadableNoFileException::class],
-            [6, UploadableNoTmpDirException::class],
-            [7, UploadableCantWriteException::class],
-            [8, UploadableExtensionException::class],
-            [999, UploadableUploadException::class],
-        ];
+        yield [1, UploadableIniSizeException::class];
+        yield [2, UploadableFormSizeException::class];
+        yield [3, UploadablePartialException::class];
+        yield [4, UploadableNoFileException::class];
+        yield [6, UploadableNoTmpDirException::class];
+        yield [7, UploadableCantWriteException::class];
+        yield [8, UploadableExtensionException::class];
+        yield [999, UploadableUploadException::class];
     }
 
     protected function getUsedEntityFixtures(): array
@@ -804,9 +796,7 @@ final class UploadableEntityTest extends BaseTestCaseORM
     }
 }
 
-class FakeFileInfo
-{
-}
+class FakeFileInfo {}
 
 class FakeFilenameGenerator implements FilenameGeneratorInterface
 {

--- a/tests/Gedmo/Wrapper/Fixture/Document/Article.php
+++ b/tests/Gedmo/Wrapper/Fixture/Document/Article.php
@@ -21,12 +21,10 @@ use Doctrine\ODM\MongoDB\Types\Type;
 class Article
 {
     /**
-     * @var string|null
-     *
      * @MongoODM\Id
      */
     #[MongoODM\Id]
-    private $id;
+    private ?string $id = null;
 
     /**
      * @MongoODM\Field(type="string")

--- a/tests/Gedmo/Wrapper/Fixture/Entity/Article.php
+++ b/tests/Gedmo/Wrapper/Fixture/Entity/Article.php
@@ -21,8 +21,6 @@ use Doctrine\ORM\Mapping as ORM;
 class Article
 {
     /**
-     * @var int|null
-     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -30,7 +28,7 @@ class Article
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(length=128)

--- a/tests/Gedmo/Wrapper/Fixture/Entity/Composite.php
+++ b/tests/Gedmo/Wrapper/Fixture/Entity/Composite.php
@@ -19,32 +19,27 @@ use Doctrine\ORM\Mapping as ORM;
 class Composite
 {
     /**
-     * @ORM\Id
-     * @ORM\Column(type="integer")
-     */
-    #[ORM\Id]
-    #[ORM\Column(type: Types::INTEGER)]
-    private int $one;
-
-    /**
-     * @ORM\Id
-     * @ORM\Column(type="integer")
-     */
-    #[ORM\Id]
-    #[ORM\Column(type: Types::INTEGER)]
-    private int $two;
-
-    /**
      * @ORM\Column(length=128)
      */
     #[ORM\Column(length: 128)]
     private ?string $title = null;
 
-    public function __construct(int $one, int $two)
-    {
-        $this->one = $one;
-        $this->two = $two;
-    }
+    public function __construct(
+        /**
+         * @ORM\Id
+         * @ORM\Column(type="integer")
+         */
+        #[ORM\Id]
+        #[ORM\Column(type: Types::INTEGER)]
+        private int $one,
+        /**
+         * @ORM\Id
+         * @ORM\Column(type="integer")
+         */
+        #[ORM\Id]
+        #[ORM\Column(type: Types::INTEGER)]
+        private int $two
+    ) {}
 
     public function getOne(): int
     {

--- a/tests/Gedmo/Wrapper/Fixture/Entity/CompositeRelation.php
+++ b/tests/Gedmo/Wrapper/Fixture/Entity/CompositeRelation.php
@@ -44,9 +44,9 @@ class CompositeRelation
     #[ORM\Column(length: 128)]
     private ?string $title = null;
 
-    public function __construct(Article $articleOne, int $status)
+    public function __construct(Article $article, int $status)
     {
-        $this->article = $articleOne;
+        $this->article = $article;
         $this->status = $status;
     }
 

--- a/tests/Gedmo/Wrapper/MongoDocumentWrapperTest.php
+++ b/tests/Gedmo/Wrapper/MongoDocumentWrapperTest.php
@@ -50,7 +50,7 @@ final class MongoDocumentWrapperTest extends BaseTestCaseMongoODM
     {
         $this->dm->clear();
         $test = $this->dm->getReference(Article::class, $this->articleId);
-        static::assertStringStartsWith('Proxy', get_class($test));
+        static::assertStringStartsWith('Proxy', $test::class);
         static::assertInstanceOf(Article::class, $test);
         $wrapped = new MongoDocumentWrapper($test, $this->dm);
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -29,7 +29,7 @@ define('TESTS_PATH', __DIR__);
 define('TESTS_TEMP_DIR', sys_get_temp_dir().'/doctrine-extension-tests');
 
 if (!is_dir(TESTS_TEMP_DIR)) {
-    mkdir(TESTS_TEMP_DIR, 0755, true);
+    mkdir(TESTS_TEMP_DIR, 0o755, true);
 }
 
 require dirname(__DIR__).'/vendor/autoload.php';


### PR DESCRIPTION
According to the Packagist stats there was a large fall off PHP 7 users after the 3.14 release, which is when the requirement was bumped up to PHP 7.4.  Since then, PHP 7.4 and 8.0 combined have had pretty small numbers on newer release branches and is generally now under 5% of the install base.  So this PR bumps the requirement to PHP 8.1.

The overwhelming majority of the code changes are from adjusting the Rector and PHP-CS-Fixer configs to apply PHP 8.1 rulesets, with a second pass specifically on the tests to add type declarations there, then only minor corrections or tweaks by my own review along the way.