### PR TITLE
Use the object managers to check for initialized objects

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -541,12 +541,6 @@ parameters:
 			path: src/Timestampable/Mapping/Driver/Yaml.php
 
 		-
-			message: '#^Access to an undefined property ProxyManager\\Proxy\\GhostObjectInterface&TObject of object\:\:\$identifier\.$#'
-			identifier: property.notFound
-			count: 1
-			path: src/Tool/Wrapper/MongoDocumentWrapper.php
-
-		-
 			message: '#^Call to function property_exists\(\) with \$this\(Gedmo\\Translatable\\Hydrator\\ORM\\ObjectHydrator\) and ''_em'' will always evaluate to false\.$#'
 			identifier: function.impossibleType
 			count: 1

--- a/src/Tool/Wrapper/EntityWrapper.php
+++ b/src/Tool/Wrapper/EntityWrapper.php
@@ -11,7 +11,6 @@ namespace Gedmo\Tool\Wrapper;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\Persistence\Proxy as PersistenceProxy;
 use Gedmo\Tool\ClassUtils;
 
 /**
@@ -34,11 +33,6 @@ class EntityWrapper extends AbstractWrapper
      * @var array<string, mixed>|null
      */
     private $identifier;
-
-    /**
-     * True if entity or proxy is loaded
-     */
-    private bool $initialized = false;
 
     /**
      * Wrap entity
@@ -124,12 +118,8 @@ class EntityWrapper extends AbstractWrapper
      */
     protected function initialize()
     {
-        if (!$this->initialized) {
-            if ($this->object instanceof PersistenceProxy) {
-                if (!$this->object->__isInitialized()) {
-                    $this->object->__load();
-                }
-            }
+        if ($this->om->isUninitializedObject($this->object)) {
+            $this->om->initializeObject($this->object);
         }
     }
 }

--- a/src/Tool/Wrapper/MongoDocumentWrapper.php
+++ b/src/Tool/Wrapper/MongoDocumentWrapper.php
@@ -33,11 +33,6 @@ class MongoDocumentWrapper extends AbstractWrapper
     private ?string $identifier = null;
 
     /**
-     * True if document or proxy is loaded
-     */
-    private bool $initialized = false;
-
-    /**
      * Wrap document
      *
      * @param TObject $document
@@ -111,24 +106,15 @@ class MongoDocumentWrapper extends AbstractWrapper
      */
     protected function initialize()
     {
-        if (!$this->initialized) {
-            if ($this->object instanceof GhostObjectInterface) {
-                $uow = $this->om->getUnitOfWork();
-                if (!$this->object->isProxyInitialized()) {
-                    $persister = $uow->getDocumentPersister($this->meta->getName());
-                    $identifier = null;
-                    if ($uow->isInIdentityMap($this->object)) {
-                        $identifier = $this->getIdentifier();
-                    } else {
-                        // this may not happen but in case
-                        $getIdentifier = \Closure::bind(fn () => $this->identifier, $this->object, get_class($this->object));
+        if (method_exists($this->om, 'isUninitializedObject') && $this->om->isUninitializedObject($this->object)) {
+            $this->om->initializeObject($this->object);
 
-                        $identifier = $getIdentifier();
-                    }
-                    $this->object->initializeProxy();
-                    $persister->load($identifier, $this->object);
-                }
-            }
+            return;
+        }
+
+        // @todo: Drop support for this fallback when requiring `doctrine/mongodb-odm:^2.6 as a minimum`
+        if ($this->object instanceof GhostObjectInterface && !$this->object->isProxyInitialized()) {
+            $this->om->initializeObject($this->object);
         }
     }
 }


### PR DESCRIPTION
Instead of handling proxy loading in the wrappers, the APIs the object managers expose (all of which are part of the interface in `doctrine/persistence` 4.0 and exist in some form in the managers themselves going back quite some time) can be used to take care of this.

This especially becomes useful as the upstream projects start adding support for PHP 8.4's lazy objects (as https://github.com/doctrine/orm/pull/11853 has done for the ORM).