### PR TITLE
Fix SA issue with AbstractAnnotationDriver::getMetaReflectionClass()

### DIFF
--- a/src/Mapping/Driver/AbstractAnnotationDriver.php
+++ b/src/Mapping/Driver/AbstractAnnotationDriver.php
@@ -101,7 +101,7 @@ abstract class AbstractAnnotationDriver implements AttributeDriverInterface
     /**
      * @param ClassMetadata<object> $meta
      *
-     * @return \ReflectionClass<object>
+     * @return \ReflectionClass<covariant object>
      */
     public function getMetaReflectionClass($meta)
     {


### PR DESCRIPTION
This will fix the failing PHPStan build

Similar change as https://github.com/doctrine/persistence/pull/476 (follow the link trail from there for the full context)