### PR TITLE
[Tree] Fix detection of uninitialized proxies with ORM native lazy objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ a release.
 ### Changed
 - All: Removed the dollar sign from the generated cache ID for extension metadata to ensure only characters mandated by [PSR-6](https://www.php-fig.org/psr/psr-6/#definitions) are used, improving compatibility with caching implementations with strict character requirements (#2978)
 
+### Fixed
+- Tree: Fix detection of uninitialized proxies with ORM native lazy objects, which caused `NestedTreeRepository::verify()` to report false errors for valid trees (#3053)
+
 ## [3.22.0] - 2025-12-13
 ### Added
 - Support for Symfony 8

--- a/src/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/src/Tree/Entity/Repository/NestedTreeRepository.php
@@ -13,7 +13,6 @@ use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
-use Doctrine\Persistence\Proxy;
 use Gedmo\Exception\InvalidArgumentException;
 use Gedmo\Exception\RuntimeException;
 use Gedmo\Exception\UnexpectedValueException;
@@ -1304,7 +1303,7 @@ class NestedTreeRepository extends AbstractTreeRepository
             } elseif ($right == $left) {
                 $errors[] = "node [{$id}] has identical left and right values";
             } elseif ($parent) {
-                if ($parent instanceof Proxy && !$parent->__isInitialized()) {
+                if ($this->getEntityManager()->isUninitializedObject($parent)) {
                     $this->getEntityManager()->refresh($parent);
                 }
                 $parentRight = $meta->getFieldValue($parent, $config['right']);

--- a/src/Tree/Strategy/ORM/Nested.php
+++ b/src/Tree/Strategy/ORM/Nested.php
@@ -13,7 +13,6 @@ use Doctrine\Common\Collections\Criteria;
 use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\Persistence\Proxy;
 use Gedmo\Exception\InvalidArgumentException;
 use Gedmo\Exception\UnexpectedValueException;
 use Gedmo\Mapping\Event\AdapterInterface;
@@ -618,7 +617,7 @@ class Nested implements Strategy
                 continue;
             }
             foreach ($nodes as $node) {
-                if ($node instanceof Proxy && !$node->__isInitialized()) {
+                if ($em->isUninitializedObject($node)) {
                     continue;
                 }
 
@@ -718,7 +717,7 @@ class Nested implements Strategy
                 continue;
             }
             foreach ($nodes as $node) {
-                if ($node instanceof Proxy && !$node->__isInitialized()) {
+                if ($em->isUninitializedObject($node)) {
                     continue;
                 }
 

--- a/tests/Gedmo/Tree/NestedTreeRootRepositoryTest.php
+++ b/tests/Gedmo/Tree/NestedTreeRootRepositoryTest.php
@@ -533,6 +533,54 @@ final class NestedTreeRootRepositoryTest extends BaseTestCaseORM
         static::assertTrue($repo->verify());
     }
 
+    public function testShouldVerifyTreeWhenParentIsAnUninitializedProxy(): void
+    {
+        /** @var NestedTreeRepository<RootCategory> $repo */
+        $repo = $this->em->getRepository(RootCategory::class);
+
+        // Move "Carrots" under "Potatoes", so that the child row is iterated during
+        // verification before its parent has been hydrated.
+        $carrots = $repo->findOneBy(['title' => 'Carrots']);
+        $potatoes = $repo->findOneBy(['title' => 'Potatoes']);
+
+        $repo->persistAsFirstChildOf($carrots, $potatoes);
+        $this->em->flush();
+
+        // clear, so that parents are loaded as uninitialized proxies during verification
+        $this->em->clear();
+
+        static::assertTrue($repo->verify());
+    }
+
+    public function testShouldNotTouchUninitializedProxiesWhenShiftingNodes(): void
+    {
+        /** @var NestedTreeRepository<RootCategory> $repo */
+        $repo = $this->em->getRepository(RootCategory::class);
+
+        $potatoesId = $repo->findOneBy(['title' => 'Potatoes'])->getId();
+        $this->em->clear();
+
+        $food = $repo->findOneBy(['title' => 'Food']);
+        // an uninitialized proxy in the identity map, its lft/rgt are affected by the shift below
+        $potatoes = $this->em->getReference(RootCategory::class, $potatoesId);
+
+        // insert a new first child of "Food", shifting "Potatoes" from 7/8 to 9/10
+        $bread = new RootCategory();
+        $bread->setTitle('Bread');
+
+        $repo->persistAsFirstChildOf($bread, $food);
+        $this->em->flush();
+
+        // the in-memory update of shifted nodes must skip uninitialized proxies
+        static::assertTrue($this->em->isUninitializedObject($potatoes));
+
+        // initializing the proxy now must yield the shifted values from the database
+        static::assertSame(9, $potatoes->getLeft());
+        static::assertSame(10, $potatoes->getRight());
+
+        static::assertTrue($repo->verify());
+    }
+
     public function testShouldRemoveTreeLeafFromTree(): void
     {
         $this->populateMore();


### PR DESCRIPTION
With `doctrine/orm` >= 3.4 and PHP >= 8.4 (native lazy objects), lazy-loaded entities are
no longer `instanceof Doctrine\Persistence\Proxy`, so the remaining
`instanceof Proxy && !__isInitialized()` checks in the Tree extension stop detecting
uninitialized objects:

- **`NestedTreeRepository::verifyTree()`**: an uninitialized parent is not refreshed and
  its `lft`/`rgt`/`lvl` are read as `null`, so `verify()` reports false errors
  ("node [X] right is greater than parent`s [Y] right value") for every valid node whose
  parent is hydrated later during the iteration. A subsequent `recover()` then "repairs"
  trees that were never broken. Covered by a regression test that fails without the fix.
- **`Nested::shiftRL()` / `shiftRangeRL()`**: the in-memory sync loops no longer skip
  uninitialized objects. Currently without observable effect (raw reads return `null` and
  fail the range checks), but only by accident of the current ORM implementation. A second
  test pins the intended behavior.

Both spots now use `EntityManagerInterface::isUninitializedObject()`, following #2946.