### PR TITLE
[Translatable] Add a way to ease bulk translations with default locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ a release.
 ---
 
 ## [Unreleased]
+### Added
+- Translatable: Support for syncing default-locale personal translations back to the main entity's field when the `preferPersonalTranslationContent` option is enabled
+
 ### Changed
 - All: Removed the dollar sign from the generated cache ID for extension metadata to ensure only characters mandated by [PSR-6](https://www.php-fig.org/psr/psr-6/#definitions) are used, improving compatibility with caching implementations with strict character requirements (#2978)
 

--- a/doc/translatable.md
+++ b/doc/translatable.md
@@ -614,6 +614,49 @@ $translatableListener->setPersistDefaultLocaleTranslation(true); // default is f
 This would always store translations in all locales, also keeping original record
 translated field values in default locale set.
 
+#### Mirroring the default-locale personal translation back onto the entity
+
+When using **personal translation tables** together with
+`setPersistDefaultLocaleTranslation(true)`, the main entity's field is normally
+treated as the source of truth for the default locale. This means consumers
+have to keep the entity field manually in sync with the default-locale
+translation, e.g.:
+
+``` php
+<?php
+$article->setTitle($translationsFromAdminUi[$defaultLocale] ?? '');
+$article->setTranslations($translationsFromAdminUi);
+```
+
+To flip the direction so that the explicitly-supplied default-locale personal
+translation is the source of truth and its `content` is automatically mirrored
+back onto the main entity's translatable field, enable:
+
+``` php
+<?php
+$translatableListener->setPersistDefaultLocaleTranslation(true);
+$translatableListener->setPreferPersonalTranslationContent(true); // default is false
+```
+
+Preconditions for this setting to take effect:
+
+- the entity uses a **personal translation** class
+  (`@Gedmo\TranslationEntity` pointing at a class extending
+  `AbstractPersonalTranslation`),
+- `setPersistDefaultLocaleTranslation(true)` is also enabled.
+
+With this enabled, persisting bulk translations from e.g. an admin UI
+simplifies to:
+
+``` php
+<?php
+$article->setTranslations($translationsFromAdminUi);
+$em->flush();
+```
+
+The default-locale personal translation's `content` will be written into the
+main entity's field automatically on both inserts and updates.
+
 To set a default translation value upon a missing translation:
 
 ``` php

--- a/src/Translatable/TranslatableListener.php
+++ b/src/Translatable/TranslatableListener.php
@@ -122,12 +122,10 @@ class TranslatableListener extends MappedEventSubscriber
     private bool $persistDefaultLocaleTranslation = false;
 
     /**
-     * Whether the explicitly-supplied default-locale personal
-     * translation should be considered the source of truth and
-     * its content mirrored back to the main entity's field.
-     *
-     * Only takes effect when used together with personal
-     * translations and {@see self::$persistDefaultLocaleTranslation}.
+     * Treat the user-authored default-locale personal translation as the
+     * source of truth, mirroring its content back onto the entity's field
+     * instead of letting the entity field win. Effective only together with
+     * personal translations and {@see self::$persistDefaultLocaleTranslation}.
      */
     private bool $preferPersonalTranslationContent = false;
 
@@ -200,15 +198,7 @@ class TranslatableListener extends MappedEventSubscriber
     }
 
     /**
-     * Whether to mirror the content of the explicitly-supplied
-     * default-locale personal translation back onto the main
-     * entity's translatable field.
-     *
-     * This only takes effect for entities using personal translations
-     * combined with {@see self::setPersistDefaultLocaleTranslation()}
-     * enabled. It removes the need to manually keep the entity's
-     * field in sync with the default-locale translation when
-     * persisting bulk translations from e.g. an admin UI.
+     * @see self::$preferPersonalTranslationContent
      *
      * @return static
      */
@@ -219,10 +209,6 @@ class TranslatableListener extends MappedEventSubscriber
         return $this;
     }
 
-    /**
-     * Check whether the default-locale personal translation
-     * content should be mirrored back to the main entity field.
-     */
     public function getPreferPersonalTranslationContent(): bool
     {
         return $this->preferPersonalTranslationContent;
@@ -467,6 +453,21 @@ class TranslatableListener extends MappedEventSubscriber
         $ea = $this->getEventAdapter($args);
         $om = $ea->getObjectManager();
         $uow = $om->getUnitOfWork();
+        // Sync-back: if only a default-locale personal translation row was
+        // modified, its owner entity is not yet scheduled. Schedule it so the
+        // loop below visits it and mirrors the translation onto its column.
+        if ($this->preferPersonalTranslationContent && $this->persistDefaultLocaleTranslation) {
+            foreach (array_merge($ea->getScheduledObjectInsertions($uow), $ea->getScheduledObjectUpdates($uow)) as $trans) {
+                if ($ea->usesPersonalTranslation(get_class($trans))
+                    && $trans->getLocale() === $this->defaultLocale
+                    && ($entity = $trans->getObject()) !== null
+                    && !$uow->isScheduledForInsert($entity)
+                    && !$uow->isScheduledForUpdate($entity)
+                ) {
+                    $uow->scheduleForUpdate($entity);
+                }
+            }
+        }
         // check all scheduled inserts for Translatable objects
         foreach ($ea->getScheduledObjectInsertions($uow) as $object) {
             $meta = $om->getClassMetadata(get_class($object));
@@ -669,7 +670,21 @@ class TranslatableListener extends MappedEventSubscriber
     }
 
     /**
-     * Creates the translation for object being flushed
+     * Creates the translation for object being flushed.
+     *
+     * Sync-back mode (gated by $shouldSyncBackPersonal below) treats the
+     * user-authored default-locale personal translation as the source of
+     * truth and mirrors its content onto the entity's field on both inserts
+     * and updates. It is implemented as three coordinated additions to the
+     * default flow:
+     *  1) The per-field tracking loops capture the default-locale row from
+     *     scheduledObjectInsertions AND scheduledObjectUpdates regardless of
+     *     the current locale.
+     *  2) The $useTranslationAsSourceOfTruth variable keeps any
+     *     user-authored translation row's content intact instead of
+     *     overwriting it with the entity's field value.
+     *  3) The final mirror block at the end of each iteration runs for updates and inserts.
+     * @see self::$preferPersonalTranslationContent
      *
      * @throws \UnexpectedValueException if locale is not valid, or
      *                                   primary key is composite, missing or invalid
@@ -693,21 +708,14 @@ class TranslatableListener extends MappedEventSubscriber
         $oid = spl_object_id($object);
         $changeSet = $ea->getObjectChangeSet($uow, $object);
         $translatableFields = $config['fields'];
-        // when enabled, the explicit default-locale personal translation
-        // is the source of truth and its content is mirrored back onto
-        // the entity's field; only effective when the entity uses
-        // personal translations and default-locale persistence is on
         $shouldSyncBackPersonal = $this->preferPersonalTranslationContent
             && $this->persistDefaultLocaleTranslation
             && $ea->usesPersonalTranslation($translationClass);
         foreach ($translatableFields as $field) {
             $wasPersistedSeparetely = false;
-            $skip = isset($this->translatedInLocale[$oid]) && $locale === $this->translatedInLocale[$oid];
-            $skip = $skip && !isset($changeSet[$field]) && !$this->getTranslationInDefaultLocale($oid, $field);
-            if ($skip) {
-                continue; // locale is same and nothing changed
-            }
-            $translation = null;
+            // Tracking runs BEFORE the skip check so the latter sees the result
+            // via getTranslationInDefaultLocale() and doesn't short-circuit
+            // entities forced into scheduledObjectUpdates purely by sync-back.
             foreach ($ea->getScheduledObjectInsertions($uow) as $trans) {
                 if (($locale !== $this->defaultLocale || $shouldSyncBackPersonal)
                     && get_class($trans) === $translationClass
@@ -720,8 +728,6 @@ class TranslatableListener extends MappedEventSubscriber
                 }
             }
 
-            // when sync-back is enabled, also pick up an existing default-locale
-            // personal translation whose content was edited (scheduled updates)
             if ($shouldSyncBackPersonal && null === $this->getTranslationInDefaultLocale($oid, $field)) {
                 foreach ($ea->getScheduledObjectUpdates($uow) as $trans) {
                     if (get_class($trans) === $translationClass
@@ -734,6 +740,13 @@ class TranslatableListener extends MappedEventSubscriber
                     }
                 }
             }
+
+            $skip = isset($this->translatedInLocale[$oid]) && $locale === $this->translatedInLocale[$oid];
+            $skip = $skip && !isset($changeSet[$field]) && !$this->getTranslationInDefaultLocale($oid, $field);
+            if ($skip) {
+                continue; // locale is same and nothing changed
+            }
+            $translation = null;
 
             // lookup persisted translations
             foreach ($ea->getScheduledObjectInsertions($uow) as $trans) {
@@ -788,14 +801,14 @@ class TranslatableListener extends MappedEventSubscriber
 
             if ($translation) {
                 $defaultLocaleTrans = $this->getTranslationInDefaultLocale($oid, $field);
+                // Sync-back: keep the user-authored translation row's content
+                // intact. Either the user persisted the row for the current
+                // locale themselves, or we tracked it as the default-locale row
+                // (e.g. picked up from the identity map on update).
                 $useTranslationAsSourceOfTruth = $shouldSyncBackPersonal
-                    && null !== $defaultLocaleTrans
-                    && $translation === $defaultLocaleTrans;
+                    && ($wasPersistedSeparetely || $translation === $defaultLocaleTrans);
 
                 if ($useTranslationAsSourceOfTruth) {
-                    // the user-supplied default-locale personal translation
-                    // wins; keep its content untouched, the final override
-                    // block below mirrors it onto the entity's field
                     $content = $translation->getContent();
                 } else {
                     // set the translated field, take value using reflection

--- a/src/Translatable/TranslatableListener.php
+++ b/src/Translatable/TranslatableListener.php
@@ -770,6 +770,23 @@ class TranslatableListener extends MappedEventSubscriber
                 }
             }
 
+            // Sync-back: also accept a user-modified existing translation row
+            // (scheduledObjectUpdates) for the current locale, so its content
+            // wins over the entity field instead of being clobbered.
+            if ($shouldSyncBackPersonal && null === $translation) {
+                foreach ($ea->getScheduledObjectUpdates($uow) as $trans) {
+                    if (get_class($trans) === $translationClass
+                        && $trans->getLocale() === $locale
+                        && $trans->getField() === $field
+                        && $this->belongsToObject($ea, $trans, $object)) {
+                        $translation = $trans;
+                        $wasPersistedSeparetely = true;
+
+                        break;
+                    }
+                }
+            }
+
             // check if translation already is created
             if (!$isInsert && !$translation) {
                 \assert($wrapped instanceof AbstractWrapper);
@@ -834,7 +851,15 @@ class TranslatableListener extends MappedEventSubscriber
                 }
             }
 
-            if (($isInsert || $shouldSyncBackPersonal) && null !== $this->getTranslationInDefaultLocale($oid, $field)) {
+            // Inner mirror block. For sync-back updates in a non-default
+            // locale we deliberately skip it: the trailing block below
+            // (locale !== defaultLocale path) already has the machinery to
+            // apply tracked default-locale content to the entity AFTER the
+            // changeset cleanup, which would otherwise wipe this mirror.
+            if (
+                ($isInsert || ($shouldSyncBackPersonal && $locale === $this->defaultLocale))
+                && null !== $this->getTranslationInDefaultLocale($oid, $field)
+            ) {
                 // We can't rely on object field value which is created in non-default locale.
                 // If we provide translation for default locale as well, the latter is considered to be trusted
                 // and object content should be overridden.

--- a/src/Translatable/TranslatableListener.php
+++ b/src/Translatable/TranslatableListener.php
@@ -122,6 +122,16 @@ class TranslatableListener extends MappedEventSubscriber
     private bool $persistDefaultLocaleTranslation = false;
 
     /**
+     * Whether the explicitly-supplied default-locale personal
+     * translation should be considered the source of truth and
+     * its content mirrored back to the main entity's field.
+     *
+     * Only takes effect when used together with personal
+     * translations and {@see self::$persistDefaultLocaleTranslation}.
+     */
+    private bool $preferPersonalTranslationContent = false;
+
+    /**
      * Tracks translation object for default locale
      *
      * @var array<int, array<string, object|Translatable>>
@@ -187,6 +197,35 @@ class TranslatableListener extends MappedEventSubscriber
     public function getPersistDefaultLocaleTranslation()
     {
         return (bool) $this->persistDefaultLocaleTranslation;
+    }
+
+    /**
+     * Whether to mirror the content of the explicitly-supplied
+     * default-locale personal translation back onto the main
+     * entity's translatable field.
+     *
+     * This only takes effect for entities using personal translations
+     * combined with {@see self::setPersistDefaultLocaleTranslation()}
+     * enabled. It removes the need to manually keep the entity's
+     * field in sync with the default-locale translation when
+     * persisting bulk translations from e.g. an admin UI.
+     *
+     * @return static
+     */
+    public function setPreferPersonalTranslationContent(bool $bool): self
+    {
+        $this->preferPersonalTranslationContent = $bool;
+
+        return $this;
+    }
+
+    /**
+     * Check whether the default-locale personal translation
+     * content should be mirrored back to the main entity field.
+     */
+    public function getPreferPersonalTranslationContent(): bool
+    {
+        return $this->preferPersonalTranslationContent;
     }
 
     /**
@@ -654,6 +693,13 @@ class TranslatableListener extends MappedEventSubscriber
         $oid = spl_object_id($object);
         $changeSet = $ea->getObjectChangeSet($uow, $object);
         $translatableFields = $config['fields'];
+        // when enabled, the explicit default-locale personal translation
+        // is the source of truth and its content is mirrored back onto
+        // the entity's field; only effective when the entity uses
+        // personal translations and default-locale persistence is on
+        $shouldSyncBackPersonal = $this->preferPersonalTranslationContent
+            && $this->persistDefaultLocaleTranslation
+            && $ea->usesPersonalTranslation($translationClass);
         foreach ($translatableFields as $field) {
             $wasPersistedSeparetely = false;
             $skip = isset($this->translatedInLocale[$oid]) && $locale === $this->translatedInLocale[$oid];
@@ -663,7 +709,7 @@ class TranslatableListener extends MappedEventSubscriber
             }
             $translation = null;
             foreach ($ea->getScheduledObjectInsertions($uow) as $trans) {
-                if ($locale !== $this->defaultLocale
+                if (($locale !== $this->defaultLocale || $shouldSyncBackPersonal)
                     && get_class($trans) === $translationClass
                     && $trans->getLocale() === $this->defaultLocale
                     && $trans->getField() === $field
@@ -671,6 +717,21 @@ class TranslatableListener extends MappedEventSubscriber
                     $this->setTranslationInDefaultLocale($oid, $field, $trans);
 
                     break;
+                }
+            }
+
+            // when sync-back is enabled, also pick up an existing default-locale
+            // personal translation whose content was edited (scheduled updates)
+            if ($shouldSyncBackPersonal && null === $this->getTranslationInDefaultLocale($oid, $field)) {
+                foreach ($ea->getScheduledObjectUpdates($uow) as $trans) {
+                    if (get_class($trans) === $translationClass
+                        && $trans->getLocale() === $this->defaultLocale
+                        && $trans->getField() === $field
+                        && $this->belongsToObject($ea, $trans, $object)) {
+                        $this->setTranslationInDefaultLocale($oid, $field, $trans);
+
+                        break;
+                    }
                 }
             }
 
@@ -726,9 +787,21 @@ class TranslatableListener extends MappedEventSubscriber
             }
 
             if ($translation) {
-                // set the translated field, take value using reflection
-                $content = $ea->getTranslationValue($object, $field);
-                $translation->setContent($content);
+                $defaultLocaleTrans = $this->getTranslationInDefaultLocale($oid, $field);
+                $useTranslationAsSourceOfTruth = $shouldSyncBackPersonal
+                    && null !== $defaultLocaleTrans
+                    && $translation === $defaultLocaleTrans;
+
+                if ($useTranslationAsSourceOfTruth) {
+                    // the user-supplied default-locale personal translation
+                    // wins; keep its content untouched, the final override
+                    // block below mirrors it onto the entity's field
+                    $content = $translation->getContent();
+                } else {
+                    // set the translated field, take value using reflection
+                    $content = $ea->getTranslationValue($object, $field);
+                    $translation->setContent($content);
+                }
                 // check if need to update in database
                 $transWrapper = AbstractWrapper::wrap($translation, $om);
                 if (((null === $content && !$isInsert) || is_bool($content) || is_int($content) || is_string($content) || !empty($content)) && ($isInsert || !$transWrapper->getIdentifier() || isset($changeSet[$field]))) {
@@ -748,7 +821,7 @@ class TranslatableListener extends MappedEventSubscriber
                 }
             }
 
-            if ($isInsert && null !== $this->getTranslationInDefaultLocale($oid, $field)) {
+            if (($isInsert || $shouldSyncBackPersonal) && null !== $this->getTranslationInDefaultLocale($oid, $field)) {
                 // We can't rely on object field value which is created in non-default locale.
                 // If we provide translation for default locale as well, the latter is considered to be trusted
                 // and object content should be overridden.

--- a/tests/Gedmo/Translatable/PersonalTranslationTest.php
+++ b/tests/Gedmo/Translatable/PersonalTranslationTest.php
@@ -245,6 +245,147 @@ final class PersonalTranslationTest extends BaseTestCaseORM
         ], $this->queryLogger->queries[0]);
     }
 
+    public function testShouldSyncDefaultLocalePersonalTranslationBackToEntityOnInsert(): void
+    {
+        $this->translatableListener->setPersistDefaultLocaleTranslation(true);
+        $this->translatableListener->setPreferPersonalTranslationContent(true);
+
+        $article = new Article();
+        // intentionally do not set title; the default-locale personal translation should drive it
+        $article->setTitle('');
+
+        $enTranslation = new PersonalArticleTranslation();
+        $enTranslation
+            ->setField('title')
+            ->setContent('Hello')
+            ->setObject($article)
+            ->setLocale('en')
+        ;
+        $this->em->persist($enTranslation);
+
+        $deTranslation = new PersonalArticleTranslation();
+        $deTranslation
+            ->setField('title')
+            ->setContent('Hallo')
+            ->setObject($article)
+            ->setLocale('de')
+        ;
+        $this->em->persist($deTranslation);
+
+        $this->em->persist($article);
+        $this->em->flush();
+        $this->em->clear();
+
+        $reloaded = $this->em->find(Article::class, ['id' => $article->getId()]);
+        static::assertSame('Hello', $reloaded->getTitle());
+
+        $trans = $this->em->createQuery('SELECT t FROM '.PersonalArticleTranslation::class.' t')->getArrayResult();
+        static::assertCount(2, $trans);
+        $byLocale = [];
+        foreach ($trans as $row) {
+            $byLocale[$row['locale']] = $row['content'];
+        }
+        static::assertSame('Hello', $byLocale['en']);
+        static::assertSame('Hallo', $byLocale['de']);
+    }
+
+    public function testShouldSyncDefaultLocalePersonalTranslationBackToEntityOnUpdate(): void
+    {
+        $this->translatableListener->setPersistDefaultLocaleTranslation(true);
+        $this->translatableListener->setPreferPersonalTranslationContent(true);
+
+        $article = new Article();
+        $article->setTitle('original');
+
+        $enTranslation = new PersonalArticleTranslation();
+        $enTranslation
+            ->setField('title')
+            ->setContent('original')
+            ->setObject($article)
+            ->setLocale('en')
+        ;
+        $this->em->persist($enTranslation);
+
+        $this->em->persist($article);
+        $this->em->flush();
+        $articleId = $article->getId();
+        $this->em->clear();
+
+        $reloaded = $this->em->find(Article::class, ['id' => $articleId]);
+        $existingEnTranslation = null;
+        foreach ($reloaded->getTranslations() as $t) {
+            if ('en' === $t->getLocale() && 'title' === $t->getField()) {
+                $existingEnTranslation = $t;
+
+                break;
+            }
+        }
+        static::assertNotNull($existingEnTranslation);
+
+        // Modify only the personal translation content; leave the entity field untouched
+        $existingEnTranslation->setContent('updated');
+        $this->em->flush();
+        $this->em->clear();
+
+        $reloaded = $this->em->find(Article::class, ['id' => $articleId]);
+        static::assertSame('updated', $reloaded->getTitle());
+
+        $trans = $this->em->createQuery('SELECT t FROM '.PersonalArticleTranslation::class.' t')->getArrayResult();
+        static::assertCount(1, $trans);
+        static::assertSame('updated', $trans[0]['content']);
+    }
+
+    public function testShouldNotAffectBehaviorWhenFlagDisabled(): void
+    {
+        // Mirror of testShouldOverrideTranslationInEntityBeingTranslated, with the new flag explicitly off:
+        // existing behavior must be preserved (entity field wins over the personal translation content).
+        $this->translatableListener->setPreferPersonalTranslationContent(false);
+        $this->translatableListener->setDefaultLocale('de');
+
+        $article = new Article();
+        $article->setTitle('override');
+
+        $enTranslation = new PersonalArticleTranslation();
+        $enTranslation
+            ->setField('title')
+            ->setContent('en')
+            ->setObject($article)
+            ->setLocale('en')
+        ;
+        $this->em->persist($enTranslation);
+        $this->em->persist($article);
+        $this->em->flush();
+
+        $trans = $this->em->createQuery('SELECT t FROM '.PersonalArticleTranslation::class.' t')->getArrayResult();
+        static::assertCount(1, $trans);
+        static::assertSame('override', $trans[0]['content']);
+    }
+
+    public function testShouldNotApplyWithoutPersistDefaultLocaleTranslation(): void
+    {
+        // Flag on, but persistDefaultLocaleTranslation left off: behavior must be unchanged.
+        $this->translatableListener->setPersistDefaultLocaleTranslation(false);
+        $this->translatableListener->setPreferPersonalTranslationContent(true);
+
+        $article = new Article();
+        $article->setTitle('entity-wins');
+
+        $enTranslation = new PersonalArticleTranslation();
+        $enTranslation
+            ->setField('title')
+            ->setContent('translation-content')
+            ->setObject($article)
+            ->setLocale('en')
+        ;
+        $this->em->persist($enTranslation);
+        $this->em->persist($article);
+        $this->em->flush();
+        $this->em->clear();
+
+        $reloaded = $this->em->find(Article::class, ['id' => $article->getId()]);
+        static::assertSame('entity-wins', $reloaded->getTitle());
+    }
+
     protected function getUsedEntityFixtures(): array
     {
         return [

--- a/tests/Gedmo/Translatable/PersonalTranslationTest.php
+++ b/tests/Gedmo/Translatable/PersonalTranslationTest.php
@@ -335,6 +335,89 @@ final class PersonalTranslationTest extends BaseTestCaseORM
         static::assertSame('updated', $trans[0]['content']);
     }
 
+    public function testShouldSyncOnInsertWhenWorkingInNonDefaultLocale(): void
+    {
+        // Admin UI is opened in a non-default locale and submits all personal
+        // translations; the entity row's column must end up holding the default
+        // locale's content, and each translation row must keep the content the
+        // user authored (no clobbering from the entity field).
+        $this->translatableListener->setPersistDefaultLocaleTranslation(true);
+        $this->translatableListener->setPreferPersonalTranslationContent(true);
+        $this->translatableListener->setTranslatableLocale('de');
+
+        $article = new Article();
+        $article->setTitle('');
+
+        $en = new PersonalArticleTranslation();
+        $en->setField('title')->setContent('Hello')->setObject($article)->setLocale('en');
+        $this->em->persist($en);
+
+        $de = new PersonalArticleTranslation();
+        $de->setField('title')->setContent('Hallo')->setObject($article)->setLocale('de');
+        $this->em->persist($de);
+
+        $this->em->persist($article);
+        $this->em->flush();
+        $this->em->clear();
+
+        $rows = $this->em->createQuery('SELECT a.id, a.title FROM '.Article::class.' a')->getArrayResult();
+        static::assertCount(1, $rows);
+        static::assertSame('Hello', $rows[0]['title']);
+
+        $trans = $this->em
+            ->createQuery('SELECT t.locale, t.content FROM '.PersonalArticleTranslation::class.' t ORDER BY t.locale')
+            ->getArrayResult();
+        static::assertCount(2, $trans);
+        static::assertSame(['locale' => 'de', 'content' => 'Hallo'], $trans[0]);
+        static::assertSame(['locale' => 'en', 'content' => 'Hello'], $trans[1]);
+    }
+
+    public function testShouldPersistSyncedTitleToDatabaseOnUpdate(): void
+    {
+        // When only the personal translation in the default locale is
+        // modified (entity itself untouched), the entity's column in the DB must
+        // also be updated. Verified via getArrayResult to bypass postLoad, which
+        // would otherwise mask a stale DB column by re-deriving the title from the
+        // (already-updated) translation row.
+        $this->translatableListener->setPersistDefaultLocaleTranslation(true);
+        $this->translatableListener->setPreferPersonalTranslationContent(true);
+
+        $article = new Article();
+        $article->setTitle('original');
+
+        $enTranslation = new PersonalArticleTranslation();
+        $enTranslation
+            ->setField('title')
+            ->setContent('original')
+            ->setObject($article)
+            ->setLocale('en')
+        ;
+        $this->em->persist($enTranslation);
+        $this->em->persist($article);
+        $this->em->flush();
+        $articleId = $article->getId();
+        $this->em->clear();
+
+        $reloaded = $this->em->find(Article::class, ['id' => $articleId]);
+        $existingEnTranslation = null;
+        foreach ($reloaded->getTranslations() as $t) {
+            if ('en' === $t->getLocale() && 'title' === $t->getField()) {
+                $existingEnTranslation = $t;
+
+                break;
+            }
+        }
+        static::assertNotNull($existingEnTranslation);
+
+        $existingEnTranslation->setContent('updated');
+        $this->em->flush();
+        $this->em->clear();
+
+        $rows = $this->em->createQuery('SELECT a.id, a.title FROM '.Article::class.' a')->getArrayResult();
+        static::assertCount(1, $rows);
+        static::assertSame('updated', $rows[0]['title']);
+    }
+
     public function testShouldNotAffectBehaviorWhenFlagDisabled(): void
     {
         // Mirror of testShouldOverrideTranslationInEntityBeingTranslated, with the new flag explicitly off:

--- a/tests/Gedmo/Translatable/PersonalTranslationTest.php
+++ b/tests/Gedmo/Translatable/PersonalTranslationTest.php
@@ -372,6 +372,67 @@ final class PersonalTranslationTest extends BaseTestCaseORM
         static::assertSame(['locale' => 'en', 'content' => 'Hello'], $trans[1]);
     }
 
+    public function testShouldSaveBothLocalesWhenUpdatingTranslationsInNonDefaultLocale(): void
+    {
+        // Default locale = 'en', listener (admin UI) locale = 'de'. User saves
+        // edits for both the en and de personal translation rows in one go.
+        // Both rows must be updated in the DB and the entity column must end
+        // up with the default-locale content.
+        $this->translatableListener->setPersistDefaultLocaleTranslation(true);
+        $this->translatableListener->setPreferPersonalTranslationContent(true);
+
+        $article = new Article();
+        $article->setTitle('initial');
+
+        $en = new PersonalArticleTranslation();
+        $en->setField('title')->setContent('initial en')->setObject($article)->setLocale('en');
+        $this->em->persist($en);
+
+        $de = new PersonalArticleTranslation();
+        $de->setField('title')->setContent('initial de')->setObject($article)->setLocale('de');
+        $this->em->persist($de);
+
+        $this->em->persist($article);
+        $this->em->flush();
+        $articleId = $article->getId();
+        $this->em->clear();
+
+        $this->translatableListener->setTranslatableLocale('de');
+        $reloaded = $this->em->find(Article::class, ['id' => $articleId]);
+
+        $enRow = null;
+        $deRow = null;
+        foreach ($reloaded->getTranslations() as $t) {
+            if ('title' !== $t->getField()) {
+                continue;
+            }
+            if ('en' === $t->getLocale()) {
+                $enRow = $t;
+            } elseif ('de' === $t->getLocale()) {
+                $deRow = $t;
+            }
+        }
+        static::assertNotNull($enRow);
+        static::assertNotNull($deRow);
+        $enRow->setContent('updated en');
+        $deRow->setContent('updated de');
+
+        $this->em->flush();
+        $this->em->clear();
+
+        $trans = $this->em
+            ->createQuery('SELECT t.locale, t.content FROM '.PersonalArticleTranslation::class.' t ORDER BY t.locale')
+            ->getArrayResult();
+        static::assertSame([
+            ['locale' => 'de', 'content' => 'updated de'],
+            ['locale' => 'en', 'content' => 'updated en'],
+        ], $trans);
+
+        $rows = $this->em->createQuery('SELECT a.id, a.title FROM '.Article::class.' a')->getArrayResult();
+        static::assertCount(1, $rows);
+        static::assertSame('updated en', $rows[0]['title']);
+    }
+
     public function testShouldPersistSyncedTitleToDatabaseOnUpdate(): void
     {
         // When only the personal translation in the default locale is


### PR DESCRIPTION
See doc/translatable.md.

Before this change, when you saved all locales translation values (including the default one) only via personal translations, the main entity's field was filled pretty randomly. Either with the default locale value, or depending on exact setup with NULL or the default empty value.
Our usecase is a simple admin UI which has a way of specifying all translations at once.
My other hunch was that the previous behavior was a bug for personal translations which does not happen with the ext_translation table, but idk. Because it seems odd that Gedmo won't sync back if I add a new entity and persist only its translations.

Yes this is a 100 line change, but some of that is the `skip` check moving down and a bunch of comments.