### PR TITLE
Use public property instead of deprecated array access

### DIFF
--- a/src/Loggable/Mapping/Driver/Attribute.php
+++ b/src/Loggable/Mapping/Driver/Attribute.php
@@ -11,6 +11,7 @@ namespace Gedmo\Loggable\Mapping\Driver;
 
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata as ClassMetadataODM;
 use Doctrine\ORM\Mapping\ClassMetadata as ClassMetadataORM;
+use Doctrine\ORM\Mapping\EmbeddedClassMapping;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Gedmo\Exception\InvalidMappingException;
 use Gedmo\Mapping\Annotation\Loggable;
@@ -137,7 +138,9 @@ class Attribute extends AbstractAnnotationDriver
      */
     private function inspectEmbeddedForVersioned(string $field, array &$config, ClassMetadataORM $meta): void
     {
-        $class = new \ReflectionClass($meta->embeddedClasses[$field]['class']);
+        /** Remove conditional when ORM 2.x is no longer supported. */
+        $className = ($meta->embeddedClasses[$field] instanceof EmbeddedClassMapping) ? $meta->embeddedClasses[$field]->class : $meta->embeddedClasses[$field]['class'];
+        $class = new \ReflectionClass($className);
 
         // property annotations
         foreach ($class->getProperties() as $property) {

--- a/src/Sluggable/Mapping/Driver/Attribute.php
+++ b/src/Sluggable/Mapping/Driver/Attribute.php
@@ -9,6 +9,7 @@
 
 namespace Gedmo\Sluggable\Mapping\Driver;
 
+use Doctrine\ORM\Mapping\EmbeddedClassMapping;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Gedmo\Exception\InvalidMappingException;
 use Gedmo\Mapping\Annotation\Slug;
@@ -82,7 +83,9 @@ class Attribute extends AbstractAnnotationDriver
         // Embedded entity
         if (property_exists($meta, 'embeddedClasses') && $meta->embeddedClasses) {
             foreach ($meta->embeddedClasses as $propertyName => $embeddedClassInfo) {
-                $embeddedClass = new \ReflectionClass($embeddedClassInfo['class']);
+                /** Remove conditional when ORM 2.x is no longer supported. */
+                $className = ($embeddedClassInfo instanceof EmbeddedClassMapping) ? $embeddedClassInfo->class : $embeddedClassInfo['class'];
+                $embeddedClass = new \ReflectionClass($className);
 
                 foreach ($embeddedClass->getProperties() as $embeddedProperty) {
                     $config = $this->retrieveSlug($meta, $config, $embeddedProperty, $propertyName);

--- a/src/Translatable/Mapping/Driver/Attribute.php
+++ b/src/Translatable/Mapping/Driver/Attribute.php
@@ -9,6 +9,7 @@
 
 namespace Gedmo\Translatable\Mapping\Driver;
 
+use Doctrine\ORM\Mapping\EmbeddedClassMapping;
 use Gedmo\Exception\InvalidMappingException;
 use Gedmo\Mapping\Annotation\Language;
 use Gedmo\Mapping\Annotation\Locale;
@@ -118,7 +119,9 @@ class Attribute extends AbstractAnnotationDriver
                     continue;
                 }
 
-                $embeddedClass = new \ReflectionClass($embeddedClassInfo['class']);
+                /** Remove conditional when ORM 2.x is no longer supported. */
+                $className = ($embeddedClassInfo instanceof EmbeddedClassMapping) ? $embeddedClassInfo->class : $embeddedClassInfo['class'];
+                $embeddedClass = new \ReflectionClass($className);
 
                 foreach ($embeddedClass->getProperties() as $embeddedProperty) {
                     if ($translatable = $this->reader->getPropertyAnnotation($embeddedProperty, self::TRANSLATABLE)) {

--- a/src/Translatable/Mapping/Driver/Xml.php
+++ b/src/Translatable/Mapping/Driver/Xml.php
@@ -9,6 +9,7 @@
 
 namespace Gedmo\Translatable\Mapping\Driver;
 
+use Doctrine\ORM\Mapping\EmbeddedClassMapping;
 use Gedmo\Exception\InvalidMappingException;
 use Gedmo\Mapping\Driver\Xml as BaseXml;
 
@@ -61,7 +62,10 @@ class Xml extends BaseXml
                 if ($meta->isInheritedEmbeddedClass($propertyName)) {
                     continue;
                 }
-                $xmlEmbeddedClass = $this->_getMapping($embeddedClassInfo['class']);
+
+                /** Remove conditional when ORM 2.x is no longer supported. */
+                $className = ($embeddedClassInfo instanceof EmbeddedClassMapping) ? $embeddedClassInfo->class : $embeddedClassInfo['class'];
+                $xmlEmbeddedClass = $this->_getMapping($className);
                 $config = $this->inspectElementsForTranslatableFields($xmlEmbeddedClass, $config, $propertyName);
             }
         }


### PR DESCRIPTION
This is a follow-up to #2925.  
It applies the fix using [`EmbeddedClassMapping`](https://github.com/doctrine/orm/blob/3.0.0/src/Mapping/EmbeddedClassMapping.php), introduced in Doctrine ORM 3.0, **only when it is available**, ensuring compatibility with previous versions.

The fix is applied on `Loggable`, `Sluggable`, and `Translatable`.