### PR TITLE
Translatable: Optimize indexes for better performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ a release.
 ---
 
 ## [Unreleased]
+### Changed
+- Translatable: Optimized database indexes for better performance by reordering unique constraint fields and removing redundant indexes
 
 ### Changed
 - Sluggable: Replaced abandoned `behat/transliterator` with `symfony/string` for default transliteration and urlization steps (#2985)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,10 @@ a release.
 ---
 
 ## [Unreleased]
-### Changed
-- Translatable: Optimized database indexes for better performance by reordering unique constraint fields and removing redundant indexes
 
 ### Changed
 - Sluggable: Replaced abandoned `behat/transliterator` with `symfony/string` for default transliteration and urlization steps (#2985)
+- Translatable: Optimized database indexes for better performance by reordering unique constraint fields and removing redundant indexes
 
 ## [3.20.1] - 2025-09-14
 ### Fixed

--- a/src/Translatable/Document/Translation.php
+++ b/src/Translatable/Document/Translation.php
@@ -18,20 +18,14 @@ use Gedmo\Translatable\Document\Repository\TranslationRepository;
  *
  * @ODM\Document(repositoryClass="Gedmo\Translatable\Document\Repository\TranslationRepository")
  * @ODM\UniqueIndex(name="lookup_unique_idx", keys={
- *     "locale": "asc",
- *     "object_class": "asc",
  *     "foreign_key": "asc",
- *     "field": "asc"
- * })
- * @ODM\Index(name="translations_lookup_idx", keys={
  *     "locale": "asc",
  *     "object_class": "asc",
- *     "foreign_key": "asc"
+ *     "field": "asc"
  * })
  */
 #[ODM\Document(repositoryClass: TranslationRepository::class)]
-#[ODM\UniqueIndex(name: 'lookup_unique_idx', keys: ['locale' => 'asc', 'object_class' => 'asc', 'foreign_key' => 'asc', 'field' => 'asc'])]
-#[ODM\Index(name: 'translations_lookup_idx', keys: ['locale' => 'asc', 'object_class' => 'asc', 'foreign_key' => 'asc'])]
+#[ODM\UniqueIndex(name: 'lookup_unique_idx', keys: ['foreign_key' => 'asc', 'locale' => 'asc', 'object_class' => 'asc', 'field' => 'asc'])]
 class Translation extends AbstractTranslation
 {
     /*

--- a/src/Translatable/Entity/Translation.php
+++ b/src/Translatable/Entity/Translation.php
@@ -19,25 +19,15 @@ use Gedmo\Translatable\Entity\Repository\TranslationRepository;
  * @ORM\Table(
  *     name="ext_translations",
  *     options={"row_format": "DYNAMIC"},
- *     indexes={
- *         @ORM\Index(name="translations_lookup_idx", columns={
- *             "locale", "object_class", "foreign_key"
- *         }),
- *         @ORM\Index(name="general_translations_lookup_idx", columns={
- *             "object_class", "foreign_key"
- *         })
- *     },
  *     uniqueConstraints={@ORM\UniqueConstraint(name="lookup_unique_idx", columns={
- *         "locale", "object_class", "field", "foreign_key"
+ *         "foreign_key", "locale", "object_class", "field"
  *     })}
  * )
  * @ORM\Entity(repositoryClass="Gedmo\Translatable\Entity\Repository\TranslationRepository")
  */
 #[ORM\Entity(repositoryClass: TranslationRepository::class)]
 #[ORM\Table(name: 'ext_translations', options: ['row_format' => 'DYNAMIC'])]
-#[ORM\Index(name: 'translations_lookup_idx', columns: ['locale', 'object_class', 'foreign_key'])]
-#[ORM\Index(name: 'general_translations_lookup_idx', columns: ['object_class', 'foreign_key'])]
-#[ORM\UniqueConstraint(name: 'lookup_unique_idx', columns: ['locale', 'object_class', 'field', 'foreign_key'])]
+#[ORM\UniqueConstraint(name: 'lookup_unique_idx', columns: ['foreign_key', 'locale', 'object_class', 'field'])]
 class Translation extends AbstractTranslation
 {
     /*


### PR DESCRIPTION
Following (https://github.com/doctrine-extensions/DoctrineExtensions/pull/2981)

This PR optimizes database indexes for the Translatable extension by reordering unique constraint fields and removing redundant indexes.

## Changes Made

  For both Entity and Document Translation classes:
  1. Reordered unique constraint from locale, object_class, field, foreign_key to foreign_key, locale, object_class, field
  2. Removed redundant indexes that are now covered by the reordered unique constraint

## Rationale

### Better Cardinality with foreign_key First

The foreign_key field has much higher cardinality than any other field (locale, object_class or field):
- locale typically has low cardinality (en, fr, es, etc.), maximum a couple of hundred
- object_class and field typically has lower cardinality than foreign_key as you usually have more entity than class of field in your application. 

### Index Prefix Rule Eliminates Redundancy

Database indexes work on prefixes - an index on columns (A, B, C, D) can efficiently support queries filtering on:
  - (A)
  - (A, B)
  - (A, B, C)
  - (A, B, C, D)

With our reordered unique constraint, that will add an index on (foreign_key, locale, object_class, field), all existing query patterns are covered:
- findTranslations(): Uses (foreign_key, object_class) 
- findTranslationsByObjectId(): Uses (foreign_key) 
- translate(): Uses all four fields

## Performance Impact

- Reduced storage overhead from fewer indexes
- Improved query performance through better cardinality ordering
- Maintained functionality - all existing queries remain efficient


## How to migrate 

Here are proposed steps to migrate your indexes on your production application. Those are examples, you should adapt to your case.

As modifying indexes in production can be 

### initial state

Say you previously created a `Translation` entity, similar to the source code :

```
#[ORM\Entity(repositoryClass: TranslationRepository::class)]
#[ORM\Table(name: 'ext_translations', options: ['row_format' => 'DYNAMIC'])]
#[ORM\Index(columns: ['locale', 'object_class', 'foreign_key'], name: 'translations_lookup_idx')]
#[ORM\Index(columns: ['object_class', 'foreign_key'], name: 'general_translations_lookup_idx')]
#[ORM\UniqueConstraint(name: 'lookup_unique_idx', columns: ['locale', 'object_class', 'field', 'foreign_key'])]
class Translation extends AbstractTranslation
{
}
```

With DDL:
```
CREATE TABLE ext_translations (id INT AUTO_INCREMENT NOT NULL, locale VARCHAR(8) NOT NULL, object_class VARCHAR(191) NOT NULL, field VARCHAR(32) NOT NULL, foreign_key VARCHAR(64) NOT NULL, content LONGTEXT DEFAULT NULL, INDEX translations_lookup_idx (locale, object_class, foreign_key), INDEX general_translations_lookup_idx (object_class, foreign_key), UNIQUE INDEX lookup_unique_idx (locale, object_class, field, foreign_key), PRIMARY KEY(id)) ENGINE = InnoDB ROW_FORMAT = DYNAMIC;
```

### Code changes

Modify your class to have something similar to:

```
#[ORM\Entity(repositoryClass: TranslationRepository::class)]
#[ORM\Table(name: 'ext_translations', options: ['row_format' => 'DYNAMIC'])]
#[ORM\UniqueConstraint(name: 'lookup_unique_foreign_key_first_idx', columns: ['foreign_key', 'locale', 'object_class', 'field'])]
class Translation extends AbstractTranslation
{
}
```

### Migrations

Doing so induces three indexes drop and one creation.
To reduce issues during those changes you should proceed this way:

1. **Create the new index**
`CREATE UNIQUE INDEX lookup_unique_foreign_key_first_idx ON ext_translations (foreign_key, locale, object_class, field);`
2. **Check on your production application** that your queries now use this new index, and other indexes are not used anymore.
3. **Drop the unused indexes**
```
DROP INDEX lookup_unique_idx ON ext_translations;
DROP INDEX translations_lookup_idx ON ext_translations;
DROP INDEX general_translations_lookup_idx ON ext_translations;
```