### PR TITLE
Replace `ClassMetadata::getReflectionProperty` with `(get|set)FieldValue`

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1039,24 +1039,6 @@ parameters:
 			path: tests/Gedmo/DoctrineExtensionsTest.php
 
 		-
-			message: '#^Property Gedmo\\Tests\\Mapping\\Fixture\\Attribute\\TranslatableModel\:\:\$title \(string\|null\) is never assigned string so it can be removed from the property type\.$#'
-			identifier: property.unusedType
-			count: 1
-			path: tests/Gedmo/Mapping/Fixture/Attribute/TranslatableModel.php
-
-		-
-			message: '#^Property Gedmo\\Tests\\Mapping\\Fixture\\Attribute\\TranslatableModel\:\:\$titleFallbackFalse \(string\|null\) is never assigned string so it can be removed from the property type\.$#'
-			identifier: property.unusedType
-			count: 1
-			path: tests/Gedmo/Mapping/Fixture/Attribute/TranslatableModel.php
-
-		-
-			message: '#^Property Gedmo\\Tests\\Mapping\\Fixture\\Attribute\\TranslatableModel\:\:\$titleFallbackTrue \(string\|null\) is never assigned string so it can be removed from the property type\.$#'
-			identifier: property.unusedType
-			count: 1
-			path: tests/Gedmo/Mapping/Fixture/Attribute/TranslatableModel.php
-
-		-
 			message: '#^Class Gedmo\\Tests\\Translatable\\Fixture\\CategoryTranslation not found\.$#'
 			identifier: class.notFound
 			count: 1
@@ -1115,12 +1097,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: tests/Gedmo/Mapping/MetadataFactory/ForcedMetadataTest.php
-
-		-
-			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\:\:getReflectionProperty\(\)\.$#'
-			identifier: method.notFound
-			count: 2
-			path: tests/Gedmo/Mapping/Mock/Extension/Encoder/EncoderListener.php
 
 		-
 			message: '#^Call to an undefined method Doctrine\\Persistence\\ObjectManager\:\:getUnitOfWork\(\)\.$#'

--- a/tests/Gedmo/Mapping/MetadataFactory/CustomDriverTest.php
+++ b/tests/Gedmo/Mapping/MetadataFactory/CustomDriverTest.php
@@ -89,8 +89,7 @@ final class CustomDriverTest extends TestCase
 
         $id = $this->em
             ->getClassMetadata(Timestampable::class)
-            ->getReflectionProperty('id')
-            ->getValue($test)
+            ->getFieldValue($test, 'id')
         ;
         static::assertNotEmpty($id);
     }

--- a/tests/Gedmo/Mapping/MetadataFactory/ForcedMetadataTest.php
+++ b/tests/Gedmo/Mapping/MetadataFactory/ForcedMetadataTest.php
@@ -94,8 +94,7 @@ final class ForcedMetadataTest extends TestCase
 
         $id = $this->em
             ->getClassMetadata(Timestampable::class)
-            ->getReflectionProperty('id')
-            ->getValue($test)
+            ->getFieldValue($test, 'id')
         ;
         static::assertNotEmpty($id);
     }

--- a/tests/Gedmo/Sluggable/SluggablePositionTest.php
+++ b/tests/Gedmo/Sluggable/SluggablePositionTest.php
@@ -40,7 +40,7 @@ final class SluggablePositionTest extends BaseTestCaseORM
         $repo = $this->em->getRepository(Position::class);
 
         $object = $repo->find(1);
-        $slug = $meta->getReflectionProperty('slug')->getValue($object);
+        $slug = $meta->getFieldValue($object, 'slug');
         static::assertSame('code-other-title-prop', $slug);
     }
 
@@ -55,10 +55,10 @@ final class SluggablePositionTest extends BaseTestCaseORM
     {
         $meta = $this->em->getClassMetadata(Position::class);
         $object = new Position();
-        $meta->getReflectionProperty('title')->setValue($object, 'title');
-        $meta->getReflectionProperty('prop')->setValue($object, 'prop');
-        $meta->getReflectionProperty('code')->setValue($object, 'code');
-        $meta->getReflectionProperty('other')->setValue($object, 'other');
+        $meta->setFieldValue($object, 'title', 'title');
+        $meta->setFieldValue($object, 'prop', 'prop');
+        $meta->setFieldValue($object, 'code', 'code');
+        $meta->setFieldValue($object, 'other', 'other');
 
         $this->em->persist($object);
         $this->em->flush();

--- a/tests/Gedmo/Timestampable/TimestampableDocumentTest.php
+++ b/tests/Gedmo/Timestampable/TimestampableDocumentTest.php
@@ -16,6 +16,7 @@ use Gedmo\Tests\Timestampable\Fixture\Document\Article;
 use Gedmo\Tests\Timestampable\Fixture\Document\Type;
 use Gedmo\Tests\Tool\BaseTestCaseMongoODM;
 use Gedmo\Timestampable\TimestampableListener;
+use MongoDB\BSON\Timestamp;
 
 /**
  * These are tests for Timestampable behavior ODM implementation
@@ -41,7 +42,11 @@ final class TimestampableDocumentTest extends BaseTestCaseMongoODM
 
         $date = new \DateTime();
         $now = time();
-        $created = $article->getCreated()->getTimestamp();
+        $created = $article->getCreated();
+        if ($created instanceof Timestamp) {
+            $created = $created->getTimestamp();
+        }
+
         static::assertTrue($created > $now - 5 && $created < $now + 5); // 5 seconds interval if lag
         static::assertSame(
             $date->format('Y-m-d H:i'),
@@ -80,10 +85,12 @@ final class TimestampableDocumentTest extends BaseTestCaseMongoODM
 
         $repo = $this->dm->getRepository(Article::class);
         $sport = $repo->findOneBy(['title' => 'sport forced']);
-        static::assertSame(
-            $created,
-            $sport->getCreated()->getTimestamp()
-        );
+        $createdField = $sport->getCreated();
+        if ($createdField instanceof Timestamp) {
+            $createdField = $createdField->getTimestamp();
+        }
+
+        static::assertSame($created, $createdField);
         static::assertSame(
             '2000-01-01 12:00:00',
             $sport->getUpdated()->format('Y-m-d H:i:s')

--- a/tests/Gedmo/Tree/ConcurrencyTest.php
+++ b/tests/Gedmo/Tree/ConcurrencyTest.php
@@ -78,15 +78,15 @@ final class ConcurrencyTest extends BaseTestCaseORM
 
         $meta = $this->em->getClassMetadata(Category::class);
         $sport = $repo->findOneBy(['title' => 'Sport']);
-        $left = $meta->getReflectionProperty('lft')->getValue($sport);
-        $right = $meta->getReflectionProperty('rgt')->getValue($sport);
+        $left = $meta->getFieldValue($sport, 'lft');
+        $right = $meta->getFieldValue($sport, 'rgt');
 
         static::assertSame(9, $left);
         static::assertSame(16, $right);
 
         $skiing = $repo->findOneBy(['title' => 'Skiing']);
-        $left = $meta->getReflectionProperty('lft')->getValue($skiing);
-        $right = $meta->getReflectionProperty('rgt')->getValue($skiing);
+        $left = $meta->getFieldValue($skiing, 'lft');
+        $right = $meta->getFieldValue($skiing, 'rgt');
 
         static::assertSame(10, $left);
         static::assertSame(13, $right);

--- a/tests/Gedmo/Tree/InMemoryUpdatesTest.php
+++ b/tests/Gedmo/Tree/InMemoryUpdatesTest.php
@@ -64,29 +64,29 @@ final class InMemoryUpdatesTest extends BaseTestCaseORM
         $this->em->clear();
 
         $node = $repo->find(2);
-        $left = $meta->getReflectionProperty('lft')->getValue($node);
-        $right = $meta->getReflectionProperty('rgt')->getValue($node);
+        $left = $meta->getFieldValue($node, 'lft');
+        $right = $meta->getFieldValue($node, 'rgt');
         static::assertSame(2, $left);
         static::assertSame(5, $right);
 
         $node = $repo->find(3);
-        $left = $meta->getReflectionProperty('lft')->getValue($node);
-        $right = $meta->getReflectionProperty('rgt')->getValue($node);
+        $left = $meta->getFieldValue($node, 'lft');
+        $right = $meta->getFieldValue($node, 'rgt');
         static::assertSame(6, $left);
         static::assertSame(7, $right);
 
         $node = $repo->find(4);
-        $left = $meta->getReflectionProperty('lft')->getValue($node);
-        $right = $meta->getReflectionProperty('rgt')->getValue($node);
+        $left = $meta->getFieldValue($node, 'lft');
+        $right = $meta->getFieldValue($node, 'rgt');
         static::assertSame(3, $left);
         static::assertSame(4, $right);
 
         /*print "Tree:\n";
         for ($i=1; $i < 5; $i++) {
             $node = $this->em->getRepository(Category::class)->find($i);
-            $left = $meta->getReflectionProperty('lft')->getValue($node);
-            $right = $meta->getReflectionProperty('rgt')->getValue($node);
-            $level = $meta->getReflectionProperty('level')->getValue($node);
+            $left = $meta->getFieldValue($node, 'lft');
+            $right = $meta->getFieldValue($node, 'rgt');
+            $level = $meta->getFieldValue($node, 'level');
             print $node->getTitle()." - $left - $right - $level\n";
         }
         print "\n\n";*/

--- a/tests/Gedmo/Tree/MultiInheritanceTest.php
+++ b/tests/Gedmo/Tree/MultiInheritanceTest.php
@@ -38,7 +38,7 @@ final class MultiInheritanceTest extends BaseTestCaseORM
         $repo = $this->em->getRepository(Node::class);
 
         $food = $repo->findOneBy(['identifier' => 'food']);
-        $left = $meta->getReflectionProperty('lft')->getValue($food);
+        $left = $meta->getFieldValue($food, 'lft');
 
         static::assertSame(1, $left);
         static::assertNotNull($food->getCreated());

--- a/tests/Gedmo/Tree/RepositoryTest.php
+++ b/tests/Gedmo/Tree/RepositoryTest.php
@@ -177,8 +177,8 @@ final class RepositoryTest extends BaseTestCaseORM
         $repo = $this->em->getRepository(Category::class);
         $meta = $this->em->getClassMetadata(Category::class);
 
-        $left = $meta->getReflectionProperty('lft')->getValue($onions);
-        $right = $meta->getReflectionProperty('rgt')->getValue($onions);
+        $left = $meta->getFieldValue($onions, 'lft');
+        $right = $meta->getFieldValue($onions, 'rgt');
 
         static::assertSame(11, $left);
         static::assertSame(12, $right);
@@ -187,8 +187,8 @@ final class RepositoryTest extends BaseTestCaseORM
 
         $repo->moveUp($onions, 1);
 
-        $left = $meta->getReflectionProperty('lft')->getValue($onions);
-        $right = $meta->getReflectionProperty('rgt')->getValue($onions);
+        $left = $meta->getFieldValue($onions, 'lft');
+        $right = $meta->getFieldValue($onions, 'rgt');
 
         static::assertSame(9, $left);
         static::assertSame(10, $right);
@@ -196,8 +196,8 @@ final class RepositoryTest extends BaseTestCaseORM
         // move down onions by one position
         $repo->moveDown($onions, 1);
 
-        $left = $meta->getReflectionProperty('lft')->getValue($onions);
-        $right = $meta->getReflectionProperty('rgt')->getValue($onions);
+        $left = $meta->getFieldValue($onions, 'lft');
+        $right = $meta->getFieldValue($onions, 'rgt');
 
         static::assertSame(11, $left);
         static::assertSame(12, $right);
@@ -206,8 +206,8 @@ final class RepositoryTest extends BaseTestCaseORM
 
         $repo->moveUp($onions, true);
 
-        $left = $meta->getReflectionProperty('lft')->getValue($onions);
-        $right = $meta->getReflectionProperty('rgt')->getValue($onions);
+        $left = $meta->getFieldValue($onions, 'lft');
+        $right = $meta->getFieldValue($onions, 'rgt');
 
         static::assertSame(5, $left);
         static::assertSame(6, $right);
@@ -220,32 +220,32 @@ final class RepositoryTest extends BaseTestCaseORM
 
         $node = $this->em->getRepository(Category::class)
             ->findOneBy(['title' => 'Cabbages']);
-        $left = $meta->getReflectionProperty('lft')->getValue($node);
-        $right = $meta->getReflectionProperty('rgt')->getValue($node);
+        $left = $meta->getFieldValue($node, 'lft');
+        $right = $meta->getFieldValue($node, 'rgt');
 
         static::assertSame(5, $left);
         static::assertSame(6, $right);
 
         $node = $this->em->getRepository(Category::class)
             ->findOneBy(['title' => 'Carrots']);
-        $left = $meta->getReflectionProperty('lft')->getValue($node);
-        $right = $meta->getReflectionProperty('rgt')->getValue($node);
+        $left = $meta->getFieldValue($node, 'lft');
+        $right = $meta->getFieldValue($node, 'rgt');
 
         static::assertSame(7, $left);
         static::assertSame(8, $right);
 
         $node = $this->em->getRepository(Category::class)
             ->findOneBy(['title' => 'Onions']);
-        $left = $meta->getReflectionProperty('lft')->getValue($node);
-        $right = $meta->getReflectionProperty('rgt')->getValue($node);
+        $left = $meta->getFieldValue($node, 'lft');
+        $right = $meta->getFieldValue($node, 'rgt');
 
         static::assertSame(9, $left);
         static::assertSame(10, $right);
 
         $node = $this->em->getRepository(Category::class)
             ->findOneBy(['title' => 'Potatoes']);
-        $left = $meta->getReflectionProperty('lft')->getValue($node);
-        $right = $meta->getReflectionProperty('rgt')->getValue($node);
+        $left = $meta->getFieldValue($node, 'lft');
+        $right = $meta->getFieldValue($node, 'rgt');
 
         static::assertSame(11, $left);
         static::assertSame(12, $right);
@@ -266,8 +266,8 @@ final class RepositoryTest extends BaseTestCaseORM
 
         $node = $this->em->getRepository(Category::class)
             ->findOneBy(['title' => 'Fruits']);
-        $left = $meta->getReflectionProperty('lft')->getValue($node);
-        $right = $meta->getReflectionProperty('rgt')->getValue($node);
+        $left = $meta->getFieldValue($node, 'lft');
+        $right = $meta->getFieldValue($node, 'rgt');
 
         static::assertSame(2, $left);
         static::assertSame(3, $right);
@@ -275,8 +275,8 @@ final class RepositoryTest extends BaseTestCaseORM
 
         $node = $this->em->getRepository(Category::class)
             ->findOneBy(['title' => 'Cabbages']);
-        $left = $meta->getReflectionProperty('lft')->getValue($node);
-        $right = $meta->getReflectionProperty('rgt')->getValue($node);
+        $left = $meta->getFieldValue($node, 'lft');
+        $right = $meta->getFieldValue($node, 'rgt');
 
         static::assertSame(4, $left);
         static::assertSame(5, $right);
@@ -297,16 +297,16 @@ final class RepositoryTest extends BaseTestCaseORM
         static::assertNull($food);
 
         $node = $repo->findOneBy(['title' => 'Fruits']);
-        $left = $meta->getReflectionProperty('lft')->getValue($node);
-        $right = $meta->getReflectionProperty('rgt')->getValue($node);
+        $left = $meta->getFieldValue($node, 'lft');
+        $right = $meta->getFieldValue($node, 'rgt');
 
         static::assertSame(1, $left);
         static::assertSame(2, $right);
         static::assertNull($node->getParent());
 
         $node = $repo->findOneBy(['title' => 'Vegitables']);
-        $left = $meta->getReflectionProperty('lft')->getValue($node);
-        $right = $meta->getReflectionProperty('rgt')->getValue($node);
+        $left = $meta->getFieldValue($node, 'lft');
+        $right = $meta->getFieldValue($node, 'rgt');
 
         static::assertSame(3, $left);
         static::assertSame(12, $right);
@@ -367,8 +367,8 @@ final class RepositoryTest extends BaseTestCaseORM
 
         $meta = $this->em->getClassMetadata(Category::class);
 
-        $left = $meta->getReflectionProperty('lft')->getValue($food);
-        $right = $meta->getReflectionProperty('rgt')->getValue($food);
+        $left = $meta->getFieldValue($food, 'lft');
+        $right = $meta->getFieldValue($food, 'rgt');
 
         static::assertSame(3, $left);
         static::assertSame(12, $right);

--- a/tests/Gedmo/Tree/TreeTest.php
+++ b/tests/Gedmo/Tree/TreeTest.php
@@ -46,8 +46,8 @@ final class TreeTest extends BaseTestCaseORM
         $this->em->clear();
 
         $root = $this->em->getRepository(Category::class)->find(1);
-        $left = $meta->getReflectionProperty('lft')->getValue($root);
-        $right = $meta->getReflectionProperty('rgt')->getValue($root);
+        $left = $meta->getFieldValue($root, 'lft');
+        $right = $meta->getFieldValue($root, 'rgt');
 
         static::assertSame(1, $left);
         static::assertSame(2, $right);
@@ -61,18 +61,18 @@ final class TreeTest extends BaseTestCaseORM
         $this->em->clear();
 
         $root = $this->em->getRepository(Category::class)->find(1);
-        $left = $meta->getReflectionProperty('lft')->getValue($root);
-        $right = $meta->getReflectionProperty('rgt')->getValue($root);
-        $level = $meta->getReflectionProperty('level')->getValue($root);
+        $left = $meta->getFieldValue($root, 'lft');
+        $right = $meta->getFieldValue($root, 'rgt');
+        $level = $meta->getFieldValue($root, 'level');
 
         static::assertSame(1, $left);
         static::assertSame(4, $right);
         static::assertSame(0, $level);
 
         $child = $this->em->getRepository(Category::class)->find(2);
-        $left = $meta->getReflectionProperty('lft')->getValue($child);
-        $right = $meta->getReflectionProperty('rgt')->getValue($child);
-        $level = $meta->getReflectionProperty('level')->getValue($child);
+        $left = $meta->getFieldValue($child, 'lft');
+        $right = $meta->getFieldValue($child, 'rgt');
+        $level = $meta->getFieldValue($child, 'level');
 
         static::assertSame(2, $left);
         static::assertSame(3, $right);
@@ -87,18 +87,18 @@ final class TreeTest extends BaseTestCaseORM
         $this->em->clear();
 
         $root = $this->em->getRepository(Category::class)->find(1);
-        $left = $meta->getReflectionProperty('lft')->getValue($root);
-        $right = $meta->getReflectionProperty('rgt')->getValue($root);
-        $level = $meta->getReflectionProperty('level')->getValue($root);
+        $left = $meta->getFieldValue($root, 'lft');
+        $right = $meta->getFieldValue($root, 'rgt');
+        $level = $meta->getFieldValue($root, 'level');
 
         static::assertSame(1, $left);
         static::assertSame(6, $right);
         static::assertSame(0, $level);
 
         $child2 = $this->em->getRepository(Category::class)->find(3);
-        $left = $meta->getReflectionProperty('lft')->getValue($child2);
-        $right = $meta->getReflectionProperty('rgt')->getValue($child2);
-        $level = $meta->getReflectionProperty('level')->getValue($child2);
+        $left = $meta->getFieldValue($child2, 'lft');
+        $right = $meta->getFieldValue($child2, 'rgt');
+        $level = $meta->getFieldValue($child2, 'level');
 
         static::assertSame(4, $left);
         static::assertSame(5, $right);
@@ -113,15 +113,15 @@ final class TreeTest extends BaseTestCaseORM
         $this->em->clear();
 
         $child2 = $this->em->getRepository(Category::class)->find(3);
-        $left = $meta->getReflectionProperty('lft')->getValue($child2);
-        $right = $meta->getReflectionProperty('rgt')->getValue($child2);
-        $level = $meta->getReflectionProperty('level')->getValue($child2);
+        $left = $meta->getFieldValue($child2, 'lft');
+        $right = $meta->getFieldValue($child2, 'rgt');
+        $level = $meta->getFieldValue($child2, 'level');
 
         static::assertSame(4, $left);
         static::assertSame(7, $right);
         static::assertSame(1, $level);
 
-        $level = $meta->getReflectionProperty('level')->getValue($childsChild);
+        $level = $meta->getFieldValue($childsChild, 'level');
 
         static::assertSame(2, $level);
 
@@ -137,9 +137,9 @@ final class TreeTest extends BaseTestCaseORM
         $this->em->clear();
 
         $child = $this->em->getRepository(Category::class)->find(2);
-        $left = $meta->getReflectionProperty('lft')->getValue($child);
-        $right = $meta->getReflectionProperty('rgt')->getValue($child);
-        $level = $meta->getReflectionProperty('level')->getValue($child);
+        $left = $meta->getFieldValue($child, 'lft');
+        $right = $meta->getFieldValue($child, 'rgt');
+        $level = $meta->getFieldValue($child, 'level');
 
         static::assertSame(2, $left);
         static::assertSame(5, $right);
@@ -152,8 +152,8 @@ final class TreeTest extends BaseTestCaseORM
         $this->em->clear();
 
         $root = $this->em->getRepository(Category::class)->find(1);
-        $left = $meta->getReflectionProperty('lft')->getValue($root);
-        $right = $meta->getReflectionProperty('rgt')->getValue($root);
+        $left = $meta->getFieldValue($root, 'lft');
+        $right = $meta->getFieldValue($root, 'rgt');
 
         static::assertSame(1, $left);
         static::assertSame(4, $right);
@@ -167,9 +167,9 @@ final class TreeTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $left = $meta->getReflectionProperty('lft')->getValue($yetAnotherChild);
-        $right = $meta->getReflectionProperty('rgt')->getValue($yetAnotherChild);
-        $level = $meta->getReflectionProperty('level')->getValue($yetAnotherChild);
+        $left = $meta->getFieldValue($yetAnotherChild, 'lft');
+        $right = $meta->getFieldValue($yetAnotherChild, 'rgt');
+        $level = $meta->getFieldValue($yetAnotherChild, 'level');
 
         static::assertSame(4, $left);
         static::assertSame(5, $right);
@@ -212,14 +212,14 @@ final class TreeTest extends BaseTestCaseORM
 
         $meta = $this->em->getClassMetadata(Category::class);
         $subNode = $repo->findOneBy(['title' => 'sub-node']);
-        $left = $meta->getReflectionProperty('lft')->getValue($subNode);
-        $right = $meta->getReflectionProperty('rgt')->getValue($subNode);
+        $left = $meta->getFieldValue($subNode, 'lft');
+        $right = $meta->getFieldValue($subNode, 'rgt');
         static::assertSame(3, $left);
         static::assertSame(4, $right);
 
         $node1 = $repo->findOneBy(['title' => 'node1']);
-        $left = $meta->getReflectionProperty('lft')->getValue($node1);
-        $right = $meta->getReflectionProperty('rgt')->getValue($node1);
+        $left = $meta->getFieldValue($node1, 'lft');
+        $right = $meta->getFieldValue($node1, 'rgt');
         static::assertSame(2, $left);
         static::assertSame(5, $right);
     }
@@ -237,8 +237,8 @@ final class TreeTest extends BaseTestCaseORM
         $this->em->clear();
 
         $root = $this->em->getRepository(CategoryUuid::class)->find($rootId);
-        $left = $meta->getReflectionProperty('lft')->getValue($root);
-        $right = $meta->getReflectionProperty('rgt')->getValue($root);
+        $left = $meta->getFieldValue($root, 'lft');
+        $right = $meta->getFieldValue($root, 'rgt');
 
         static::assertSame(1, $left);
         static::assertSame(2, $right);
@@ -253,18 +253,18 @@ final class TreeTest extends BaseTestCaseORM
         $this->em->clear();
 
         $root = $this->em->getRepository(CategoryUuid::class)->find($rootId);
-        $left = $meta->getReflectionProperty('lft')->getValue($root);
-        $right = $meta->getReflectionProperty('rgt')->getValue($root);
-        $level = $meta->getReflectionProperty('level')->getValue($root);
+        $left = $meta->getFieldValue($root, 'lft');
+        $right = $meta->getFieldValue($root, 'rgt');
+        $level = $meta->getFieldValue($root, 'level');
 
         static::assertSame(1, $left);
         static::assertSame(4, $right);
         static::assertSame(0, $level);
 
         $child = $this->em->getRepository(CategoryUuid::class)->find($childId);
-        $left = $meta->getReflectionProperty('lft')->getValue($child);
-        $right = $meta->getReflectionProperty('rgt')->getValue($child);
-        $level = $meta->getReflectionProperty('level')->getValue($child);
+        $left = $meta->getFieldValue($child, 'lft');
+        $right = $meta->getFieldValue($child, 'rgt');
+        $level = $meta->getFieldValue($child, 'level');
 
         static::assertSame(2, $left);
         static::assertSame(3, $right);
@@ -280,18 +280,18 @@ final class TreeTest extends BaseTestCaseORM
         $this->em->clear();
 
         $root = $this->em->getRepository(CategoryUuid::class)->find($rootId);
-        $left = $meta->getReflectionProperty('lft')->getValue($root);
-        $right = $meta->getReflectionProperty('rgt')->getValue($root);
-        $level = $meta->getReflectionProperty('level')->getValue($root);
+        $left = $meta->getFieldValue($root, 'lft');
+        $right = $meta->getFieldValue($root, 'rgt');
+        $level = $meta->getFieldValue($root, 'level');
 
         static::assertSame(1, $left);
         static::assertSame(6, $right);
         static::assertSame(0, $level);
 
         $child2 = $this->em->getRepository(CategoryUuid::class)->find($child2Id);
-        $left = $meta->getReflectionProperty('lft')->getValue($child2);
-        $right = $meta->getReflectionProperty('rgt')->getValue($child2);
-        $level = $meta->getReflectionProperty('level')->getValue($child2);
+        $left = $meta->getFieldValue($child2, 'lft');
+        $right = $meta->getFieldValue($child2, 'rgt');
+        $level = $meta->getFieldValue($child2, 'level');
 
         static::assertSame(4, $left);
         static::assertSame(5, $right);
@@ -307,15 +307,15 @@ final class TreeTest extends BaseTestCaseORM
         $this->em->clear();
 
         $child2 = $this->em->getRepository(CategoryUuid::class)->find($child2Id);
-        $left = $meta->getReflectionProperty('lft')->getValue($child2);
-        $right = $meta->getReflectionProperty('rgt')->getValue($child2);
-        $level = $meta->getReflectionProperty('level')->getValue($child2);
+        $left = $meta->getFieldValue($child2, 'lft');
+        $right = $meta->getFieldValue($child2, 'rgt');
+        $level = $meta->getFieldValue($child2, 'level');
 
         static::assertSame(4, $left);
         static::assertSame(7, $right);
         static::assertSame(1, $level);
 
-        $level = $meta->getReflectionProperty('level')->getValue($childsChild);
+        $level = $meta->getFieldValue($childsChild, 'level');
 
         static::assertSame(2, $level);
 
@@ -331,9 +331,9 @@ final class TreeTest extends BaseTestCaseORM
         $this->em->clear();
 
         $child = $this->em->getRepository(CategoryUuid::class)->find($childId);
-        $left = $meta->getReflectionProperty('lft')->getValue($child);
-        $right = $meta->getReflectionProperty('rgt')->getValue($child);
-        $level = $meta->getReflectionProperty('level')->getValue($child);
+        $left = $meta->getFieldValue($child, 'lft');
+        $right = $meta->getFieldValue($child, 'rgt');
+        $level = $meta->getFieldValue($child, 'level');
 
         static::assertSame(2, $left);
         static::assertSame(5, $right);
@@ -346,8 +346,8 @@ final class TreeTest extends BaseTestCaseORM
         $this->em->clear();
 
         $root = $this->em->getRepository(CategoryUuid::class)->find($rootId);
-        $left = $meta->getReflectionProperty('lft')->getValue($root);
-        $right = $meta->getReflectionProperty('rgt')->getValue($root);
+        $left = $meta->getFieldValue($root, 'lft');
+        $right = $meta->getFieldValue($root, 'rgt');
 
         static::assertSame(1, $left);
         static::assertSame(4, $right);
@@ -361,9 +361,9 @@ final class TreeTest extends BaseTestCaseORM
         $this->em->flush();
         $this->em->clear();
 
-        $left = $meta->getReflectionProperty('lft')->getValue($yetAnotherChild);
-        $right = $meta->getReflectionProperty('rgt')->getValue($yetAnotherChild);
-        $level = $meta->getReflectionProperty('level')->getValue($yetAnotherChild);
+        $left = $meta->getFieldValue($yetAnotherChild, 'lft');
+        $right = $meta->getFieldValue($yetAnotherChild, 'rgt');
+        $level = $meta->getFieldValue($yetAnotherChild, 'level');
 
         static::assertSame(4, $left);
         static::assertSame(5, $right);


### PR DESCRIPTION
This avoids a new deprecation.

Fixes #3032