### PR TITLE
[Translatable] Add methods to remove translations by entity, by field or by locale

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage.xml
 phpstan.neon
 .phpunit.result.cache
 phpunit.xml
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ a release.
 ## [Unreleased]
 ### Changed
 - All: Removed the dollar sign from the generated cache ID for extension metadata to ensure only characters mandated by [PSR-6](https://www.php-fig.org/psr/psr-6/#definitions) are used, improving compatibility with caching implementations with strict character requirements (#2978)
+- Translatable: Introduce a method to remove translations for a specific entity. Either all at once, or by field and/or locale.
 
 ## [3.22.0] - 2025-12-13
 ### Added

--- a/tests/Gedmo/Translatable/TranslatableEntityCollectionTest.php
+++ b/tests/Gedmo/Translatable/TranslatableEntityCollectionTest.php
@@ -150,6 +150,144 @@ final class TranslatableEntityCollectionTest extends BaseTestCaseORM
         static::assertSame('content lt', $translations['lt_lt']['content']);
     }
 
+    public function testShouldRemoveAllTranslations(): void
+    {
+        $this->populate();
+        $repo = $this->em->getRepository(Translation::class);
+        $sport = $this->em->getRepository(Article::class)->find(1);
+        $repo
+            ->translate($sport, 'title', 'lt_lt', 'sport lt')
+            ->translate($sport, 'content', 'lt_lt', 'content lt')
+            ->translate($sport, 'title', 'ru_ru', 'sport ru change')
+            ->translate($sport, 'content', 'ru_ru', 'content ru change')
+            ->translate($sport, 'title', 'en_us', 'sport en update')
+            ->translate($sport, 'content', 'en_us', 'content en update')
+        ;
+        $this->em->flush();
+        $repo->removeTranslations($sport);
+
+        $translations = $repo->findTranslations($sport);
+        static::assertCount(0, $translations);
+    }
+
+    public function testShouldRemoveTitleTranslations(): void
+    {
+        $this->populate();
+        $repo = $this->em->getRepository(Translation::class);
+        $sport = $this->em->getRepository(Article::class)->find(1);
+        $repo
+            ->translate($sport, 'title', 'lt_lt', 'sport lt')
+            ->translate($sport, 'content', 'lt_lt', 'content lt')
+            ->translate($sport, 'title', 'ru_ru', 'sport ru change')
+            ->translate($sport, 'content', 'ru_ru', 'content ru change')
+            ->translate($sport, 'title', 'en_us', 'sport en update')
+            ->translate($sport, 'content', 'en_us', 'content en update')
+        ;
+        $this->em->flush();
+        $repo->removeTranslations($sport, 'title');
+
+        $translations = $repo->findTranslations($sport);
+        static::assertCount(3, $translations);
+
+        static::assertArrayHasKey('de_de', $translations);
+        static::assertArrayNotHasKey('title', $translations['de_de']);
+        static::assertArrayHasKey('content', $translations['de_de']);
+        static::assertSame('sport de', $translations['de_de']['title']);
+        static::assertSame('content de', $translations['de_de']['content']);
+
+        static::assertArrayHasKey('ru_ru', $translations);
+        static::assertArrayNotHasKey('title', $translations['ru_ru']);
+        static::assertArrayHasKey('content', $translations['ru_ru']);
+        static::assertSame('sport ru change', $translations['ru_ru']['title']);
+        static::assertSame('content ru change', $translations['ru_ru']['content']);
+
+        static::assertArrayHasKey('lt_lt', $translations);
+        static::assertArrayNotHasKey('title', $translations['lt_lt']);
+        static::assertArrayHasKey('content', $translations['lt_lt']);
+        static::assertSame('sport lt', $translations['lt_lt']['title']);
+        static::assertSame('content lt', $translations['lt_lt']['content']);
+    }
+
+    public function testShouldRemoveLocaleTranslations(): void
+    {
+        $this->populate();
+        $repo = $this->em->getRepository(Translation::class);
+        $sport = $this->em->getRepository(Article::class)->find(1);
+        $repo
+            ->translate($sport, 'title', 'lt_lt', 'sport lt')
+            ->translate($sport, 'content', 'lt_lt', 'content lt')
+            ->translate($sport, 'title', 'ru_ru', 'sport ru change')
+            ->translate($sport, 'content', 'ru_ru', 'content ru change')
+            ->translate($sport, 'title', 'en_us', 'sport en update')
+            ->translate($sport, 'content', 'en_us', 'content en update')
+        ;
+        $this->em->flush();
+
+        $translations = $repo->findTranslations($sport);
+        static::assertCount(3, $translations);
+
+        $repo->removeTranslations($sport, null, 'lt_lt');
+
+        $translations = $repo->findTranslations($sport);
+        static::assertCount(2, $translations);
+
+        static::assertArrayHasKey('de_de', $translations);
+        static::assertArrayNotHasKey('title', $translations['de_de']);
+        static::assertArrayHasKey('content', $translations['de_de']);
+        static::assertSame('sport de', $translations['de_de']['title']);
+        static::assertSame('content de', $translations['de_de']['content']);
+
+        static::assertArrayHasKey('ru_ru', $translations);
+        static::assertArrayNotHasKey('title', $translations['ru_ru']);
+        static::assertArrayHasKey('content', $translations['ru_ru']);
+        static::assertSame('sport ru change', $translations['ru_ru']['title']);
+        static::assertSame('content ru change', $translations['ru_ru']['content']);
+
+        static::assertArrayNotHasKey('lt_lt', $translations);
+    }
+
+    public function testShouldRemoveFieldAndLocaleTranslations(): void
+    {
+        $this->populate();
+        $repo = $this->em->getRepository(Translation::class);
+        $sport = $this->em->getRepository(Article::class)->find(1);
+        $repo
+            ->translate($sport, 'title', 'lt_lt', 'sport lt')
+            ->translate($sport, 'content', 'lt_lt', 'content lt')
+            ->translate($sport, 'title', 'ru_ru', 'sport ru change')
+            ->translate($sport, 'content', 'ru_ru', 'content ru change')
+            ->translate($sport, 'title', 'en_us', 'sport en update')
+            ->translate($sport, 'content', 'en_us', 'content en update')
+        ;
+        $this->em->flush();
+
+        $translations = $repo->findTranslations($sport);
+        static::assertCount(3, $translations);
+
+        $repo->removeTranslations($sport, 'title', 'lt_lt');
+
+        $translations = $repo->findTranslations($sport);
+        static::assertCount(3, $translations);
+
+        static::assertArrayHasKey('de_de', $translations);
+        static::assertArrayHasKey('title', $translations['de_de']);
+        static::assertArrayHasKey('content', $translations['de_de']);
+        static::assertSame('sport de', $translations['de_de']['title']);
+        static::assertSame('content de', $translations['de_de']['content']);
+
+        static::assertArrayHasKey('ru_ru', $translations);
+        static::assertArrayHasKey('title', $translations['ru_ru']);
+        static::assertArrayHasKey('content', $translations['ru_ru']);
+        static::assertSame('sport ru change', $translations['ru_ru']['title']);
+        static::assertSame('content ru change', $translations['ru_ru']['content']);
+
+        static::assertArrayHasKey('lt_lt', $translations);
+        static::assertArrayNotHasKey('title', $translations['lt_lt']);
+        static::assertArrayHasKey('content', $translations['lt_lt']);
+        static::assertSame('sport lt', $translations['lt_lt']['title']);
+        static::assertSame('content lt', $translations['lt_lt']['content']);
+    }
+
     protected function getUsedEntityFixtures(): array
     {
         return [


### PR DESCRIPTION
I have found myself in the situation when I needed to find and remove translations. One of the specific use cases goes like this:

1. Create a TranslationEntity

```
#[ORM\Table(name: 'article_translations')]
#[ORM\Index(name: 'article_translation_idx', columns: ['foreign_key', 'locale', 'object_class', 'field'])]
#[ORM\Entity(repositoryClass: TranslationRepository::class)]
class ArticleTranslation extends AbstractTranslation
{
    /**
     * All required columns are mapped through inherited superclass
     */
}
```

2. Set up the TranslatinoRepository (I do it in Symfony services as per docs)

```
# services.yaml

  Gedmo\Translatable\Entity\Repository\TranslationRepository:
    factory: [ '@doctrine.orm.entity_manager', 'getRepository' ]
    arguments:
      - 'Gedmo\Translatable\Entity\Translation'
```

3. Inject the repository and try to translate:

```
class SomeHandler
{
  public function __construct() {
    private TranslationRepository $translationRepository,
  }

  public function handle(...) {
    $this->translationRepository->translate($entity, "field", $locale, "Some value");
  }
}
```

When run multiple times, I end up with multiple translations in the database.

I believe, `article_translation_idx` should be `UniqueConstraint` instead of `Index`, but I decided to introduce the missing removal method before digging deeper into this.