### PR TITLE
Use getFieldValue and setFieldValue methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ a release.
 
 ### Changed
 - Sluggable: Replaced abandoned `behat/transliterator` with `symfony/string` for default transliteration and urlization steps (#2985)
+- Use `getFieldValue` and `setFieldValue` methods to support `doctrine/orm` >= 3.4 (#2966)
 
 ## [3.20.1] - 2025-09-14
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,10 @@ a release.
 
 ### Changed
 - Sluggable: Replaced abandoned `behat/transliterator` with `symfony/string` for default transliteration and urlization steps (#2985)
-- Use `getFieldValue` and `setFieldValue` methods to support `doctrine/orm` >= 3.4 (#2966)
+- Use `ClassMetadata::getFieldValue()` and `ClassMetadata::setFieldValue(` methods to support `doctrine/orm` >= 3.4 (#2966)
+
+### Fixed
+- Sluggable: Fix type error when generating slug using embedded properties (#2965)
 
 ## [3.20.1] - 2025-09-14
 ### Fixed

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,9 +1,15 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\:\:getReflectionProperty\(\)\.$#'
+			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\:\:getFieldValue\(\)\.$#'
 			identifier: method.notFound
 			count: 4
+			path: src/AbstractTrackingListener.php
+
+		-
+			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\:\:setFieldValue\(\)\.$#'
+			identifier: method.notFound
+			count: 1
 			path: src/AbstractTrackingListener.php
 
 		-
@@ -73,13 +79,13 @@ parameters:
 			path: src/Loggable/Entity/Repository/LogEntryRepository.php
 
 		-
-			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<Gedmo\\Loggable\\LogEntryInterface\<T of object\>\>\:\:getReflectionProperty\(\)\.$#'
+			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<Gedmo\\Loggable\\LogEntryInterface\<T of object\>\>\:\:newInstance\(\)\.$#'
 			identifier: method.notFound
 			count: 1
 			path: src/Loggable/LoggableListener.php
 
 		-
-			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<Gedmo\\Loggable\\LogEntryInterface\<T of object\>\>\:\:newInstance\(\)\.$#'
+			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<Gedmo\\Loggable\\LogEntryInterface\<T of object\>\>\:\:setFieldValue\(\)\.$#'
 			identifier: method.notFound
 			count: 1
 			path: src/Loggable/LoggableListener.php
@@ -205,7 +211,7 @@ parameters:
 			path: src/Mapping/ExtensionMetadataFactory.php
 
 		-
-			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\:\:getReflectionProperty\(\)\.$#'
+			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\:\:setFieldValue\(\)\.$#'
 			identifier: method.notFound
 			count: 1
 			path: src/Mapping/MappedEventSubscriber.php
@@ -235,7 +241,7 @@ parameters:
 			path: src/ReferenceIntegrity/ReferenceIntegrityListener.php
 
 		-
-			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\:\:getReflectionProperty\(\)\.$#'
+			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\:\:getFieldValue\(\)\.$#'
 			identifier: method.notFound
 			count: 3
 			path: src/ReferenceIntegrity/ReferenceIntegrityListener.php
@@ -253,13 +259,19 @@ parameters:
 			path: src/ReferenceIntegrity/ReferenceIntegrityListener.php
 
 		-
+			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\:\:setFieldValue\(\)\.$#'
+			identifier: method.notFound
+			count: 4
+			path: src/ReferenceIntegrity/ReferenceIntegrityListener.php
+
+		-
 			message: '#^Access to offset ''inherited'' on an unknown class Doctrine\\ODM\\MongoDB\\Mapping\\AssociationFieldMapping\.$#'
 			identifier: class.notFound
 			count: 1
 			path: src/References/Mapping/Driver/Attribute.php
 
 		-
-			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\:\:getReflectionProperty\(\)\.$#'
+			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\:\:getFieldValue\(\)\.$#'
 			identifier: method.notFound
 			count: 1
 			path: src/References/Mapping/Event/Adapter/ODM.php
@@ -283,7 +295,7 @@ parameters:
 			path: src/References/Mapping/Event/Adapter/ODM.php
 
 		-
-			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\:\:getReflectionProperty\(\)\.$#'
+			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\:\:getFieldValue\(\)\.$#'
 			identifier: method.notFound
 			count: 2
 			path: src/References/Mapping/Event/Adapter/ORM.php
@@ -343,9 +355,15 @@ parameters:
 			path: src/References/ReferencesListener.php
 
 		-
-			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\:\:getReflectionProperty\(\)\.$#'
+			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\:\:getFieldValue\(\)\.$#'
 			identifier: method.notFound
-			count: 2
+			count: 1
+			path: src/Sluggable/Handler/InversedRelativeSlugHandler.php
+
+		-
+			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\:\:setFieldValue\(\)\.$#'
+			identifier: method.notFound
+			count: 1
 			path: src/Sluggable/Handler/InversedRelativeSlugHandler.php
 
 		-
@@ -361,9 +379,15 @@ parameters:
 			path: src/Sluggable/Handler/RelativeSlugHandler.php
 
 		-
-			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\:\:getReflectionProperty\(\)\.$#'
+			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\:\:getFieldValue\(\)\.$#'
 			identifier: method.notFound
-			count: 2
+			count: 1
+			path: src/Sluggable/Handler/TreeSlugHandler.php
+
+		-
+			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\:\:setFieldValue\(\)\.$#'
+			identifier: method.notFound
+			count: 1
 			path: src/Sluggable/Handler/TreeSlugHandler.php
 
 		-
@@ -421,9 +445,15 @@ parameters:
 			path: src/Sluggable/SluggableListener.php
 
 		-
-			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\:\:getReflectionProperty\(\)\.$#'
+			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\:\:getFieldValue\(\)\.$#'
 			identifier: method.notFound
-			count: 7
+			count: 5
+			path: src/Sluggable/SluggableListener.php
+
+		-
+			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\:\:setFieldValue\(\)\.$#'
+			identifier: method.notFound
+			count: 2
 			path: src/Sluggable/SluggableListener.php
 
 		-
@@ -493,9 +523,15 @@ parameters:
 			path: src/Sortable/Mapping/Driver/Yaml.php
 
 		-
-			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\:\:getReflectionProperty\(\)\.$#'
+			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\:\:getFieldValue\(\)\.$#'
 			identifier: method.notFound
-			count: 9
+			count: 8
+			path: src/Sortable/SortableListener.php
+
+		-
+			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\:\:setFieldValue\(\)\.$#'
+			identifier: method.notFound
+			count: 1
 			path: src/Sortable/SortableListener.php
 
 		-
@@ -631,7 +667,7 @@ parameters:
 			path: src/Translatable/Query/TreeWalker/TranslationWalker.php
 
 		-
-			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\:\:getReflectionProperty\(\)\.$#'
+			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\:\:getFieldValue\(\)\.$#'
 			identifier: method.notFound
 			count: 1
 			path: src/Translatable/TranslatableListener.php
@@ -853,21 +889,27 @@ parameters:
 			path: src/Tree/Strategy/AbstractMaterializedPath.php
 
 		-
+			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\:\:getFieldValue\(\)\.$#'
+			identifier: method.notFound
+			count: 8
+			path: src/Tree/Strategy/AbstractMaterializedPath.php
+
+		-
 			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\:\:getIdentifierValue\(\)\.$#'
 			identifier: method.notFound
 			count: 1
 			path: src/Tree/Strategy/AbstractMaterializedPath.php
 
 		-
-			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\:\:getReflectionProperty\(\)\.$#'
-			identifier: method.notFound
-			count: 10
-			path: src/Tree/Strategy/AbstractMaterializedPath.php
-
-		-
 			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\:\:getSingleIdentifierFieldName\(\)\.$#'
 			identifier: method.notFound
 			count: 1
+			path: src/Tree/Strategy/AbstractMaterializedPath.php
+
+		-
+			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\:\:setFieldValue\(\)\.$#'
+			identifier: method.notFound
+			count: 4
 			path: src/Tree/Strategy/AbstractMaterializedPath.php
 
 		-
@@ -973,7 +1015,13 @@ parameters:
 			path: src/Uploadable/MimeType/MimeTypeGuesser.php
 
 		-
-			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\:\:getReflectionProperty\(\)\.$#'
+			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\:\:getFieldValue\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Uploadable/UploadableListener.php
+
+		-
+			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\:\:setFieldValue\(\)\.$#'
 			identifier: method.notFound
 			count: 1
 			path: src/Uploadable/UploadableListener.php

--- a/src/AbstractTrackingListener.php
+++ b/src/AbstractTrackingListener.php
@@ -149,7 +149,7 @@ abstract class AbstractTrackingListener extends MappedEventSubscriber
                                 }
                                 $objectMeta = $om->getClassMetadata(get_class($changingObject));
                                 $om->initializeObject($changingObject);
-                                $value = $objectMeta->getReflectionProperty($trackedChild)->getValue($changingObject);
+                                $value = $objectMeta->getFieldValue($changingObject, $trackedChild);
                             } else {
                                 $value = $changes[1];
                             }
@@ -189,14 +189,14 @@ abstract class AbstractTrackingListener extends MappedEventSubscriber
         if ($config = $this->getConfiguration($om, $meta->getName())) {
             if (isset($config['update'])) {
                 foreach ($config['update'] as $field) {
-                    if (null === $meta->getReflectionProperty($field)->getValue($object)) { // let manual values
+                    if (null === $meta->getFieldValue($object, $field)) { // let manual values
                         $this->updateField($object, $ea, $meta, $field);
                     }
                 }
             }
             if (isset($config['create'])) {
                 foreach ($config['create'] as $field) {
-                    if (null === $meta->getReflectionProperty($field)->getValue($object)) { // let manual values
+                    if (null === $meta->getFieldValue($object, $field)) { // let manual values
                         $this->updateField($object, $ea, $meta, $field);
                     }
                 }
@@ -227,8 +227,7 @@ abstract class AbstractTrackingListener extends MappedEventSubscriber
      */
     protected function updateField($object, $eventAdapter, $meta, $field)
     {
-        $property = $meta->getReflectionProperty($field);
-        $oldValue = $property->getValue($object);
+        $oldValue = $meta->getFieldValue($object, $field);
         $newValue = $this->getFieldValue($meta, $field, $eventAdapter);
 
         // if field value is reference, persist object
@@ -241,7 +240,7 @@ abstract class AbstractTrackingListener extends MappedEventSubscriber
             }
         }
 
-        $property->setValue($object, $newValue);
+        $meta->setFieldValue($object, $field, $newValue);
 
         if ($object instanceof NotifyPropertyChanged) {
             $uow = $eventAdapter->getObjectManager()->getUnitOfWork();

--- a/src/Loggable/LoggableListener.php
+++ b/src/Loggable/LoggableListener.php
@@ -173,7 +173,7 @@ class LoggableListener extends MappedEventSubscriber
             $logEntryMeta = $om->getClassMetadata(get_class($logEntry));
 
             $id = $wrapped->getIdentifier(false, true);
-            $logEntryMeta->getReflectionProperty('objectId')->setValue($logEntry, $id);
+            $logEntryMeta->setFieldValue($logEntry, 'objectId', $id);
             $uow->scheduleExtraUpdate($logEntry, [
                 'objectId' => [null, $id],
             ]);

--- a/src/Loggable/Mapping/Event/Adapter/ODM.php
+++ b/src/Loggable/Mapping/Event/Adapter/ODM.php
@@ -43,7 +43,7 @@ final class ODM extends BaseAdapterODM implements LoggableAdapter
         $dm = $this->getObjectManager();
         $objectMeta = $dm->getClassMetadata(get_class($object));
         $identifierField = $this->getSingleIdentifierFieldName($objectMeta);
-        $objectId = $objectMeta->getReflectionProperty($identifierField)->getValue($object);
+        $objectId = $objectMeta->getFieldValue($object, $identifierField);
 
         $qb = $dm->createQueryBuilder($meta->getName());
         $qb->select('version');

--- a/src/Mapping/MappedEventSubscriber.php
+++ b/src/Mapping/MappedEventSubscriber.php
@@ -307,7 +307,7 @@ abstract class MappedEventSubscriber implements EventSubscriber
         $meta = $manager->getClassMetadata(get_class($object));
         $uow = $manager->getUnitOfWork();
 
-        $meta->getReflectionProperty($field)->setValue($object, $newValue);
+        $meta->setFieldValue($object, $field, $newValue);
         $uow->propertyChanged($object, $field, $oldValue, $newValue);
         $adapter->recomputeSingleObjectChangeSet($uow, $meta, $object);
     }

--- a/src/References/Mapping/Event/Adapter/ODM.php
+++ b/src/References/Mapping/Event/Adapter/ODM.php
@@ -38,7 +38,7 @@ final class ODM extends BaseAdapterODM implements ReferencesAdapter
                 $meta = $om->getClassMetadata(get_class($object));
                 $id = [];
                 foreach ($meta->getIdentifier() as $name) {
-                    $id[$name] = $meta->getReflectionProperty($name)->getValue($object);
+                    $id[$name] = $meta->getFieldValue($object, $name);
                     // return null if one of identifiers is missing
                     if (!$id[$name]) {
                         return null;
@@ -73,7 +73,7 @@ final class ODM extends BaseAdapterODM implements ReferencesAdapter
         if ($object instanceof GhostObjectInterface) {
             $id = $om->getUnitOfWork()->getDocumentIdentifier($object);
         } else {
-            $id = $meta->getReflectionProperty($meta->getIdentifier()[0])->getValue($object);
+            $id = $meta->getFieldValue($object, $meta->getIdentifier()[0]);
         }
 
         if ($single || !$id) {

--- a/src/References/Mapping/Event/Adapter/ORM.php
+++ b/src/References/Mapping/Event/Adapter/ORM.php
@@ -38,7 +38,7 @@ final class ORM extends BaseAdapterORM implements ReferencesAdapter
             if ($object instanceof GhostObjectInterface) {
                 $id = $om->getUnitOfWork()->getDocumentIdentifier($object);
             } else {
-                $id = $meta->getReflectionProperty($meta->getIdentifier()[0])->getValue($object);
+                $id = $meta->getFieldValue($object, $meta->getIdentifier()[0]);
             }
 
             if ($single || !$id) {
@@ -51,7 +51,7 @@ final class ORM extends BaseAdapterORM implements ReferencesAdapter
         if ($om instanceof PhpcrDocumentManager) {
             $meta = $om->getClassMetadata(get_class($object));
             assert(1 === count($meta->getIdentifier()));
-            $id = $meta->getReflectionProperty($meta->getIdentifier()[0])->getValue($object);
+            $id = $meta->getFieldValue($object, $meta->getIdentifier()[0]);
 
             if ($single || !$id) {
                 return $id;
@@ -85,7 +85,7 @@ final class ORM extends BaseAdapterORM implements ReferencesAdapter
             $meta = $om->getClassMetadata(get_class($object));
             $id = [];
             foreach ($meta->getIdentifier() as $name) {
-                $id[$name] = $meta->getReflectionProperty($name)->getValue($object);
+                $id[$name] = $meta->getFieldValue($object, $name);
                 // return null if one of identifiers is missing
                 if (!$id[$name]) {
                     return null;

--- a/src/Sluggable/Handler/InversedRelativeSlugHandler.php
+++ b/src/Sluggable/Handler/InversedRelativeSlugHandler.php
@@ -105,10 +105,10 @@ class InversedRelativeSlugHandler implements SlugHandlerInterface
                             continue;
                         }
 
-                        $objectSlug = (string) $meta->getReflectionProperty($mappedByConfig['slug'])->getValue($object);
+                        $objectSlug = (string) $meta->getFieldValue($object, $mappedByConfig['slug']);
                         if (preg_match("@^{$oldSlug}@smi", $objectSlug)) {
                             $objectSlug = str_replace($oldSlug, $slug, $objectSlug);
-                            $meta->getReflectionProperty($mappedByConfig['slug'])->setValue($object, $objectSlug);
+                            $meta->setFieldValue($object, $mappedByConfig['slug'], $objectSlug);
                             $ea->setOriginalObjectProperty($uow, $object, $mappedByConfig['slug'], $objectSlug);
                         }
                     }

--- a/src/Sluggable/Handler/TreeSlugHandler.php
+++ b/src/Sluggable/Handler/TreeSlugHandler.php
@@ -137,10 +137,10 @@ class TreeSlugHandler implements SlugHandlerWithUniqueCallbackInterface
                         continue;
                     }
 
-                    $objectSlug = (string) $meta->getReflectionProperty($config['slug'])->getValue($object);
+                    $objectSlug = (string) $meta->getFieldValue($object, $config['slug']);
                     if (preg_match("@^{$target}{$config['pathSeparator']}@smi", $objectSlug)) {
                         $objectSlug = str_replace($target, $slug, $objectSlug);
-                        $meta->getReflectionProperty($config['slug'])->setValue($object, $objectSlug);
+                        $meta->setFieldValue($object, $config['slug'], $objectSlug);
                         $ea->setOriginalObjectProperty($uow, $object, $config['slug'], $objectSlug);
                     }
                 }

--- a/src/SoftDeleteable/SoftDeleteableListener.php
+++ b/src/SoftDeleteable/SoftDeleteableListener.php
@@ -94,8 +94,7 @@ class SoftDeleteableListener extends MappedEventSubscriber
             $config = $this->getConfiguration($om, $meta->getName());
 
             if (isset($config['softDeleteable']) && $config['softDeleteable']) {
-                $reflProp = $meta->getReflectionProperty($config['fieldName']);
-                $oldValue = $reflProp->getValue($object);
+                $oldValue = $meta->getFieldValue($object, $config['fieldName']);
                 $date = $ea->getDateValue($meta, $config['fieldName']);
 
                 if (isset($config['hardDelete']) && $config['hardDelete'] && $oldValue instanceof \DateTimeInterface && $oldValue <= $date) {
@@ -114,7 +113,7 @@ class SoftDeleteableListener extends MappedEventSubscriber
                     );
                 }
 
-                $reflProp->setValue($object, $date);
+                $meta->setFieldValue($object, $config['fieldName'], $date);
 
                 $om->persist($object);
                 $uow->propertyChanged($object, $config['fieldName'], $oldValue, $date);

--- a/src/Sortable/Mapping/Event/Adapter/ODM.php
+++ b/src/Sortable/Mapping/Event/Adapter/ODM.php
@@ -51,7 +51,7 @@ final class ODM extends BaseAdapterODM implements SortableAdapter
         $document = $qb->getQuery()->getSingleResult();
 
         if ($document) {
-            return $meta->getReflectionProperty($config['position'])->getValue($document);
+            return $meta->getFieldValue($document, $config['position']);
         }
 
         return -1;

--- a/src/Sortable/SortableListener.php
+++ b/src/Sortable/SortableListener.php
@@ -135,7 +135,7 @@ class SortableListener extends MappedEventSubscriber
         foreach ($ea->getScheduledObjectUpdates($uow) as $object) {
             $meta = $om->getClassMetadata(get_class($object));
             if ($config = $this->getConfiguration($om, $meta->getName())) {
-                $position = $meta->getReflectionProperty($config['position'])->getValue($object);
+                $position = $meta->getFieldValue($object, $config['position']);
                 $updateValues[$position] = [$ea, $config, $meta, $object];
             }
         }
@@ -278,12 +278,12 @@ class SortableListener extends MappedEventSubscriber
                         }
 
                         $oid = spl_object_id($object);
-                        $pos = $meta->getReflectionProperty($config['position'])->getValue($object);
+                        $pos = $meta->getFieldValue($object, $config['position']);
                         $matches = $pos >= $delta['start'];
                         $matches = $matches && ($delta['stop'] <= 0 || $pos < $delta['stop']);
                         $value = reset($relocation['groups']);
                         while ($matches && ($group = key($relocation['groups']))) {
-                            $gr = $meta->getReflectionProperty($group)->getValue($object);
+                            $gr = $meta->getFieldValue($object, $group);
                             if (null === $value) {
                                 $matches = null === $gr;
                             } elseif (is_object($gr) && is_object($value) && $gr !== $value) {
@@ -326,7 +326,7 @@ class SortableListener extends MappedEventSubscriber
                             }
                             $updatedObjects[$oid]['newValue'] = $pos + $delta['delta'];
 
-                            $meta->getReflectionProperty($config['position'])->setValue($object, $updatedObjects[$oid]['newValue']);
+                            $meta->setFieldValue($object, $config['position'], $updatedObjects[$oid]['newValue']);
                         }
                     }
                 }
@@ -355,8 +355,8 @@ class SortableListener extends MappedEventSubscriber
      */
     protected function processInsert(SortableAdapter $ea, array $config, $meta, $object)
     {
-        $old = $meta->getReflectionProperty($config['position'])->getValue($object);
-        $newPosition = $meta->getReflectionProperty($config['position'])->getValue($object);
+        $old = $meta->getFieldValue($object, $config['position']);
+        $newPosition = $meta->getFieldValue($object, $config['position']);
 
         if (null === $newPosition) {
             $newPosition = -1;
@@ -451,7 +451,7 @@ class SortableListener extends MappedEventSubscriber
             if (array_key_exists($config['position'], $changeSet)) {
                 $oldPosition = $changeSet[$config['position']][0];
             } else {
-                $oldPosition = $meta->getReflectionProperty($config['position'])->getValue($object);
+                $oldPosition = $meta->getFieldValue($object, $config['position']);
             }
             $this->addRelocation($oldHash, $config['useObjectClass'], $oldGroups, $oldPosition + 1, $this->maxPositions[$oldHash] + 1, -1);
             $groupHasChanged = true;
@@ -557,7 +557,7 @@ class SortableListener extends MappedEventSubscriber
      */
     protected function processDeletion(SortableAdapter $ea, array $config, $meta, $object)
     {
-        $position = $meta->getReflectionProperty($config['position'])->getValue($object);
+        $position = $meta->getFieldValue($object, $config['position']);
 
         // Get groups
         $groups = $this->getGroups($meta, $config, $object);
@@ -724,7 +724,7 @@ class SortableListener extends MappedEventSubscriber
         $groups = [];
         if (isset($config['groups'])) {
             foreach ($config['groups'] as $group) {
-                $groups[$group] = $meta->getReflectionProperty($group)->getValue($object);
+                $groups[$group] = $meta->getFieldValue($object, $group);
             }
         }
 

--- a/src/Tool/Wrapper/EntityWrapper.php
+++ b/src/Tool/Wrapper/EntityWrapper.php
@@ -50,13 +50,13 @@ class EntityWrapper extends AbstractWrapper
     {
         $this->initialize();
 
-        return $this->meta->getReflectionProperty($property)->getValue($this->object);
+        return $this->meta->getFieldValue($this->object, $property);
     }
 
     public function setPropertyValue($property, $value)
     {
         $this->initialize();
-        $this->meta->getReflectionProperty($property)->setValue($this->object, $value);
+        $this->meta->setFieldValue($this->object, $property, $value);
 
         return $this;
     }

--- a/src/Tool/Wrapper/MongoDocumentWrapper.php
+++ b/src/Tool/Wrapper/MongoDocumentWrapper.php
@@ -48,7 +48,7 @@ class MongoDocumentWrapper extends AbstractWrapper
     {
         $this->initialize();
 
-        return $this->meta->getReflectionProperty($property)->getValue($this->object);
+        return $this->meta->getFieldValue($this->object, $property);
     }
 
     public function getRootObjectName()
@@ -59,7 +59,7 @@ class MongoDocumentWrapper extends AbstractWrapper
     public function setPropertyValue($property, $value)
     {
         $this->initialize();
-        $this->meta->getReflectionProperty($property)->setValue($this->object, $value);
+        $this->meta->setFieldValue($this->object, $property, $value);
 
         return $this;
     }

--- a/src/Translatable/Document/Repository/TranslationRepository.php
+++ b/src/Translatable/Document/Repository/TranslationRepository.php
@@ -74,7 +74,7 @@ class TranslationRepository extends DocumentRepository
             || $listener->getTranslatableLocale($document, $meta, $this->getDocumentManager()) === $locale
         ;
         if ($modRecordValue) {
-            $meta->getReflectionProperty($field)->setValue($document, $value);
+            $meta->setFieldValue($document, $field, $value);
             $this->dm->persist($document);
         } else {
             if (isset($config['translationClass'])) {
@@ -83,7 +83,7 @@ class TranslationRepository extends DocumentRepository
                 $ea = new TranslatableAdapterODM();
                 $class = $listener->getTranslationClass($ea, $config['useObjectClass']);
             }
-            $foreignKey = $meta->getReflectionProperty($meta->getIdentifier()[0])->getValue($document);
+            $foreignKey = $meta->getFieldValue($document, $meta->getIdentifier()[0]);
             $objectClass = $config['useObjectClass'];
             $transMeta = $this->dm->getClassMetadata($class);
             $trans = $this->findOneBy([
@@ -94,15 +94,15 @@ class TranslationRepository extends DocumentRepository
             ]);
             if (!$trans) {
                 $trans = $transMeta->newInstance();
-                $transMeta->getReflectionProperty('foreignKey')->setValue($trans, $foreignKey);
-                $transMeta->getReflectionProperty('objectClass')->setValue($trans, $objectClass);
-                $transMeta->getReflectionProperty('field')->setValue($trans, $field);
-                $transMeta->getReflectionProperty('locale')->setValue($trans, $locale);
+                $transMeta->setFieldValue($trans, 'foreignKey', $foreignKey);
+                $transMeta->setFieldValue($trans, 'objectClass', $objectClass);
+                $transMeta->setFieldValue($trans, 'field', $field);
+                $transMeta->setFieldValue($trans, 'locale', $locale);
             }
             $mapping = $meta->getFieldMapping($field);
             $type = $this->getType($mapping['type']);
             $transformed = $type->convertToDatabaseValue($value);
-            $transMeta->getReflectionProperty('content')->setValue($trans, $transformed);
+            $transMeta->setFieldValue($trans, 'content', $transformed);
             if ($this->dm->getUnitOfWork()->isInIdentityMap($document)) {
                 $this->dm->persist($trans);
             } else {

--- a/src/Translatable/Entity/Repository/TranslationRepository.php
+++ b/src/Translatable/Entity/Repository/TranslationRepository.php
@@ -68,7 +68,7 @@ class TranslationRepository extends EntityRepository
         }
         $needsPersist = true;
         if ($locale === $listener->getTranslatableLocale($entity, $meta, $this->getEntityManager())) {
-            $meta->getReflectionProperty($field)->setValue($entity, $value);
+            $meta->setFieldValue($entity, $field, $value);
             $this->getEntityManager()->persist($entity);
         } else {
             if (isset($config['translationClass'])) {
@@ -77,7 +77,7 @@ class TranslationRepository extends EntityRepository
                 $ea = new TranslatableAdapterORM();
                 $class = $listener->getTranslationClass($ea, $config['useObjectClass']);
             }
-            $foreignKey = $meta->getReflectionProperty($meta->getSingleIdentifierFieldName())->getValue($entity);
+            $foreignKey = $meta->getFieldValue($entity, $meta->getSingleIdentifierFieldName());
             $objectClass = $config['useObjectClass'];
             $transMeta = $this->getEntityManager()->getClassMetadata($class);
             $trans = $this->findOneBy([
@@ -88,10 +88,10 @@ class TranslationRepository extends EntityRepository
             ]);
             if (!$trans) {
                 $trans = $transMeta->newInstance();
-                $transMeta->getReflectionProperty('foreignKey')->setValue($trans, $foreignKey);
-                $transMeta->getReflectionProperty('objectClass')->setValue($trans, $objectClass);
-                $transMeta->getReflectionProperty('field')->setValue($trans, $field);
-                $transMeta->getReflectionProperty('locale')->setValue($trans, $locale);
+                $transMeta->setFieldValue($trans, 'foreignKey', $foreignKey);
+                $transMeta->setFieldValue($trans, 'objectClass', $objectClass);
+                $transMeta->setFieldValue($trans, 'field', $field);
+                $transMeta->setFieldValue($trans, 'locale', $locale);
             }
             if ($listener->getDefaultLocale() != $listener->getTranslatableLocale($entity, $meta, $this->getEntityManager())
                 && $locale === $listener->getDefaultLocale()) {
@@ -99,7 +99,7 @@ class TranslationRepository extends EntityRepository
                 $needsPersist = $listener->getPersistDefaultLocaleTranslation();
             }
             $transformed = $this->getEntityManager()->getConnection()->convertToDatabaseValue($value, $meta->getTypeOfField($field));
-            $transMeta->getReflectionProperty('content')->setValue($trans, $transformed);
+            $transMeta->setFieldValue($trans, 'content', $transformed);
             if ($needsPersist) {
                 if ($this->getEntityManager()->getUnitOfWork()->isInIdentityMap($entity)) {
                     $this->getEntityManager()->persist($trans);

--- a/src/Translatable/TranslatableListener.php
+++ b/src/Translatable/TranslatableListener.php
@@ -551,7 +551,7 @@ class TranslatableListener extends MappedEventSubscriber
                         $om->getUnitOfWork(),
                         $object,
                         $field,
-                        $meta->getReflectionProperty($field)->getValue($object)
+                        $meta->getFieldValue($object, $field)
                     );
                 }
             }

--- a/src/Tree/Entity/Repository/ClosureTreeRepository.php
+++ b/src/Tree/Entity/Repository/ClosureTreeRepository.php
@@ -278,8 +278,8 @@ class ClosureTreeRepository extends AbstractTreeRepository
 
         try {
             foreach ($nodesToReparent as $nodeToReparent) {
-                $id = $meta->getReflectionProperty($pk)->getValue($nodeToReparent);
-                $meta->getReflectionProperty($config['parent'])->setValue($nodeToReparent, $parent);
+                $id = $meta->getFieldValue($nodeToReparent, $pk);
+                $meta->setFieldValue($nodeToReparent, $config['parent'], $parent);
 
                 $dql = "UPDATE {$config['useObjectClass']} node";
                 $dql .= " SET node.{$config['parent']} = :parent";

--- a/src/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/src/Tree/Entity/Repository/NestedTreeRepository.php
@@ -1023,10 +1023,11 @@ class NestedTreeRepository extends AbstractTreeRepository
                 $doRecover($child, $count, $depth);
             }
             $right = $count++;
-            $meta->getReflectionProperty($config['left'])->setValue($root, $left);
-            $meta->getReflectionProperty($config['right'])->setValue($root, $right);
+
+            $meta->setFieldValue($root, $config['left'], $left);
+            $meta->setFieldValue($root, $config['right'], $right);
             if (isset($config['level'])) {
-                $meta->getReflectionProperty($config['level'])->setValue($root, $lvl);
+                $meta->setFieldValue($root, $config['level'], $lvl);
             }
             $em->persist($root);
         };
@@ -1197,10 +1198,10 @@ class NestedTreeRepository extends AbstractTreeRepository
         $config = $this->listener->getConfiguration($this->getEntityManager(), $meta->getName());
 
         $identifier = $meta->getSingleIdentifierFieldName();
-        if (isset($config['root'])) {
-            $rootId = $meta->getReflectionProperty($config['root'])->getValue($root);
+        if ($root && isset($config['root'])) {
+            $rootId = $meta->getFieldValue($root, $config['root']);
             if (is_object($rootId)) {
-                $rootId = $meta->getReflectionProperty($identifier)->getValue($rootId);
+                $rootId = $meta->getFieldValue($rootId, $identifier);
             }
         } else {
             $rootId = null;
@@ -1294,10 +1295,10 @@ class NestedTreeRepository extends AbstractTreeRepository
         }
 
         foreach ($qb->getQuery()->toIterable() as $node) {
-            $right = $meta->getReflectionProperty($config['right'])->getValue($node);
-            $left = $meta->getReflectionProperty($config['left'])->getValue($node);
-            $id = $meta->getReflectionProperty($identifier)->getValue($node);
-            $parent = $meta->getReflectionProperty($config['parent'])->getValue($node);
+            $right = $meta->getFieldValue($node, $config['right']);
+            $left = $meta->getFieldValue($node, $config['left']);
+            $id = $meta->getFieldValue($node, $identifier);
+            $parent = $meta->getFieldValue($node, $config['parent']);
             if (!$right || !$left) {
                 $errors[] = "node [{$id}] has invalid left or right values";
             } elseif ($right == $left) {
@@ -1306,9 +1307,9 @@ class NestedTreeRepository extends AbstractTreeRepository
                 if ($parent instanceof Proxy && !$parent->__isInitialized()) {
                     $this->getEntityManager()->refresh($parent);
                 }
-                $parentRight = $meta->getReflectionProperty($config['right'])->getValue($parent);
-                $parentLeft = $meta->getReflectionProperty($config['left'])->getValue($parent);
-                $parentId = $meta->getReflectionProperty($identifier)->getValue($parent);
+                $parentRight = $meta->getFieldValue($parent, $config['right']);
+                $parentLeft = $meta->getFieldValue($parent, $config['left']);
+                $parentId = $meta->getFieldValue($parent, $identifier);
                 if ($left < $parentLeft) {
                     $errors[] = "node [{$id}] left is less than parent`s [{$parentId}] left value";
                 } elseif ($right > $parentRight) {
@@ -1316,8 +1317,8 @@ class NestedTreeRepository extends AbstractTreeRepository
                 }
                 // check that level of node is exactly after its parent's level
                 if (isset($config['level'])) {
-                    $parentLevel = $meta->getReflectionProperty($config['level'])->getValue($parent);
-                    $level = $meta->getReflectionProperty($config['level'])->getValue($node);
+                    $parentLevel = $meta->getFieldValue($parent, $config['level']);
+                    $level = $meta->getFieldValue($node, $config['level']);
                     if ($level !== $parentLevel + 1) {
                         $errors[] = "node [{$id}] should be on the level right after its parent`s [{$parentId}] level";
                     }
@@ -1326,7 +1327,7 @@ class NestedTreeRepository extends AbstractTreeRepository
                 // check that level of the root node is the base level defined
                 if (isset($config['level'])) {
                     $baseLevel = $config['level_base'] ?? 0;
-                    $level = $meta->getReflectionProperty($config['level'])->getValue($node);
+                    $level = $meta->getFieldValue($node, $config['level']);
                     if ($level !== $baseLevel) {
                         $errors[] = "node [{$id}] should be on level {$baseLevel}, not {$level}";
                     }

--- a/src/Tree/Hydrator/ORM/TreeObjectHydrator.php
+++ b/src/Tree/Hydrator/ORM/TreeObjectHydrator.php
@@ -60,7 +60,7 @@ class TreeObjectHydrator extends ObjectHydrator
     public function setPropertyValue($object, $property, $value)
     {
         $meta = $this->getEntityManager()->getClassMetadata(get_class($object));
-        $meta->getReflectionProperty($property)->setValue($object, $value);
+        $meta->setFieldValue($object, $property, $value);
     }
 
     /**
@@ -298,6 +298,6 @@ class TreeObjectHydrator extends ObjectHydrator
     {
         $meta = $this->getEntityManager()->getClassMetadata(get_class($object));
 
-        return $meta->getReflectionProperty($property)->getValue($object);
+        return $meta->getFieldValue($object, $property);
     }
 }

--- a/src/Tree/Strategy/ODM/MongoDB/MaterializedPath.php
+++ b/src/Tree/Strategy/ODM/MongoDB/MaterializedPath.php
@@ -71,10 +71,8 @@ class MaterializedPath extends AbstractMaterializedPath
         foreach ($this->rootsOfTreesWhichNeedsLocking as $root) {
             $meta = $om->getClassMetadata(get_class($root));
             $config = $this->listener->getConfiguration($om, $meta->getName());
-            $lockTimeProp = $meta->getReflectionProperty($config['lock_time']);
-            $lockTimeProp->setAccessible(true);
             $lockTimeValue = new UTCDateTime();
-            $lockTimeProp->setValue($root, $lockTimeValue);
+            $meta->setFieldValue($root, $config['lock_time'], $lockTimeValue);
 
             $ea->recomputeSingleObjectChangeSet($uow, $meta, $root);
         }
@@ -90,10 +88,8 @@ class MaterializedPath extends AbstractMaterializedPath
         foreach ($this->rootsOfTreesWhichNeedsLocking as $oid => $root) {
             $meta = $om->getClassMetadata(get_class($root));
             $config = $this->listener->getConfiguration($om, $meta->getName());
-            $lockTimeProp = $meta->getReflectionProperty($config['lock_time']);
-            $lockTimeProp->setAccessible(true);
             $lockTimeValue = null;
-            $lockTimeProp->setValue($root, $lockTimeValue);
+            $meta->setFieldValue($root, $config['lock_time'], $lockTimeValue);
 
             $ea->recomputeSingleObjectChangeSet($uow, $meta, $root);
 

--- a/src/Tree/Strategy/ORM/Closure.php
+++ b/src/Tree/Strategy/ORM/Closure.php
@@ -312,8 +312,8 @@ class Closure implements Strategy
             $config = $this->listener->getConfiguration($em, $meta->getName());
 
             $identifier = $meta->getSingleIdentifierFieldName();
-            $nodeId = $meta->getReflectionProperty($identifier)->getValue($node);
-            $parent = $meta->getReflectionProperty($config['parent'])->getValue($node);
+            $nodeId = $meta->getFieldValue($node, $identifier);
+            $parent = $meta->getFieldValue($node, $config['parent']);
 
             $closureClass = $config['closure'];
             $closureMeta = $em->getClassMetadata($closureClass);
@@ -366,8 +366,7 @@ class Closure implements Strategy
             } elseif (isset($config['level'])) {
                 $uow->scheduleExtraUpdate($node, [$config['level'] => [null, 1]]);
                 $ea->setOriginalObjectProperty($uow, $node, $config['level'], 1);
-                $levelProp = $meta->getReflectionProperty($config['level']);
-                $levelProp->setValue($node, 1);
+                $meta->setFieldValue($node, $config['level'], 1);
             }
 
             foreach ($entries as $closure) {
@@ -569,14 +568,13 @@ class Closure implements Strategy
             foreach ($this->pendingNodesLevelProcess as $nodeId => $node) {
                 // Update new level
                 $level = $levels[$nodeId];
-                $levelProp = $meta->getReflectionProperty($config['level']);
                 $uow->scheduleExtraUpdate(
                     $node,
                     [$config['level'] => [
-                        $levelProp->getValue($node), $level,
+                        $meta->getFieldValue($node, $config['level']), $level,
                     ]]
                 );
-                $levelProp->setValue($node, $level);
+                $meta->setFieldValue($node, $config['level'], $level);
                 $uow->setOriginalEntityProperty(spl_object_id($node), $config['level'], $level);
             }
 

--- a/src/Tree/Strategy/ORM/Nested.php
+++ b/src/Tree/Strategy/ORM/Nested.php
@@ -128,15 +128,15 @@ class Nested implements Strategy
         $meta = $em->getClassMetadata(get_class($node));
         $config = $this->listener->getConfiguration($em, $meta->getName());
 
-        $meta->getReflectionProperty($config['left'])->setValue($node, 0);
-        $meta->getReflectionProperty($config['right'])->setValue($node, 0);
+        $meta->setFieldValue($node, $config['left'], 0);
+        $meta->setFieldValue($node, $config['right'], 0);
         if (isset($config['level'])) {
-            $meta->getReflectionProperty($config['level'])->setValue($node, 0);
+            $meta->setFieldValue($node, $config['level'], 0);
         }
         if (isset($config['root']) && !$meta->hasAssociation($config['root']) && !isset($config['rootIdentifierMethod'])) {
-            $meta->getReflectionProperty($config['root'])->setValue($node, 0);
-        } elseif (isset($config['rootIdentifierMethod']) && null === $meta->getReflectionProperty($config['root'])->getValue($node)) {
-            $meta->getReflectionProperty($config['root'])->setValue($node, 0);
+            $meta->setFieldValue($node, $config['root'], 0);
+        } elseif (isset($config['rootIdentifierMethod']) && null === $meta->getFieldValue($node, $config['root'])) {
+            $meta->setFieldValue($node, $config['root'], 0);
         }
     }
 
@@ -189,7 +189,7 @@ class Nested implements Strategy
         $meta = $em->getClassMetadata(get_class($node));
 
         $config = $this->listener->getConfiguration($em, $meta->getName());
-        $parent = $meta->getReflectionProperty($config['parent'])->getValue($node);
+        $parent = $meta->getFieldValue($node, $config['parent']);
         $this->updateNode($em, $node, $parent, self::LAST_CHILD);
     }
 
@@ -640,15 +640,15 @@ class Nested implements Strategy
                 }
 
                 $oid = spl_object_id($node);
-                $left = $meta->getReflectionProperty($config['left'])->getValue($node);
-                $currentRoot = isset($config['root']) ? $meta->getReflectionProperty($config['root'])->getValue($node) : null;
+                $left = $meta->getFieldValue($node, $config['left']);
+                $currentRoot = isset($config['root']) ? $meta->getFieldValue($node, $config['root']) : null;
                 if ($currentRoot === $root && $left >= $first) {
-                    $meta->getReflectionProperty($config['left'])->setValue($node, $left + $delta);
+                    $meta->setFieldValue($node, $config['left'], $left + $delta);
                     $em->getUnitOfWork()->setOriginalEntityProperty($oid, $config['left'], $left + $delta);
                 }
-                $right = $meta->getReflectionProperty($config['right'])->getValue($node);
+                $right = $meta->getFieldValue($node, $config['right']);
                 if ($currentRoot === $root && $right >= $first) {
-                    $meta->getReflectionProperty($config['right'])->setValue($node, $right + $delta);
+                    $meta->setFieldValue($node, $config['right'], $right + $delta);
                     $em->getUnitOfWork()->setOriginalEntityProperty($oid, $config['right'], $right + $delta);
                 }
             }
@@ -739,24 +739,24 @@ class Nested implements Strategy
                     }
                 }
 
-                $left = $meta->getReflectionProperty($config['left'])->getValue($node);
-                $right = $meta->getReflectionProperty($config['right'])->getValue($node);
-                $currentRoot = isset($config['root']) ? $meta->getReflectionProperty($config['root'])->getValue($node) : null;
+                $left = $meta->getFieldValue($node, $config['left']);
+                $right = $meta->getFieldValue($node, $config['right']);
+                $currentRoot = isset($config['root']) ? $meta->getFieldValue($node, $config['root']) : null;
                 if ($currentRoot === $root && $left >= $first && $right <= $last) {
                     $oid = spl_object_id($node);
                     $uow = $em->getUnitOfWork();
 
-                    $meta->getReflectionProperty($config['left'])->setValue($node, $left + $delta);
+                    $meta->setFieldValue($node, $config['left'], $left + $delta);
                     $uow->setOriginalEntityProperty($oid, $config['left'], $left + $delta);
-                    $meta->getReflectionProperty($config['right'])->setValue($node, $right + $delta);
+                    $meta->setFieldValue($node, $config['right'], $right + $delta);
                     $uow->setOriginalEntityProperty($oid, $config['right'], $right + $delta);
                     if (isset($config['root'])) {
-                        $meta->getReflectionProperty($config['root'])->setValue($node, $destRoot);
+                        $meta->setFieldValue($node, $config['root'], $destRoot);
                         $uow->setOriginalEntityProperty($oid, $config['root'], $destRoot);
                     }
                     if (isset($config['level'])) {
-                        $level = $meta->getReflectionProperty($config['level'])->getValue($node);
-                        $meta->getReflectionProperty($config['level'])->setValue($node, $level + $levelDelta);
+                        $level = $meta->getFieldValue($node, $config['level']);
+                        $meta->setFieldValue($node, $config['level'], $level + $levelDelta);
                         $uow->setOriginalEntityProperty($oid, $config['level'], $level + $levelDelta);
                     }
                 }

--- a/src/Uploadable/UploadableListener.php
+++ b/src/Uploadable/UploadableListener.php
@@ -791,9 +791,8 @@ class UploadableListener extends MappedEventSubscriber
      */
     protected function updateField($object, $uow, AdapterInterface $ea, ClassMetadata $meta, $field, $value, $notifyPropertyChanged = true)
     {
-        $property = $meta->getReflectionProperty($field);
-        $oldValue = $property->getValue($object);
-        $property->setValue($object, $value);
+        $oldValue = $meta->getFieldValue($object, $field);
+        $meta->setFieldValue($object, $field, $value);
 
         if ($notifyPropertyChanged && $object instanceof NotifyPropertyChanged) {
             $uow = $ea->getObjectManager()->getUnitOfWork();

--- a/tests/Gedmo/Sluggable/Fixture/Embeddable/Address.php
+++ b/tests/Gedmo/Sluggable/Fixture/Embeddable/Address.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Sluggable\Fixture\Embeddable;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Embeddable
+ */
+#[ORM\Embeddable]
+class Address
+{
+    /**
+     * @ORM\Column(name="street", type="string", length=64)
+     */
+    #[ORM\Column(name: 'street', type: Types::STRING, length: 64)]
+    private ?string $street = null;
+
+    /**
+     * @ORM\Column(name="postalCode", type="string", length=64)
+     */
+    #[ORM\Column(name: 'postalCode', type: Types::STRING, length: 64)]
+    private ?string $postalCode = null;
+
+    /**
+     * @ORM\Column(name="city", type="string", length=64)
+     */
+    #[ORM\Column(name: 'city', type: Types::STRING, length: 64)]
+    private ?string $city = null;
+
+    /**
+     * @ORM\Column(name="country", type="string", length=64)
+     */
+    #[ORM\Column(name: 'country', type: Types::STRING, length: 64)]
+    private ?string $country = null;
+
+    public function getStreet(): ?string
+    {
+        return $this->street;
+    }
+
+    public function setStreet(?string $street): void
+    {
+        $this->street = $street;
+    }
+
+    public function getPostalCode(): ?string
+    {
+        return $this->postalCode;
+    }
+
+    public function setPostalCode(?string $postalCode): void
+    {
+        $this->postalCode = $postalCode;
+    }
+
+    public function getCity(): ?string
+    {
+        return $this->city;
+    }
+
+    public function setCity(?string $city): void
+    {
+        $this->city = $city;
+    }
+
+    public function getCountry(): ?string
+    {
+        return $this->country;
+    }
+
+    public function setCountry(?string $country): void
+    {
+        $this->country = $country;
+    }
+}

--- a/tests/Gedmo/Sluggable/Fixture/Embeddable/User.php
+++ b/tests/Gedmo/Sluggable/Fixture/Embeddable/User.php
@@ -49,7 +49,7 @@ class User implements Sluggable
     private ?string $slug = null;
 
     /**
-     * @ORM\Embeddable(class=Address::class)
+     * @ORM\Embedded(class=Address::class)
      */
     #[Embedded(class: Address::class)]
     private Address $address;

--- a/tests/Gedmo/Sluggable/Fixture/Embeddable/User.php
+++ b/tests/Gedmo/Sluggable/Fixture/Embeddable/User.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gedmo\Tests\Sluggable\Fixture\Embeddable;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Embedded;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Gedmo\Sluggable\Sluggable;
+
+/**
+ * @ORM\Entity
+ */
+#[ORM\Entity]
+class User implements Sluggable
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    private ?int $id = null;
+
+    /**
+     * @ORM\Column(name="username", type="string", length=64)
+     */
+    #[ORM\Column(name: 'username', type: Types::STRING, length: 64)]
+    private ?string $username = null;
+
+    /**
+     * @Gedmo\Slug(separator="-", updatable=true, fields={"username", "address.city", "address.country"})
+     *
+     * @ORM\Column(name="slug", type="string", length=64, unique=true)
+     */
+    #[Gedmo\Slug(separator: '-', updatable: true, fields: ['username', 'address.city', 'address.country'])]
+    #[ORM\Column(name: 'slug', type: Types::STRING, length: 64, unique: true)]
+    private ?string $slug = null;
+
+    /**
+     * @ORM\Embeddable(class=Address::class)
+     */
+    #[Embedded(class: Address::class)]
+    private Address $address;
+
+    public function __construct()
+    {
+        $this->address = new Address();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getUsername(): ?string
+    {
+        return $this->username;
+    }
+
+    public function setUsername(?string $username): void
+    {
+        $this->username = $username;
+    }
+
+    public function setSlug(?string $slug): void
+    {
+        $this->slug = $slug;
+    }
+
+    public function getSlug(): ?string
+    {
+        return $this->slug;
+    }
+
+    public function getAddress(): Address
+    {
+        return $this->address;
+    }
+
+    public function setAddress(Address $address): void
+    {
+        $this->address = $address;
+    }
+}

--- a/tests/Gedmo/Sluggable/SluggableEmbeddableTest.php
+++ b/tests/Gedmo/Sluggable/SluggableEmbeddableTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Doctrine Behavioral Extensions package.
+ * (c) Gediminas Morkevicius <gediminas.morkevicius@gmail.com> http://www.gediminasm.org
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Doctrine\Common\EventManager;
+use Gedmo\Sluggable\SluggableListener;
+use Gedmo\Tests\Sluggable\Fixture\Embeddable\Address;
+use Gedmo\Tests\Sluggable\Fixture\Embeddable\User;
+use Gedmo\Tests\Tool\BaseTestCaseORM;
+
+final class SluggableEmbeddableTest extends BaseTestCaseORM
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $evm = new EventManager();
+        $evm->addEventSubscriber(new SluggableListener());
+
+        $this->getDefaultMockSqliteEntityManager($evm);
+    }
+
+    public function testShouldHandleSlugWithEmbeddable(): void
+    {
+        $address = new Address();
+        $address->setStreet('street');
+        $address->setCity('city');
+        $address->setPostalCode('postal code');
+        $address->setCountry('country');
+
+        $user = new User();
+        $user->setUsername('username');
+        $user->setAddress($address);
+
+        $this->em->persist($user);
+        $this->em->flush();
+        $this->em->clear();
+
+        static::assertSame('username-city-country', $user->getSlug());
+    }
+
+    protected function getUsedEntityFixtures(): array
+    {
+        return [
+            User::class,
+        ];
+    }
+}


### PR DESCRIPTION
Replace call to `getReflectionProperty($field)->getValue($entity)` and `getReflectionProperty($field)->setValue($entity, $value)` with `getFieldValue()` and `setFieldValue()` methods which are available in both ORM [2.x](https://github.com/doctrine/orm/blob/2.21.x/src/Mapping/ClassMetadataInfo.php#L921) and [3.x](https://github.com/doctrine/orm/blob/3.4.x/src/Mapping/ClassMetadata.php#L678)

This makes it possible to use the new `propertyAccessor` property introduced in ORM 3.4 and fallback to `reflFields` with ORM < 3.4

PR contain patch #2945 and also fix #2965
