### PR TITLE
[Translatable] Reorder article_translation_idx columns to improve performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,6 @@ a release.
 ### Fixed
 - SoftDeleteable: Resolved a bug where a soft-deleted object isn't remove from the ObjectManager (#2930)
 
-### Changed
-- Translatable: Reorder article_translation_idx columns to improve performance
-
 ### Added
 - IP address provider for use with extensions with IP address references (#2928)
 


### PR DESCRIPTION
### Summary
Reorder the `article_translation_idx` columns to better match common query patterns and improve selectivity:

**Old:** `(locale, object_class, field, foreign_key)`  
**New:** `(foreign_key, locale, object_class, field)`

### Rationale
- `foreign_key` typically has far higher cardinality than `locale`, so putting it first increases index selectivity across databases.
- `field` is moved last. In a frequent query shape like:
  ```sql
  SELECT content, field
  FROM activity_translation a0_
  WHERE a0_.foreign_key = ? AND a0_.locale = ? AND a0_.object_class = ?
  ```
  field is not part of the filtering conditions, so we keep it last, allowing the query to fully leverage the index.
  
### Production context / results

Our team observed significant performance issues in production for queries relying on this index.
After reordering the columns as above, we saw strong improvements (lower latency and reduced load).

In our post-mortem, we realized we had followed the documentation’s previous column order; aligning the default here should help future users avoid similar pitfalls.