### PR TITLE
Optimze DQL cache usage in NestedTreeRepository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ a release.
 ---
 
 ## [Unreleased]
+### Fixed
+- Tree: Optimize DQL cache usage and prevent memory leaks by using parameterized queries in NestedTreeRepository
 
 ## [3.21.0] - 2025-09-22
 ### Added


### PR DESCRIPTION
This PR optimizes DQL cache usage and prevents memory leaks in the NestedTreeRepository by replacing direct value interpolation with parameterized queries.

Performance Impact
This change prevents the creation of excessive DQL cache entries by ensuring that queries with different values use the same parameterized DQL structure.

Before changes (direct value interpolation):

```
php
// Each unique value combination created a new DQL string:
$dql1 = "SELECT node FROM Entity\Category WHERE node.lft <= 5 AND node.rgt >= 10"
$dql2 = "SELECT node FROM Entity\Category WHERE node.lft <= 15 AND node.rgt >= 20"
$dql3 = "SELECT node FROM Entity\Category WHERE node.lft <= 25 AND node.rgt >= 30"
// Result: 1000 different nodes → 1000 unique DQL strings in cache
```
After changes (parameterized queries):

```
php
// Single DQL string reused for all queries:
$dql = "SELECT node FROM Entity\Category WHERE node.lft <= :left AND node.rgt >= :right"
```