### PR TITLE
Run the tests for the ORM using the native lazy objects when able

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -541,12 +541,6 @@ parameters:
 			path: src/Timestampable/Mapping/Driver/Yaml.php
 
 		-
-			message: '#^Access to an undefined property ProxyManager\\Proxy\\GhostObjectInterface&TObject of object\:\:\$identifier\.$#'
-			identifier: property.notFound
-			count: 1
-			path: src/Tool/Wrapper/MongoDocumentWrapper.php
-
-		-
 			message: '#^Call to function property_exists\(\) with \$this\(Gedmo\\Translatable\\Hydrator\\ORM\\ObjectHydrator\) and ''_em'' will always evaluate to false\.$#'
 			identifier: function.impossibleType
 			count: 1

--- a/src/Tool/Wrapper/EntityWrapper.php
+++ b/src/Tool/Wrapper/EntityWrapper.php
@@ -11,7 +11,6 @@ namespace Gedmo\Tool\Wrapper;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\Persistence\Proxy as PersistenceProxy;
 use Gedmo\Tool\ClassUtils;
 
 /**
@@ -34,11 +33,6 @@ class EntityWrapper extends AbstractWrapper
      * @var array<string, mixed>|null
      */
     private $identifier;
-
-    /**
-     * True if entity or proxy is loaded
-     */
-    private bool $initialized = false;
 
     /**
      * Wrap entity
@@ -124,12 +118,8 @@ class EntityWrapper extends AbstractWrapper
      */
     protected function initialize()
     {
-        if (!$this->initialized) {
-            if ($this->object instanceof PersistenceProxy) {
-                if (!$this->object->__isInitialized()) {
-                    $this->object->__load();
-                }
-            }
+        if ($this->om->isUninitializedObject($this->object)) {
+            $this->om->initializeObject($this->object);
         }
     }
 }

--- a/src/Tool/Wrapper/MongoDocumentWrapper.php
+++ b/src/Tool/Wrapper/MongoDocumentWrapper.php
@@ -33,11 +33,6 @@ class MongoDocumentWrapper extends AbstractWrapper
     private ?string $identifier = null;
 
     /**
-     * True if document or proxy is loaded
-     */
-    private bool $initialized = false;
-
-    /**
      * Wrap document
      *
      * @param TObject $document
@@ -111,24 +106,15 @@ class MongoDocumentWrapper extends AbstractWrapper
      */
     protected function initialize()
     {
-        if (!$this->initialized) {
-            if ($this->object instanceof GhostObjectInterface) {
-                $uow = $this->om->getUnitOfWork();
-                if (!$this->object->isProxyInitialized()) {
-                    $persister = $uow->getDocumentPersister($this->meta->getName());
-                    $identifier = null;
-                    if ($uow->isInIdentityMap($this->object)) {
-                        $identifier = $this->getIdentifier();
-                    } else {
-                        // this may not happen but in case
-                        $getIdentifier = \Closure::bind(fn () => $this->identifier, $this->object, get_class($this->object));
+        if (method_exists($this->om, 'isUninitializedObject') && $this->om->isUninitializedObject($this->object)) {
+            $this->om->initializeObject($this->object);
 
-                        $identifier = $getIdentifier();
-                    }
-                    $this->object->initializeProxy();
-                    $persister->load($identifier, $this->object);
-                }
-            }
+            return;
+        }
+
+        // @todo: Drop support for this fallback when requiring `doctrine/mongodb-odm:^2.6 as a minimum`
+        if ($this->object instanceof GhostObjectInterface && !$this->object->isProxyInitialized()) {
+            $this->om->initializeObject($this->object);
         }
     }
 }

--- a/tests/Gedmo/Mapping/MappingTest.php
+++ b/tests/Gedmo/Mapping/MappingTest.php
@@ -40,8 +40,14 @@ final class MappingTest extends TestCase
     protected function setUp(): void
     {
         $config = new Configuration();
-        $config->setProxyDir(TESTS_TEMP_DIR);
-        $config->setProxyNamespace('Gedmo\Mapping\Proxy');
+
+        /** @phpstan-ignore-next-line function.alreadyNarrowedType */
+        if (PHP_VERSION_ID >= 80400 && method_exists($config, 'enableNativeLazyObjects')) {
+            $config->enableNativeLazyObjects(true);
+        } else {
+            $config->setProxyDir(TESTS_TEMP_DIR);
+            $config->setProxyNamespace('Gedmo\Mapping\Proxy');
+        }
 
         if (PHP_VERSION_ID >= 80000) {
             $config->setMetadataDriverImpl(new AttributeDriver([]));

--- a/tests/Gedmo/Mapping/MetadataFactory/CustomDriverTest.php
+++ b/tests/Gedmo/Mapping/MetadataFactory/CustomDriverTest.php
@@ -39,9 +39,15 @@ final class CustomDriverTest extends TestCase
     protected function setUp(): void
     {
         $config = new Configuration();
-        $config->setProxyDir(TESTS_TEMP_DIR);
-        $config->setProxyNamespace('Gedmo\Mapping\Proxy');
         $config->setMetadataDriverImpl(new CustomDriver());
+
+        /** @phpstan-ignore-next-line function.alreadyNarrowedType */
+        if (PHP_VERSION_ID >= 80400 && method_exists($config, 'enableNativeLazyObjects')) {
+            $config->enableNativeLazyObjects(true);
+        } else {
+            $config->setProxyDir(TESTS_TEMP_DIR);
+            $config->setProxyNamespace('Gedmo\Mapping\Proxy');
+        }
 
         $conn = [
             'driver' => 'pdo_sqlite',

--- a/tests/Gedmo/Mapping/MetadataFactory/ForcedMetadataTest.php
+++ b/tests/Gedmo/Mapping/MetadataFactory/ForcedMetadataTest.php
@@ -41,8 +41,14 @@ final class ForcedMetadataTest extends TestCase
     protected function setUp(): void
     {
         $config = new Configuration();
-        $config->setProxyDir(TESTS_TEMP_DIR);
-        $config->setProxyNamespace('Gedmo\Mapping\Proxy');
+
+        /** @phpstan-ignore-next-line function.alreadyNarrowedType */
+        if (PHP_VERSION_ID >= 80400 && method_exists($config, 'enableNativeLazyObjects')) {
+            $config->enableNativeLazyObjects(true);
+        } else {
+            $config->setProxyDir(TESTS_TEMP_DIR);
+            $config->setProxyNamespace('Gedmo\Mapping\Proxy');
+        }
 
         if (PHP_VERSION_ID >= 80000) {
             $config->setMetadataDriverImpl(new AttributeDriver([]));

--- a/tests/Gedmo/Mapping/ORMMappingTestCase.php
+++ b/tests/Gedmo/Mapping/ORMMappingTestCase.php
@@ -43,8 +43,14 @@ abstract class ORMMappingTestCase extends TestCase
         $config = new Configuration();
         $config->setMetadataCache(new ArrayAdapter());
         $config->setQueryCache(new ArrayAdapter());
-        $config->setProxyDir(TESTS_TEMP_DIR);
-        $config->setProxyNamespace('Gedmo\Mapping\Proxy');
+
+        /** @phpstan-ignore-next-line function.alreadyNarrowedType */
+        if (PHP_VERSION_ID >= 80400 && method_exists($config, 'enableNativeLazyObjects')) {
+            $config->enableNativeLazyObjects(true);
+        } else {
+            $config->setProxyDir(TESTS_TEMP_DIR);
+            $config->setProxyNamespace('Gedmo\Mapping\Proxy');
+        }
 
         return $config;
     }

--- a/tests/Gedmo/Timestampable/TimestampableTest.php
+++ b/tests/Gedmo/Timestampable/TimestampableTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace Gedmo\Tests\Timestampable;
 
 use Doctrine\Common\EventManager;
-use Doctrine\Persistence\Proxy;
 use Gedmo\Tests\Clock;
 use Gedmo\Tests\Timestampable\Fixture\Article;
 use Gedmo\Tests\Timestampable\Fixture\Author;
@@ -230,7 +229,7 @@ final class TimestampableTest extends BaseTestCaseORM
         $this->em->clear();
 
         $type = $this->em->getReference(Type::class, $type->getId());
-        static::assertInstanceOf(Proxy::class, $type);
+        static::assertTrue($this->em->isUninitializedObject($type));
 
         $art = new Article();
         $art->setTitle('Art');

--- a/tests/Gedmo/Tool/BaseTestCaseORM.php
+++ b/tests/Gedmo/Tool/BaseTestCaseORM.php
@@ -96,8 +96,15 @@ abstract class BaseTestCaseORM extends TestCase
     protected function getDefaultConfiguration(): Configuration
     {
         $config = new Configuration();
-        $config->setProxyDir(TESTS_TEMP_DIR);
-        $config->setProxyNamespace('Proxy');
+
+        /** @phpstan-ignore-next-line function.alreadyNarrowedType */
+        if (PHP_VERSION_ID >= 80400 && method_exists($config, 'enableNativeLazyObjects')) {
+            $config->enableNativeLazyObjects(true);
+        } else {
+            $config->setProxyDir(TESTS_TEMP_DIR);
+            $config->setProxyNamespace('Gedmo\Mapping\Proxy');
+        }
+
         $config->setMetadataDriverImpl($this->getMetadataDriverImplementation());
         $config->setMiddlewares([
             new Middleware($this->queryLogger),

--- a/tests/Gedmo/Translatable/Issue/Issue84Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue84Test.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace Gedmo\Tests\Translatable\Issue;
 
 use Doctrine\Common\EventManager;
-use Doctrine\Persistence\Proxy;
 use Gedmo\Tests\Tool\BaseTestCaseORM;
 use Gedmo\Tests\Translatable\Fixture\Article;
 use Gedmo\Translatable\Entity\Translation;
@@ -51,7 +50,7 @@ final class Issue84Test extends BaseTestCaseORM
         $this->em->clear();
 
         $article = $this->em->getReference(Article::class, 1);
-        static::assertInstanceOf(Proxy::class, $article);
+        static::assertTrue($this->em->isUninitializedObject($article));
 
         $trans = $repo->findTranslations($article);
         static::assertCount(1, $trans);

--- a/tests/Gedmo/Translator/TranslatableTest.php
+++ b/tests/Gedmo/Translator/TranslatableTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace Gedmo\Tests\Translator;
 
 use Doctrine\Common\EventManager;
-use Doctrine\Persistence\Proxy;
 use Gedmo\Tests\Tool\BaseTestCaseORM;
 use Gedmo\Tests\Translator\Fixture\Person;
 use Gedmo\Tests\Translator\Fixture\PersonCustom;
@@ -114,7 +113,7 @@ final class TranslatableTest extends BaseTestCaseORM
         $person = $this->em->getRepository(Person::class)->findOneBy(['name' => 'Jen']);
         static::assertSame('Женя', $person->translate('ru')->getName());
         $parent = $person->getParent();
-        static::assertInstanceOf(Proxy::class, $parent);
+        static::assertTrue($this->em->isUninitializedObject($parent));
         static::assertInstanceOf(Person::class, $parent);
         static::assertSame('Женя starshai', $parent->translate('ru')->getName());
         static::assertSame('zenia', $parent->translate('fr')->getName());
@@ -133,7 +132,7 @@ final class TranslatableTest extends BaseTestCaseORM
         $this->em->clear();
 
         $personProxy = $this->em->getReference(Person::class, ['id' => 1]);
-        static::assertInstanceOf(Proxy::class, $personProxy);
+        static::assertTrue($this->em->isUninitializedObject($personProxy));
         $name = $personProxy->translate('ru_RU')->getName();
         static::assertSame('Женя', $name);
     }
@@ -153,7 +152,7 @@ final class TranslatableTest extends BaseTestCaseORM
         $this->em->clear();
 
         $personProxy = $this->em->getReference(Person::class, ['id' => 1]);
-        static::assertInstanceOf(Proxy::class, $personProxy);
+        static::assertTrue($this->em->isUninitializedObject($personProxy));
         $name = $personProxy->translate('ru_RU')->getName();
         static::assertSame('Женя', $name);
         $lastName = $personProxy->translate('ru_RU')->getLastName();

--- a/tests/Gedmo/Tree/MaterializedPathORMRepositoryTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathORMRepositoryTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace Gedmo\Tests\Tree;
 
 use Doctrine\Common\EventManager;
-use Doctrine\Persistence\Proxy;
 use Gedmo\Exception\InvalidArgumentException;
 use Gedmo\Tests\Tool\BaseTestCaseORM;
 use Gedmo\Tests\Tree\Fixture\MPCategory;
@@ -332,8 +331,7 @@ final class MaterializedPathORMRepositoryTest extends BaseTestCaseORM
         $newNode = $this->createCategory();
         $parent = $node->getParent();
 
-        static::assertInstanceOf(Proxy::class, $parent);
-        static::assertFalse($parent->__isInitialized());
+        static::assertTrue($this->em->isUninitializedObject($parent));
 
         $newNode->setTitle('New Node');
         $newNode->setParent($parent);

--- a/tests/Gedmo/Tree/TranslatableSluggableTreeTest.php
+++ b/tests/Gedmo/Tree/TranslatableSluggableTreeTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace Gedmo\Tests\Tree;
 
 use Doctrine\Common\EventManager;
-use Doctrine\Persistence\Proxy;
 use Gedmo\Sluggable\SluggableListener;
 use Gedmo\Tests\Tool\BaseTestCaseORM;
 use Gedmo\Tests\Tree\Fixture\Article;
@@ -94,7 +93,7 @@ final class TranslatableSluggableTreeTest extends BaseTestCaseORM
         static::assertSame('Vegitables', $vegies->getTitle());
         $food = $vegies->getParent();
         // test if proxy triggers postLoad event
-        static::assertInstanceOf(Proxy::class, $food);
+        static::assertTrue($this->em->isUninitializedObject($food));
         static::assertInstanceOf(BehavioralCategory::class, $food);
         static::assertSame('Food', $food->getTitle());
 
@@ -104,7 +103,7 @@ final class TranslatableSluggableTreeTest extends BaseTestCaseORM
         $vegies = $repo->find(4);
         static::assertSame('Gemüse', $vegies->getTitle());
         $food = $vegies->getParent();
-        static::assertInstanceOf(Proxy::class, $food);
+        static::assertTrue($this->em->isUninitializedObject($food));
         static::assertInstanceOf(BehavioralCategory::class, $food);
         static::assertSame('Lebensmittel', $food->getTitle());
     }

--- a/tests/Gedmo/Wrapper/EntityWrapperTest.php
+++ b/tests/Gedmo/Wrapper/EntityWrapperTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace Gedmo\Tests\Wrapper;
 
 use Doctrine\Common\EventManager;
-use Doctrine\Persistence\Proxy;
 use Gedmo\Tests\Tool\BaseTestCaseORM;
 use Gedmo\Tests\Wrapper\Fixture\Entity\Article;
 use Gedmo\Tests\Wrapper\Fixture\Entity\Composite;
@@ -51,7 +50,7 @@ final class EntityWrapperTest extends BaseTestCaseORM
     {
         $this->em->clear();
         $test = $this->em->getReference(Article::class, ['id' => 1]);
-        static::assertInstanceOf(Proxy::class, $test);
+        static::assertTrue($this->em->isUninitializedObject($test));
         $wrapped = new EntityWrapper($test, $this->em);
 
         $id = $wrapped->getIdentifier(false);
@@ -139,7 +138,7 @@ final class EntityWrapperTest extends BaseTestCaseORM
         $this->em->clear();
         $art1 = $this->em->getReference(Article::class, ['id' => 1]);
         $test = $this->em->getReference(CompositeRelation::class, ['article' => $art1->getId(), 'status' => 2]);
-        static::assertInstanceOf(Proxy::class, $test);
+        static::assertTrue($this->em->isUninitializedObject($test));
         $wrapped = new EntityWrapper($test, $this->em);
 
         static::assertSame('1 2', $wrapped->getIdentifier(false, true));

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -28,6 +28,10 @@ use Symfony\Component\Cache\Adapter\ArrayAdapter;
 define('TESTS_PATH', __DIR__);
 define('TESTS_TEMP_DIR', sys_get_temp_dir().'/doctrine-extension-tests');
 
+if (!is_dir(TESTS_TEMP_DIR)) {
+    mkdir(TESTS_TEMP_DIR, 0755, true);
+}
+
 require dirname(__DIR__).'/vendor/autoload.php';
 
 if (class_exists(AnnotationReader::class)) {


### PR DESCRIPTION
As advertised

Builds on #2946 because the initialization checks are needed to fix a couple of test failures when using native lazy objects