### PR TITLE
Add a deprecations baseline to ignore selected deprecations in tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
         "rector/rector": "^2.0.6",
         "symfony/console": "^5.4 || ^6.0 || ^7.0",
         "symfony/doctrine-bridge": "^5.4 || ^6.0 || ^7.0",
-        "symfony/phpunit-bridge": "^6.0 || ^7.0",
+        "symfony/phpunit-bridge": "^6.4 || ^7.0",
         "symfony/uid": "^5.4 || ^6.0 || ^7.0",
         "symfony/yaml": "^5.4 || ^6.0 || ^7.0"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -67,7 +67,7 @@
         </testsuite>
     </testsuites>
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="ignoreFile=./tests/symfony-deprecations-baseline&amp;max[self]=0" />
         <env name="MONGODB_SERVER" value="mongodb://mongodb:27017"/>
     </php>
     <listeners>

--- a/tests/symfony-deprecations-baseline
+++ b/tests/symfony-deprecations-baseline
@@ -1,0 +1,6 @@
+# Ignore MongoDB deprecations from low dependencies
+%Passing an integer mode to "MongoDB\\Driver\\ReadPreference::__construct" is deprecated%
+# Ignore deprecated ORM 2.x proxies
+%class implements "Doctrine\\ORM\\Proxy\\Proxy" that is deprecated%
+# Ignore symfony/var-dumper lazy ghost deprecations (required for PHP 8.3 and earlier compat)
+%Using ProxyHelper::generateLazyGhost() is deprecated%


### PR DESCRIPTION
Symfony 7.3 deprecates the lazy ghosts functionality in the VarExporter component in favor of the native PHP lazy objects features.  As this is an unfixable deprecation from this package's perspective, the indirect deprecation notices this raises can be ignored.