### PR TITLE
[Tree] Nested set treeRootNode option - fix tricky and improve performance

### DIFF
--- a/src/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/src/Tree/Entity/Repository/NestedTreeRepository.php
@@ -1034,29 +1034,20 @@ class NestedTreeRepository extends AbstractTreeRepository
 
         // if it's a forest
         if (isset($config['root'])) {
-            foreach ($this->getRootNodes($options['sortByField'], $options['sortDirection']) as $root) {
-                // if a root node is specified, recover only it
-                if (null !== $options['treeRootNode'] && $options['treeRootNode'] !== $root) {
-                    continue;
-                }
-
-                $count = 1; // reset on every root node
-                $lvl = $config['level_base'] ?? 0;
-                $doRecover($root, $count, $lvl);
-
-                if ($options['flush']) {
-                    $em->flush();
-                }
-            }
+            $roots = null !== $options['treeRootNode']
+                ? [$options['treeRootNode']]
+                : $this->getRootNodes($options['sortByField'], $options['sortDirection']);
         } else {
+            $roots = $this->getChildren(null, true, $options['sortByField'], $options['sortDirection']);
+        }
+
+        foreach ($roots as $root) {
             $count = 1;
             $lvl = $config['level_base'] ?? 0;
-            foreach ($this->getChildren(null, true, $options['sortByField'], $options['sortDirection']) as $root) {
-                $doRecover($root, $count, $lvl);
+            $doRecover($root, $count, $lvl);
 
-                if ($options['flush']) {
-                    $em->flush();
-                }
+            if ($options['flush']) {
+                $em->flush();
             }
         }
     }

--- a/src/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/src/Tree/Entity/Repository/NestedTreeRepository.php
@@ -879,12 +879,10 @@ class NestedTreeRepository extends AbstractTreeRepository
         $meta = $this->getClassMetadata();
         $config = $this->listener->getConfiguration($this->getEntityManager(), $meta->getName());
         if (isset($config['root'])) {
-            $trees = $this->getRootNodes();
+            $trees = null !== $options['treeRootNode']
+                ? [$options['treeRootNode']] // if a root node is specified, verify only it
+                : $this->getRootNodes();
             foreach ($trees as $tree) {
-                // if a root node is specified, verify only it
-                if (null !== $options['treeRootNode'] && $options['treeRootNode'] !== $tree) {
-                    continue;
-                }
                 $this->verifyTree($errors, $tree);
             }
         } else {


### PR DESCRIPTION
Hello!

I came across a "bug" when using the `recover` method with the `treeRootNode` option:
```
->recover(
            [
                'treeRootNode' => $rootStructure
            ]
);
```

In `NestedTreeRepository`, the code loops through each root node and compares the current node with the one provided in the options. However, comparing objects can be tricky in PHP, and in my case, it wasn't working.

My root node is a Doctrine entity. When I pass this node as an option, it has a fully instantiated `User` attribute. But `getRootNodes()` returns an entity with a lazy-loaded `User` object. Because of this, the comparison was wrongly returning false.

The attribute of the root node I give in option:
<img width="588" height="44" alt="image" src="https://github.com/user-attachments/assets/97820f3d-579d-4b19-b6a6-dd3997e133b6" />

The attribute of the root node being iterated by `NestedTreeRepository`:
<img width="447" height="43" alt="image" src="https://github.com/user-attachments/assets/f72e9840-2a16-423f-a82b-936004ca63a6" />


I suggest a refactor to unify the logic whether it's a forest, a specific root node, or a single tree. This way, we avoid the direct object comparison entirely, and it works like a charm.

I am not very familiar with this type of contribution, so feel free to request changes or ask questions :pray: 

edit: I've also updated the `verify` method to apply the same logic.

Thank you,
Johan