### PR TITLE
[Translateable] Document the usage of refresh query hint if cache is used

### DIFF
--- a/doc/translatable.md
+++ b/doc/translatable.md
@@ -506,6 +506,11 @@ $query->setHint(
     \Gedmo\Translatable\TranslatableListener::HINT_FALLBACK,
     1 // fallback to default values in case if record is not translated
 );
+// refresh entities
+$query->setHint(
+    \Doctrine\ORM\Query::HINT_REFRESH,
+    true // update entity with correct locale if it was already loaded before
+);
 
 $articles = $query->getResult(); // object hydration
 ```


### PR DESCRIPTION
This addition to the documentation helps to prevent for running into the issue #1021.

This is the issue in short:
If query caching is enabled the `TranslationWalker` won't be used anymore once the query is cached. Therefore the `Query::HINT_REFRESH`, which is normally set by the `TranslationWalker`, won't be set automatically.
This leads to the issue, that once a translatable entity is loaded a second query with another locale won't update the translatable properties in the entity.

Adding the `Query::HINT_REFRESH` manually to the query will fix the issue.