### PR TITLE
Disallow "stringable_for_to_string" CS rule

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -80,6 +80,8 @@ return (new PhpCsFixer\Config())
         'self_accessor' => true,
         'static_lambda' => true,
         'strict_param' => true,
+        // @todo: Change the following rule to `true` when support for PHP < 8 is dropped.
+        'stringable_for_to_string' => false,
         'ternary_to_null_coalescing' => true,
         'trailing_comma_in_multiline' => [
             'elements' => [


### PR DESCRIPTION
The error related to the call-site variance introduced at #3014 will be attended in a different PR.

See PHP-CS-Fixer/PHP-CS-Fixer#9248.