### PR TITLE
Add checks for scheduled deletions in SortableListener

### DIFF
--- a/src/Sortable/SortableListener.php
+++ b/src/Sortable/SortableListener.php
@@ -567,8 +567,8 @@ class SortableListener extends MappedEventSubscriber
         // and it would cause errors trying to bind entities without identifiers
         $em = $ea->getObjectManager();
         $uow = $em->getUnitOfWork();
-        foreach ($groups as $group => $value) {
-            if (is_object($value) && $uow->isScheduledForDelete($value)) {
+        foreach ($groups as $val) {
+            if (is_object($val) && $uow->isScheduledForDelete($val)) {
                 // Skip relocation - parent entity is being deleted anyway
                 return;
             }

--- a/src/Sortable/SortableListener.php
+++ b/src/Sortable/SortableListener.php
@@ -562,6 +562,18 @@ class SortableListener extends MappedEventSubscriber
         // Get groups
         $groups = $this->getGroups($meta, $config, $object);
 
+        // Check if any group entities are scheduled for deletion
+        // If the parent entity is being deleted, there's no point in reorganizing positions
+        // and it would cause errors trying to bind entities without identifiers
+        $em = $ea->getObjectManager();
+        $uow = $em->getUnitOfWork();
+        foreach ($groups as $group => $value) {
+            if (is_object($value) && $uow->isScheduledForDelete($value)) {
+                // Skip relocation - parent entity is being deleted anyway
+                return;
+            }
+        }
+
         // Get hash
         $hash = $this->getHash($groups, $config);
 
@@ -654,8 +666,10 @@ class SortableListener extends MappedEventSubscriber
         // Check for groups that are associations. If the value is an object and is
         // scheduled for insert, it has no identifier yet and is obviously new
         // see issue #226
+        // Also check if the group entity is scheduled for deletion - if so, we should
+        // skip position updates as the parent and all children are being deleted
         foreach ($groups as $val) {
-            if (is_object($val) && ($uow->isScheduledForInsert($val) || !$em->getMetadataFactory()->isTransient(ClassUtils::getClass($val)) && $uow::STATE_MANAGED !== $ea->getObjectState($uow, $val))) {
+            if (is_object($val) && ($uow->isScheduledForInsert($val) || $uow->isScheduledForDelete($val) || !$em->getMetadataFactory()->isTransient(ClassUtils::getClass($val)) && $uow::STATE_MANAGED !== $ea->getObjectState($uow, $val))) {
                 return -1;
             }
         }


### PR DESCRIPTION
fixes issue https://github.com/doctrine-extensions/DoctrineExtensions/issues/3009

1. In `processDeletion()`
Added an early check that skips position reorganization entirely if any entity is scheduled for deletion. There's no point reorganizing positions for items that are all about to be deleted anyway.

2. In `getMaxPosition()`
Extended the existing check to also detect when group entities are scheduled for deletion. This prevents queries from being built with deleted entities.