### PR TITLE
[Tree] Fix recover() not forwarding treeRootNode to verify(), causing unscoped forest verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ a release.
 ---
 
 ## [Unreleased]
+### Fixed
+- Tree: Fix `NestedTreeRepository::recover()` not forwarding `treeRootNode` to `verify()`, causing unscoped verification of the entire forest when recovering a single tree
+
 ### Changed
 - All: Removed the dollar sign from the generated cache ID for extension metadata to ensure only characters mandated by [PSR-6](https://www.php-fig.org/psr/psr-6/#definitions) are used, improving compatibility with caching implementations with strict character requirements (#2978)
 

--- a/src/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/src/Tree/Entity/Repository/NestedTreeRepository.php
@@ -1008,7 +1008,7 @@ class NestedTreeRepository extends AbstractTreeRepository
         ];
         $options += $defaultOptions;
 
-        if (!$options['skipVerify'] && (true === $this->verify())) {
+        if (!$options['skipVerify'] && (true === $this->verify(['treeRootNode' => $options['treeRootNode']]))) {
             return;
         }
 

--- a/tests/Gedmo/Tree/NestedTreeRootRepositoryTest.php
+++ b/tests/Gedmo/Tree/NestedTreeRootRepositoryTest.php
@@ -539,8 +539,11 @@ final class NestedTreeRootRepositoryTest extends BaseTestCaseORM
 
         $sports = $repo->findOneBy(['title' => 'Sports']);
 
-        $dql = 'UPDATE '.RootCategory::class.' node SET node.rgt = 5 WHERE node.id = '.$sports->getId();
-        $this->em->createQuery($dql)->getSingleScalarResult();
+        $dql = 'UPDATE '.RootCategory::class.' node SET node.rgt = :rgt WHERE node.id = :id';
+        $this->em->createQuery($dql)
+            ->setParameter('rgt', 5)
+            ->setParameter('id', $sports->getId())
+            ->execute();
         $this->em->clear();
 
         $food = $repo->findOneBy(['title' => 'Food']);

--- a/tests/Gedmo/Tree/NestedTreeRootRepositoryTest.php
+++ b/tests/Gedmo/Tree/NestedTreeRootRepositoryTest.php
@@ -533,6 +533,35 @@ final class NestedTreeRootRepositoryTest extends BaseTestCaseORM
         static::assertTrue($repo->verify());
     }
 
+    public function testRecoverWithTreeRootNodeScopesVerifyToSpecifiedTree(): void
+    {
+        $repo = $this->em->getRepository(RootCategory::class);
+
+        $sports = $repo->findOneBy(['title' => 'Sports']);
+
+        $dql = 'UPDATE '.RootCategory::class.' node SET node.rgt = 5 WHERE node.id = '.$sports->getId();
+        $this->em->createQuery($dql)->getSingleScalarResult();
+        $this->em->clear();
+
+        $food = $repo->findOneBy(['title' => 'Food']);
+
+        // Food's tree is valid; the full forest has errors due to the corrupted Sports tree
+        static::assertTrue($repo->verify(['treeRootNode' => $food]));
+        static::assertIsArray($repo->verify());
+
+        $repo->recover([
+            'treeRootNode' => $food,
+            'sortByField' => 'title',
+            'sortDirection' => 'DESC',
+            'flush' => true,
+        ]);
+
+        $this->em->clear();
+        $fruits = $repo->findOneBy(['title' => 'Fruits']);
+
+        static::assertSame(2, $fruits->getLeft());
+    }
+
     public function testShouldRemoveTreeLeafFromTree(): void
     {
         $this->populateMore();


### PR DESCRIPTION
## Problem

`recover()` accepts a `treeRootNode` option to scope recovery to a single tree, but the internal `verify()` call does not forward it. This causes `verify()` to check the entire forest instead of only the target tree.

If any other tree in the forest has errors, the early-exit optimisation is bypassed and the target tree is unnecessarily recovered. At scale (many roots, large trees), the unscoped `verify()` iterates every lft/rgt index across all trees, producing a query per index and leading to timeouts.

## Solution

Forward treeRootNode to verify(), which already supports it.