### PR TITLE
fix: avoid deprecation with nullable fields

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -73,12 +73,6 @@ parameters:
 			path: src/Loggable/Entity/Repository/LogEntryRepository.php
 
 		-
-			message: '#^Unable to resolve the template type T in call to method Doctrine\\ORM\\EntityManagerInterface\:\:getReference\(\)$#'
-			identifier: argument.templateType
-			count: 1
-			path: src/Loggable/Entity/Repository/LogEntryRepository.php
-
-		-
 			message: '#^Call to an undefined method Doctrine\\Persistence\\Mapping\\ClassMetadata\<Gedmo\\Loggable\\LogEntryInterface\<T of object\>\>\:\:newInstance\(\)\.$#'
 			identifier: method.notFound
 			count: 1
@@ -1289,4 +1283,3 @@ parameters:
 			identifier: deadCode.unreachable
 			count: 1
 			path: tests/Gedmo/Tree/MaterializedPathODMMongoDBTreeLockingTest.php
-

--- a/src/Loggable/Entity/Repository/LogEntryRepository.php
+++ b/src/Loggable/Entity/Repository/LogEntryRepository.php
@@ -156,7 +156,9 @@ class LogEntryRepository extends EntityRepository
         }
 
         $mapping = $objectMeta->getAssociationMapping($field);
-        $value = $value ? $this->getEntityManager()->getReference($mapping->targetEntity ?? $mapping['targetEntity'], $value) : null;
+        // @phpstan-ignore-next-line BC layer for doctrine/ORM
+        $targetEntity = $mapping->targetEntity ?? $mapping['targetEntity'];
+        $value = $value ? $this->getEntityManager()->getReference($targetEntity, $value) : null;
     }
 
     /**

--- a/src/Loggable/Mapping/Driver/Yaml.php
+++ b/src/Loggable/Mapping/Driver/Yaml.php
@@ -11,7 +11,6 @@ namespace Gedmo\Loggable\Mapping\Driver;
 
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Gedmo\Exception\InvalidMappingException;
-use Gedmo\Mapping\Driver;
 use Gedmo\Mapping\Driver\File;
 
 /**

--- a/src/Sluggable/SluggableListener.php
+++ b/src/Sluggable/SluggableListener.php
@@ -10,6 +10,7 @@
 namespace Gedmo\Sluggable;
 
 use Doctrine\Common\EventArgs;
+use Doctrine\ORM\Mapping\FieldMapping;
 use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
 use Doctrine\Persistence\Event\ManagerEventArgs;
@@ -398,6 +399,7 @@ class SluggableListener extends MappedEventSubscriber
             }
             // if slug is changed, do further processing
             if ($needToChangeSlug) {
+                /** @var FieldMapping|array<mixed> $mapping */
                 $mapping = $meta->getFieldMapping($slugField);
                 // notify slug handlers --> postSlugBuild
                 $urlized = false;
@@ -457,12 +459,17 @@ class SluggableListener extends MappedEventSubscriber
                 }
 
                 // cut slug if exceeded in length
-                $length = $mapping->length ?? $mapping['length'] ?? null;
+                $length = \is_object($mapping)
+                    ? $mapping->length
+                    : ($mapping['length'] ?? null);
                 if (null !== $length && strlen($slug) > $length) {
                     $slug = substr($slug, 0, $length);
                 }
 
-                if (($mapping->nullable ?? $mapping['nullable'] ?? false) && 0 === strlen($slug)) {
+                $nullable = \is_object($mapping)
+                    ? ($mapping->nullable ?? false)
+                    : ($mapping['nullable'] ?? false);
+                if ($nullable && 0 === strlen($slug)) {
                     $slug = null;
                 }
 
@@ -564,7 +571,9 @@ class SluggableListener extends MappedEventSubscriber
             }
 
             $mapping = $meta->getFieldMapping($config['slug']);
-            $length = $mapping->length ?? $mapping['length'] ?? null;
+            $length = \is_object($mapping)
+                ? $mapping->length
+                : ($mapping['length'] ?? null);
             if (null !== $length && strlen($generatedSlug) > $length) {
                 $generatedSlug = substr(
                     $generatedSlug,

--- a/src/SoftDeleteable/Mapping/Driver/Attribute.php
+++ b/src/SoftDeleteable/Mapping/Driver/Attribute.php
@@ -45,7 +45,7 @@ class Attribute extends AbstractAnnotationDriver
 
             $config['timeAware'] = false;
 
-            if (isset($annot->timeAware)) {
+            if (isset($annot->timeAware)) { // @phpstan-ignore-line
                 if (!is_bool($annot->timeAware)) {
                     throw new InvalidMappingException('timeAware must be boolean. '.gettype($annot->timeAware).' provided.');
                 }
@@ -55,7 +55,7 @@ class Attribute extends AbstractAnnotationDriver
 
             $config['hardDelete'] = true;
 
-            if (isset($annot->hardDelete)) {
+            if (isset($annot->hardDelete)) { // @phpstan-ignore-line
                 if (!is_bool($annot->hardDelete)) {
                     throw new InvalidMappingException('hardDelete must be boolean. '.gettype($annot->hardDelete).' provided.');
                 }

--- a/tests/Gedmo/Sluggable/SluggableDateTimeTypesTest.php
+++ b/tests/Gedmo/Sluggable/SluggableDateTimeTypesTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace Gedmo\Tests\Sluggable;
 
 use Doctrine\Common\EventManager;
-use Gedmo\Sluggable\Sluggable;
 use Gedmo\Sluggable\SluggableListener;
 use Gedmo\Tests\Sluggable\Fixture\DateTimeTypes\ArticleDate;
 use Gedmo\Tests\Sluggable\Fixture\DateTimeTypes\ArticleDateImmutable;

--- a/tests/Gedmo/Timestampable/TimestampableDocumentTest.php
+++ b/tests/Gedmo/Timestampable/TimestampableDocumentTest.php
@@ -16,6 +16,7 @@ use Gedmo\Tests\Timestampable\Fixture\Document\Article;
 use Gedmo\Tests\Timestampable\Fixture\Document\Type;
 use Gedmo\Tests\Tool\BaseTestCaseMongoODM;
 use Gedmo\Timestampable\TimestampableListener;
+use MongoDB\BSON\Timestamp;
 
 /**
  * These are tests for Timestampable behavior ODM implementation
@@ -41,7 +42,11 @@ final class TimestampableDocumentTest extends BaseTestCaseMongoODM
 
         $date = new \DateTime();
         $now = time();
-        $created = $article->getCreated()->getTimestamp();
+        $created = $article->getCreated();
+        if ($created instanceof Timestamp) {
+            $created = $created->getTimestamp();
+        }
+
         static::assertTrue($created > $now - 5 && $created < $now + 5); // 5 seconds interval if lag
         static::assertSame(
             $date->format('Y-m-d H:i'),
@@ -80,9 +85,14 @@ final class TimestampableDocumentTest extends BaseTestCaseMongoODM
 
         $repo = $this->dm->getRepository(Article::class);
         $sport = $repo->findOneBy(['title' => 'sport forced']);
+        $sportCreated = $sport->getCreated();
+        if ($sportCreated instanceof Timestamp) {
+            $sportCreated = $sportCreated->getTimestamp();
+        }
+
         static::assertSame(
             $created,
-            $sport->getCreated()->getTimestamp()
+            $sportCreated
         );
         static::assertSame(
             '2000-01-01 12:00:00',

--- a/tests/Gedmo/Tree/Fixture/Mock/TreeListenerMock.php
+++ b/tests/Gedmo/Tree/Fixture/Mock/TreeListenerMock.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace Gedmo\Tests\Tree\Fixture\Mock;
 
 use Doctrine\Persistence\ObjectManager;
-use Gedmo\Tree\Strategy;
 use Gedmo\Tree\TreeListener;
 
 /**


### PR DESCRIPTION
Hi @phansys 

The last PR from @Jean85 (https://github.com/doctrine-extensions/DoctrineExtensions/pull/2889) works fine except for the SlugListener.

Since `length` and `nullable` are optional properties they are nullable ; which means something like
```
$mapping->nullable ?? $mapping['nullable'] ?? null
```
might still try to access to the array.

All the CI failure are unrelated to this PR, but I fixed them in another commit.