### PR TITLE
[Sluggable] Make sure the parameter to `strpos` is always a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ a release.
 ---
 
 ## [Unreleased]
+### Fixed
+- Sluggable: Make sure the parameter to `strpos` is always a string (#2995)
 
 ## [3.21.0] - 2025-09-22
 ### Added

--- a/src/Sluggable/SluggableListener.php
+++ b/src/Sluggable/SluggableListener.php
@@ -365,7 +365,7 @@ class SluggableListener extends MappedEventSubscriber
             $slug = $meta->getFieldValue($object, $slugField);
 
             // if slug should not be updated, skip it
-            if (!$options['updatable'] && !$isInsert && (!isset($changeSet[$slugField]) || 0 === strpos($slug, '__sluggable_placeholder__'))) {
+            if (!$options['updatable'] && !$isInsert && (!isset($changeSet[$slugField]) || 0 === strpos((string)$slug, '__sluggable_placeholder__'))) {
                 continue;
             }
             // must fetch the old slug from changeset, since $object holds the new version


### PR DESCRIPTION
Fixes #2995 