### PR TITLE
[#2006] Allow `integer` type for blamable fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ a release.
 ### Changed
 - All: Removed the dollar sign from the generated cache ID for extension metadata to ensure only characters mandated by [PSR-6](https://www.php-fig.org/psr/psr-6/#definitions) are used, improving compatibility with caching implementations with strict character requirements (#2978)
 
+### Fixed
+- Blameable: (Re-) Added integer in allowed types list for Blameable fields (#2006)
+
 ## [3.22.0] - 2025-12-13
 ### Added
 - Support for Symfony 8

--- a/src/Blameable/Mapping/Driver/Attribute.php
+++ b/src/Blameable/Mapping/Driver/Attribute.php
@@ -36,6 +36,7 @@ class Attribute extends AbstractAnnotationDriver
         'one',
         'string',
         'int',
+        'integer',
         'ulid',
         'uuid',
         'ascii_string',
@@ -65,12 +66,12 @@ class Attribute extends AbstractAnnotationDriver
 
                 if ($meta->hasField($field)) {
                     if (!$this->isValidField($meta, $field)) {
-                        throw new InvalidMappingException("Field - [{$field}] type is not valid and must be 'string' or a one-to-many relation in class - {$meta->getName()}");
+                        throw new InvalidMappingException("Field - [{$field}] type is not valid and must be 'string', 'integer' or a one-to-many relation in class - {$meta->getName()}");
                     }
                 } else {
                     // association
                     if (!$meta->isSingleValuedAssociation($field)) {
-                        throw new InvalidMappingException("Association - [{$field}] is not valid, it must be a one-to-many relation or a string field - {$meta->getName()}");
+                        throw new InvalidMappingException("Association - [{$field}] is not valid, it must be a one-to-many relation or a string or integer field - {$meta->getName()}");
                     }
                 }
 

--- a/tests/Gedmo/Blameable/BlameableIntegerTest.php
+++ b/tests/Gedmo/Blameable/BlameableIntegerTest.php
@@ -47,7 +47,7 @@ final class BlameableIntegerTest extends BaseTestCaseORM
          * @var CompanyInteger $foundCompany
          */
         $foundCompany = $this->em->getRepository(CompanyInteger::class)->findOneBy(['name' => 'My Name']);
-        $creator      = $foundCompany->getCreator();
+        $creator = $foundCompany->getCreator();
 
         static::assertSame($this->userId, $creator);
     }

--- a/tests/Gedmo/Blameable/BlameableIntegerTest.php
+++ b/tests/Gedmo/Blameable/BlameableIntegerTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Blameable;
+
+use Doctrine\Common\EventManager;
+use Gedmo\Tests\Blameable\Fixture\Entity\CompanyInteger;
+use Gedmo\Tests\Tool\BaseTestCaseORM;
+
+final class BlameableIntegerTest extends BaseTestCaseORM
+{
+    private int $userId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->userId = 42;
+
+        $listener = new BlameableListener();
+        $listener->setUserValue($this->userId);
+
+        $evm = new EventManager();
+        $evm->addEventSubscriber($listener);
+
+        $this->getDefaultMockSqliteEntityManager($evm);
+    }
+
+    public function testBlameableInteger(): void
+    {
+        $company = new CompanyInteger();
+        $company->setName('My Name');
+
+        $this->em->persist($company);
+        $this->em->flush();
+        $this->em->clear();
+
+        /**
+         * @var CompanyInteger $foundCompany
+         */
+        $foundCompany = $this->em->getRepository(CompanyInteger::class)->findOneBy(['name' => 'My Name']);
+        $creator      = $foundCompany->getCreator();
+
+        static::assertSame($this->userId, $creator);
+    }
+
+    protected function getUsedEntityFixtures(): array
+    {
+        return [
+            CompanyInteger::class,
+        ];
+    }
+}

--- a/tests/Gedmo/Blameable/BlameableIntegerTest.php
+++ b/tests/Gedmo/Blameable/BlameableIntegerTest.php
@@ -43,10 +43,8 @@ final class BlameableIntegerTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        /**
-         * @var CompanyInteger $foundCompany
-         */
         $foundCompany = $this->em->getRepository(CompanyInteger::class)->findOneBy(['name' => 'My Name']);
+        assert($foundCompany instanceof CompanyInteger);
         $creator = $foundCompany->getCreator();
 
         static::assertSame($this->userId, $creator);

--- a/tests/Gedmo/Blameable/Fixture/Entity/CompanyInteger.php
+++ b/tests/Gedmo/Blameable/Fixture/Entity/CompanyInteger.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Gedmo\Tests\Blameable\Fixture\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * @ORM\Entity
+ */
+#[ORM\Entity]
+class CompanyInteger
+{
+    /**
+     * @var int|null
+     *
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    private $id;
+
+    /**
+     * @ORM\Column(name="name", type="string", length=128)
+     */
+    #[ORM\Column(name: 'name', type: Types::STRING, length: 128)]
+    private ?string $name = null;
+
+    /**
+     * @var int|null
+     *
+     * @Gedmo\Blameable(on="create")
+     * @ORM\Column(name="creator", type="integer")
+     */
+    #[ORM\Column(name: 'creator', type: Types::INTEGER)]
+    #[Gedmo\Blameable(on: 'create')]
+    private $creator;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setName(?string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function getCreator(): ?int
+    {
+        return $this->creator;
+    }
+
+    public function setCreator(?int $creator): void
+    {
+        $this->creator = $creator;
+    }
+}


### PR DESCRIPTION
As discussed in #2006 it is currently not possible to have blamable fields backed by `integer` columns. This PR (re-) adds the `integer` type to the list of valid field types.
